### PR TITLE
AC Test Improvement - LRAC-12832 | master

### DIFF
--- a/build-test-analytics-cloud.xml
+++ b/build-test-analytics-cloud.xml
@@ -229,7 +229,7 @@ networks:
 			/>
 
 			<echo file="${analytics.cloud.asah.dir}/local.env">OSB_ASAH_BACKEND_URL=${analytics.cloud.asah.backend.url}
-OSB_ASAH_POSTGRESQL_ENABLED=true
+OSB_ASAH_POSTGRESQL_ENABLED=false
 OSB_ASAH_PUBLISHER_URL=${analytics.cloud.asah.publisher.url}
 OSB_FARO_FRONTEND_URL=${analytics.cloud.faro.frontend.url}</echo>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-12832

ℹ️ **Reason for Change:**
All customer workspaces are still using ES on AC. Only Liferay's workspace is using BQ. We are currently validating the regression using a workspace with BQ and we don't know how things are working for the customers as they are still using ES. So we must make our tests run with ES so that we can have a general result of the operation of ES by automation.

- When the variable has the value `true`, the AC will use Postgres:
`OSB_ASAH_POSTGRESQL_ENABLED=true`

- When the variable has the value `false`, the AC will use Elasticsearch:
`OSB_ASAH_POSTGRESQL_ENABLED=false`