### PR TITLE
AC Test Improvement - LRAC-13739 | master

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1218,13 +1218,12 @@
         subrepository-unit-jdk8
 
     test.batch.osb.asah.github.url=https://github.com/liferay/com-liferay-osb-asah-private/tree/latest
-    test.batch.osb.asah.github.url[com-liferay-osb-faro-private][3.1.x]=https://github.com/liferay/com-liferay-osb-asah-private/tree/3.6.x
     test.batch.osb.asah.github.url[com-liferay-osb-faro-private][7.1.x]=https://github.com/liferay/com-liferay-osb-asah-private/tree/7.0.x
 
     test.batch.osb.faro.github.url=https://github.com/liferay/com-liferay-osb-faro-private/tree/latest
-    test.batch.osb.faro.github.url[com-liferay-osb-asah-private][3.6.x]=https://github.com/liferay/com-liferay-osb-faro-private/tree/3.1.x
+    test.batch.osb.faro.github.url[com-liferay-osb-asah-private][4.0.x]=https://github.com/liferay/com-liferay-osb-faro-private/tree/v4.0.0-rc8
     test.batch.osb.faro.github.url[com-liferay-osb-asah-private][7.0.x]=https://github.com/liferay/com-liferay-osb-faro-private/tree/7.1.x
-    test.batch.osb.faro.github.url[com-liferay-osb-asah-private][release]=https://github.com/liferay/com-liferay-osb-faro-private/tree/3.1.x
+    test.batch.osb.faro.github.url[com-liferay-osb-asah-private][release]=https://github.com/liferay/com-liferay-osb-faro-private/tree/v4.0.0-rc8
 
     test.batch.run.property.query[functional-alpine38-tomcat90-mysql57-jdk8]=\
         (\
@@ -3271,8 +3270,8 @@
         ) AND \
         (testray.main.component.name == "Analytics Cloud")
 
-    test.batch.osb.asah.github.url[analytics-cloud-release]=https://github.com/liferay/com-liferay-osb-asah-private/tree/3.6.x
-    test.batch.osb.faro.github.url[analytics-cloud-release]=https://github.com/liferay/com-liferay-osb-faro-private/tree/3.1.x
+    test.batch.osb.asah.github.url[analytics-cloud-release]=https://github.com/liferay/com-liferay-osb-asah-private/tree/4.0.x
+    test.batch.osb.faro.github.url[analytics-cloud-release]=https://github.com/liferay/com-liferay-osb-faro-private/tree/v4.0.0-rc8
 
     testray.project.name[analytics-cloud-release]=Analytics Cloud
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-13739

**What will change with these modifications?**

- PRs that are pushed to Asah's 4.0.x branch will now run acceptance tests correctly with the most current tag of Faro

- The Testray release routine will run the tests using the most current version of Asah and Faro equal to UAT (Change made in Jenkins settings as well)