### PR TITLE
AC Disable Automated Test - LRAC-13984 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SitesPropertyAnalytics.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SitesPropertyAnalytics.testcase
@@ -118,8 +118,13 @@ definition {
 	}
 
 	@description = "Feature ID: Legacy | Automation ID: LRAC-8329 | Test Summary: Assert Chart ticks for Site Metrics standardized"
+	@ignore = "true"
 	@priority = 3
 	test AssertChartTicksSiteMetricsStandardized {
+
+		// AC Refactor: x-axis chart ticks does not appear with no data. Requires past data
+		// AC Refactor ticket: LRAC-13982
+
 		task ("Switch to new property in AC") {
 			ACUtils.launchAC();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRAC-13984

Let me know what you think about disabling this test. So it's currently failing because now the x-axis on the activities chart does not show the ticks when there is no data present. This test checks all time periods to make sure the x-axis marks are showing the correct pattern