### PR TITLE
LPD-50205 LPD-52180 Create Dashboard menu item in the new CMS

### DIFF
--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/01_dashboard/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/site-initializer/layouts/01_dashboard/page-definition.json
@@ -1,6 +1,21 @@
 {
 	"pageElement": {
+		"id": "7a813efa-c2e5-4621-a448-a25fbdc5cbc6",
 		"pageElements": [
+			{
+				"definition": {
+					"fragment": {
+						"key": "com.liferay.site.cms.site.initializer.internal.fragment.renderer.ViewDashboardFragmentRenderer"
+					},
+					"fragmentConfig": {
+					},
+					"fragmentFields": [
+					],
+					"indexed": true
+				},
+				"id": "c6aa5b3f-06d7-49ae-a482-baabc9e33daa",
+				"type": "Fragment"
+			}
 		],
 		"type": "Root"
 	},
@@ -8,5 +23,6 @@
 		"masterPage": {
 			"key": "cms-master"
 		}
-	}
+	},
+	"version": 1.1
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewDashboardDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewDashboardDisplayContext.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.display.context;
+
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.util.Map;
+
+/**
+ * @author Adriano Interaminense
+ */
+public class ViewDashboardDisplayContext {
+
+	public ViewDashboardDisplayContext(ThemeDisplay themeDisplay) {
+		_themeDisplay = themeDisplay;
+	}
+
+	public Map<String, Object> getReactData() throws PortalException {
+		return HashMapBuilder.<String, Object>put(
+			"dashboard",
+			PortalUtil.getLayoutFullURL(
+				LayoutLocalServiceUtil.getLayoutByFriendlyURL(
+					_themeDisplay.getScopeGroupId(), false, "/dashboard"),
+				_themeDisplay)
+		).build();
+	}
+
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewDashboardFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/ViewDashboardFragmentRenderer.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
+
+import com.liferay.fragment.renderer.FragmentRenderer;
+import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.site.cms.site.initializer.internal.display.context.ViewDashboardDisplayContext;
+
+import java.io.IOException;
+
+import java.util.Locale;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Adriano Interaminense
+ */
+@Component(service = FragmentRenderer.class)
+public class ViewDashboardFragmentRenderer extends BaseSectionFragmentRenderer {
+
+	@Override
+	public String getCollectionKey() {
+		return "dashboard";
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _language.get(locale, "dashboard");
+	}
+
+	@Override
+	public void render(
+			FragmentRendererContext fragmentRendererContext,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		try {
+			RequestDispatcher requestDispatcher =
+				_servletContext.getRequestDispatcher("/view_dashboard.jsp");
+
+			httpServletRequest.setAttribute(
+				ViewDashboardDisplayContext.class.getName(),
+				new ViewDashboardDisplayContext(
+					(ThemeDisplay)httpServletRequest.getAttribute(
+						WebKeys.THEME_DISPLAY)));
+
+			requestDispatcher.include(httpServletRequest, httpServletResponse);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+	}
+
+	@Reference
+	private Language _language;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.site.cms.site.initializer)"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/init.jsp
@@ -17,6 +17,7 @@ page import="com.liferay.site.cms.site.initializer.internal.display.context.AllS
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ContentsSectionDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.FilesSectionDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.StructuresSectionDisplayContext" %><%@
+page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewDashboardDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewTagsDisplayContext" %><%@
 page import="com.liferay.site.cms.site.initializer.internal.display.context.ViewVocabulariesDisplayContext" %>
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/index.ts
@@ -10,5 +10,6 @@ export {default as StructuresFDSPropsTransformer} from './main/FDSPropsTransform
 export {default as ViewTags} from './main/categorization/tags/ViewTags';
 export {default as ViewVocabularies} from './main/categorization/vocabularies/ViewVocabularies';
 export {default as SpacesSticker} from './main/components/SpaceSticker';
+export {default as ViewDashboard} from './main/dashboard/ViewDashboard';
 export {default as SpacesNavigation} from './main/spaces_navigation/SpacesNavigation';
 export {default as StructureBuilder} from './structure_builder/components/StructureBuilder';

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/dashboard/ViewDashboard.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main/dashboard/ViewDashboard.tsx
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Text} from '@clayui/core';
+import ClayLayout from '@clayui/layout';
+import React from 'react';
+
+export default function ViewDashboard() {
+	return (
+		<ClayLayout.Container fluid>
+			<Text size={1} weight="bold">
+				{Liferay.Language.get('dashboard')}
+			</Text>
+		</ClayLayout.Container>
+	);
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_dashboard.jsp
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/view_dashboard.jsp
@@ -1,0 +1,19 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+ViewDashboardDisplayContext viewDashboardDisplayContext = (ViewDashboardDisplayContext)request.getAttribute(ViewDashboardDisplayContext.class.getName());
+%>
+
+<div class="cms-section">
+	<react:component
+		module="{ViewDashboard} from site-cms-site-initializer"
+		props="<%= viewDashboardDisplayContext.getReactData() %>"
+	/>
+</div>


### PR DESCRIPTION
> [!NOTE]
> This PR will create the Dashboard menu item that renders a basic React component with a title. 

In order to display the new CMS in the local DXP, you need to follow these steps:

1. Add at least the two necessary FFs in the portal-ext.properties
```
feature.flag.LPD-17564=true
feature.flag.LPD-11232=true
```
2. Start up DXP locally
3. Create a new Site: Control Panel > Sites > New > CMS
4. Open the new CMS
5. Having fun :tada: 