### PR TITLE
AC Test Fix - LRAC-15294 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/ABTest.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ABTest.macro
@@ -113,6 +113,8 @@ definition {
 		Click(
 			key_name = "Save",
 			locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
+
+		WaitForElementNotPresent(locator1 = "Modal#MODAL_CONTENT");
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ABTest.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ABTest.macro
@@ -117,13 +117,18 @@ definition {
 
 	@summary = "Default summary"
 	macro deleteABTest() {
-		Click(locator1 = "ABTest#KEBAB_AB_TEST");
+		if (IsElementNotPresent(locator1 = "Modal#MODAL_CONTENT")) {
+			if (IsElementPresent(locator1 = "ABTest#KEBAB_AB_TEST")) {
+				Click(locator1 = "ABTest#KEBAB_AB_TEST");
 
-		MenuItem.click(menuItem = "Delete");
+				MenuItem.clickNoError(menuItem = "Delete");
+			}
+			else {
+				Click(locator1 = "Button#TRASH_ENABLED");
+			}
+		}
 
-		Click(
-			key_text = "Delete",
-			locator1 = "Modal#MODAL_FOOTER_BUTTON");
+		Click(locator1 = "ACSettings#CONFIRMATION_BUTTON");
 
 		Alert.viewSuccessMessageText(successMessage = "Success:Your request completed successfully.");
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRAC-15294 (Test Fix)
https://liferay.atlassian.net/browse/LPS-203756 (Ticket that caused the problem)

**Solution:**
- Revert the LPS-203756 modifications so that the `deleteABTest` macro works to delete the AB test regardless of its status;
- Place a `WaitForElementNotPresent` to ensure that variant creation has completed so that the variant name modal does not disturb the validation of the first condition of the `deleteABTest` macro;
  - It will avoid the problem that affected the echo test ([ABTesting#DeleteABTest](https://testray.liferay.com/home/-/testray/case_results/2474369176?tab=history))