### PR TITLE
LRAC-14117 The icon representing the static and dynamic segments are dark in the Associated Segments card in the details of a known individual

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/__tests__/__snapshots__/AssociatedSegmentsCard.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/__tests__/__snapshots__/AssociatedSegmentsCard.jsx.snap
@@ -63,7 +63,7 @@ exports[`AssociatedSegmentsCard should render 1`] = `
               class="autofit-col"
             >
               <div
-                class="sticker sticker-root sticker-static sticker-rounded sticker-light"
+                class="sticker sticker-root sticker-static sticker-rounded sticker-primary"
               >
                 <svg
                   class="lexicon-icon lexicon-icon-individual-dynamic-segment icon-root"
@@ -104,7 +104,7 @@ exports[`AssociatedSegmentsCard should render 1`] = `
               class="autofit-col"
             >
               <div
-                class="sticker sticker-root sticker-static sticker-rounded sticker-light"
+                class="sticker sticker-root sticker-static sticker-rounded sticker-primary"
               >
                 <svg
                   class="lexicon-icon lexicon-icon-individual-dynamic-segment icon-root"

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/Overview.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/Overview.jsx.snap
@@ -218,7 +218,7 @@ exports[`AccountOverview should render 1`] = `
                   class="autofit-col"
                 >
                   <div
-                    class="sticker sticker-root sticker-static sticker-rounded sticker-light"
+                    class="sticker sticker-root sticker-static sticker-rounded sticker-primary"
                   >
                     <svg
                       class="lexicon-icon lexicon-icon-individual-dynamic-segment icon-root"

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/Overview.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/Overview.jsx.snap
@@ -639,7 +639,7 @@ Chrome"
                   class="autofit-col"
                 >
                   <div
-                    class="sticker sticker-root sticker-static sticker-rounded sticker-light"
+                    class="sticker sticker-root sticker-static sticker-rounded sticker-primary"
                   >
                     <svg
                       class="lexicon-icon lexicon-icon-individual-dynamic-segment icon-root"

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/EntityList.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/EntityList.jsx
@@ -84,7 +84,7 @@ class EntityListItem extends React.Component {
 				<ListGroup.ItemField>
 					{type === EntityTypes.IndividualsSegment ? (
 						<Sticker
-							display='light'
+							display='primary'
 							symbol={
 								segmentType === SegmentTypes.Static
 									? 'individual-static-segment'


### PR DESCRIPTION
LRAC- 14117: [Jira Issue](https://liferay.atlassian.net/jira/software/c/projects/LRAC/boards/595?modal=detail&selectedIssue=LRAC-14117)