### PR TITLE
AC Test Fix - LRAC-14824 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
@@ -647,7 +647,7 @@ definition {
 			locator1 = "ACSegments#ACTIVITIES_CRITERION");
 
 		Click(
-			locator1 = "ACSegments#ACTIVITIES_CRITERION_DROPDOWN",
+			locator1 = "ACSegments#CRITERION_DROPDOWN_VALUE",
 			operator = ${operator});
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
@@ -365,10 +365,13 @@ definition {
 	@summary = "Default summary"
 	macro editWebBehaviorCriterion(month2 = null,occurenceNumber = null,year = null,indexField = null,year2 = null,atLeastMost = null,searchTerm = null,month = null,activitiesOption = null,day2 = null,timePeriod = null,day = null,timeOption = null) {
 		if (isSet(activitiesOption)) {
-			Select(
+			Click(
 				key_indexField = ${indexField},
-				locator1 = "ACSegments#ACTIVITIES_CRITERION",
-				value1 = ${activitiesOption});
+				locator1 = "ACSegments#ACTIVITIES_CRITERION");
+
+			Click(
+				locator1 = "ACSegments#CRITERION_DROPDOWN_VALUE",
+				operator = ${activitiesOption});
 		}
 
 		if (isSet(searchTerm)) {
@@ -378,10 +381,13 @@ definition {
 		}
 
 		if (isSet(atLeastMost)) {
-			Select(
+			Click(
 				key_indexField = ${indexField},
-				locator1 = "ACSegments#OCCURENCE_SELECT",
-				value1 = ${atLeastMost});
+				locator1 = "ACSegments#OCCURENCE_SELECT");
+
+			Click(
+				locator1 = "ACSegments#CRITERION_DROPDOWN_VALUE",
+				operator = ${atLeastMost});
 		}
 
 		if (isSet(occurenceNumber)) {
@@ -410,16 +416,19 @@ definition {
 				locator1 = "ACSegments#TIME_INPUT_CRITERION_CONJUNCTION");
 
 			Click(
-				locator1 = "ACSegments#ACTIVITIES_CRITERION_DROPDOWN",
+				locator1 = "ACSegments#CRITERION_DROPDOWN_VALUE",
 				operator = ${timeOption});
 		}
 
 		if (isSet(timePeriod)) {
 			if ((${timeOption} == "since") || !(isSet(timeOption))) {
-				Select(
+				Click(
 					key_indexField = ${indexField},
-					locator1 = "ACSegments#TIME_INPUT_CRITERION",
-					value1 = ${timePeriod});
+					locator1 = "ACSegments#TIME_INPUT_CRITERION");
+
+				Click(
+					locator1 = "ACSegments#CRITERION_DROPDOWN_VALUE",
+					operator = ${timePeriod});
 			}
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
@@ -165,7 +165,7 @@
 </tr>
 <tr>
 	<td>OCCURENCE_SELECT</td>
-	<td>xpath=(//div[(@class='criterion')])[${key_indexField}]//select[@class='form-control operator-input']</td>
+	<td>xpath=((//div[(@class='criterion')])[${key_indexField}]//button[contains(@class,'operator-input')])[2]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
@@ -392,8 +392,8 @@
 	<td></td>
 </tr>
 <tr>
-	<td>ACTIVITIES_CRITERION_DROPDOWN</td>
-	<td>xpath=(//button[contains(@class,'dropdown-item') and text()='${operator}'])</td>
+	<td>CRITERION_DROPDOWN_VALUE</td>
+	<td>//button[contains(@class,'dropdown-item') and text()='${operator}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SitesCohortAnalysis.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SitesCohortAnalysis.testcase
@@ -82,7 +82,7 @@ definition {
 			Click(locator1 = "ACSites#COHORT_ANALYSIS_SELECT_VISITOR_TYPE");
 
 			Click(
-				locator1 = "ACSegments#ACTIVITIES_CRITERION_DROPDOWN",
+				locator1 = "ACSegments#CRITERION_DROPDOWN_VALUE",
 				operator = "Anonymous Visitors");
 
 			AssertTextEquals(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRAC-14824

**Problem:**
After the Clay migration, the segment criteria customization buttons are no longer `Select` elements and are now `Button` elements. So we need to modify all the buttons so they don't use the `Select` function.

**Solution:**
To correct this, you need to click on the button and then click on the option that appears in the dropdown.