### PR TITLE
AC Test Fix - LRAC-11941 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/ACAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/ACAdmin.testcase
@@ -91,6 +91,7 @@ definition {
 	@description = "Bug: LRAC-11339 | Automation ID: LRAC-11364 | Test Summary: A new user created in the admin page can not access that page but the user Test Test can"
 	@priority = "5"
 	test NewUserCanNotAccessAdminPage {
+		var analyticsCloudURL = PropsUtil.get("analytics.cloud.url");
 		var userFirstName = "ac";
 		var userLastName = "ac";
 		var userScreenName = "acnonadmin";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/ACAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/ACAdmin.testcase
@@ -149,6 +149,8 @@ definition {
 				emailAddress = "${userEmailAddress}",
 				password = "test");
 
+			Open(locator1 = "${analyticsCloudURL}");
+
 			ACAdmin.goToACAdmin();
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-11941
[Testray](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=2012157665)
Hey guys looking more into the test, I noticed that it still runs past the add user step and fails when trying to go to admin page. Did not find a reason why the step fails when creating a user and it looks like the test passes with these changes.