### PR TITLE
AC Test Fix - LRAC-11962 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACUtils.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACUtils.path
@@ -22,7 +22,7 @@
 </tr>
 <tr>
 	<td>GENERIC_TEXT</td>
-	<td>//*[normalize-space(text())='${key_textValue}']</td>
+	<td>//*[text()='${key_textValue}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EmailReport.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EmailReport.testcase
@@ -67,7 +67,7 @@ definition {
 		}
 
 		task ("Check that email report has been disabled") {
-			ACUtils.viewGenericText(textValueList = "Email Reports: Disabled");
+			ACUtils.viewGenericText(textValueList = "Email Reports: ,Disabled");
 		}
 	}
 
@@ -90,7 +90,7 @@ definition {
 			for (var frequencyOption : list "${frequencyList}") {
 				ACEmailReport.enableEmailReport(frequency = "${frequencyOption}");
 
-				ACUtils.viewGenericText(textValueList = "Email Reports: Enabled");
+				ACUtils.viewGenericText(textValueList = "Email Reports: ,Enabled");
 
 				Alert.viewSuccessMessageText(successMessage = "Changes to email reports saved.");
 
@@ -117,7 +117,7 @@ definition {
 		}
 
 		task ("See in the property that the email report has the status of enabled and the success alert appears") {
-			ACUtils.viewGenericText(textValueList = "Email Reports: Enabled");
+			ACUtils.viewGenericText(textValueList = "Email Reports: ,Enabled");
 
 			Alert.viewSuccessMessageText(successMessage = "Changes to email reports saved.");
 		}
@@ -127,7 +127,7 @@ definition {
 		}
 
 		task ("See in the property that the email report has the status of disabled and the success alert appears") {
-			ACUtils.viewGenericText(textValueList = "Email Reports: Disabled");
+			ACUtils.viewGenericText(textValueList = "Email Reports: ,Disabled");
 
 			Alert.viewSuccessMessageText(successMessage = "Changes to email reports saved.");
 		}
@@ -192,7 +192,7 @@ definition {
 			}
 
 			task ("Check that email report is disabled") {
-				ACUtils.viewGenericText(textValueList = "Email Reports: Disabled");
+				ACUtils.viewGenericText(textValueList = "Email Reports: ,Disabled");
 			}
 
 			task ("Enable and configure email report frequency") {
@@ -200,7 +200,7 @@ definition {
 			}
 
 			task ("Check that email report has been enabled") {
-				ACUtils.viewGenericText(textValueList = "Email Reports: Enabled");
+				ACUtils.viewGenericText(textValueList = "Email Reports: ,Enabled");
 			}
 		}
 	}
@@ -221,7 +221,7 @@ definition {
 		task ("Enable email reports with the daily option and then see in the property that the email report has the status of enabled") {
 			ACEmailReport.enableEmailReport(frequency = "Daily");
 
-			ACUtils.viewGenericText(textValueList = "Email Reports: Enabled");
+			ACUtils.viewGenericText(textValueList = "Email Reports: ,Enabled");
 		}
 
 		task ("Login AC with a different user then go to Settings > Go to Properties > Open the new property") {
@@ -237,13 +237,13 @@ definition {
 		}
 
 		task ("See that the changes made in another account did not affect the actual account") {
-			ACUtils.viewGenericText(textValueList = "Email Reports: Disabled");
+			ACUtils.viewGenericText(textValueList = "Email Reports: ,Disabled");
 		}
 
 		task ("Enable the email reports with the monthly option and then see in the property that the email report has the status of enabled") {
 			ACEmailReport.enableEmailReport(frequency = "Monthly");
 
-			ACUtils.viewGenericText(textValueList = "Email Reports: Enabled");
+			ACUtils.viewGenericText(textValueList = "Email Reports: ,Enabled");
 		}
 
 		task ("Login with the Test Test account and then go to Settings > Go to Properties > Open the new property") {
@@ -271,7 +271,7 @@ definition {
 
 			Button.clickSave();
 
-			ACUtils.viewGenericText(textValueList = "Email Reports: Disabled");
+			ACUtils.viewGenericText(textValueList = "Email Reports: ,Disabled");
 		}
 
 		task ("Login with Corbin then go to Settings > Go to Properties > Open the new property") {
@@ -287,7 +287,7 @@ definition {
 		}
 
 		task ("Observe that the change made to another account did not affect the current account") {
-			ACUtils.viewGenericText(textValueList = "Email Reports: Enabled");
+			ACUtils.viewGenericText(textValueList = "Email Reports: ,Enabled");
 
 			ACEmailReport.accessEmailReportSettings();
 
@@ -315,7 +315,7 @@ definition {
 		}
 
 		task ("Check that the Email Reports field appears and has the status disabled") {
-			ACUtils.viewGenericText(textValueList = "Email Reports: Disabled");
+			ACUtils.viewGenericText(textValueList = "Email Reports: ,Disabled");
 		}
 
 		task ("Check that the Email Reports widget icon is disabled if the property is not synced") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EmptyState.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EmptyState.testcase
@@ -774,12 +774,7 @@ definition {
 
 			ACUtils.viewGenericText(textValueList = "There are no tests found.");
 
-			for (var textValue : list "Create a new test from Liferay DXP by clicking on the , icon in the toolbar when viewing a page in DXP.") {
-				AssertTextEquals.assertPartialText(
-					key_textValue = "${textValue}",
-					locator1 = "ACUtils#GENERIC_TEXT",
-					value1 = "${textValue}");
-			}
+			ACUtils.viewGenericText(textValueList = "Create a new test from Liferay DXP by clicking on the , icon in the toolbar when viewing a page in DXP.");
 
 			ACUtils.clickGenericHyperlink(hyperlinkText = "Learn more about tests.");
 
@@ -1534,7 +1529,7 @@ definition {
 			ACUtils.closeModal();
 		}
 
-		task ("Asset that there are no properties on the sites page") {
+		task ("Assert that there are no properties on the sites page") {
 			AssertElementPresent(locator1 = "ACSidebar#PROPERTY_MENU_NO_PROPERTIES");
 
 			AssertElementPresent(locator1 = "TextInput#NO_PROPERTIES_AVAILABLE_TEXT");


### PR DESCRIPTION
[Jira ticket](https://issues.liferay.com/browse/LRAC-11962)
[Testray execution](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=2008317734&testrayRunId=2008317804)

- Hey guys, I don't think it's necessary to create a new XPath or macro, since we are able to use the original generic text xpath to validate the texts.
- The reason I'm doing this: `textValueList = "Email Reports: ,Disabled"` it's because in the email report we have a line break, so it's only possible to validate these cases by passing a list to the macro and giving some space between the elements.