### PR TITLE
AC Test Fix - LRAC-14774 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/UserManagement.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/UserManagement.testcase
@@ -856,6 +856,10 @@ definition {
 				password = "test");
 		}
 
+		task ("Open the URL again") {
+			Open.openNoError(locator1 = ${workspaceURL});
+		}
+
 		task ("Assert Page Title") {
 			ACUtils.assertPageTitle(pageTitle = "Sites");
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRAC-14774

**Issue:**
When trying to access a specific workspace page via the URL without logging in, the AC redirects the user to the login page and clears the URL leaving only the base URL

The test after login waits for the specific workspace he is trying to access via the URL to be loaded

**Solution:**
Access the AC using the specific workspace URL and check that the login page appears then we must log in and after that load the workspace URL again