### PR TITLE
AC Test Fix - LRAC-11898 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACUtils.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACUtils.path
@@ -22,12 +22,12 @@
 </tr>
 <tr>
 	<td>GENERIC_TEXT</td>
-	<td>//*[normalize-space()='${key_textValue}']</td>
+	<td>//*[normalize-space(text())='${key_textValue}']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>GENERIC_TEXT_ORDER</td>
-	<td>xpath=(//*[normalize-space()='${key_textValue}'])[${index}]</td>
+	<td>xpath=(//*[normalize-space(text())='${key_textValue}'])[${index}]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-11898
normalize-space is unable to find text for certain xpaths that have multiple separate texts within the same node `(e.g. <div class="no-results-description">Create a segment to get started.<a class="d-block" href="https://learn.liferay.com/analytics-cloud/latest/en/people/segments/segments.html" target="_blank">Access our documentation to learn more.</a></div>)`