### PR TITLE
LPS-191826 Quarantining AnalyticsSettingsManagerTest due to implementation silent failure

### DIFF
--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/internal/manager/test/AnalyticsSettingsManagerTest.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/internal/manager/test/AnalyticsSettingsManagerTest.java
@@ -34,6 +34,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -70,6 +71,7 @@ public class AnalyticsSettingsManagerTest {
 		_groupLocalService.deleteGroup(_siteGroup2);
 	}
 
+	@Ignore
 	@Test
 	public void testGetCommerceChannelIds() throws Exception {
 		Long[] emptyCommerceChannelIds =


### PR DESCRIPTION
This test is Quarantined due to this reasons mentioned in this [ticket](https://liferay.atlassian.net/browse/LPS-191826)