### PR TITLE
LPD-28871 | Master

### DIFF
--- a/modules/apps/analytics/analytics-layout-page-template-web/src/main/java/com/liferay/analytics/layout/page/template/web/internal/servlet/taglib/AnalyticsRenderFragmentLayoutPostDynamicInclude.java
+++ b/modules/apps/analytics/analytics-layout-page-template-web/src/main/java/com/liferay/analytics/layout/page/template/web/internal/servlet/taglib/AnalyticsRenderFragmentLayoutPostDynamicInclude.java
@@ -105,7 +105,7 @@ public class AnalyticsRenderFragmentLayoutPostDynamicInclude
 		try {
 			StringBundler sb = new StringBundler(9);
 
-			sb.append("Analytics.track(\"");
+			sb.append("window.onload = function() {Analytics.track(\"");
 
 			InfoItemClassDetails infoItemClassDetails =
 				new InfoItemClassDetails(
@@ -126,7 +126,7 @@ public class AnalyticsRenderFragmentLayoutPostDynamicInclude
 			sb.append(layoutDisplayPageObjectProvider.getTitle(locale));
 			sb.append("', 'type': '");
 			sb.append(label);
-			sb.append("'});");
+			sb.append("'})};");
 
 			Writer writer = pageContext.getOut();
 


### PR DESCRIPTION
Each Analytics.track event fired after page load must wait for the window.Analytics instance to load to fire the event. So I'm adding a `window.onload` to do that.