### PR TITLE
LPS-199327 Remove 'metal-promise'

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
@@ -47,7 +47,6 @@
 		"metal-dom": "^2.16.2",
 		"metal-events": "^2.16.2",
 		"metal-position": "^2.1.0",
-		"metal-promise": "^2.0.1",
 		"metal-storage": "^1.1.0",
 		"metal-structs": "^1.0.1",
 		"metal-uri": "^2.4.0",

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/EntityDetailsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/EntityDetailsList.tsx
@@ -3,7 +3,6 @@ import Card from 'shared/components/Card';
 import Checkbox from 'shared/components/Checkbox';
 import getCN from 'classnames';
 import Nav from 'shared/components/Nav';
-import Promise from 'metal-promise';
 import React from 'react';
 import SearchableEntityTable from 'shared/components/SearchableEntityTable';
 import {detailsListColumns} from 'shared/util/table-columns';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/__tests__/AssociatedSegmentsCard.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/__tests__/AssociatedSegmentsCard.jsx
@@ -1,7 +1,6 @@
 import * as data from 'test/data';
 import AssociatedSegmentsCard from '../AssociatedSegmentsCard';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
-import Promise from 'metal-promise';
 import React from 'react';
 import {render} from '@testing-library/react';
 import {StaticRouter} from 'react-router';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/__tests__/AssociatedSegmentsList.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/__tests__/AssociatedSegmentsList.js
@@ -1,5 +1,4 @@
 import AssociatedSegmentsList from '../AssociatedSegmentsList';
