### PR TITLE
AC Test Fix - LRAC-14861 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACSegments.macro
@@ -453,7 +453,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro filterAndOrderForSegLists(filterName = null) {
+	macro filterAndOrderForSegLists(filterName) {
 		var key_filterName = ${filterName};
 
 		if (!(isSet(key_dropdownName))) {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/analyticscloud/ACSegments.path
@@ -494,12 +494,12 @@
 
 <tr>
 	<td>FILTER_AND_ORDER_BUTTON</td>
-	<td>//button[contains(@data-testid,'filter-and-order-button')]/span[@class='text-truncate' and text()='${key_dropdownName}']</td>
+	<td>//div[contains(@class,'filter-and-order-root')]//button[text()='${key_dropdownName}']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>FILTER_DROPDOWN_OPTION</td>
-	<td>//div[contains(@class,'dropdown-item')]//label/input//following-sibling::span/span[text()='${key_filterName}']</td>
+	<td>//span[contains(@class,'dropdown-item')]//label/input//following-sibling::span/span[text()='${key_filterName}']</td>
 	<td></td>
 </tr>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/DeleteSegments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/DeleteSegments.testcase
@@ -202,15 +202,23 @@ definition {
 			ACProperties.switchProperty(propertyName = ${propertyName});
 		}
 
-		task ("Go to Segments and add a new segment") {
+		task ("Add a new dynamic segment") {
 			ACNavigation.goToSegments();
 
-			ACSegments.createStaticSegment();
+			ACSegments.createDynamicSegment();
 
 			ACUtils.setItemName(itemName = "New Segment Test");
+		}
 
-			ACSegments.addStaticMember(tableMember = "ac ac");
+		task ("Add an email field") {
+			ACSegments.goToSidebarAttributes(criterion = "Individual Attributes");
 
+			ACSegments.addSegmentField(segmentField = "email");
+
+			ACSegments.editTextCriterion(textInput = "ac@liferay.com");
+		}
+
+		task ("Save the segment") {
 			ACSegments.saveSegment();
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EditSegments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/EditSegments.testcase
@@ -590,23 +590,31 @@ definition {
 				siteName = "Site Name");
 		}
 
-		task ("Close session, go to AC and segments") {
+		task ("Close session and Go to AC") {
 			ACUtils.closeAllSessionsAndWait();
 
 			ACUtils.launchAC();
 
 			ACProperties.switchProperty(propertyName = ${propertyName});
-
-			ACNavigation.goToSegments();
 		}
 
-		task ("Create segment test and save") {
-			ACSegments.createStaticSegment();
+		task ("Add a new dynamic segment") {
+			ACNavigation.goToSegments();
 
-			ACUtils.setItemName(itemName = "Static Segment Test");
+			ACSegments.createDynamicSegment();
 
-			ACSegments.addStaticMember(tableMember = "ac ac");
+			ACUtils.setItemName(itemName = "New Segment Test");
+		}
 
+		task ("Add an email field") {
+			ACSegments.goToSidebarAttributes(criterion = "Individual Attributes");
+
+			ACSegments.addSegmentField(segmentField = "email");
+
+			ACSegments.editTextCriterion(textInput = "ac@liferay.com");
+		}
+
+		task ("Save the segment") {
 			ACSegments.saveSegment();
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsList.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsList.testcase
@@ -173,58 +173,102 @@ definition {
 			ACProperties.switchProperty(propertyName = ${assignedPropertyName});
 		}
 
-		task ("Add 3 new Static Segments") {
-			for (var segmentName : list "Static Segment Test1,Static Segment Test2,Static Segment Test3") {
-				ACNavigation.goToSegments();
+		task ("Add 3 new Dynamic Segments") {
+			for (var segmentName : list "Dynamic Segment Test1,Dynamic Segment Test2,Dynamic Segment Test3") {
+				task ("Add a new dynamic segment") {
+					ACNavigation.goToSegments();
 
-				ACSegments.createStaticSegment();
+					ACSegments.createDynamicSegment();
 
-				ACUtils.setItemName(itemName = ${segmentName});
+					ACUtils.setItemName(itemName = "New Segment Test");
+				}
 
-				ACSegments.addStaticMember(tableMember = "userfn userln");
+				task ("Add an email field") {
+					ACSegments.goToSidebarAttributes(criterion = "Individual Attributes");
 
-				ACSegments.saveSegment();
+					ACSegments.addSegmentField(segmentField = "email");
+
+					ACSegments.editTextCriterion(textInput = "userea@liferay.com");
+				}
+
+				task ("Save the segment") {
+					ACSegments.saveSegment();
+				}
 			}
 		}
 
-		task ("Go to Segments and filter by 'Name'") {
+		task ("Go to Segments and Sort by 'Name'") {
 			ACNavigation.goToSegments();
 
 			ACSegments.filterAndOrderForSegLists(filterName = "Name");
 		}
 
-		task ("Assert 3 segments filter by name display") {
+		task ("Assert 3 segments sorted by name display") {
 			ACUtils.viewNameListInOrder(
 				index = 1,
-				name = "Static Segment Test1");
+				name = "Dynamic Segment Test1");
 
 			ACUtils.viewNameListInOrder(
 				index = 2,
-				name = "Static Segment Test2");
+				name = "Dynamic Segment Test2");
 
 			ACUtils.viewNameListInOrder(
 				index = 3,
-				name = "Static Segment Test3");
+				name = "Dynamic Segment Test3");
 		}
 
-		task ("Go to Segments and filter by descending order of 'Name'") {
-			ACNavigation.goToSegments();
-
+		task ("Go to Segments and Sort by descending order of 'Name'") {
 			ACUtils.orderArrow(type = "descending");
 		}
 
-		task ("Assert 3 segments in order filter by membership display") {
+		task ("Assert 3 segments sorted by name display") {
 			ACUtils.viewNameListInOrder(
 				index = 1,
-				name = "Static Segment Test3");
+				name = "Dynamic Segment Test3");
 
 			ACUtils.viewNameListInOrder(
 				index = 2,
-				name = "Static Segment Test2");
+				name = "Dynamic Segment Test2");
 
 			ACUtils.viewNameListInOrder(
 				index = 3,
-				name = "Static Segment Test1");
+				name = "Dynamic Segment Test1");
+		}
+
+		task ("Sort by 'Last Modified'") {
+			ACSegments.filterAndOrderForSegLists(filterName = "Last Modified");
+		}
+
+		task ("Assert 3 segments sorted by Last Modified") {
+			ACUtils.viewNameListInOrder(
+				index = 1,
+				name = "Dynamic Segment Test1");
+
+			ACUtils.viewNameListInOrder(
+				index = 2,
+				name = "Dynamic Segment Test2");
+
+			ACUtils.viewNameListInOrder(
+				index = 3,
+				name = "Dynamic Segment Test3");
+		}
+
+		task ("Sort by descending order of 'Last Modified'") {
+			ACUtils.orderArrow(type = "descending");
+		}
+
+		task ("Assert 3 segments sorted by Last Modified") {
+			ACUtils.viewNameListInOrder(
+				index = 1,
+				name = "Dynamic Segment Test3");
+
+			ACUtils.viewNameListInOrder(
+				index = 2,
+				name = "Dynamic Segment Test2");
+
+			ACUtils.viewNameListInOrder(
+				index = 3,
+				name = "Dynamic Segment Test1");
 		}
 	}
 
@@ -270,24 +314,34 @@ definition {
 			ACProperties.switchProperty(propertyName = ${assignedPropertyName});
 		}
 
-		task ("Add 6 new Static Segments") {
-			for (var segmentName : list "Static Segment Test1,Static Segment Test2,Static Segment Test3,Static Segment Test4,Static Segment Test5,Static Segment Test6") {
-				ACNavigation.goToSegments();
+		task ("Add 5 new Static Segments") {
+			for (var segmentName : list "Dynamic Segment Test1,Dynamic Segment Test2,Dynamic Segment Test3,Dynamic Segment Test4,Dynamic Segment Test5") {
+				task ("Add a new dynamic segment") {
+					ACNavigation.goToSegments();
 
-				ACSegments.createStaticSegment();
+					ACSegments.createDynamicSegment();
 
-				ACUtils.setItemName(itemName = ${segmentName});
+					ACUtils.setItemName(itemName = ${segmentName});
+				}
 
-				ACSegments.addStaticMember(tableMember = "userfn userln");
+				task ("Add an email field") {
+					ACSegments.goToSidebarAttributes(criterion = "Individual Attributes");
 
-				ACSegments.saveSegment();
+					ACSegments.addSegmentField(segmentField = "email");
+
+					ACSegments.editTextCriterion(textInput = "userea@liferay.com");
+				}
+
+				task ("Save the segment") {
+					ACSegments.saveSegment();
+				}
 			}
 		}
 
-		task ("Assert 6 segments display") {
+		task ("Assert 5 segments display") {
 			ACNavigation.goToSegments();
 
-			for (var segmentName : list "Static Segment Test1,Static Segment Test2,Static Segment Test3,Static Segment Test4,Static Segment Test5,Static Segment Test6") {
+			for (var segmentName : list "Dynamic Segment Test1,Dynamic Segment Test2,Dynamic Segment Test3,Dynamic Segment Test4,Dynamic Segment Test5") {
 				ACSegments.assertSegmentPresent(segmentName = ${segmentName});
 			}
 		}
@@ -297,7 +351,7 @@ definition {
 				locator1 = "ACUtils#PAGINATION_ITEMS_PER_PAGE_SELECT",
 				value1 = "20 Items");
 
-			ACUtils.viewResultsMessage(results = "Showing 1 to 6 of 6 entries.");
+			ACUtils.viewResultsMessage(results = "Showing 1 to 5 of 5 entries.");
 
 			ACUtils.viewResultsPages(pageNumber = 1);
 		}
@@ -305,27 +359,29 @@ definition {
 		task ("Change the pagination to "4"") {
 			ACUtils.changePagination(itemsPerPage = 4);
 
-			for (var segmentName : list "Static Segment Test1,Static Segment Test2,Static Segment Test3,Static Segment Test4") {
+			for (var segmentName : list "Dynamic Segment Test1,Dynamic Segment Test2,Dynamic Segment Test3,Dynamic Segment Test4") {
 				ACSegments.assertSegmentPresent(segmentName = ${segmentName});
 			}
 
-			ACUtils.viewResultsMessage(results = "Showing 1 to 4 of 6 entries.");
+			ACUtils.viewResultsMessage(results = "Showing 1 to 4 of 5 entries.");
 
 			ACUtils.viewResultsPages(pageNumber = 1);
 
 			ACUtils.viewResultsPages(pageNumber = 2);
 		}
 
-		task ("Page number display 1 2 and check previous next button") {
+		task ("Go to the second page and check if only one segment appears") {
 			ACUtils.checkPreviousNextButton(nextButton = "true");
 
-			ACUtils.viewResultsMessage(results = "Showing 5 to 6 of 6 entries.");
+			ACUtils.viewResultsMessage(results = "Showing 5 to 5 of 5 entries.");
 
-			ACSegments.assertSegmentPresent(segmentName = "Static Segment Test6");
+			ACSegments.assertSegmentPresent(segmentName = "Dynamic Segment Test5");
+		}
 
+		task ("Previous to the first page and check that only 4 segments appear") {
 			ACUtils.checkPreviousNextButton(previousButton = "true");
 
-			ACUtils.viewResultsMessage(results = "Showing 1 to 4 of 6 entries.");
+			ACUtils.viewResultsMessage(results = "Showing 1 to 4 of 5 entries.");
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRAC-14861

**Context:**
Some segment tests are failing because individuals take a long time to appear to be added to the static segment.

**Solution:**
I analyzed some of these cases and observed that some tests have objectives like validating the deletion, pagination, and ordering of the list of segments, so it is not important for the test objective if the segment is dynamic or static and also if it has added members or not.

I will modify these tests so that they do not check if the segment has already processed the data or use a dynamic segment instead of the static segment to avoid the individual problem.