### PR TITLE
Disable test from upstream and release routine - LRAC-11408 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsBlockEvents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsBlockEvents.testcase
@@ -172,10 +172,9 @@ definition {
 	}
 
 	@description = "Feature ID: LRAC-7346 | Automation ID: LRAC-10152 | Test Summary: Blocked events are not shown on Segments"
+	@ignore = "true"
 	@priority = "5"
 	test CheckBlockedEventsNotShownOnSegments {
-		property analytics.cloud.upstream = "false";
-		property analytics.cloud.release = "false";
 		property test.name.skip.portal.instance = "CustomEventsBlockEvents#CheckBlockedEventsNotShownOnSegments";
 
 		task ("Fill fields and create custom event") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsBlockEvents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsBlockEvents.testcase
@@ -174,6 +174,8 @@ definition {
 	@description = "Feature ID: LRAC-7346 | Automation ID: LRAC-10152 | Test Summary: Blocked events are not shown on Segments"
 	@priority = "5"
 	test CheckBlockedEventsNotShownOnSegments {
+		property analytics.cloud.upstream = "false";
+		property analytics.cloud.release = "false";
 		property test.name.skip.portal.instance = "CustomEventsBlockEvents#CheckBlockedEventsNotShownOnSegments";
 
 		task ("Fill fields and create custom event") {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-11408 (Ticket)
Note: Disabling this test since Segments does not show any custom events, hence this test is irrelevant and can be disregard.