### PR TITLE
AC New Automated Test - LRAC-11726 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACCustomEvents.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACCustomEvents.macro
@@ -104,7 +104,7 @@ definition {
 
 		var sampleJavascript = StringUtil.replace("${sampleJavascript}", " ", "");
 
-		if (!(isSet(oldCustomEventName))) {
+		if (isSet(oldCustomEventName)) {
 
 			// Change the custom event name to the new name
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACCustomEvents.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACCustomEvents.macro
@@ -105,6 +105,7 @@ definition {
 		var sampleJavascript = StringUtil.replace("${sampleJavascript}", " ", "");
 
 		if (!(isSet(oldCustomEventName))) {
+
 			// Change the custom event name to the new name
 
 			var sampleJavascript = StringUtil.replace("${sampleJavascript}", "${oldCustomEventName}", "${newCustomEventName}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACCustomEvents.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACCustomEvents.macro
@@ -104,9 +104,11 @@ definition {
 
 		var sampleJavascript = StringUtil.replace("${sampleJavascript}", " ", "");
 
-		// Change the custom event name to the new name
+		if (!(isSet(oldCustomEventName))) {
+			// Change the custom event name to the new name
 
-		var sampleJavascript = StringUtil.replace("${sampleJavascript}", "${oldCustomEventName}", "${newCustomEventName}");
+			var sampleJavascript = StringUtil.replace("${sampleJavascript}", "${oldCustomEventName}", "${newCustomEventName}");
+		}
 
 		if (isSet(oldAttributeList)) {
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsEventAnalysis.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsEventAnalysis.testcase
@@ -311,10 +311,12 @@ definition {
 				disableAttributesList = "${disableAttributesList}");
 		}
 
-		task ("Close sessions") {
+		task ("Close sessions and launch DXP") {
 			ACUtils.closeAllSessions();
 
 			ACUtils.launchDXP();
+
+			ACUtils.navigateToSitePage( pageName = "AC Page", siteName = "Site Name");
 		}
 
 		task ("Start Har recording") {
@@ -329,7 +331,7 @@ definition {
 			ACUtils.waitForSendingRequest();
 		}
 
-		task ("View the properties of blogClicked event") {
+		task ("View the properties of assetViewed event") {
 			ACUtils.assertEventPropertyValue(
 				applicationId = "CustomEvent",
 				eventId = "assetViewed",
@@ -356,7 +358,7 @@ definition {
 				siteName = "Site Name");
 		}
 
-		task ("View the properties of blogClicked event") {
+		task ("View the properties of assetViewed event") {
 			ACUtils.assertEventPropertyValue(
 				applicationId = "Custom",
 				eventId = "assetViewed",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsEventAnalysis.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsEventAnalysis.testcase
@@ -283,11 +283,9 @@ definition {
 	@description = "Bug ID: LRAC-11659 | Automation ID: LRAC-11726 | Test Summary: Check Default Events Counted as Default when event sent by console"
 	@priority = "5"
 	test CheckDefaultEventsCountedAsDefaultWhenEventSentByConsole {
-		var layoutName = "Custom 1";
-		var globalAttributesList = "canonicalUrl,pageTitle,referrer,url";
-
-		var disableAttributesList = "${globalAttributesList}";
-		var attributesList = "category,like";
+		var layoutName = "Custom Asset";
+		var disableAttributesList = "assetId,canonicalUrl,category,pageDescription,pageKeywords,pageTitle,title,referrer,url";
+		var eventName = "assetViewed";
 
 		task ("Navigation to default events tab") {
 			ACUtils.launchAC();
@@ -302,68 +300,40 @@ definition {
 		}
 
 		task ("Access the assetViewed") {
-			ACNavigation.openItem(itemName = "assetViewed");
+			ACNavigation.openItem(itemName = "${eventName}");
 		}
 
-		task ("Copy the sample JS and replace an existing attribute with a new one") {
-			ACCustomEvents.copySampleJavascript(
-				attributesList = "${attributesList}",
-				disableAttributesList = "${disableAttributesList}");
+		task ("Copy the sample JS and disable existing attribute") {
+			ACCustomEvents.copySampleJavascript(disableAttributesList = "${disableAttributesList}");
 		}
 
-		task ("Close sessions and launch DXP") {
-			ACUtils.closeAllSessions();
-
+		task ("Go to DXP > Go to AC Page") {
 			ACUtils.launchDXP();
 
-			ACUtils.navigateToSitePage( pageName = "AC Page", siteName = "Site Name");
+			ACUtils.navigateToSitePage(
+				pageName = "AC Page",
+				siteName = "Site Name");
 		}
 
-		task ("Start Har recording") {
-			ProxyUtil.startHarRecording("pageViewed");
-		}
-
-		task ("Send the JavaScript custom event") {
-			var sampleJavascript = "${sampleJavascript}";
-
+		task ("Submit JS sample via browser console") {
 			ACUtils.executeJSInBrowserConsole(javaScriptCode = "${sampleJavascript}");
 
 			ACUtils.waitForSendingRequest();
-		}
-
-		task ("View the properties of assetViewed event") {
-			ACUtils.assertEventPropertyValue(
-				applicationId = "CustomEvent",
-				eventId = "assetViewed",
-				property = "entryId",
-				value = "${entryId}");
 		}
 
 		task ("Add a new site with a public widget page") {
 			ACUtils.addPage(layoutName = "${layoutName}");
 		}
 
-		task ("Add a Web Content Display to page and display a web content") {
+		task ("Add a Web Content Display to page and display a Custom Asset") {
 			ACUtils.createWCAndAddToPage(
 				layoutName = "${layoutName}",
 				webContentContent = '''<div data-analytics-asset-type="custom" data-analytics-asset-id="analytics-portal" data-analytics-asset-category="AC" data-analytics-asset-title="Custom Asset Analytics Cloud">%0A<h1> What'\''s your favorite portal? </h1>%0A</div>''',
 				webContentTitle = "Custom Asset AC Title");
 		}
 
-		task ("View web content") {
-			ACUtils.navigateToSitePage(
-				actionType = "View WC",
-				documentTitleList = "Custom Asset AC Title",
-				pageName = "${layoutName}",
-				siteName = "Site Name");
-		}
-
-		task ("View the properties of assetViewed event") {
-			ACUtils.assertEventPropertyValue(
-				applicationId = "Custom",
-				eventId = "assetViewed",
-				property = "entryId",
-				value = "${entryId}");
+		task ("Close sessions") {
+			ACUtils.closeAllSessionsAndWait();
 		}
 
 		task ("Switch the property in AC and go to event analysis") {
@@ -380,18 +350,34 @@ definition {
 			ACNavigation.switchTabInCard(tabName = "Custom");
 		}
 
-		task ("Search for assetViewed in Custom") {
-			ACEventAnalysis.searchEventAnalysis(searchItem = "assetViewed");
+		task ("Search for assetViewed in Custom tab and check that the event does not appear") {
+			ACEventAnalysis.searchEventAnalysis(searchItem = "${eventName}");
 
-			ACEventAnalysis.viewEventAnalysisListNotPresent(eventList = "assetViewed");
+			ACEventAnalysis.viewEventAnalysisListNotPresent(eventList = "${eventName}");
 		}
 
-		task ("Switch to Default event and search") {
+		task ("Search for assetViewed in Default tab and check that the event appears") {
 			ACNavigation.switchTabInCard(tabName = "Default");
 
-			ACEventAnalysis.searchEventAnalysis(searchItem = "assetViewed");
+			ACEventAnalysis.searchEventAnalysis(searchItem = "${eventName}");
 
-			ACEventAnalysis.viewEventAnalysisList(eventList = "assetViewed");
+			ACEventAnalysis.viewEventAnalysisList(eventList = "${eventName}");
+		}
+
+		task ("Add the custom event to analysis") {
+			Click(
+				key_buttonName = "${eventName}",
+				locator1 = "ACUtils#GENERIC_BUTTON");
+		}
+
+		task ("Change the time filter to 24 hours") {
+			ACTimeFilter.clickTimeFilterButton();
+
+			ACTimeFilter.setLast24Hours();
+		}
+
+		task ("Check the number of interactions with the event") {
+			ACEventAnalysis.viewAnalysisInformation(informationValueList = "2");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsEventAnalysis.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsEventAnalysis.testcase
@@ -285,6 +285,7 @@ definition {
 	test CheckDefaultEventsCountedAsDefaultWhenEventSentByConsole {
 		var layoutName = "Custom 1";
 		var globalAttributesList = "canonicalUrl,pageTitle,referrer,url";
+
 		var disableAttributesList = "${globalAttributesList}";
 		var attributesList = "category,like";
 
@@ -305,7 +306,6 @@ definition {
 		}
 
 		task ("Copy the sample JS and replace an existing attribute with a new one") {
-
 			ACCustomEvents.copySampleJavascript(
 				attributesList = "${attributesList}",
 				disableAttributesList = "${disableAttributesList}");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsEventAnalysis.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsEventAnalysis.testcase
@@ -280,6 +280,119 @@ definition {
 		}
 	}
 
+	@description = "Bug ID: LRAC-11659 | Automation ID: LRAC-11726 | Test Summary: Check Default Events Counted as Default when event sent by console"
+	@priority = "5"
+	test CheckDefaultEventsCountedAsDefaultWhenEventSentByConsole {
+		var layoutName = "Custom 1";
+		var globalAttributesList = "canonicalUrl,pageTitle,referrer,url";
+		var disableAttributesList = "${globalAttributesList}";
+		var attributesList = "category,like";
+
+		task ("Navigation to default events tab") {
+			ACUtils.launchAC();
+
+			ACNavigation.goToSettings();
+
+			ACSettings.goToDefinitions();
+
+			ACSettings.goToEvents();
+
+			ACNavigation.openItem(itemName = "Default Events");
+		}
+
+		task ("Access the assetViewed") {
+			ACNavigation.openItem(itemName = "assetViewed");
+		}
+
+		task ("Copy the sample JS and replace an existing attribute with a new one") {
+
+			ACCustomEvents.copySampleJavascript(
+				attributesList = "${attributesList}",
+				disableAttributesList = "${disableAttributesList}");
+		}
+
+		task ("Close sessions") {
+			ACUtils.closeAllSessions();
+
+			ACUtils.launchDXP();
+		}
+
+		task ("Start Har recording") {
+			ProxyUtil.startHarRecording("pageViewed");
+		}
+
+		task ("Send the JavaScript custom event") {
+			var sampleJavascript = "${sampleJavascript}";
+
+			ACUtils.executeJSInBrowserConsole(javaScriptCode = "${sampleJavascript}");
+
+			ACUtils.waitForSendingRequest();
+		}
+
+		task ("View the properties of blogClicked event") {
+			ACUtils.assertEventPropertyValue(
+				applicationId = "CustomEvent",
+				eventId = "assetViewed",
+				property = "entryId",
+				value = "${entryId}");
+		}
+
+		task ("Add a new site with a public widget page") {
+			ACUtils.addPage(layoutName = "${layoutName}");
+		}
+
+		task ("Add a Web Content Display to page and display a web content") {
+			ACUtils.createWCAndAddToPage(
+				layoutName = "${layoutName}",
+				webContentContent = '''<div data-analytics-asset-type="custom" data-analytics-asset-id="analytics-portal" data-analytics-asset-category="AC" data-analytics-asset-title="Custom Asset Analytics Cloud">%0A<h1> What'\''s your favorite portal? </h1>%0A</div>''',
+				webContentTitle = "Custom Asset AC Title");
+		}
+
+		task ("View web content") {
+			ACUtils.navigateToSitePage(
+				actionType = "View WC",
+				documentTitleList = "Custom Asset AC Title",
+				pageName = "${layoutName}",
+				siteName = "Site Name");
+		}
+
+		task ("View the properties of blogClicked event") {
+			ACUtils.assertEventPropertyValue(
+				applicationId = "Custom",
+				eventId = "assetViewed",
+				property = "entryId",
+				value = "${entryId}");
+		}
+
+		task ("Switch the property in AC and go to event analysis") {
+			ACUtils.launchAC();
+
+			ACProperties.switchProperty(propertyName = "${assignedPropertyName}");
+
+			ACNavigation.goToEventAnalysis();
+		}
+
+		task ("Click to add event and switch tab to Custom") {
+			ACEventAnalysis.clickToAddEventButton();
+
+			ACNavigation.switchTabInCard(tabName = "Custom");
+		}
+
+		task ("Search for assetViewed in Custom") {
+			ACEventAnalysis.searchEventAnalysis(searchItem = "assetViewed");
+
+			ACEventAnalysis.viewEventAnalysisListNotPresent(eventList = "assetViewed");
+		}
+
+		task ("Switch to Default event and search") {
+			ACNavigation.switchTabInCard(tabName = "Default");
+
+			ACEventAnalysis.searchEventAnalysis(searchItem = "assetViewed");
+
+			ACEventAnalysis.viewEventAnalysisList(eventList = "assetViewed");
+		}
+	}
+
 	@description = "Feature ID: LRAC-4266 | Automation ID: LRAC-10307 | Test Summary: Total Chart, Unique Chart and Average Chart data shown"
 	@priority = "5"
 	test CheckTotalAndUniqueAndAverageChartDataIsShown {


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-11726 (automation ticket)
https://issues.liferay.com/browse/LRAC-11659 (Bug ticket)
[Testray Result](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=1990534192&testrayRunId=1990534196)

Hey guys, I thought it was better not to check the event during this automation, the purpose of this automation is to verify that even a default event being sent using `Analytics.track` will be counted in the AC as a default event and not a custom event, so check the event is not important in this case and we could still have problems with a possible `browserMob` crash that could prejudice our test.

So I'm generating the event through `Analytics.track` and through the normal view of a WC with the custom asset and I'm verifying that the two interactions are being counted for the default event in the event analysis.