### PR TITLE
AC Test fix - LRAC-11277 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EmptyState.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EmptyState.testcase
@@ -1334,15 +1334,16 @@ definition {
 			ACUtils.launchAC(workspaceName = "New AC Workspace");
 		}
 
-		task ("Check empty state of tooltip in sites activities") {
-			MouseOver(locator1 = "ACCards#GRAPH_WITHOUT_DATA");
+		task ("Check empty state of site activities card") {
+			ACUtils.viewGenericText(textValueList = "There is no data for site activity.,Check back later to verify if data has been received from your data sources.");
 
-			for (var type : list "Known,Anonymous,Total") {
-				AssertElementPresent(
-					key_value = "0",
-					key_visitors = "${type}",
-					locator1 = "ACSites#TOOLTIP_UNIQUE_VISITORS");
-			}
+			ACUtils.clickGenericHyperlink(hyperlinkText = "Learn more about site activity.");
+
+			SelectWindow(locator1 = "title=Sites Dashboard — Liferay Learn");
+
+			ACUtils.viewGenericText(textValueList = "Documentation,Site Activities");
+
+			Close.closeWindow();
 		}
 
 		task ("Check the empty state and documentation link of the top pages card") {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-11277 (Ticket)
[Testray](https://testray.liferay.com/home/-/testray/case_results/index?p_p_state=normal&orderByCol=status_sortable&orderByType=asc&testrayBuildId=1865384107)

Solutions:
The change was made to place an empty state message on the graph in case it has no data ([LRAC-11016](https://issues.liferay.com/browse/LRAC-11016)). We should stop validating the tooltip and validating only the message on the chart in case we don't have data in the workspace.