### PR TITLE
AC Automated Test - LRAC-12142 and LRAC-12146 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
@@ -71,7 +71,7 @@ definition {
 
 		if (isSet(displayLanguageId) && isSet(groupId) && isSet(page) && isSet(size) && isSet(sort)) {
 			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?size=${size}&displayLanguageId=${displayLanguageId}&page=${page}&groupId=${groupId}&sort=${sort} \
+				${faroBackendURL}/api/1.0/pages/search-keywords?size=${size}&displayLanguageId=${displayLanguageId}&page=${page}&groupId=${groupId}&sort=${sort},lastModifiedDate,desc \
 				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
 				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
 				''';
@@ -85,35 +85,35 @@ definition {
 		}
 		else if (isSet(displayLanguageId)) {
 			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?displayLanguageId=${displayLanguageId} \
+				${faroBackendURL}/api/1.0/pages/search-keywords?displayLanguageId=${displayLanguageId}&sort=lastModifiedDate,desc \
 				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
 				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
 				''';
 		}
 		else if (isSet(groupId)) {
 			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?groupId=${groupId} \
+				${faroBackendURL}/api/1.0/pages/search-keywords?groupId=${groupId}&sort=lastModifiedDate,desc \
 				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
 				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
 				''';
 		}
 		else if (isSet(page)) {
 			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?page=${page} \
+				${faroBackendURL}/api/1.0/pages/search-keywords?page=${page}&sort=lastModifiedDate,desc \
 				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
 				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
 				''';
 		}
 		else if (isSet(size)) {
 			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?size=${size} \
+				${faroBackendURL}/api/1.0/pages/search-keywords?size=${size}&sort=lastModifiedDate,desc \
 				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
 				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
 				''';
 		}
 		else if (isSet(sort)) {
 			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?sort=${sort} \
+				${faroBackendURL}/api/1.0/pages/search-keywords?sort=${sort},lastModifiedDate,desc \
 				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
 				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
 				''';

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
@@ -75,9 +75,51 @@ definition {
 				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
 				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
 				''';
-
-			static var apiResponse = JSONCurlUtil.get("${curl}");
 		}
+		else if (!(isSet(displayLanguageId)) && !(isSet(groupId)) && !(isSet(page)) && !(isSet(size)) && !(isSet(sort))) {
+			var curl = '''
+				${faroBackendURL}/api/1.0/pages/search-keywords \
+				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
+				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
+				''';
+		}
+		else if (isSet(displayLanguageId)) {
+			var curl = '''
+				${faroBackendURL}/api/1.0/pages/search-keywords?displayLanguageId=${displayLanguageId} \
+				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
+				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
+				''';
+		}
+		else if (isSet(groupId)) {
+			var curl = '''
+				${faroBackendURL}/api/1.0/pages/search-keywords?groupId=${groupId} \
+				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
+				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
+				''';
+		}
+		else if (isSet(page)) {
+			var curl = '''
+				${faroBackendURL}/api/1.0/pages/search-keywords?page=${page} \
+				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
+				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
+				''';
+		}
+		else if (isSet(size)) {
+			var curl = '''
+				${faroBackendURL}/api/1.0/pages/search-keywords?size=${size} \
+				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
+				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
+				''';
+		}
+		else if (isSet(sort)) {
+			var curl = '''
+				${faroBackendURL}/api/1.0/pages/search-keywords?sort=${sort} \
+				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
+				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
+				''';
+		}
+
+		static var apiResponse = JSONCurlUtil.get("${curl}");
 
 		return "${apiResponse}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
@@ -69,51 +69,16 @@ definition {
 
 		Pause(locator1 = "10000");
 
-		if (isSet(displayLanguageId) && isSet(groupId) && isSet(page) && isSet(size) && isSet(sort)) {
+		if (isSet(parameters)) {
 			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?size=${size}&displayLanguageId=${displayLanguageId}&page=${page}&groupId=${groupId}&sort=${sort},lastModifiedDate,desc \
+				${faroBackendURL}/api/1.0/pages/search-keywords?${parameters} \
 				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
 				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
 				''';
 		}
-		else if (!(isSet(displayLanguageId)) && !(isSet(groupId)) && !(isSet(page)) && !(isSet(size)) && !(isSet(sort))) {
+		else if (!(isSet(parameters))) {
 			var curl = '''
 				${faroBackendURL}/api/1.0/pages/search-keywords \
-				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
-				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
-				''';
-		}
-		else if (isSet(displayLanguageId)) {
-			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?displayLanguageId=${displayLanguageId}&sort=lastModifiedDate,desc \
-				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
-				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
-				''';
-		}
-		else if (isSet(groupId)) {
-			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?groupId=${groupId}&sort=lastModifiedDate,desc \
-				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
-				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
-				''';
-		}
-		else if (isSet(page)) {
-			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?page=${page}&sort=lastModifiedDate,desc \
-				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
-				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
-				''';
-		}
-		else if (isSet(size)) {
-			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?size=${size}&sort=lastModifiedDate,desc \
-				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
-				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
-				''';
-		}
-		else if (isSet(sort)) {
-			var curl = '''
-				${faroBackendURL}/api/1.0/pages/search-keywords?sort=${sort},lastModifiedDate,desc \
 				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \
 				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
 				''';

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
@@ -8,6 +8,18 @@ definition {
 			expected = "${expected}");
 	}
 
+	macro assertSearchKeywordNotPresent {
+		if (!(isSet(keywordPosition))) {
+			var keywordPosition = "0";
+		}
+
+		var actual = JSONUtil.getWithJSONPath("${apiResponse}", "$..search-keywords[${keywordPosition}].keywords");
+
+		TestUtils.assertNotEquals(
+			actual = "${actual}",
+			expected = "${expected}");
+	}
+
 	macro createNewExportSchedule {
 		var analyticsCloudURL = PropsUtil.get("analytics.cloud.url");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
@@ -76,7 +76,7 @@ definition {
 				-H "OSB-Asah-Project-ID: ${osbAsahProjectId}"
 				''';
 		}
-		else if (!(isSet(parameters))) {
+		else {
 			var curl = '''
 				${faroBackendURL}/api/1.0/pages/search-keywords \
 				-H "OSB-Asah-Faro-Backend-Security-Signature: ${osbAsahFaroBackendSS}" \

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
@@ -1,7 +1,11 @@
 definition {
 
 	macro assertSearchResponse {
-		var actual = JSONUtil.getWithJSONPath("${apiResponse}", "$..search-keywords[0].keywords");
+		if (!(isSet(keywordPosition))) {
+			var keywordPosition = "0";
+		}
+
+		var actual = JSONUtil.getWithJSONPath("${apiResponse}", "$..search-keywords[${keywordPosition}].keywords");
 
 		TestUtils.assertEquals(
 			actual = "${actual}",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACApi.macro
@@ -1,17 +1,5 @@
 definition {
 
-	macro assertSearchResponse {
-		if (!(isSet(keywordPosition))) {
-			var keywordPosition = "0";
-		}
-
-		var actual = JSONUtil.getWithJSONPath("${apiResponse}", "$..search-keywords[${keywordPosition}].keywords");
-
-		TestUtils.assertEquals(
-			actual = "${actual}",
-			expected = "${expected}");
-	}
-
 	macro assertSearchKeywordNotPresent {
 		if (!(isSet(keywordPosition))) {
 			var keywordPosition = "0";
@@ -20,6 +8,18 @@ definition {
 		var actual = JSONUtil.getWithJSONPath("${apiResponse}", "$..search-keywords[${keywordPosition}].keywords");
 
 		TestUtils.assertNotEquals(
+			actual = "${actual}",
+			expected = "${expected}");
+	}
+
+	macro assertSearchResponse {
+		if (!(isSet(keywordPosition))) {
+			var keywordPosition = "0";
+		}
+
+		var actual = JSONUtil.getWithJSONPath("${apiResponse}", "$..search-keywords[${keywordPosition}].keywords");
+
+		TestUtils.assertEquals(
 			actual = "${actual}",
 			expected = "${expected}");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
@@ -148,4 +148,67 @@ definition {
 				expected = "${keyword2}");
 		}
 	}
+
+	@description = "Feature ID: LRAC-12058 | Automation ID: LRAC-12146 | Test Summary: Fetch keywords with size parameter "
+	@priority = "3"
+	test RequestKeywordsUsingSize {
+		var keyword1 = "with size parameters 1";
+		var keyword2 = "with size parameters 2";
+		var keyword3 = "with size parameters 3";
+		var keywordList = "${keyword1},${keyword2},${keyword3}";
+		var size = "2";
+
+		task ("Go to Server Administration") {
+			ServerAdministration.openServerAdmin();
+		}
+
+		task ("Get Faro Backend URL") {
+			var faroBackendURL = ACApi.getSearchHeaderValues(header = "liferayAnalyticsFaroBackendURL");
+		}
+
+		task ("Get OSB-Asah-Faro-Backend-Security-Signature") {
+			var osbAsahFaroBackendSS = ACApi.getSearchHeaderValues(header = "liferayAnalyticsFaroBackendSecuritySignature");
+		}
+
+		task ("Get OSB-Asah-Project-Id") {
+			var osbAsahProjectId = ACApi.getSearchHeaderValues(header = "liferayAnalyticsProjectId");
+		}
+
+		task ("Go to Site Page") {
+			ACUtils.navigateToSitePage(
+				pageName = "Home",
+				siteName = "guest");
+		}
+
+		task ("Type keyword in search bar") {
+			for (var keyword : list "${keywordList}") {
+				SearchPortlets.searchEmbedded(searchTerm = "${keyword}");
+			}
+		}
+
+		task ("Run curl command to get keyword results") {
+			ACApi.getSearchKeywords(
+				faroBackendURL = "${faroBackendURL}",
+				osbAsahFaroBackendSS = "${osbAsahFaroBackendSS}",
+				osbAsahProjectId = "${osbAsahProjectId}",
+				size = "${size}");
+		}
+
+		task ("Assert response returns keyword") {
+			ACApi.assertSearchResponse(expected = "${keyword1}");
+		}
+
+		task ("Assert response returns keyword") {
+			ACApi.assertSearchResponse(
+				keywordPosition = "1",
+				expected = "${keyword2}");
+		}
+
+		task ("Assert response does not return keyword") {
+			ACApi.assertSearchKeywordNotPresent(
+				keywordPosition = "2",
+				expected = "${keyword3}");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
@@ -44,6 +44,8 @@ definition {
 	@description = "Feature ID: LRAC-12058 | Automation ID: LRAC-12141 | Test Summary: Request search keywords using all parameters"
 	@priority = "3"
 	test RequestKeywordsUsingAllParameters {
+		property test.name.skip.portal.instance = "SearchAPI#RequestKeywordsUsingAllParameters";
+
 		var groupId = JSONGroupSetter.setGroupId(groupName = "Guest");
 		var keyword = "all parameters";
 		var parameters = "size=10&displayLanguageId=en-US&page=0&groupId=${groupId}&sort=counts,desc,lastModifiedDate,desc";
@@ -144,6 +146,8 @@ definition {
 	@description = "Feature ID: LRAC-12058 | Automation ID: LRAC-12146 | Test Summary: Fetch keywords with size parameter "
 	@priority = "3"
 	test RequestKeywordsUsingSize {
+		property test.name.skip.portal.instance = "SearchAPI#RequestKeywordsUsingSize";
+
 		var keyword1 = "with size parameters 1";
 		var keyword2 = "with size parameters 2";
 		var keyword3 = "with size parameters 3";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
@@ -101,6 +101,7 @@ definition {
 	test RequestKeywordsUsingNoParameters {
 		var keyword1 = "without optional parameters 1";
 		var keyword2 = "without optional parameters 2";
+
 		var keywordList = "${keyword1},${keyword2}";
 
 		task ("Go to Server Administration") {
@@ -144,8 +145,8 @@ definition {
 
 		task ("Assert response returns keyword") {
 			ACApi.assertSearchResponse(
-				keywordPosition = "1",
-				expected = "${keyword2}");
+				expected = "${keyword2}",
+				keywordPosition = "1");
 		}
 	}
 
@@ -155,6 +156,7 @@ definition {
 		var keyword1 = "with size parameters 1";
 		var keyword2 = "with size parameters 2";
 		var keyword3 = "with size parameters 3";
+
 		var keywordList = "${keyword1},${keyword2},${keyword3}";
 		var size = "2";
 
@@ -200,14 +202,14 @@ definition {
 
 		task ("Assert response returns keyword") {
 			ACApi.assertSearchResponse(
-				keywordPosition = "1",
-				expected = "${keyword2}");
+				expected = "${keyword2}",
+				keywordPosition = "1");
 		}
 
 		task ("Assert response does not return keyword") {
 			ACApi.assertSearchKeywordNotPresent(
-				keywordPosition = "2",
-				expected = "${keyword3}");
+				expected = "${keyword3}",
+				keywordPosition = "2");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
@@ -44,12 +44,9 @@ definition {
 	@description = "Feature ID: LRAC-12058 | Automation ID: LRAC-12141 | Test Summary: Request search keywords using all parameters"
 	@priority = "3"
 	test RequestKeywordsUsingAllParameters {
-		var displayLanguageId = "en-US";
 		var groupId = JSONGroupSetter.setGroupId(groupName = "Guest");
 		var keyword = "all parameters";
-		var page = "0";
-		var size = "10";
-		var sort = "counts,desc";
+		var parameters = "size=10&displayLanguageId=en-US&page=0&groupId=${groupId}&sort=counts,desc,lastModifiedDate,desc";
 
 		task ("Go to Server Administration") {
 			ServerAdministration.openServerAdmin();
@@ -79,14 +76,10 @@ definition {
 
 		task ("Run curl command to get keyword results") {
 			ACApi.getSearchKeywords(
-				displayLanguageId = "${displayLanguageId}",
 				faroBackendURL = "${faroBackendURL}",
-				groupId = "${groupId}",
 				osbAsahFaroBackendSS = "${osbAsahFaroBackendSS}",
 				osbAsahProjectId = "${osbAsahProjectId}",
-				page = "${page}",
-				size = "${size}",
-				sort = "${sort}");
+				parameters = "${parameters}");
 		}
 
 		task ("Assert response returns keyword") {
@@ -101,8 +94,6 @@ definition {
 
 		var keyword1 = "without optional parameters 1";
 		var keyword2 = "without optional parameters 2";
-
-		var keywordList = "${keyword1},${keyword2}";
 
 		task ("Go to Server Administration") {
 			ServerAdministration.openServerAdmin();
@@ -127,7 +118,7 @@ definition {
 		}
 
 		task ("Type keyword in search bar") {
-			for (var keyword : list "${keywordList}") {
+			for (var keyword : list "${keyword1},${keyword2}") {
 				SearchPortlets.searchEmbedded(searchTerm = "${keyword}");
 			}
 		}
@@ -156,8 +147,7 @@ definition {
 		var keyword1 = "with size parameters 1";
 		var keyword2 = "with size parameters 2";
 		var keyword3 = "with size parameters 3";
-
-		var keywordList = "${keyword1},${keyword2},${keyword3}";
+		var parameters = "size=2&sort=lastModifiedDate,desc";
 		var size = "2";
 
 		task ("Go to Server Administration") {
@@ -183,7 +173,7 @@ definition {
 		}
 
 		task ("Type keyword in search bar") {
-			for (var keyword : list "${keywordList}") {
+			for (var keyword : list "${keyword1},${keyword2},${keyword3}") {
 				SearchPortlets.searchEmbedded(searchTerm = "${keyword}");
 			}
 		}
@@ -193,7 +183,7 @@ definition {
 				faroBackendURL = "${faroBackendURL}",
 				osbAsahFaroBackendSS = "${osbAsahFaroBackendSS}",
 				osbAsahProjectId = "${osbAsahProjectId}",
-				size = "${size}");
+				parameters = "${parameters}");
 		}
 
 		task ("Assert response returns keyword") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
@@ -96,4 +96,56 @@ definition {
 		}
 	}
 
+	@description = "Feature ID: LRAC-12058 | Automation ID: LRAC-12142 | Test Summary: Fetch keywords without optional parameters"
+	@priority = "3"
+	test RequestKeywordsUsingNoParameters {
+		var keyword1 = "without optional parameters 1";
+		var keyword2 = "without optional parameters 2";
+		var keywordList = "${keyword1},${keyword2}";
+
+		task ("Go to Server Administration") {
+			ServerAdministration.openServerAdmin();
+		}
+
+		task ("Get Faro Backend URL") {
+			var faroBackendURL = ACApi.getSearchHeaderValues(header = "liferayAnalyticsFaroBackendURL");
+		}
+
+		task ("Get OSB-Asah-Faro-Backend-Security-Signature") {
+			var osbAsahFaroBackendSS = ACApi.getSearchHeaderValues(header = "liferayAnalyticsFaroBackendSecuritySignature");
+		}
+
+		task ("Get OSB-Asah-Project-Id") {
+			var osbAsahProjectId = ACApi.getSearchHeaderValues(header = "liferayAnalyticsProjectId");
+		}
+
+		task ("Go to Site Page") {
+			ACUtils.navigateToSitePage(
+				pageName = "Home",
+				siteName = "guest");
+		}
+
+		task ("Type keyword in search bar") {
+			for (var keyword : list "${keywordList}") {
+				SearchPortlets.searchEmbedded(searchTerm = "${keyword}");
+			}
+		}
+
+		task ("Run curl command without optional parameters to get keyword results") {
+			ACApi.getSearchKeywords(
+				faroBackendURL = "${faroBackendURL}",
+				osbAsahFaroBackendSS = "${osbAsahFaroBackendSS}",
+				osbAsahProjectId = "${osbAsahProjectId}");
+		}
+
+		task ("Assert response returns keyword") {
+			ACApi.assertSearchResponse(expected = "${keyword1}");
+		}
+
+		task ("Assert response returns keyword") {
+			ACApi.assertSearchResponse(
+				keywordPosition = "1",
+				expected = "${keyword2}");
+		}
+	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
@@ -19,8 +19,6 @@ definition {
 			TestCase.setUpPortalInstance();
 
 			ACUtils.launchDXP();
-
-			JSONGroup.addGroup(groupName = "Site Name");
 		}
 
 		task ("Connect the DXP to AC") {
@@ -99,6 +97,8 @@ definition {
 	@description = "Feature ID: LRAC-12058 | Automation ID: LRAC-12142 | Test Summary: Fetch keywords without optional parameters"
 	@priority = "3"
 	test RequestKeywordsUsingNoParameters {
+		property test.name.skip.portal.instance = "SearchAPI#RequestKeywordsUsingNoParameters";
+
 		var keyword1 = "without optional parameters 1";
 		var keyword2 = "without optional parameters 2";
 
@@ -197,7 +197,7 @@ definition {
 		}
 
 		task ("Assert response returns keyword") {
-			ACApi.assertSearchResponse(expected = "${keyword1}");
+			ACApi.assertSearchResponse(expected = "${keyword3}");
 		}
 
 		task ("Assert response returns keyword") {
@@ -208,7 +208,7 @@ definition {
 
 		task ("Assert response does not return keyword") {
 			ACApi.assertSearchKeywordNotPresent(
-				expected = "${keyword3}",
+				expected = "${keyword1}",
 				keywordPosition = "2");
 		}
 	}


### PR DESCRIPTION
- https://issues.liferay.com/browse/LRAC-12142 (Automation Ticket):
 [Testray Result](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=2012217949&testrayRunId=2012218206)
 I needed to isolate the test so that searches generated by other tests do not change the position of the keywords that the test is waiting for.

- https://issues.liferay.com/browse/LRAC-12146 (Automation Ticket):
[Testray Result](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=2015703012&testrayRunId=2015703068)
This automation is set to `size=2`, so the expectation is that only two keywords appear in the API response, as all the tests in the file will do searches so I'm going to be sorted by `LastModifiedDate`, this way it will return the last two words that were searched.

    **We should always use the `LastModifiedDate` desc order on all tests to ensure that the test is not affected by searches of the other tests in the file.**

- **Changes in the `getSearchKeywords`:**
[Testray Result](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=2014840816&testrayRunId=2014847194)
I modified it to put two possible cases in the macro:
   1. If you are going to use the API without parameters, then just don't pass the `parameters` variable to the macro
   2. If you are going to use any parameter in the API, then just pass the `parameters` variable to the macro with the value of the parameters that will be used.

    That way we will be able to use the macro combining different parameters for the API, I thought that this would be the best way to not make the macro too big with several conditions and we will be able to reuse the macro in different cases.