### PR TITLE
LRAC-13917 [BUG] The icon for copying the token is wrong in the connection modal and in the API page

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/CopyButton.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/CopyButton.tsx
@@ -37,7 +37,7 @@ const CopyButton: React.FC<ICopyButtonProps> = ({
 			title={Liferay.Language.get('click-to-copy')}
 			{...otherProps}
 		>
-			{buttonText || <ClayIcon className='icon-root' symbol='paste' />}
+			{buttonText || <ClayIcon className='icon-root' symbol='copy' />}
 		</ClayButton>
 	);
 };


### PR DESCRIPTION
LRAC-13917: [Jira Issue](https://issues.liferay.com/browse/LRAC-13917)