### PR TITLE
AC Test Fix - LRAC-11340 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/IdentityEvents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/IdentityEvents.testcase
@@ -289,6 +289,10 @@ definition {
 			UserBar.signOut();
 		}
 
+		task ("Clear local storage") {
+			ACUtils.clearLocalStorage();
+		}
+
 		task ("Start Har recording") {
 			ProxyUtil.startHarRecording("identity");
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-11340 (ticket)
[Testray Result](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=1872588750&testrayRunId=1872588760)

**Solutions:**
This test started to fail after the [story](https://issues.liferay.com/browse/LRAC-10999) changes, before the identity event was triggered every time you log in, the userId was changed, but now when you log out the userId remains the same, so you need to clear the local storage so when you log in again it needs to pull the userId again, that way the identity event will be resent.