### PR TITLE
LPD-20916 | 4.8.x

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/__tests__/useQueryParams.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/__tests__/useQueryParams.ts
@@ -1,0 +1,30 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {useLocation} from 'react-router-dom';
+import {useQueryParams} from '../useQueryParams';
+
+jest.mock('react-router-dom', () => ({
+	useLocation: jest.fn()
+}));
+
+describe('useQueryParams', () => {
+	it('returns an empty object if no query parameters are present', () => {
+		useLocation.mockReturnValue({search: ''});
+		const {result} = renderHook(() => useQueryParams());
+
+		expect(result.current).toEqual({});
+	});
+
+	it('parses query parameters correctly', () => {
+		useLocation.mockReturnValue({search: '?name=Marcio&age=30'});
+		const {result} = renderHook(() => useQueryParams());
+
+		expect(result.current).toEqual({age: '30', name: 'Marcio'});
+	});
+
+	it('decodes query parameters correctly', () => {
+		useLocation.mockReturnValue({search: '?name=Marcio+Fonseca&age=30'});
+		const {result} = renderHook(() => useQueryParams());
+
+		expect(result.current).toEqual({age: '30', name: 'Marcio Fonseca'});
+	});
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useQueryParams.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useQueryParams.ts
@@ -1,5 +1,9 @@
 import {useLocation} from 'react-router-dom';
 
+function decodeQueryParam(param) {
+	return decodeURIComponent(param.replace(/\+/g, ' '));
+}
+
 function queryStringToObject(initialQueryString: string): any {
 	if (!initialQueryString) return {};
 
@@ -10,7 +14,7 @@ function queryStringToObject(initialQueryString: string): any {
 
 	params.forEach(param => {
 		const [key, value] = param.split('=');
-		query[key] = value;
+		query[key] = decodeQueryParam(value);
 	});
 
 	return query;


### PR DESCRIPTION
- LPD-20916 decodeURIComponent cannot be used directly to parse query parameters from a URL
- LPD-20916 Create unit test for useQueryParams
