### PR TITLE
LPD-28831 | Master

### DIFF
--- a/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
+++ b/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
@@ -23,6 +23,22 @@
 	var analyticsFeatureFlagEnabled =
 		<%= FeatureFlagManagerUtil.isEnabled("LPD-10588") %>;
 
+	function <portlet:namespace />getAnalyticsSDKVersion() {
+		switch (
+			'<%= GetterUtil.getString(PropsUtil.get(PropsKeys.ANALYTICS_CLOUD_CLIENT_JS_VERSION)) %>'
+		) {
+			case 'DEV': {
+				return 'https://analytics-js-dev-cdn.liferay.com';
+			}
+			case 'INTERNAL': {
+				return 'https://analytics-js-internal-cdn.liferay.com';
+			}
+			default: {
+				return 'https://analytics-js-cdn.liferay.com';
+			}
+		}
+	}
+
 	var cookieManagers = {
 		'cookie.onetrust': {
 			checkConsent: () => {
@@ -121,7 +137,7 @@
 				a.src = u;
 				a.onload = c;
 				m.parentNode.insertBefore(a, m);
-			})('https://analytics-js-cdn.liferay.com', () => {
+			})(<portlet:namespace />getAnalyticsSDKVersion(), () => {
 				var config =
 					<%= (String)request.getAttribute(AnalyticsWebKeys.ANALYTICS_CLIENT_CONFIG) %>;
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -10270,6 +10270,18 @@
         tunneling.servlet.shared.secret
 
 ##
+## Analytics Cloud
+##
+
+    #
+    # Add a client js version by using these 3 options PROD, INTERNAL or DEV.
+    # LPD-27620 for more information.
+    #
+    # Env: LIFERAY_ANALYTICS_PERIOD_CLOUD_PERIOD_CLIENT_PERIOD_JS_PERIOD_VERSION
+    #
+    analytics.cloud.client.js.version=PROD
+
+##
 ## Announcements Portlet
 ##
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -121,6 +121,9 @@ public interface PropsKeys {
 	public static final String ADMIN_SYNC_DEFAULT_ASSOCIATIONS =
 		"admin.sync.default.associations";
 
+	public static final String ANALYTICS_CLOUD_CLIENT_JS_VERSION =
+		"analytics.cloud.client.js.version";
+
 	public static final String ANNOUNCEMENTS_EMAIL_BODY =
 		"announcements.email.body";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 79.0.0
+version 79.1.0


### PR DESCRIPTION
## How to change analytics client js CDN version

With the introduction of the [analytics-internal.liferay.com](http://analytics-internal.liferay.com/), and the new canary release process we want to completely isolate this environment build and artifacts from the other production environments.

This includes the analytics.js code pointing to the latest published CDN version.

With this new feature, we aim to have the JS SDK URL configurable so all the internal DXPs connected to Analytics Cloud point to a release candidate version.

We will change the analytics client js CDN version via `portal.properties`.
There are two ways to change the property value:

### Via portal-ext.properties
Add `analytics.cloud.client.js.version=INTERNAL` to portal-ext.properties.

### Via UI on DXP
1. Go to Control Panel > Server Administrator > Script
2. Execute the following code:
```
import com.liferay.portal.util.PropsUtil;

PropsUtil.set("analytics.cloud.client.js.version", "INTERNAL");
```

| Options | Points to |
|--------|--------|
| PROD | https://analytics-js-cdn.liferay.com |
| INTERNAL | https://analytics-js-internal-cdn.liferay.com |
| DEV | https://analytics-js-dev-cdn.liferay.com |

Documentation https://liferay.atlassian.net/wiki/spaces/ENGAC/pages/2949775389/How+to+change+analytics+client+js+CDN+version