### PR TITLE
faro v4.5.x 3

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/experiments/components/SessionsCard.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/experiments/components/SessionsCard.tsx
@@ -62,13 +62,14 @@ const TotalSessionsTooltip = ({dataPoint}) => {
 };
 
 const PerVariantTooltip = ({dataPoint}) => {
+	const control = dataPoint[0];
+	const variant = dataPoint[1];
+
 	const header = [
 		{
 			columns: [
 				{
-					label: d3.utcFormat('%b %-d')(
-						getDate(dataPoint[0].payload.key)
-					),
+					label: d3.utcFormat('%b %-d')(getDate(control.payload.key)),
 					weight: Weights.Semibold,
 					width: 80
 				},
@@ -84,26 +85,28 @@ const PerVariantTooltip = ({dataPoint}) => {
 		{
 			columns: [
 				{
-					color: dataPoint[0].color,
-					label: dataPoint[0].name
+					color: control.color,
+					label: control.name
 				},
 				{
 					align: Alignments.Right,
-					label: toThousandsABTesting(dataPoint[0].value)
+					label: toThousandsABTesting(control.value)
 				}
 			]
 		},
 		{
-			columns: [
-				{
-					color: dataPoint[1].color,
-					label: dataPoint[1].name
-				},
-				{
-					align: Alignments.Right,
-					label: toThousandsABTesting(dataPoint[1].value)
-				}
-			]
+			columns: variant
+				? [
+						{
+							color: dataPoint[1].color,
+							label: dataPoint[1].name
+						},
+						{
+							align: Alignments.Right,
+							label: toThousandsABTesting(dataPoint[1].value)
+						}
+				  ]
+				: []
 		}
 	];
 
@@ -122,7 +125,7 @@ const formatTotalSessionsData = experiment => {
 	control.sessionsHistogram.forEach((session, index) => {
 		chartData.push({
 			data_control:
-				session.value + variant.sessionsHistogram[index].value,
+				session.value + variant.sessionsHistogram?.[index]?.value || 0,
 			key: session.key
 		});
 	});
@@ -146,7 +149,7 @@ const formatPerVariantsData = experiment => {
 	control.sessionsHistogram.forEach((session, index) => {
 		chartData.push({
 			data_control: session.value,
-			data_variant: variant.sessionsHistogram[index].value,
+			data_variant: variant.sessionsHistogram?.[index]?.value || 0,
 			key: session.key
 		});
 	});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/experiments/components/variant-card/variant-columns.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/experiments/components/variant-card/variant-columns.js
@@ -105,7 +105,10 @@ export default ({
 			/>
 		),
 		className: 'text-right',
-		label: Liferay.Language.get('unique-visitors'),
+		label:
+			type === 'AB'
+				? Liferay.Language.get('unique-visitors')
+				: Liferay.Language.get('traffic-split'),
 		sortable: true
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/resolvers/ExperimentResolver.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/resolvers/ExperimentResolver.js
@@ -823,7 +823,7 @@ const DXP_VARIANTS = [
 			}
 		],
 		trafficSplit: 50,
-		uniqueVisitors: null
+		uniqueVisitors: 1000
 	},
 	{
 		__typename: 'ExperimentVariant',
@@ -833,7 +833,7 @@ const DXP_VARIANTS = [
 		dxpVariantName: 'var',
 		sessionsHistogram: SESSIONS_HISTOGRAM,
 		trafficSplit: 50,
-		uniqueVisitors: null
+		uniqueVisitors: 500
 	}
 ];
 


### PR DESCRIPTION
- LRAC-15212 Rename column to traffic split when test is MAB
- LRAC-15225 Ensure that data will be rendered even without sessionHistogram
