### PR TITLE
LRAC-14051 | master

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-docker/common/resources/configs/com.liferay.oauth2.provider.rest.internal.configuration.OAuth2AuthorizationServerConfiguration.config
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-docker/common/resources/configs/com.liferay.oauth2.provider.rest.internal.configuration.OAuth2AuthorizationServerConfiguration.config
@@ -1,0 +1,1 @@
+oauth2.authorization.server.issue.jwt.access.token="false"

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/dev/configs/osgi/configs/com.liferay.oauth2.provider.rest.internal.configuration.OAuth2AuthorizationServerConfiguration.config
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/dev/configs/osgi/configs/com.liferay.oauth2.provider.rest.internal.configuration.OAuth2AuthorizationServerConfiguration.config
@@ -1,0 +1,1 @@
+oauth2.authorization.server.issue.jwt.access.token="false"

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/prd/configs/osgi/configs/com.liferay.oauth2.provider.rest.internal.configuration.OAuth2AuthorizationServerConfiguration.config
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/prd/configs/osgi/configs/com.liferay.oauth2.provider.rest.internal.configuration.OAuth2AuthorizationServerConfiguration.config
@@ -1,0 +1,1 @@
+oauth2.authorization.server.issue.jwt.access.token="false"

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/uat/configs/osgi/configs/com.liferay.oauth2.provider.rest.internal.configuration.OAuth2AuthorizationServerConfiguration.config
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/uat/configs/osgi/configs/com.liferay.oauth2.provider.rest.internal.configuration.OAuth2AuthorizationServerConfiguration.config
@@ -1,0 +1,1 @@
+oauth2.authorization.server.issue.jwt.access.token="false"


### PR DESCRIPTION
Faro was based on 7.1.x, after migrating to master we got a unnexpected default value for `oauth2.authorization.server.issue.jwt.access.token` ([See](https://github.com/liferay-ac/liferay-portal/blob/c31442f7c68cb19f519791e87812699f796dc454/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/configuration/OAuth2AuthorizationServerConfigurationGenerator.java#L54))

Fix: added file to prevent default value for `auth2.authorization.server.issue.jwt.access.token`