### PR TITLE
LPS-164566 Replace document.cookie usage with new consent-based API

### DIFF
--- a/modules/apps/analytics/analytics-client-js/src/analytics.js
+++ b/modules/apps/analytics/analytics-client-js/src/analytics.js
@@ -484,11 +484,19 @@ class Analytics {
 	 * @protected
 	 */
 	_setCookie(key, data) {
-		const expirationDate = new Date();
+		const expires = new Date();
 
-		expirationDate.setDate(expirationDate.getDate() + 365);
+		expires.setDate(expires.getDate() + 365);
 
-		document.cookie = `${key}=${data}; expires=${expirationDate.toUTCString()}; path=/; Secure`;
+		return Liferay.Util.Cookie.set(
+			key,
+			data,
+			Liferay.Util.Cookie.TYPES.PERSONALIZATION,
+			{
+				expires,
+				secure: true,
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
⚠️ **This PR requires additional changes from Analytics Cloud team** ⚠️ 

### References

- [LPS-164566](https://issues.liferay.com/browse/LPS-164566)

### What is the goal?

#### Use the new `Liferay.Util.Cookie` API to only add cookies when user has consented

This is partial work, I have just updated the existing usage of `document.cookie`, which will soon be disallowed across Liferay portal. 

The new cookie utility will not allow cookies to be set when the user hasn't consented to them, so you must discuss with your product team what you should do when they haven't been set.

After these changes, the `_setCookie` method from the `Analytics` class will now return a boolean representing whether the cookie has been set, as follows.

```js
if (!_setCookie('key', 'value')) {
   // Cookie hasn't been set, show tooltip
   ...
} else {
   // Cookie has been set, continue
   ...
}
```

You can use this to handle the logic for the new case if necessary.

### How to replicate

The cookie banner where you can set your cookie preferences is currently behind a feature flag (`feature.flag.LPS-142518`), so to test this:
* Add `feature.flag.LPS-142518=true` to `portal-ext.properties`
* Restart portal
* Navigate to `Control Panel > System Settings > Cookies`
* Enable the cookie banner by checking the corresponding checkbox and click `Save`
* Cookie banner should now be visible

In your specific use case, as per [this Confluence document](https://liferay.atlassian.net/wiki/spaces/ENGR/pages/1998849368/Liferay+cookies), the only cookie has **Personalization** consent type, so you must test the affected functionality with Personalization cookies accepted and rejected, with unset preferences (banner still visible) and without the feature flag. 