-import Promise from 'metal-promise';
 import {renderWithStore} from 'test/mock-store';
 
 describe('AssociatedSegmentsList', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/__tests__/BaseListPage.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/__tests__/BaseListPage.jsx
@@ -2,7 +2,6 @@ import * as data from 'test/data';
 import * as useDataSource from 'shared/hooks/useDataSource';
 import BaseListPage from '../BaseListPage';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {ChannelContext} from 'shared/context/channel';
 import {cleanup, render, waitForElement} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/__tests__/ActivitiesCard.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/__tests__/ActivitiesCard.jsx
@@ -1,7 +1,6 @@
 import * as API from 'shared/api';
 import * as data from 'test/data';
 import ActivitiesCard from '../ActivitiesCard';
-import Promise from 'metal-promise';
 import React from 'react';
 import {Account} from 'shared/util/records';
 import {render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/__tests__/KnownIndividualsCard.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/__tests__/KnownIndividualsCard.jsx
@@ -1,6 +1,5 @@
 import * as data from 'test/data';
 import KnownIndividualsCard from '../KnownIndividualsCard';
-import Promise from 'metal-promise';
 import React from 'react';
 import {render} from '@testing-library/react';
 import {StaticRouter} from 'react-router';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/distribution-card/DistributionChart.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/distribution-card/DistributionChart.tsx
@@ -4,7 +4,6 @@ import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import ErrorDisplay from 'shared/components/ErrorDisplay';
 import Loading from 'shared/components/Loading';
-import Promise from 'metal-promise';
 import React from 'react';
 import {ANIMATION_DURATION, AXIS, getTextWidth} from 'shared/util/recharts';
 import {autoCancel, hasRequest} from 'shared/util/request-decorator';
@@ -54,7 +53,7 @@ interface IDistributionChartProps extends PropsFromRedux {
 	channelId: string;
 	distributionKey: string;
 	error: boolean;
-	fetchDistribution: (params: object) => typeof Promise;
+	fetchDistribution: (params: object) => Promise<any>;
 	groupId: string;
 	id: string;
 	individualFieldDistributionIList: List<Map<string, any>>;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/distribution-card/__tests__/DistributionChart.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/distribution-card/__tests__/DistributionChart.jsx
@@ -1,6 +1,5 @@
 import DistributionChart from '../DistributionChart';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {BrowserRouter} from 'react-router-dom';
 import {cleanup, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/distribution-card/__tests__/index.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/distribution-card/__tests__/index.jsx
@@ -1,6 +1,5 @@
 import DistributionCard from '../index';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {BrowserRouter} from 'react-router-dom';
 import {cleanup, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/distribution-card/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/distribution-card/index.tsx
@@ -5,7 +5,6 @@ import Card from 'shared/components/Card';
 import DistributionChart from './DistributionChart';
 import ErrorDisplay from 'shared/components/ErrorDisplay';
 import Loading from 'shared/components/Loading';
-import Promise from 'metal-promise';
 import React from 'react';
 import Tabs from './Tabs';
 import {addAlert} from 'shared/actions/alerts';
@@ -49,7 +48,7 @@ interface IDistributionCardProps
 		PropsFromRedux {
 	channelId: string;
 	distributionKey: string;
-	fetchDistribution: (params: object) => typeof Promise;
+	fetchDistribution: (params: object) => Promise<any>;
 	groupId: string;
 	id: string;
 	noResultsRenderer?: () => React.ReactElement;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/__tests__/BaseDetails.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/__tests__/BaseDetails.jsx
@@ -1,7 +1,6 @@
 import * as data from 'test/data';
 import BaseDetails from '../BaseDetails';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {cleanup, render} from '@testing-library/react';
 import {Provider} from 'react-redux';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/Activities.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/Activities.jsx
@@ -2,7 +2,6 @@ import * as API from 'shared/api';
 import * as data from 'test/data';
 import Activities from '../Activities';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {Account} from 'shared/util/records';
 import {MemoryRouter, Route} from 'react-router-dom';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/custom-types/metal-promise.d.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/custom-types/metal-promise.d.ts
@@ -1,1 +1,0 @@
-declare module 'metal-promise';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/hocs/DistributionCard.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/hocs/DistributionCard.tsx
@@ -5,6 +5,7 @@ import URLConstants from 'shared/util/url-constants';
 import {connect, ConnectedProps} from 'react-redux';
 import {fetchIndividualsDistribution} from 'shared/actions/distributions';
 import {Routes, toRoute} from 'shared/util/router';
+import {toPromise} from 'shared/util/validators';
 import {useParams} from 'react-router-dom';
 
 const connector = connect(null, {
@@ -31,7 +32,7 @@ const IndividualsDistributionCard: React.FC<IIndividualsDistributionCardProps> =
 		<DistributionCard
 			channelId={channelId}
 			distributionKey='individualsDashboard'
-			fetchDistribution={fetchDistribution}
+			fetchDistribution={name => toPromise(fetchDistribution(name))}
 			groupId={groupId}
 			id={id}
 			noResultsRenderer={() => (

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/hocs/__tests__/EnrichedProfilesCard.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/hocs/__tests__/EnrichedProfilesCard.jsx
@@ -1,6 +1,5 @@
 import * as API from 'shared/api';
 import EnrichedProfilesCard from '../EnrichedProfilesCard';
-import Promise from 'metal-promise';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {cleanup, queryByText, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/__tests__/ProfileCard.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/__tests__/ProfileCard.jsx
@@ -1,6 +1,5 @@
 import * as API from 'shared/api';
 import IndividualProfileCard from '../ProfileCard';
-import Promise from 'metal-promise';
 import React from 'react';
 import {fireEvent, render} from '@testing-library/react';
 import {Individual} from 'shared/util/records';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/List.tsx
@@ -1,7 +1,6 @@
 import * as API from 'shared/api';
 import BaseListPage from 'contacts/components/BaseListPage';
 import ClayButton from '@clayui/button';
-import Promise from 'metal-promise';
 import React, {useContext, useEffect, useRef, useState} from 'react';
 import RowActions from 'shared/components/RowActions';
 import SearchableEntityTable from 'shared/components/SearchableEntityTable';
@@ -120,7 +119,7 @@ export const List: React.FC<IListProps> = ({
 
 	const [alerts, setAlerts] = useState([]);
 
-	const _disableSegmentsRequestRef = useRef<typeof Promise>();
+	const _disableSegmentsRequestRef = useRef<Promise<any>>();
 	const {
 		showUnassignedAlert,
 		unassignedSegments,
@@ -128,14 +127,24 @@ export const List: React.FC<IListProps> = ({
 	} = useContext(UnassignedSegmentsContext);
 
 	useEffect(() => {
-		_disableSegmentsRequestRef.current = getDisabledSegmentsAlert();
+		const abortController = new AbortController();
 
-		return () => _disableSegmentsRequestRef.current.cancel();
+		_disableSegmentsRequestRef.current = getDisabledSegmentsAlert(
+			abortController.signal
+		);
+
+		return () => {
+			abortController.abort();
+		};
 	}, []);
 
-	const getDisabledSegmentsAlert = () =>
+	const getDisabledSegmentsAlert = (abortSignal: AbortSignal) =>
 		fetchDisabledSegments(channelId, groupId, orderIOMap).then(
 			({total}) => {
+				if (abortSignal.aborted) {
+					return;
+				}
+
 				if (total) {
 					setAlerts(() => handleDisabledSegmentsAlert());
 				}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/edit/Static.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/edit/Static.jsx
@@ -4,7 +4,6 @@ import ClayButton from '@clayui/button';
 import ClayLink from '@clayui/link';
 import Form, {validateRequired} from 'shared/components/form';
 import NavigationWarning from 'shared/components/NavigationWarning';
-import Promise from 'metal-promise';
 import React from 'react';
 import SegmentEditStatic from 'segment/segment-editor/static/SegmentEditStatic';
 import Sheet from 'shared/components/Sheet';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/hoc/WithPropertyGroups.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/hoc/WithPropertyGroups.tsx
@@ -1,7 +1,6 @@
 import * as API from 'shared/api';
 import client from 'shared/apollo/client';
 import EventDefinitionsQuery from 'event-analysis/queries/EventDefinitionsQuery';
-import Promise from 'metal-promise';
 import React from 'react';
 import {compose} from 'redux';
 import {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/hoc/__tests__/WithPropertyGroups.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/hoc/__tests__/WithPropertyGroups.jsx
@@ -1,6 +1,5 @@
 import * as API from 'shared/api';
 import client from 'shared/apollo/client';
-import Promise from 'metal-promise';
 import React from 'react';
 import withPropertyGroups from '../WithPropertyGroups';
 import {render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
@@ -5,7 +5,6 @@ import CriteriaSidebar from './criteria-sidebar';
 import EmbeddedAlertList from 'shared/components/EmbeddedAlertList';
 import Form, {withField} from 'shared/components/form';
 import NavigationWarning from 'shared/components/NavigationWarning';
-import Promise from 'metal-promise';
 import React from 'react';
 import Toolbar from './Toolbar';
 import {AlertTypes} from 'shared/components/Alert';
@@ -83,7 +82,7 @@ interface ISegmentEditorProps {
 	onSubmit: (
 		form: FormValues,
 		ref: React.Ref<Formik>,
-		requestFn: (params: FormValues) => typeof Promise
+		requestFn: (params: FormValues) => Promise<any>
 	) => void;
 	propertyGroupsIList: List<PropertyGroup>;
 	segment: Segment;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/AccountInput.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/AccountInput.tsx
@@ -2,7 +2,6 @@ import * as API from 'shared/api';
 import autobind from 'autobind-decorator';
 import CustomNumberInput from './CustomNumberInput';
 import CustomStringInput from './CustomStringInput';
-import Promise from 'metal-promise';
 import React from 'react';
 import {getPropertyValue} from '../utils/custom-inputs';
 import {ISegmentEditorCustomInputBase} from '../utils/types';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/GeolocationInput.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/GeolocationInput.tsx
@@ -5,7 +5,6 @@ import ClayButton from '@clayui/button';
 import DateFilterConjunctionInput from './components/DateFilterConjunctionInput';
 import Form from 'shared/components/form';
 import getCN from 'classnames';
-import Promise from 'metal-promise';
 import React from 'react';
 import {CustomValue} from 'shared/util/records';
 import {fromJS, Map} from 'immutable';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/SelectEntityFromModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/SelectEntityFromModal.tsx
@@ -1,7 +1,6 @@
 import Form from 'shared/components/form';
 import getCN from 'classnames';
 import Input from 'shared/components/Input';
-import Promise from 'metal-promise';
 import React from 'react';
 import {close, modalTypes, open} from 'shared/actions/modals';
 import {Columns} from 'shared/types';
@@ -17,7 +16,7 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 
 interface ISelectEntityFromModalProps extends PropsFromRedux {
 	columns: Columns;
-	dataSourceFn?: (params: {[key: string]: any}) => typeof Promise;
+	dataSourceFn?: (params: {[key: string]: any}) => Promise<any>;
 	entity: {dataSourceName?: string; [key: string]: any};
 	error: boolean;
 	graphqlProps?: {[key: string]: any};

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/SelectEntityInput.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/SelectEntityInput.tsx
@@ -1,6 +1,5 @@
 import Form from 'shared/components/form';
 import getCN from 'classnames';
-import Promise from 'metal-promise';
 import React, {useContext, useEffect} from 'react';
 import SelectEntityFromModal from '../components/SelectEntityFromModal';
 import {Columns} from 'shared/types';
@@ -14,7 +13,7 @@ import {OrderParams} from 'shared/util/records';
 
 interface ISelectEntityInputProps {
 	columns: Columns;
-	dataSourceFn?: () => typeof Promise;
+	dataSourceFn?: () => Promise<any>;
 	delta?: number;
 	entityLabel: string;
 	entityType: EntityType;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/static/SegmentEditStatic.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/static/SegmentEditStatic.tsx
@@ -1,7 +1,6 @@
 import * as API from 'shared/api';
 import EntityRowActions from './EntityRowActions';
 import getCN from 'classnames';
-import Promise from 'metal-promise';
 import React, {useEffect, useState} from 'react';
 import SearchableTableWithAdded from './SearchableTableWithAdded';
 import ToolbarActionsRenderer from './ToolbarActionsRenderer';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/static/__tests__/SearchableTableWithAdded.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/static/__tests__/SearchableTableWithAdded.jsx
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import React from 'react';
 import SearchableTableWithAdded from '../SearchableTableWithAdded';
 import {cleanup, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/apis/pages/__tests__/AccessTokenList.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/apis/pages/__tests__/AccessTokenList.jsx
@@ -2,7 +2,6 @@ import 'test/mock-modal';
 import * as API from 'shared/api';
 import * as data from 'test/data';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {AccessTokenList} from '../AccessTokenList';
 import {cleanup, fireEvent, getByText, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/pages/__tests__/View.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/pages/__tests__/View.jsx
@@ -2,7 +2,6 @@ import * as API from 'shared/api';
 import * as data from 'test/data';
 import mockStore from 'test/mock-store';
 import ModalRenderer from 'shared/components/ModalRenderer';
-import Promise from 'metal-promise';
 import React from 'react';
 import View from '../View';
 import {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/__tests__/DataTransformation.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/__tests__/DataTransformation.jsx
@@ -1,6 +1,5 @@
 import * as API from 'shared/api';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {DataTransformation, processFieldMappings} from '../DataTransformation';
 import {fireEvent, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/data-source/__tests__/BaseFieldMappingView.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/data-source/__tests__/BaseFieldMappingView.jsx
@@ -2,7 +2,6 @@ import * as API from 'shared/api';
 import * as data from 'test/data';
 import BaseFieldMappingView from '../BaseFieldMappingView';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {DataSource, User} from 'shared/util/records';
 import {FieldContexts} from 'shared/util/constants';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/liferay/Overview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/liferay/Overview.tsx
@@ -197,7 +197,9 @@ class LiferayOverview extends React.Component<ILiferayOverviewProps> {
 							inputWidth={100}
 							label={Liferay.Language.get('name')}
 							name='dataSourceName'
-							onSubmit={this.handleUpdateName}
+							onSubmit={name =>
+								toPromise(this.handleUpdateName(name))
+							}
 							required
 							validate={sequence([
 								validateRequired,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/liferay/__tests__/Overview.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/liferay/__tests__/Overview.jsx
@@ -2,7 +2,6 @@ import * as API from 'shared/api';
 import * as data from 'test/data';
 import LiferayOverview from '../Overview';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import {DataSource, User} from 'shared/util/records';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/definitions/pages/__tests__/InterestTopics.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/definitions/pages/__tests__/InterestTopics.jsx
@@ -2,7 +2,6 @@ import * as API from 'shared/api';
 import * as data from 'test/data';
 import InterestTopics from '../InterestTopics';
 import mockStore, {mockStoreData, toRD} from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {cleanup, render} from '@testing-library/react';
 import {MemoryRouter, Route} from 'react-router-dom';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/Workspace.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/Workspace.tsx
@@ -1,7 +1,6 @@
 import * as API from 'shared/api';
 import AddWorkspaceForm from 'shared/components/workspaces/AddWorkspaceForm';
 import BasePage from 'settings/components/BasePage';
-import Promise from 'metal-promise';
 import React from 'react';
 import {addAlert} from 'shared/actions/alerts';
 import {Alert} from 'shared/types';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/__tests__/DataSourceList.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/__tests__/DataSourceList.jsx
@@ -7,7 +7,6 @@ import DataSourceList, {
 	StatusRenderer
 } from '../DataSourceList';
 import mockStore, {mockStoreData} from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {cleanup, render} from '@testing-library/react';
 import {DataSourceStates} from 'shared/util/constants';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/recommendations/components/StringMatchInput.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/recommendations/components/StringMatchInput.tsx
@@ -1,7 +1,6 @@
 import BaseSelect from 'shared/components/BaseSelect';
 import getCN from 'classnames';
 import MetadataTag from './MetadataTag';
-import Promise from 'metal-promise';
 import React, {useEffect, useRef} from 'react';
 import {BACKSPACE, ENTER} from 'shared/util/key-constants';
 import {METADATA_TAGS} from '../utils/utils';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/accounts.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/accounts.js
@@ -1,5 +1,4 @@
 import * as data from 'test/data';
-import Promise from 'metal-promise';
 
 export const fetch = jest.fn(() => Promise.resolve(data.mockAccount()));
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/activities.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/activities.js
@@ -1,5 +1,4 @@
 import * as data from 'test/data';
-import Promise from 'metal-promise';
 
 export const fetchGroup = jest.fn(() =>
 	Promise.resolve({

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/api-tokens.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/api-tokens.js
@@ -1,5 +1,4 @@
 import * as data from 'test/data';
-import Promise from 'metal-promise';
 
 export const generate = jest.fn(() => Promise.resolve(data.mockApiToken()));
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/assets.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/assets.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {mockAsset, mockSearch} from 'test/data';
 
 export const search = jest.fn(() => Promise.resolve(mockSearch(mockAsset)));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/blocked-keywords.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/blocked-keywords.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {mockBlockedKeyword, mockSearch} from 'test/data';
 
 export const search = jest.fn(() =>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/channels.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/channels.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {mockChannel, mockSearch, mockUser} from 'test/data';
 
 export const create = jest.fn(() => Promise.resolve([mockChannel()]));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/contacts-cards.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/contacts-cards.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {mockCardTemplate, mockFieldMapping, mockSegment} from 'test/data';
 
 export const preview = jest.fn(() =>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/data-source.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/data-source.js
@@ -1,5 +1,4 @@
 import * as data from 'test/data';
-import Promise from 'metal-promise';
 import {EntityTypes} from 'shared/util/constants';
 
 export const fetch = jest.fn(() => Promise.resolve(data.mockCSVDataSource()));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/definitions.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/definitions.js
@@ -1,5 +1,4 @@
 import * as data from 'test/data';
-import Promise from 'metal-promise';
 
 export const searchIndividualAttributes = jest.fn(() =>
 	Promise.resolve(data.mockSearch(data.mockIndividualAttributes, 5))

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/distributions.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/distributions.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {mockDistribution} from 'test/data';
 
 export const fetch = jest.fn(() => Promise.resolve([mockDistribution()]));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/field-mappings.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/field-mappings.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {mockFieldMapping, mockSearch} from 'test/data';
 
 export const fetch = jest.fn(() => Promise.resolve(mockFieldMapping()));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/individual-segment.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/individual-segment.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {
 	mockMembershipChange,
 	mockMembershipChangeAggregation,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/individuals.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/individuals.js
@@ -1,5 +1,4 @@
 import * as data from 'test/data';
-import Promise from 'metal-promise';
 
 export const fetch = jest.fn(() => Promise.resolve(data.mockIndividual()));
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/interests.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/interests.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {mockInterestData, mockSearch} from 'test/data';
 
 export const fetch = jest.fn(() => Promise.resolve(mockInterestData()));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/issue.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/issue.ts
@@ -1,3 +1,1 @@
-import Promise from 'metal-promise';
-
 export const create = jest.fn(() => Promise.resolve());

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/notifications.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/notifications.js
@@ -1,5 +1,3 @@
-import Promise from 'metal-promise';
-
 export const fetchNotifications = jest.fn(() => Promise.resolve([]));
 
 export const readNotification = jest.fn(() => Promise.resolve(''));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/pages-visited.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/pages-visited.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {mockPageVisited, mockSearch} from 'test/data';
 
 export const search = jest.fn(() =>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/preferences.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/preferences.js
@@ -1,5 +1,3 @@
-import Promise from 'metal-promise';
-
 export const addDistributionTab = jest.fn(() =>
 	Promise.resolve({
 		distributionCardTabPreferencesMap: {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/projects.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/projects.js
@@ -1,5 +1,4 @@
 import * as data from 'test/data';
-import Promise from 'metal-promise';
 import {range} from 'lodash';
 import {TimeZone} from 'shared/util/records';
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/subscriptions.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/subscriptions.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {mockSubscription} from 'test/data';
 
 export const fetch = jest.fn(() => Promise.resolve(mockSubscription()));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/user.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__mocks__/user.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {mockSearch, mockUser} from 'test/data';
 
 const delete$ = jest.fn(() => Promise.resolve(''));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/session.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/session.ts
@@ -1,5 +1,4 @@
 import FaroConstants from 'shared/util/constants';
-import Promise from 'metal-promise';
 import sendRequest from 'shared/util/request';
 import {escapeSingleQuotes} from 'segment/segment-editor/dynamic/utils/odata';
 import {RESTParams} from 'shared/types';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/BaseSelect.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/BaseSelect.tsx
@@ -4,7 +4,6 @@ import getCN from 'classnames';
 import Input from './Input';
 import Loading from 'shared/components/Loading';
 import Overlay from './Overlay';
-import Promise from 'metal-promise';
 import React, {useEffect, useImperativeHandle, useRef, useState} from 'react';
 import {ARROW_DOWN, ARROW_UP, ENTER} from '../util/key-constants';
 import {DocumentNode} from 'graphql';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/InputWithEditToggle.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/InputWithEditToggle.tsx
@@ -5,7 +5,6 @@ import Form from 'shared/components/form';
 import getCN from 'classnames';
 import Label from 'shared/components/form/Label';
 import Loading, {Align} from 'shared/components/Loading';
-import Promise from 'metal-promise';
 import React from 'react';
 import {Formik} from 'formik';
 interface IInputWithEditToggleProps {
@@ -14,9 +13,9 @@ interface IInputWithEditToggleProps {
 	inputWidth?: number;
 	label: string;
 	name?: string;
-	onSubmit: (value, name) => typeof Promise;
+	onSubmit: (value, name) => Promise<any>;
 	required: boolean;
-	validate: typeof Promise;
+	validate: (value) => Promise<any>;
 	value: string;
 }
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/BaseResults.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/BaseResults.jsx
@@ -1,6 +1,5 @@
 import * as data from 'test/data';
 import BaseResults from '../BaseResults';
-import Promise from 'metal-promise';
 import React from 'react';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import {noop, times} from 'lodash';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/BaseSelect.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/BaseSelect.jsx
@@ -2,7 +2,6 @@ import BaseSelect, {Item} from '../BaseSelect';
 import client from 'shared/apollo/client';
 import EventAttributeValuesQuery from 'event-analysis/queries/EventAttributeValuesQuery';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {ApolloProvider} from '@apollo/react-components';
 import {fireEvent, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/NotificationAlertList.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/NotificationAlertList.jsx
@@ -2,7 +2,6 @@ import * as API from 'shared/api';
 import * as data from 'test/data';
 import mockStore from 'test/mock-store';
 import NotificationAlertList from '../NotificationAlertList';
-import Promise from 'metal-promise';
 import React from 'react';
 import {fireEvent, render} from '@testing-library/react';
 import {Provider} from 'react-redux';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/SearchableEntityTable.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/SearchableEntityTable.jsx
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import React from 'react';
 import SearchableEntityTable from '../SearchableEntityTable';
 import {cleanup, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/SelectInput.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/SelectInput.jsx
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import React from 'react';
 import SelectInput from '../SelectInput';
 import {cleanup, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/BatchActionModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/BatchActionModal.tsx
@@ -3,7 +3,6 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import getCN from 'classnames';
 import Modal from 'shared/components/modal';
-import Promise from 'metal-promise';
 import React, {useEffect, useState} from 'react';
 import Table, {Column} from 'shared/components/table';
 import {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/ConfirmationModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/ConfirmationModal.tsx
@@ -2,7 +2,6 @@ import ClayButton from '@clayui/button';
 import getCN from 'classnames';
 import Loading, {Align} from 'shared/components/Loading';
 import Modal from 'shared/components/modal';
-import Promise from 'metal-promise';
 import React, {useState} from 'react';
 import {DisplayType} from '@clayui/button/lib/Button';
 import {noop} from 'lodash';
@@ -69,7 +68,7 @@ const ConfirmationModal: React.FC<IConfirmationModalProps> = ({
 						const submitVal: any = onSubmit();
 
 						if (submitVal instanceof Promise) {
-							(submitVal as typeof Promise)
+							submitVal
 								.then(() => {
 									setSubmitting(false);
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/ExportLogModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/ExportLogModal.tsx
@@ -3,7 +3,6 @@ import DateRangeInput, {DateRange} from 'shared/components/DateRangeInput';
 import Loading, {Align} from 'shared/components/Loading';
 import Modal from 'shared/components/modal';
 import moment from 'moment';
-import Promise from 'metal-promise';
 import React, {useState} from 'react';
 import {downloadDataAsFile} from 'shared/util/util';
 
@@ -17,7 +16,7 @@ interface IExportLogModalProps {
 	}: {
 		fromDate: string;
 		toDate: string;
-	}) => typeof Promise;
+	}) => Promise<any>;
 	title: string;
 }
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/FieldPreviewModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/FieldPreviewModal.tsx
@@ -1,7 +1,6 @@
 import getCN from 'classnames';
 import ListGroup from 'shared/components/list-group';
 import Modal from 'shared/components/modal';
-import Promise from 'metal-promise';
 import React, {useEffect, useState} from 'react';
 import {get, noop} from 'lodash';
 import {sub} from 'shared/util/lang';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/InviteUsersModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/InviteUsersModal.tsx
@@ -3,14 +3,13 @@ import getCN from 'classnames';
 import Input from 'shared/components/Input';
 import InputList from 'shared/components/InputList';
 import Modal from 'shared/components/modal';
-import Promise from 'metal-promise';
 import React, {useState} from 'react';
 import {validateEmail} from 'shared/util/email-validators';
 
 interface IInviteUsersModalProps {
 	className: string;
 	onClose: () => void;
-	onSubmit: (emails: string[]) => typeof Promise;
+	onSubmit: (emails: string[]) => Promise<any>;
 }
 
 const InviteUsersModal: React.FC<IInviteUsersModalProps> = ({

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/SelectItemsModal.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/SelectItemsModal.jsx
@@ -6,7 +6,6 @@ import ListView from 'shared/components/ListView';
 import Loading, {Align} from 'shared/components/Loading';
 import Modal from 'shared/components/modal';
 import omitDefinedProps from 'shared/util/omitDefinedProps';
-import Promise from 'metal-promise';
 import React from 'react';
 import SearchableModal from './SearchableModal';
 import {noop} from 'lodash';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/ConfirmationModal.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/ConfirmationModal.jsx
@@ -1,5 +1,4 @@
 import ConfirmationModal from '../ConfirmationModal';
-import Promise from 'metal-promise';
 import React from 'react';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import {noop} from 'lodash';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/DeleteChannelModal.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/DeleteChannelModal.jsx
@@ -1,6 +1,5 @@
 import * as API from 'shared/api';
 import DeleteChannelModal from '../DeleteChannelModal';
-import Promise from 'metal-promise';
 import React from 'react';
 import {cleanup, render} from '@testing-library/react';
 import {noop} from 'lodash';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/ExportLogModal.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/ExportLogModal.jsx
@@ -1,5 +1,4 @@
 import ExportLogModal from '../ExportLogModal';
-import Promise from 'metal-promise';
 import React from 'react';
 import {
 	cleanup,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/FieldPreviewModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/FieldPreviewModal.tsx
@@ -1,5 +1,4 @@
 import FieldPreviewModal from '../FieldPreviewModal';
-import Promise from 'metal-promise';
 import React from 'react';
 import {noop} from 'lodash';
 import {render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/SearchableEntitiesTableModal.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/SearchableEntitiesTableModal.jsx
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import React from 'react';
 import SearchableEntitiesTableModal from '../SearchableEntitiesTableModal';
 import {cleanup, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/SearchableModal.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/SearchableModal.jsx
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import React from 'react';
 import SearchableModal from '../SearchableModal';
 import {cleanup, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/SearchableTableModal.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/SearchableTableModal.jsx
@@ -1,5 +1,4 @@
 import * as data from 'test/data';
-import Promise from 'metal-promise';
 import React from 'react';
 import SearchableTableModal from '../SearchableTableModal';
 import {cleanup, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/SelectItemsModal.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/SelectItemsModal.jsx
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import React from 'react';
 import SelectItemsModal, {ItemComponent} from '../SelectItemsModal';
 import {cleanup, fireEvent, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/onboarding-modal/__tests__/ConnectDXP.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/onboarding-modal/__tests__/ConnectDXP.jsx
@@ -1,7 +1,6 @@
 import * as API from 'shared/api';
 import ConnectDXP from '../ConnectDXP';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {fireEvent, render} from '@testing-library/react';
 import {noop} from 'lodash';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/workspace-list/__tests__/ListItem.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/workspace-list/__tests__/ListItem.jsx
@@ -1,6 +1,5 @@
 import * as API from 'shared/api';
 import * as data from 'test/data';
-import Promise from 'metal-promise';
 import React from 'react';
 import WorkspaceListItem from '../ListItem';
 import {cleanup, fireEvent, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/WithAction.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/WithAction.jsx
@@ -1,6 +1,5 @@
 import ErrorPage from '../pages/ErrorPage';
 import Loading from 'shared/components/Loading';
-import Promise from 'metal-promise';
 import React from 'react';
 import {connect} from 'react-redux';
 import {isFunction, noop} from 'lodash';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/CheckProjectState.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/CheckProjectState.jsx
@@ -5,7 +5,6 @@ jest.mock('shared/components/workspaces/SuccessDisplay', () => () =>
 import * as API from 'shared/api';
 import checkProjectState from '../CheckProjectState';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import {cleanup, render} from '@testing-library/react';
 import {Provider} from 'react-redux';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/CheckSegmentLink.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/CheckSegmentLink.jsx
@@ -1,6 +1,5 @@
 import * as API from 'shared/api';
 import CheckSegmentLink from '../CheckSegmentLink';
-import Promise from 'metal-promise';
 import React from 'react';
 import {cleanup, render} from '@testing-library/react';
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/WithOnboarding.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/WithOnboarding.jsx
@@ -2,7 +2,6 @@ import 'test/mock-modal';
 
 import * as API from 'shared/api';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import withOnboarding from '../WithOnboarding';
 import {cleanup, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/WithPolling.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/WithPolling.jsx
@@ -1,5 +1,4 @@
 import * as Redux from 'react-redux';
-import Promise from 'metal-promise';
 import React from 'react';
 import withPolling from '../WithPolling';
 import {renderWithStore} from 'test/mock-store';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/WithQuery.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/WithQuery.jsx
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import React from 'react';
 import withQuery from '../WithQuery';
 import {cleanup, render} from '@testing-library/react';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/WithRequest.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/WithRequest.jsx
@@ -1,6 +1,5 @@
 jest.mock('shared/hoc/WithQuery');
 
-import Promise from 'metal-promise';
 import React from 'react';
 import withQuery from 'shared/hoc/WithQuery';
 import withRequest from '../WithRequest';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/WithUnassignedSegments.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/WithUnassignedSegments.jsx
@@ -2,7 +2,6 @@ import 'test/mock-modal';
 
 import * as API from 'shared/api';
 import mockStore from 'test/mock-store';
-import Promise from 'metal-promise';
 import React from 'react';
 import withUnassignedSegments from '../WithUnassignedSegments';
 import {ChannelContext} from 'shared/context/channel';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/__tests__/useModalNotifications.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/__tests__/useModalNotifications.jsx
@@ -2,7 +2,6 @@ import * as API from 'shared/api';
 import * as data from 'test/data';
 import mockStore from 'test/mock-store';
 import ModalRenderer from 'shared/components/ModalRenderer';
-import Promise from 'metal-promise';
 import React from 'react';
 import useModalNotifications from '../useModalNotifications';
 import {close, open} from 'shared/actions/modals';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/__tests__/useRequest.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/__tests__/useRequest.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import useRequest from '../useRequest';
 import {renderHook} from '@testing-library/react-hooks';
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useRequest.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useRequest.ts
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import useDeepEqualEffect from './useDeepEqualEffect';
 import {debounce} from 'lodash/fp';
 import {useCallback, useRef, useState} from 'react';
@@ -28,13 +27,19 @@ const useRequest = ({
 	skipRequest?: boolean;
 	variables: {[key: string]: any};
 }) => {
-	const requestRef = useRef<typeof Promise>();
+	const requestAbortControllerRef = useRef<AbortController>();
 	const debounceRef = useRef<ReturnType<typeof debounce>>();
 
 	const debouncedDataSourceFn = useCallback<any>(
 		debounce(debounceDelay)(vars => {
-			requestRef.current = dataSourceFn(vars)
+			requestAbortControllerRef.current = new AbortController();
+
+			dataSourceFn(vars)
 				.then(result => {
+					if (requestAbortControllerRef.current?.signal.aborted) {
+						return;
+					}
+
 					setState({
 						...state,
 						data: normalize(result),
@@ -70,7 +75,7 @@ const useRequest = ({
 
 		return () => {
 			debounceRef.current?.cancel?.();
-			requestRef.current?.cancel?.();
+			requestAbortControllerRef.current?.abort();
 		};
 	}, [skipRequest, variables]);
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/middleware/__tests__/api.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/middleware/__tests__/api.js
@@ -1,7 +1,6 @@
 jest.mock('shared/util/request');
 
 import api, {CALL_API, toAction} from '../api';
-import Promise from 'metal-promise';
 import sendRequest from 'shared/util/request';
 
 describe('API Middleware', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/pages/__tests__/NoPropertiesAvailable.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/pages/__tests__/NoPropertiesAvailable.jsx
@@ -8,7 +8,6 @@ jest.mock('shared/actions/modals', () => ({
 import * as API from 'shared/api';
 import mockStore from 'test/mock-store';
 import NoPropertiesAvailable from '../NoPropertiesAvailable';
-import Promise from 'metal-promise';
 import React from 'react';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import {getImmutableMock, mockMemberUser, mockUser} from 'test/data';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__mocks__/request.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__mocks__/request.js
@@ -1,5 +1,3 @@
-import Promise from 'metal-promise';
-
 let responseData;
 
 function setResponseData(data) {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/data-sources.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/data-sources.js
@@ -1,6 +1,5 @@
 import * as API from 'shared/api';
 import * as data from 'test/data';
-import Promise from 'metal-promise';
 import {
 	CredentialTypes,
 	DataSourceStates,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/fetch.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/fetch.js
@@ -2,7 +2,6 @@ jest.mock('metal-ajax');
 
 import Ajax from 'metal-ajax';
 import fetch from '../fetch';
-import Promise from 'metal-promise';
 
 describe('fetch', () => {
 	it('should return a Promise', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/oauth.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/oauth.js
@@ -1,5 +1,4 @@
 import * as API from 'shared/api';
-import Promise from 'metal-promise';
 import {
 	emitAuthCode,
 	emitError,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/promise.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/promise.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {sequence} from '../promise';
 
 describe('sequence', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/request.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/request.js
@@ -2,7 +2,6 @@ jest.mock('../fetch');
 jest.mock('../router');
 
 import fetch from '../fetch';
-import Promise from 'metal-promise';
 import request, {
 	addParams,
 	getFormData,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/validators.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/validators.js
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {
 	toPromise,
 	validateGreaterThanZero,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/oauth.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/oauth.js
@@ -1,5 +1,4 @@
 import * as API from 'shared/api';
-import Promise from 'metal-promise';
 import {Routes} from 'shared/util/router';
 
 export const OAUTH_CALLBACK_URL = `${location.origin}${Routes.OAUTH_RECEIVE}`;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/promise.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/promise.ts
@@ -1,5 +1,3 @@
-import Promise from 'metal-promise';
-
 /**
  * Executes functions that return Promises in sequence. If a Promise is to reject, the execution will stop.
  * @param {Array} fns - an array of functions that return Promises.

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/validators.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/validators.ts
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import {formatStringToLowercase} from 'shared/util/util';
 import {formatTime, getMillisecondsFromTime} from 'shared/util/time';
 import {isArray, isNil, isObject, isString} from 'lodash';
@@ -10,11 +9,9 @@ import {sub} from 'shared/util/lang';
  * @return {Promise}
  */
 
-export function toPromise(
-	value: typeof Promise | Object | string
-): typeof Promise {
+export function toPromise<T>(value: Promise<T> | T): Promise<T> {
 	if (value instanceof Promise) {
-		return (value as typeof Promise).then(val => toPromise(val));
+		return value;
 	} else if (value) {
 		return Promise.reject(value);
 	}
@@ -156,7 +153,7 @@ export function validateMaxLength(maxLength: number) {
 export function validatePattern(
 	regex,
 	errorMessage: string
-): (value: any) => typeof Promise {
+): (value: any) => Promise<any> {
 	return value => {
 		let error = '';
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/AssociatedSegmentsListKit.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/AssociatedSegmentsListKit.jsx
@@ -1,6 +1,5 @@
 import * as data from 'test/data';
 import AssociatedSegmentsList from 'contacts/components/AssociatedSegmentsList';
-import Promise from 'metal-promise';
 import React from 'react';
 
 const dataSourceFn = () =>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/BaseSelectKit.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/BaseSelectKit.jsx
@@ -1,6 +1,5 @@
 import BaseSelect from 'shared/components/BaseSelect';
 import Item from '../components/Item';
-import Promise from 'metal-promise';
 import React from 'react';
 import Row from '../components/Row';
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/ConfirmationModalKit.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/ConfirmationModalKit.jsx
@@ -1,7 +1,6 @@
 import ConfirmationModal from 'shared/components/modals/ConfirmationModal';
 import mockStore from 'test/mock-store';
 import ModalRenderer from 'shared/components/ModalRenderer';
-import Promise from 'metal-promise';
 import React from 'react';
 import {Provider} from 'react-redux';
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/DataTransformationKit.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/DataTransformationKit.jsx
@@ -2,7 +2,6 @@ import * as API from 'shared/api';
 import * as data from 'test/data';
 import DataTransformation from 'settings/components/DataTransformation';
 import Item from '../components/Item';
-import Promise from 'metal-promise';
 import React from 'react';
 import Row from '../components/Row';
 import {noop} from 'lodash';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/FieldPreviewModalKit.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/FieldPreviewModalKit.jsx
@@ -1,5 +1,4 @@
 import FieldPreviewModal from 'shared/components/modals/FieldPreviewModal';
-import Promise from 'metal-promise';
 import React from 'react';
 
 class FieldPreviewModalKit extends React.Component {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/SearchableEntityTableKit.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/SearchableEntityTableKit.jsx
@@ -1,5 +1,4 @@
 import autobind from 'autobind-decorator';
-import Promise from 'metal-promise';
 import React from 'react';
 import SearchableEntityTable from 'shared/components/SearchableEntityTable';
 import {createOrderIOMap} from 'shared/util/pagination';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/SearchableVerticalTimelineKit.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/SearchableVerticalTimelineKit.jsx
@@ -1,5 +1,4 @@
 import * as data from 'test/data';
-import Promise from 'metal-promise';
 import React from 'react';
 import SearchableVerticalTimeline from 'shared/components/SearchableVerticalTimelineDeprecated';
 import {formatSessions} from 'shared/util/activitiesDeprecated';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/SelectInputKit.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/SelectInputKit.jsx
@@ -1,5 +1,4 @@
 import autobind from 'autobind-decorator';
-import Promise from 'metal-promise';
 import React from 'react';
 import SelectInput from 'shared/components/SelectInput';
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/SelectItemsModalKit.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/ui-kit/pages/SelectItemsModalKit.jsx
@@ -1,4 +1,3 @@
-import Promise from 'metal-promise';
 import React from 'react';
 import SelectItemsModal from 'shared/components/modals/SelectItemsModal';
 

--- a/modules/dxp/apps/osb/osb-faro/yarn.lock
+++ b/modules/dxp/apps/osb/osb-faro/yarn.lock
@@ -9750,7 +9750,7 @@ metal-position@^2.1.2:
     metal "^2.16.6"
     metal-dom "^2.16.6"
 
-metal-promise@^2.0.0, metal-promise@^2.0.1:
+metal-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/metal-promise/-/metal-promise-2.0.1.tgz#28ff43210e4c69e5fff51dbf201e4ae2fe6f83d5"
   integrity sha1-KP9DIQ5MaeX/9R2/IB5K4v5vg9U=


### PR DESCRIPTION
The goal of this PR is removing the deprecated metal-promise dependency with no behavior change.

For most cases the standard Promise class works exactly the same way, but I had to add a bit of implementation for a couple of cases that rely on Promise cancellation, which does not exist right now. I relied on AbortController to solve this situation: https://github.com/liferay-ac/liferay-portal/commit/7c25fc7a5827ca86fa0301eab80cb1cd078f568d

I also found some code that had (I think) wrong typing, as the API was not returning any promise: https://github.com/liferay-ac/liferay-portal/commit/868ca36f0865b04f89624e27fa579ff6cc0a7554

Apart from that, everything else is just removing the mentioned dependency.

However I broke lots of unit tests, and I am not sure how I can test the application, so I need a little guidance to see what is happening. I tried running the webpack server with `yarn run start`, but it looks like it just starts a proxy to liferay portal :thinking: 