### PR TITLE
AC Test Fix - LRAC-15262 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACDXPSettings.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/analyticscloud/ACDXPSettings.macro
@@ -80,6 +80,22 @@ definition {
 		WaitForElementNotPresent(locator1 = "ACDXPSettings#CONNECT_BUTTON_DISABLED");
 
 		Click(locator1 = "ACDXPSettings#CONNECT_BUTTON");
+
+		WaitForVisible(
+			key_text = "Next",
+			locator1 = "Button#ANY");
+
+		WaitForElementNotPresent(locator1 = "ACSettings#LOADING_ANIMATION");
+
+		while (IsElementPresent(key_text = "Try Again", locator1 = "Button#ANY")) {
+			Click(
+				key_text = "Next",
+				locator1 = "Button#ANY");
+
+			Click(
+				key_text = "Previous",
+				locator1 = "Button#ANY");
+		}
 	}
 
 	@summary = "Default summary"
@@ -270,16 +286,6 @@ definition {
 
 	@summary = "Default summary"
 	macro getAssignedPropertyName() {
-		while (IsElementPresent(key_text = "Try Again", locator1 = "Button#ANY")) {
-			Click(
-				key_text = "Next",
-				locator1 = "Button#ANY");
-
-			Click(
-				key_text = "Previous",
-				locator1 = "Button#ANY");
-		}
-
 		WaitForVisible(
 			key_text = "Assign",
 			locator1 = "Button#ANY");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRAC-15262

**Description:**

The Try Again button issue was with the workaround being used in the getAssignedPropertyName macro. Tests that did not use this macro could continue to suffer from the problem.

**Solution:**

Move the alternative to avoid the Try Again button to the connectAnalyticsCloud macro, this macro is used by all tests that make the connection between AC and DXP and this problem should not affect other tests. I researched and all uses of the getAssignedPropertyName macro always have the use of the connectAnalyticsCloud macro before.