### PR TITLE
LPD-58383 Remove Poshi tests with Priority 3 and lower from acceptance - AC

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/abtest/ABTesting.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/abtest/ABTesting.testcase
@@ -1803,7 +1803,7 @@ definition {
 	@description = "LPS-97882: Validate if each A/B Test is related for one experience, if the user changes between the site pages, the context about the A/B Test changes too"
 	@priority = 3
 	test SwitchSitePage {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("Create content page") {
 			JSONLayout.addPublicLayout(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/ExperienceWithContentPages.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/ExperienceWithContentPages.testcase
@@ -197,7 +197,7 @@ definition {
 	@priority = 3
 	@uitest
 	test AddTwoExperiencesBelowDefault {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("Add segment for the user created") {
 			JSONSegmentsentry.addSegment(
@@ -270,7 +270,7 @@ definition {
 	@priority = 3
 	@uitest
 	test AddTwoExperiencesOverDefault {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("Add segment for the user created") {
 			JSONSegmentsentry.addSegment(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/SegmentationCreateSegment.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/segmentation/SegmentationCreateSegment.testcase
@@ -3262,7 +3262,7 @@ definition {
 	@priority = 3
 	@uitest
 	test ViewSegmentFieldsType {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("Check the field types appear in the segments editor") {
 			LexiconEntry.gotoAdd();


### PR DESCRIPTION
Hi team, Release team is looking to remove Poshi tests that are marked as priority 3 or lower from running on acceptance.
If you believe any of these tests should not be removed from acceptance, please let us know so we can update the priority and keep the test running on acceptance.
Thank you!