### PR TITLE
AC Disable Test - LRAC-15280 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/analyticscloud/SegmentsCreation.testcase
@@ -1607,9 +1607,13 @@ definition {
 			value1 = "DYNAMIC SEGMENT");
 	}
 
-	@description = "Bug: LRAC-10972 | Automation ID: LRAC-11506 | Test Summary: Check Autocomplete Suggestions For All Criteria Types"
+	@description = "Bug: LRAC-10972 | Automation ID: LRAC-11506 | Test Summary: Check autocomplete suggestions for Session Attributes"
+	@ignore = "true"
 	@priority = 3
-	test CheckAutocompleteSuggestionsForAllCriteriaTypes {
+	test CheckAutocompleteSuggestionsForSessionAttributes {
+
+		// AC Ignored: Data doesn't appear on time (Need to wait for the session to close)
+
 		task ("Sign in as new user") {
 			User.logoutAndLoginPG(
 				userLoginEmailAddress = "userea@liferay.com",
@@ -1654,34 +1658,6 @@ definition {
 			ACSegments.viewAutocompleteSuggestions(
 				autocompleteText = ${myURL},
 				notPresent = "home");
-		}
-
-		task ("Cancel the creation") {
-			ACSegments.cancelSegment();
-
-			Button.click(button = "Leave Page");
-		}
-
-		task ("Add a new dynamic segment") {
-			ACNavigation.goToSegments();
-
-			ACSegments.createDynamicSegment();
-
-			ACUtils.setItemName(itemName = "Dynamic Segment Test");
-		}
-
-		task ("Check URL autocomplete from Session Attributes") {
-			ACSegments.goToSidebarAttributes(criterion = "Individual Attributes");
-
-			ACSegments.addSegmentField(segmentField = "givenName");
-
-			ACSegments.editTextCriterion(
-				skip = "true",
-				textInput = "user");
-
-			ACSegments.viewAutocompleteSuggestions(
-				autocompleteText = "userfn",
-				notPresent = "Abram");
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRAC-15280

**Update:**
1. I changed the name of the test. This test case covered autocomplete for a Session Attribute and Individual Attribute criterion, so I noticed that we have another automated case that only checks autocomplete for the Individual Attribute (`CheckIfAutocompleteSuggestionEmailPresentInKnownIndividualsList`). So I modified the ignored test just to cover the Session Attribute case, which is the only one that doesn't work in automation;
2. The test case was ignored because it needed to wait for the session to close for the URL to appear in the criteria. Closing the session takes a while locally;