### PR TITLE
AC Test fix - LRAC-11341 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/PageEvents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/PageEvents.testcase
@@ -863,6 +863,18 @@ definition {
 			Open.openInTheNewTab(locator1 = "https://www.bbc.com");
 		}
 
+		task ("Switch to the DXP tab") {
+			SelectWindow(locator1 = "title=AC Page - Site Name - ${dataSource}");
+		}
+
+		task ("Hard refresh the page to clear the network") {
+			TestUtils.hardRefresh();
+		}
+
+		task ("Switch to the BCC tab") {
+			SelectWindow(locator1 = "title=BBC - Homepage");
+		}
+
 		task ("Start Har recording") {
 			ProxyUtil.startHarRecording("tabFocused");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/PageEvents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/PageEvents.testcase
@@ -25,25 +25,6 @@ definition {
 			ACUtils.addSiteAndPage();
 		}
 
-		task ("Add a Blogs widget to page") {
-			ACUtils.addWidgetToPage(
-				layoutName = "AC Page",
-				widgetName = "Blogs");
-		}
-
-		task ("Add 10 blogs entries with long content") {
-			var n = "0";
-
-			while ("${n}" != "10") {
-				var n = ${n} + 1;
-
-				ACUtils.createBlogsAndAddToPage(
-					entryContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce in lacus nunc. Etiam et volutpat est. Quisque quis mi erat. Donec maximus mauris augue, nec convallis metus aliquet vitae. Nullam venenatis a nisl in tincidunt. Aliquam venenatis, enim in venenatis aliquam, mauris erat blandit nulla, sit amet tincidunt elit enim sit amet dolor. Aliquam fringilla condimentum varius. Maecenas tincidunt elit eget lacinia aliquam. Proin congue diam lorem. Vestibulum tristique elit mi, non dapibus erat lobortis.",
-					entryTitle = "Blogs Entry Title ${n}",
-					groupName = "Site Name");
-			}
-		}
-
 		task ("Connect the DXP to AC") {
 			ACDXPSettings.connectDXPtoAnalyticsCloud(siteName = "Site Name");
 		}
@@ -68,6 +49,25 @@ definition {
 	@priority = "5"
 	test CheckPageDepthReachedTo25 {
 		property proxy.server.enabled = "true";
+
+		task ("Add a Blogs widget to page") {
+			ACUtils.addWidgetToPage(
+				layoutName = "AC Page",
+				widgetName = "Blogs");
+		}
+
+		task ("Add 10 blogs entries with long content") {
+			var n = "0";
+
+			while ("${n}" != "10") {
+				var n = ${n} + 1;
+
+				ACUtils.createBlogsAndAddToPage(
+					entryContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce in lacus nunc. Etiam et volutpat est. Quisque quis mi erat. Donec maximus mauris augue, nec convallis metus aliquet vitae. Nullam venenatis a nisl in tincidunt. Aliquam venenatis, enim in venenatis aliquam, mauris erat blandit nulla, sit amet tincidunt elit enim sit amet dolor. Aliquam fringilla condimentum varius. Maecenas tincidunt elit eget lacinia aliquam. Proin congue diam lorem. Vestibulum tristique elit mi, non dapibus erat lobortis.",
+					entryTitle = "Blogs Entry Title ${n}",
+					groupName = "Site Name");
+			}
+		}
 
 		task ("Get the Property ID in AC") {
 			ACUtils.launchAC();
@@ -129,6 +129,25 @@ definition {
 	test CheckPageDepthReachedTo50 {
 		property proxy.server.enabled = "true";
 
+		task ("Add a Blogs widget to page") {
+			ACUtils.addWidgetToPage(
+				layoutName = "AC Page",
+				widgetName = "Blogs");
+		}
+
+		task ("Add 10 blogs entries with long content") {
+			var n = "0";
+
+			while ("${n}" != "10") {
+				var n = ${n} + 1;
+
+				ACUtils.createBlogsAndAddToPage(
+					entryContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce in lacus nunc. Etiam et volutpat est. Quisque quis mi erat. Donec maximus mauris augue, nec convallis metus aliquet vitae. Nullam venenatis a nisl in tincidunt. Aliquam venenatis, enim in venenatis aliquam, mauris erat blandit nulla, sit amet tincidunt elit enim sit amet dolor. Aliquam fringilla condimentum varius. Maecenas tincidunt elit eget lacinia aliquam. Proin congue diam lorem. Vestibulum tristique elit mi, non dapibus erat lobortis.",
+					entryTitle = "Blogs Entry Title ${n}",
+					groupName = "Site Name");
+			}
+		}
+
 		task ("Get the Property ID in AC") {
 			ACUtils.launchAC();
 
@@ -188,6 +207,25 @@ definition {
 	@priority = "5"
 	test CheckPageDepthReachedTo75 {
 		property proxy.server.enabled = "true";
+
+		task ("Add a Blogs widget to page") {
+			ACUtils.addWidgetToPage(
+				layoutName = "AC Page",
+				widgetName = "Blogs");
+		}
+
+		task ("Add 10 blogs entries with long content") {
+			var n = "0";
+
+			while ("${n}" != "10") {
+				var n = ${n} + 1;
+
+				ACUtils.createBlogsAndAddToPage(
+					entryContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce in lacus nunc. Etiam et volutpat est. Quisque quis mi erat. Donec maximus mauris augue, nec convallis metus aliquet vitae. Nullam venenatis a nisl in tincidunt. Aliquam venenatis, enim in venenatis aliquam, mauris erat blandit nulla, sit amet tincidunt elit enim sit amet dolor. Aliquam fringilla condimentum varius. Maecenas tincidunt elit eget lacinia aliquam. Proin congue diam lorem. Vestibulum tristique elit mi, non dapibus erat lobortis.",
+					entryTitle = "Blogs Entry Title ${n}",
+					groupName = "Site Name");
+			}
+		}
 
 		task ("Get the Property ID in AC") {
 			ACUtils.launchAC();


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-11341 (Automation ticket)
[Testray Result](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=1884488956&testrayRunId=1884490039)
[Commit that caused the problem](https://github.com/ViniLopes20/liferay-portal/commit/b4962479e7b728f7179e86bef7173e7bfa72bd38)

**Solution:**
This commit caused the problem, after this change the test started to fail on the CI. The problem is because when the macro opens the BBC site in a new browser tab, it first opens a new tab (Crtl + t) after the macro quickly returns to the AC page causing the _tabFocused_ event to be sent. So when the test comes to the end, two _tabFocused_ events are present, not just one.