### PR TITLE
LPD-60049 | Update DXP image

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-docker/cloud/Dockerfile
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-docker/cloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM liferay/dxp:7.4.13-u128
+FROM liferay/dxp:2025.q2.5
 
 COPY --chown=liferay:liferay configs /home/liferay/configs
 COPY --chown=liferay:liferay license /home/liferay/deploy

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-docker/local/Dockerfile
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-docker/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM liferay/dxp:7.4.13-u128
+FROM liferay/dxp:2025.q2.5
 
 USER root
 

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/dev/Dockerfile
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM liferay/dxp:7.4.13-u78
+FROM liferay/dxp:2025.q2.5
 
 COPY --chown=liferay:liferay configs /home/liferay/configs
 COPY --chown=liferay:liferay deploy /mnt/liferay/deploy

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/prd/Dockerfile
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/prd/Dockerfile
@@ -1,4 +1,4 @@
-FROM liferay/dxp:7.4.13-u78
+FROM liferay/dxp:2025.q2.5
 
 COPY --chown=liferay:liferay configs /home/liferay/configs
 COPY --chown=liferay:liferay deploy /mnt/liferay/deploy

--- a/modules/dxp/apps/osb/osb-faro/wedeploy/uat/Dockerfile
+++ b/modules/dxp/apps/osb/osb-faro/wedeploy/uat/Dockerfile
@@ -1,4 +1,4 @@
-FROM liferay/dxp:7.4.13-u78
+FROM liferay/dxp:2025.q2.5
 
 COPY --chown=liferay:liferay configs /home/liferay/configs
 COPY --chown=liferay:liferay deploy /mnt/liferay/deploy


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-60049

Migrating to a more recent version of DXP as u128 has security issues.

I ran ant all with Java17, compile Faro image and everything seems to be working fine.