### PR TITLE
LRAC-14749 Change script ID when portal updates language to remove cache and load it again and then send events

### DIFF
--- a/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
+++ b/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
@@ -19,7 +19,7 @@
 	var analyticsClientGroupIds = <%= (String)request.getAttribute(AnalyticsWebKeys.ANALYTICS_CLIENT_GROUP_IDS) %>;
 </script>
 
-<script data-senna-track="permanent" id="liferayAnalyticsScript" type="text/javascript">
+<script data-senna-track="permanent" id='<%= "liferayAnalyticsScript_" + themeDisplay.getLanguageId() %>' type="text/javascript">
 	(function (u, c, a, m, o, l) {
 		o = 'script';
 		l = document;


### PR DESCRIPTION
JIRA Issue: https://liferay.atlassian.net/browse/LRAC-14749

## Motivation

Senna (DXP's SPA) makes a kind of cache for scripts with `data-senna-track="permanent"` and that prevents in some way (still unknown) that the script is not loaded after repeating the steps below:

### Steps

1. Create two users on DXP;
2. The second user should have a different language from the first one;
3. Log in with the first user, navigate SPA, and console should render (OK);
4. Now, log in with the second user and console isn't rendering (BUG);

### Code to reproduce

Add the code below on DXP
```javascript
<script data-senna-track="permanent" id="requiredId" type="text/javascript">
    Liferay.on('endNavigate', () => {
        console.log('it is working!');
    });
</script>
```