### PR TITLE
LPD-22239 | 4.8.x

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/__tests__/odata.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/__tests__/odata.js
@@ -521,7 +521,7 @@ describe('odata', () => {
 			testConversionToAndFrom(testQuery);
 		});
 
-		fit('should be able to translate a query string with "accounts.filter" to map and back to string', () => {
+		it('should be able to translate a query string with "accounts.filter" to map and back to string', () => {
 			const testQuery =
 				"(accounts.filter(filter='(id eq ''48853654381438580'')'))";
 
@@ -602,34 +602,46 @@ describe('odata', () => {
 			testConversionToAndFrom(testQuery);
 		});
 
-		xit('should be able to translate a collection type query string with "contains" to map and back to string', () => {
+		it('should be able to translate a query string with brackets characters', () => {
+			const testQuery = "(value eq '[A, B]')";
+
+			testConversionToAndFrom(testQuery);
+		});
+
+		it('should be able to translate a query string with greater than / less than characters', () => {
+			const testQuery = "(value eq '<A>, <B>')";
+
+			testConversionToAndFrom(testQuery);
+		});
+
+		it.skip('should be able to translate a collection type query string with "contains" to map and back to string', () => {
 			const testQuery =
 				"(cookies/any(c:contains(c, 'keyTest=valueTest')))";
 
 			testConversionToAndFrom(testQuery);
 		});
 
-		xit('should be able to translate a collection type query string with "not contains" to map and back to string', () => {
+		it.skip('should be able to translate a collection type query string with "not contains" to map and back to string', () => {
 			const testQuery =
 				"((not (cookies/any(c:contains(c, 'keyTest=valueTest')))))";
 
 			testConversionToAndFrom(testQuery);
 		});
 
-		xit('should be able to translate a collection type query string with "eq" to map and back to string', () => {
+		it.skip('should be able to translate a collection type query string with "eq" to map and back to string', () => {
 			const testQuery = "(cookies/any(c:c eq 'keyTest=valueTest'))";
 
 			testConversionToAndFrom(testQuery);
 		});
 
-		xit('should be able to translate a collection type query string with "not" to map and back to string', () => {
+		it.skip('should be able to translate a collection type query string with "not" to map and back to string', () => {
 			const testQuery =
 				"((not (cookies/any(c:c eq 'keyTest=valueTest'))))";
 
 			testConversionToAndFrom(testQuery);
 		});
 
-		xit('should be able to translate a nested and complex collection type query string to map and back to string', () => {
+		it.skip('should be able to translate a nested and complex collection type query string to map and back to string', () => {
 			const testQuery =
 				"((not (cookies/any(c:c eq 'keyTest1=valueTest1'))) and ((not (cookies/any(c:c eq 'keyTest2=valueTest2'))) or (cookies/any(c:c eq 'keyTest3=valueTest3') and cookies/any(c:c eq 'keyTest4=valueTest4'))) and name eq 'test')";
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/odata.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/odata.ts
@@ -90,6 +90,14 @@ const FARO_SPECIAL_CHARS = {
 		encoded: '_FARO_AT_',
 		raw: '@'
 	},
+	bracketLeft: {
+		encoded: '_FARO_LEFT_BRACKET_',
+		raw: '['
+	},
+	bracketRight: {
+		encoded: '_FARO_RIGHT_BRACKET_',
+		raw: ']'
+	},
 	dash: {
 		encoded: '_FARO_DASH_',
 		raw: '-'
@@ -98,9 +106,17 @@ const FARO_SPECIAL_CHARS = {
 		encoded: '_FARO_DOLLAR_',
 		raw: '$'
 	},
+	greaterThan: {
+		encoded: '_FARO_GREATER_THAN_',
+		raw: '>'
+	},
 	hash: {
 		encoded: '_FARO_HASH_',
 		raw: '#'
+	},
+	lessThan: {
+		encoded: '_FARO_LESS_THAN_',
+		raw: '<'
 	},
 	percent: {
 		encoded: '_FARO_PERCENT_',
@@ -265,50 +281,24 @@ const buildQueryString = (
  * Converts custom encodings back to original characters.
  */
 const decodeSpecialCharacters = (queryString: string): string => {
-	const {
-		ampersand,
-		at,
-		dash,
-		dollar,
-		hash,
-		percent,
-		plus,
-		question,
-		slash,
-		underscore
-	} = FARO_SPECIAL_CHARS;
+	const specialCharactersArr = Object.values(FARO_SPECIAL_CHARS);
 
-	const specialCharsEncoded = Object.values(FARO_SPECIAL_CHARS)
+	const specialCharsEncoded = specialCharactersArr
 		.map(({encoded}) => encoded)
 		.join('|');
 
 	const pattern = new RegExp(specialCharsEncoded, 'g');
 
 	return queryString.replace(pattern, match => {
-		switch (match) {
-			case ampersand.encoded:
-				return ampersand.raw;
-			case at.encoded:
-				return at.raw;
-			case dollar.encoded:
-				return dollar.raw;
-			case dash.encoded:
-				return dash.raw;
-			case hash.encoded:
-				return hash.raw;
-			case percent.encoded:
-				return percent.raw;
-			case plus.encoded:
-				return plus.raw;
-			case question.encoded:
-				return question.raw;
-			case slash.encoded:
-				return slash.raw;
-			case underscore.encoded:
-				return underscore.raw;
-			default:
-				return match;
+		const specialCharacter = specialCharactersArr.find(
+			({encoded}) => encoded === match
+		);
+
+		if (specialCharacter) {
+			return specialCharacter.raw;
 		}
+
+		return match;
 	});
 };
 
@@ -318,52 +308,25 @@ const encodeQuotes = (text: string): string => text.replace(/'/g, '%27');
  * Encode certain special characters with our own encoding.
  */
 const encodeSpecialCharacters = (queryString: string): string => {
-	const {
-		ampersand,
-		at,
-		dash,
-		dollar,
-		hash,
-		percent,
-		plus,
-		question,
-		slash,
-		underscore
-	} = FARO_SPECIAL_CHARS;
+	const charsNeedEscaped = ['+', '?', '$', '[', ']'];
+	const specialCharactersArr = Object.values(FARO_SPECIAL_CHARS);
 
-	const charsNeedEscaped = ['+', '?', '$'];
-
-	const specialCharsPattern = Object.values(FARO_SPECIAL_CHARS)
+	const specialCharsPattern = specialCharactersArr
 		.map(({raw}) => (charsNeedEscaped.includes(raw) ? `\\${raw}` : raw))
 		.join('|');
 
 	const pattern = new RegExp(specialCharsPattern, 'g');
 
 	return queryString.replace(pattern, match => {
-		switch (match) {
-			case ampersand.raw:
-				return ampersand.encoded;
-			case at.raw:
-				return at.encoded;
-			case dash.raw:
-				return dash.encoded;
-			case dollar.raw:
-				return dollar.encoded;
-			case hash.raw:
-				return hash.encoded;
-			case percent.raw:
-				return percent.encoded;
-			case plus.raw:
-				return plus.encoded;
-			case question.raw:
-				return question.encoded;
-			case slash.raw:
-				return slash.encoded;
-			case underscore.raw:
-				return underscore.encoded;
-			default:
-				return match;
+		const specialCharacter = specialCharactersArr.find(
+			({raw}) => raw === match
+		);
+
+		if (specialCharacter) {
+			return specialCharacter.encoded;
 		}
+
+		return match;
 	});
 };
 
@@ -560,24 +523,16 @@ const skipGroup = ({oDataASTNode, prevConjunction}: Context): Context => ({
  * oDataV4Parser can't handle between.
  */
 export const convertBetweenToSubstring = (queryString: string): string =>
-	queryString.replace(
-		/between(?=\([\w-:]+,('[\w-:]+',?){2}\))/g,
-		'substring'
-	);
+	queryString
+		.replace(/between(?=\([\w-:]+,('[\w-:]+',?){2}\))/g, 'substring')
+		.replaceAll('"', '');
 
 /**
  * Converts an OData filter query string to an object that can be used by the
  * criteria builder
  */
-const translateQueryToCriteria = (initialQueryString: string): Criteria => {
+const translateQueryToCriteria = (queryString: string): Criteria => {
 	let criteria;
-
-	const regex = new RegExp(/\[*\]|\[*\[/);
-	const queryStringWithBrackets = regex.test(initialQueryString);
-
-	const queryString = queryStringWithBrackets
-		? initialQueryString.replaceAll('[', '').replaceAll(']', '')
-		: initialQueryString;
 
 	try {
 		if (queryString === '()') {
@@ -597,7 +552,6 @@ const translateQueryToCriteria = (initialQueryString: string): Criteria => {
 				)
 			)
 		);
-
 		const criteriaArray = toCriteria({oDataASTNode});
 
 		criteria = isCriterionGroup(criteriaArray[0])
@@ -605,17 +559,6 @@ const translateQueryToCriteria = (initialQueryString: string): Criteria => {
 			: wrapInCriteriaGroup(criteriaArray);
 	} catch (e) {
 		criteria = null;
-	}
-
-	if (queryStringWithBrackets) {
-		const initialValueList = initialQueryString.match(/'([^']*)'/g);
-
-		const items = criteria.items.map((item, index) => ({
-			...item,
-			value: initialValueList[index].slice(1, -1)
-		}));
-
-		return {...criteria, items};
 	}
 
 	return criteria;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/table-columns.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/table-columns.tsx
@@ -810,7 +810,7 @@ export const sitePagesListColumns = {
 					toRoute(route, {
 						channelId,
 						groupId,
-						touchpoint: assetId,
+						touchpoint: encodeURIComponent(assetId),
 						...(assetTitle && {
 							title: assetTitle
 						})

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/util.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/util.ts
@@ -5,7 +5,6 @@ import {
 	RangeKeyTimeRanges
 } from 'shared/util/constants';
 import {flow, get, isFinite, isNil, isString, toLower, trim} from 'lodash';
-import {isJapaneseLang} from './lang';
 import {
 	RangeSelectors,
 	RawRangeSelectors,
@@ -85,19 +84,8 @@ export const getSafeDisplayValue = (
 	defaultValue: string | number = '-'
 ): string | number => (isBlank(value) ? defaultValue : value);
 
-export const getSafeTouchpoint = (touchpoint: string) => {
-	const decodedTouchpoint = decodeURIComponent(touchpoint);
-
-	if (isJapaneseLang(decodedTouchpoint)) {
-		const values = decodedTouchpoint.split('/');
-		const path = values.slice(3).join('/');
-		const pathEncoded = encodeURIComponent(path);
-
-		return `${values.slice(0, 3).join('/')}/${pathEncoded}`;
-	}
-
-	return touchpoint !== 'Any' ? decodedTouchpoint : null;
-};
+export const getSafeTouchpoint = (touchpoint: string) =>
+	touchpoint !== 'Any' ? decodeURIComponent(touchpoint) : null;
 
 /**
  * Create a Blob object from data string and temporarily attach

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/sites/touchpoints/pages/TouchpointRoutes.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/sites/touchpoints/pages/TouchpointRoutes.jsx
@@ -92,7 +92,9 @@ function TouchpointRoutes({className, router}) {
 					subtitle={
 						<TextTruncate title={decodedTouchpoint}>
 							<ClayLink href={decodedTouchpoint} target='_blank'>
-								{decodedTouchpoint}
+								{/* It should have double decode for cases when there are special characters */}
+
+								{decodeURIComponent(decodedTouchpoint)}
 							</ClayLink>
 						</TextTruncate>
 					}


### PR DESCRIPTION
- LPD-20256 It must encode the assetId so that when you navigate to the page and make a request to the backend, the URL must remain the same
- LPD-22239 Use the correct way to encode/decode a query string with special characters
- LPD-22239 Fix unit tests and create new ones
