### PR TITLE
AC Remove tests from Quarantine - LRAC-12526 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/IdentityEvents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/IdentityEvents.testcase
@@ -56,11 +56,7 @@ definition {
 	@priority = "3"
 	test CheckDeleteBrowserStorageChangesUserId {
 		property analytics.cloud.upstream = "false";
-		property portal.upstream = "quarantine";
 		property proxy.server.enabled = "true";
-
-		// AC Quarantine Reason: Temporarily disable Total Individuals Card LRAC-12523
-		// AC Refactor ticket: LRAC-12526
 
 		task ("Add a new user") {
 			JSONUser.addUser(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/IndividualsDashboard.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/IndividualsDashboard.testcase
@@ -219,11 +219,6 @@ definition {
 	@description = "Total Individuals increase by one when a new individual is added via event"
 	@priority = "5"
 	test CanViewTotalIndividualsIncreaseByOne {
-		property portal.upstream = "quarantine";
-
-		// AC Quarantine Reason: Temporarily disable Total Individuals Card LRAC-12523
-		// AC Refactor ticket: LRAC-12526
-
 		ACUtils.launchAC();
 
 		ACProperties.switchProperty(propertyName = "${assignedPropertyName}");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/IndividualsEnrichedProfiles.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/IndividualsEnrichedProfiles.testcase
@@ -53,10 +53,6 @@ definition {
 		property analytics.cloud.upstream = "false";
 		property portal.acceptance = "false";
 		property portal.release = "false";
-		property portal.upstream = "quarantine";
-
-		// AC Quarantine Reason: Temporarily disable Total Individuals Card LRAC-12523
-		// AC Refactor ticket: LRAC-12526
 
 		task ("Add a new user") {
 			JSONUser.addUser(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/Properties.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/Properties.testcase
@@ -378,11 +378,6 @@ definition {
 	@description = "Bug ID: LRAC-8093 | Automation ID: LRAC-11533 | Test Summary: Able to clear property data"
 	@priority = "4"
 	test ClearPropertyData {
-		property portal.upstream = "quarantine";
-
-		// AC Quarantine Reason: Temporarily disable Total Individuals Card LRAC-12523
-		// AC Refactor ticket: LRAC-12526
-
 		task ("Connect the DXP to Analytics Cloud") {
 			JSONUser.addUser(
 				userEmailAddress = "userea@liferay.com",


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-12526
Removing these tests from quarantine as Total Individuals Card is enabled on UAT