### PR TITLE
LRAC-14553 osb-faro-docker: update Liferay Docker image version

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-docker/common/resources/portal-ext.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-docker/common/resources/portal-ext.properties
@@ -19,6 +19,7 @@ module.framework.properties.lpkg.index.validator.enabled=false
 module.framework.properties.osgi.console=0.0.0.0:11311
 scheduler.group.name.max.length=85
 scheduler.job.name.max.length=85
+virtual.hosts.valid.hosts=*
 com.liferay.portal.servlet.filters.gzip.GZipFilter=true
 com.liferay.portal.sharepoint.SharepointFilter=false
 com.liferay.portal.servlet.filters.strip.StripFilter=false

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-docker/local/Dockerfile
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-docker/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM liferay/dxp:7.4.13-u78
+FROM liferay/dxp:7.4.13-u90
 
 USER root
 

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/dev/Dockerfile
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM liferay/dxp:7.4.13-u78
+FROM liferay/dxp:7.4.13-u90
 
 COPY --chown=liferay:liferay configs /home/liferay/configs
 COPY --chown=liferay:liferay deploy /mnt/liferay/deploy

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/dev/LCP.json
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/dev/LCP.json
@@ -20,7 +20,7 @@
 		}
 	},
 	"id": "liferay",
-	"image": "liferaycloud/liferay-dxp:7.4-5.2.1",
+	"image": "liferay/dxp:7.4.13-u90",
 	"kind": "Deployment",
 	"livenessProbe": {
 		"failureThreshold": 3,

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/prd/Dockerfile
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/prd/Dockerfile
@@ -1,4 +1,4 @@
-FROM liferay/dxp:7.4.13-u78
+FROM liferay/dxp:7.4.13-u90
 
 COPY --chown=liferay:liferay configs /home/liferay/configs
 COPY --chown=liferay:liferay deploy /mnt/liferay/deploy

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/prd/LCP.json
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/prd/LCP.json
@@ -21,7 +21,7 @@
 		}
 	},
 	"id": "liferay",
-	"image": "liferaycloud/liferay-dxp:7.4-5.2.1",
+	"image": "liferay/dxp:7.4.13-u90",
 	"kind": "Deployment",
 	"livenessProbe": {
 		"failureThreshold": 3,

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/uat/Dockerfile
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/uat/Dockerfile
@@ -1,4 +1,4 @@
-FROM liferay/dxp:7.4.13-u78
+FROM liferay/dxp:7.4.13-u90
 
 COPY --chown=liferay:liferay configs /home/liferay/configs
 COPY --chown=liferay:liferay deploy /mnt/liferay/deploy

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/uat/LCP.json
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/uat/LCP.json
@@ -20,7 +20,7 @@
 		}
 	},
 	"id": "liferay",
-	"image": "liferaycloud/liferay-dxp:7.4-5.2.1",
+	"image": "liferay/dxp:7.4.13-u90",
 	"kind": "Deployment",
 	"livenessProbe": {
 		"failureThreshold": 3,


### PR DESCRIPTION
### Issue
Error when trying to add a user to a property.The addUserGroup method from GroupdLocalService had its return type [updated](https://github.com/liferay/liferay-portal/commit/f38eec0d4b381bc276cb074d737a9447f8d24d09), giving us the following error `Caused by: java.lang.NoSuchMethodError: 'boolean com.liferay.portal.kernel.service.GroupLocalService.addUserGroup(long, long)'
	at com.liferay.osb.faro.service.impl.FaroChannelLocalServiceImpl.addUsers(FaroChannelLocalServiceImpl.java:107) ~[?:?]`

### Proposed solution
The Liferay Docker image was updated in the [Dockerfile](https://github.com/liferay-ac/liferay-portal/blob/master/modules/dxp/apps/osb/osb-faro/osb-faro-docker/local/Dockerfile) file in osb-faro, the update was from version [u78](https://customer.liferay.com/downloads/-/download/liferay-dxp-7-4-update-78-download) to [u90](https://customer.liferay.com/downloads/-/download/liferay-dxp-7-4-update-90-download) where the addUserGroup method was being found.