### PR TITLE
AC Test fix - LPS-177768 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/AnalyticsCloud.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/AnalyticsCloud.macro
@@ -41,7 +41,7 @@ definition {
 			locator1 = "ACDXPSettings#TOKEN_INPUT_FIELD",
 			value1 = "TEST123");
 
-		Click(locator1 = "ACDXPSettings#CONNECT_DISCONNECT_BUTTON");
+		Click(locator1 = "ACDXPSettings#CONNECT_BUTTON");
 
 		Alert.viewErrorMessage(errorMessage = "An unexpected system error occurred.");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/AnalyticsCloud.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/AnalyticsCloud.macro
@@ -46,17 +46,4 @@ definition {
 		Alert.viewErrorMessage(errorMessage = "An unexpected system error occurred.");
 	}
 
-	macro teardownAnalyticsCloud {
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Instance Settings");
-
-		Click(locator1 = "AnalyticsCloudConnection#ANALYTICS_CLOUD_DXP_BUTTON");
-
-		ClickNoError(locator1 = "AnalyticsCloudConnection#DISCONNECT_ANALYTICS_CLOUD_BUTTON");
-
-		AssertConfirm.assertConfirmationNoError(value1 = "Are you sure you want to disconnect your Analytics Cloud workspace from this DXP instance?");
-	}
-
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACDXPSettings.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACDXPSettings.macro
@@ -50,7 +50,7 @@ definition {
 
 		WaitForElementNotPresent(locator1 = "ACDXPSettings#CONNECT_BUTTON_DISABLED");
 
-		Click(locator1 = "ACDXPSettings#CONNECT_DISCONNECT_BUTTON");
+		Click(locator1 = "ACDXPSettings#CONNECT_BUTTON");
 	}
 
 	macro connectDXPtoAnalyticsCloud {
@@ -136,8 +136,8 @@ definition {
 	macro disconnectDXPFromAnalyticsCloud {
 		ACDXPSettings.goToInstanceSettingsAC();
 
-		if (IsElementNotPresent(locator1 = "ACDXPSettings#CONNECT_BUTTON_DISABLED")) {
-			ClickNoError(locator1 = "ACDXPSettings#CONNECT_DISCONNECT_BUTTON");
+		if (IsElementPresent(locator1 = "ACDXPSettings#DISCONNECT_BUTTON")) {
+			ClickNoError(locator1 = "ACDXPSettings#DISCONNECT_BUTTON");
 
 			Click(locator1 = "ACSettings#DISCONNECT_CONFIRMATION_BUTTON");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACDXPSettings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACDXPSettings.path
@@ -32,8 +32,13 @@
 	<td></td>
 </tr>
 <tr>
-	<td>CONNECT_DISCONNECT_BUTTON</td>
-	<td>//button[@type='button' and text()='Connect'] | //button[@type='button' and text()='Disconnect']</td>
+	<td>CONNECT_BUTTON</td>
+	<td>//button[@type='button' and text()='Connect']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>DISCONNECT_BUTTON</td>
+	<td>//button[@type='button' and text()='Disconnect']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/ConnectACWithDXP.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/ConnectACWithDXP.testcase
@@ -176,7 +176,7 @@ definition {
 				locator1 = "ACDXPSettings#TOKEN_INPUT_FIELD",
 				value1 = "InvalidTokenAC");
 
-			Click(locator1 = "ACDXPSettings#CONNECT_DISCONNECT_BUTTON");
+			Click(locator1 = "ACDXPSettings#CONNECT_BUTTON");
 		}
 
 		task ("Check that the connection is not made and an error message appears") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboardWithAC.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboardWithAC.testcase
@@ -37,7 +37,7 @@ definition {
 
 		Navigator.openURL();
 
-		AnalyticsCloud.teardownAnalyticsCloud();
+		ACDXPSettings.disconnectDXPFromAnalyticsCloud();
 
 		if (${testPortalInstance} == "true") {
 			PortalInstances.tearDownCP();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentperformance/ContentPerformanceWithoutAC.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentperformance/ContentPerformanceWithoutAC.testcase
@@ -272,7 +272,7 @@ definition {
 		}
 
 		task ("End connection with Analytics Cloud") {
-			AnalyticsCloud.teardownAnalyticsCloud();
+			ACDXPSettings.disconnectDXPFromAnalyticsCloud();
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentperformance/ContentPerformanceWithoutButtonCD.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentperformance/ContentPerformanceWithoutButtonCD.testcase
@@ -23,7 +23,7 @@ definition {
 
 		Navigator.openURL();
 
-		AnalyticsCloud.teardownAnalyticsCloud();
+		ACDXPSettings.disconnectDXPFromAnalyticsCloud();
 
 		if (${testPortalInstance} == "true") {
 			PortalInstances.tearDownCP();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-177768
https://issues.liferay.com/browse/LRAC-13085
[Testray](https://testray.liferay.com/home/-/testray/case_results?testrayBuildId=2224084322&testrayRunId=2224085200) - I ran a test from the Tango team which was failing with the click on disconnect issue

**Solution for the AC team:**
I noticed that we used the same path for the connect and disconnect buttons, so I think he would click on the connect button and then wait for the confirmation to disconnect (but this only happens when clicking the disconnect button), so I separated the paths. But I still don't know why Poshi pass in the `IF` condition when it wasn't imagined to enter, so I modified the condition to enter in the `IF` and hope this can solve this problem

**Solutions for the Tango team:**
The Tango team had a test fail because the path they used didn't work with the new wizard, that path was the click on the disconnect button that was performed in the disconnect macro that the Tango team used. I've updated the Tango tests to use the AC disconnect macro. I don't think that in this case, it's good for the Tango team to have macros and paths for the AC product that is separate from ours, that way increasing the chance of their tests failing since we may not be able to maintain and update their macros and paths.