### PR TITLE
AC Test fix - LPS-178939 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACUtils.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACUtils.macro
@@ -27,7 +27,7 @@ definition {
 			var siteName = "Site Name";
 		}
 
-		JSONGroup.addGroup(groupName = ${siteName});
+		HeadlessSite.addSite(siteName = ${siteName});
 
 		if (!(isSet(layoutName))) {
 			var layoutName = "AC Page";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/ABTest.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/ABTest.testcase
@@ -22,7 +22,7 @@ definition {
 		}
 
 		task ("Add a new site with a public widget page") {
-			JSONGroup.addGroup(groupName = "Site Name");
+			HeadlessSite.addSite(siteName = "Site Name");
 
 			ACUtils.addSiteAndPage(
 				groupName = "Site Name",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/GeneralEvents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/GeneralEvents.testcase
@@ -22,7 +22,7 @@ definition {
 		}
 
 		task ("Add a new site") {
-			JSONGroup.addGroup(groupName = "Site Name");
+			HeadlessSite.addSite(siteName = "Site Name");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SearchAPI.testcase
@@ -123,7 +123,7 @@ definition {
 	test RequestKeywordsUsingGroupID {
 		property test.name.skip.portal.instance = "SearchAPI#RequestKeywordsUsingGroupID";
 
-		JSONGroup.addGroup(groupName = "Site Name");
+		HeadlessSite.addSite(siteName = "Site Name");
 
 		var groupId1 = JSONGroupSetter.setGroupId(groupName = "Guest");
 		var groupId2 = JSONGroupSetter.setGroupId(groupName = "Site Name");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-178939
Deprecating JSONGroup.addGroup, JSONGroup.addChildGroup by the end of Q2. Using the new headless api macros in its place. Can read more about in the parent ticket.