### PR TITLE
AC Test Fix - LRAC-14799 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsAttributeSettings.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/CustomEventsAttributeSettings.testcase
@@ -318,12 +318,15 @@ definition {
 	@description = "Feature ID: LRAC-4265 | Automation ID: LRAC-10013 | Test Summary: Rename Attributes Display Name"
 	@priority = 4
 	test RenameAttributeDisplayName {
-		var attributeName = "category";
+		var attributeName = "team";
+		var attributeValue = "analytics cloud";
 
 		task ("Fill fields and create custom event") {
 			var customEventName = ACCustomEvents.generateCustomEventName();
 
 			ACCustomEvents.createCustomEvent(
+				attributesName = ${attributeName},
+				attributesValue = ${attributeValue},
 				customEventName = ${customEventName},
 				timeToSendCustomEvent = 1);
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRAC-14799

**Problem:**
`CustomEventsAttributeSettings#RenameAttributeDisplayName` modified the Display Name of the `category` attribute and when `CustomEventsSavingAnalysis#UserWithMemberPermissionCanViewAndCreateAnalysisReport` was executed, it did not add the `category` attribute to the filter because the Display Name expected by this test was `category` and the other test had changed it to `category Display Name`

**Solution:**
I modified `CustomEventsAttributeSettings#RenameAttributeDisplayName` to use the `team` attribute to change the Display Name since this attribute is not used in any other test, so it will not impact other cases