### PR TITLE
AC Test Fix - LRAC-11448 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/Workspace.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/Workspace.testcase
@@ -291,8 +291,8 @@ definition {
 
 		task ("Change the timezone to Tokyo of Japan") {
 			ACWorkspace.configureWorkspaceSettings(
-				timezone = "Japan",
-				timezoneId = "UTC+09:00 Japan Time (Asia/Tokyo)");
+				timezone = "China",
+				timezoneId = "UTC+06:00 Xinjiang Time (Asia/Urumqi)");
 
 			ACUtils.waitForLoading();
 		}
@@ -302,7 +302,7 @@ definition {
 		}
 
 		task ("View the information banner") {
-			ACUtils.viewAlertInfo(infoMessage = "Workspace timezone has changed to UTC+09:00 Japan Time");
+			ACUtils.viewAlertInfo(infoMessage = "Workspace timezone has changed to UTC+06:00 XinJiang Time");
 		}
 
 		task ("Change the timezone to Shanghai of China") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/Workspace.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/Workspace.testcase
@@ -289,7 +289,7 @@ definition {
 			ACSettings.goToWorkspace();
 		}
 
-		task ("Change the timezone to Tokyo of Japan") {
+		task ("Change the timezone to Xinjiang of China") {
 			ACWorkspace.configureWorkspaceSettings(
 				timezone = "China",
 				timezoneId = "UTC+06:00 Xinjiang Time (Asia/Urumqi)");


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-11448 (Test fix ticket)
Since this test checks for 1 banner after time zone change, I want to try keeping the same time zone (China), but using a different region (XinJiang), note that this will also changing the information banner since XinJiang timezone is different than Shanghai timezone. I've run this test on CI and it seems to stable the test.
[Testray Result 1](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=1905872321)
[Testray Result 2](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=1906045460)
[Testray Result 3](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=1906736990)