### PR TITLE
LPD-64766 Add support for folder deletion on /bulk-action-item/preview endpoint

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/BulkActionResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/java/com/liferay/headless/cms/resource/v1_0/BulkActionResource.java
@@ -54,7 +54,7 @@ public interface BulkActionResource {
 		throws Exception;
 
 	public Page<BulkActionItem> postBulkActionItemPreviewPage(
-			String search,
+			Boolean fetchChildren, String search,
 			com.liferay.portal.kernel.search.filter.Filter filter,
 			Pagination pagination,
 			com.liferay.portal.kernel.search.Sort[] sorts,

--- a/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/BulkActionResource.java
+++ b/modules/apps/headless/headless-cms/headless-cms-client/src/main/java/com/liferay/headless/cms/client/resource/v1_0/BulkActionResource.java
@@ -46,13 +46,13 @@ public interface BulkActionResource {
 		throws Exception;
 
 	public Page<BulkActionItem> postBulkActionItemPreviewPage(
-			String search, String filterString, Pagination pagination,
-			String sortString, BulkAction bulkAction)
+			Boolean fetchChildren, String search, String filterString,
+			Pagination pagination, String sortString, BulkAction bulkAction)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postBulkActionItemPreviewPageHttpResponse(
-			String search, String filterString, Pagination pagination,
-			String sortString, BulkAction bulkAction)
+			Boolean fetchChildren, String search, String filterString,
+			Pagination pagination, String sortString, BulkAction bulkAction)
 		throws Exception;
 
 	public static class Builder {
@@ -278,13 +278,14 @@ public interface BulkActionResource {
 		}
 
 		public Page<BulkActionItem> postBulkActionItemPreviewPage(
-				String search, String filterString, Pagination pagination,
-				String sortString, BulkAction bulkAction)
+				Boolean fetchChildren, String search, String filterString,
+				Pagination pagination, String sortString, BulkAction bulkAction)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postBulkActionItemPreviewPageHttpResponse(
-					search, filterString, pagination, sortString, bulkAction);
+					fetchChildren, search, filterString, pagination, sortString,
+					bulkAction);
 
 			String content = httpResponse.getContent();
 
@@ -347,8 +348,9 @@ public interface BulkActionResource {
 
 		public HttpInvoker.HttpResponse
 				postBulkActionItemPreviewPageHttpResponse(
-					String search, String filterString, Pagination pagination,
-					String sortString, BulkAction bulkAction)
+					Boolean fetchChildren, String search, String filterString,
+					Pagination pagination, String sortString,
+					BulkAction bulkAction)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -373,6 +375,11 @@ public interface BulkActionResource {
 			}
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (fetchChildren != null) {
+				httpInvoker.parameter(
+					"fetchChildren", String.valueOf(fetchChildren));
+			}
 
 			if (search != null) {
 				httpInvoker.parameter("search", String.valueOf(search));

--- a/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/rest-openapi.yaml
@@ -170,6 +170,10 @@ paths:
             operationId: postBulkActionItemPreviewPage
             parameters:
                 -   in: query
+                    name: fetchChildren
+                    schema:
+                        type: boolean
+                -   in: query
                     name: filter
                     schema:
                         type: string

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/graphql/mutation/v1_0/Mutation.java
@@ -65,6 +65,7 @@ public class Mutation {
 		description = "Creates a preview for each item based on the bulk action type"
 	)
 	public java.util.Collection<BulkActionItem> createBulkActionItemPreviewPage(
+			@GraphQLName("fetchChildren") Boolean fetchChildren,
 			@GraphQLName("search") String search,
 			@GraphQLName("filter") String filterString,
 			@GraphQLName("pageSize") int pageSize,
@@ -79,7 +80,7 @@ public class Mutation {
 			bulkActionResource -> {
 				Page paginationPage =
 					bulkActionResource.postBulkActionItemPreviewPage(
-						search,
+						fetchChildren, search,
 						_filterBiFunction.apply(
 							bulkActionResource, filterString),
 						Pagination.of(page, pageSize),

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseBulkActionResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BaseBulkActionResourceImpl.java
@@ -102,6 +102,10 @@ public abstract class BaseBulkActionResourceImpl
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fetchChildren"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
 				name = "filter"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
@@ -131,6 +135,9 @@ public abstract class BaseBulkActionResourceImpl
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
 	public Page<BulkActionItem> postBulkActionItemPreviewPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("fetchChildren")
+			Boolean fetchChildren,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -823,10 +823,9 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 					objectEntry.getObjectEntryId())
 			).build());
 
-		bulkActionItem.setClassName(objectDefinition::getClassName);
-
 		bulkActionItem.setClassExternalReferenceCode(
 			objectEntry::getExternalReferenceCode);
+		bulkActionItem.setClassName(objectDefinition::getClassName);
 		bulkActionItem.setName(
 			() -> objectEntry.getTitleValue(
 				LocaleUtil.toLanguageId(contextUser.getLocale()), true));
@@ -867,9 +866,9 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			).put(
 				"type", "FOLDER"
 			).build());
-		bulkActionItem.setClassName(objectEntryFolder::getModelClassName);
 		bulkActionItem.setClassExternalReferenceCode(
 			objectEntryFolder::getExternalReferenceCode);
+		bulkActionItem.setClassName(objectEntryFolder::getModelClassName);
 		bulkActionItem.setName(objectEntryFolder::getName);
 
 		return bulkActionItem;

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -787,6 +787,25 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 				"deletionType",
 				() -> _getDeletionType(objectEntryFolder.getGroupId())
 			).put(
+				"itemsCount",
+				() -> {
+					long itemsCount =
+						_objectEntryFolderLocalService.
+							getObjectEntryFoldersCount(
+								objectEntryFolder.getGroupId(),
+								objectEntryFolder.getCompanyId(),
+								objectEntryFolder.
+									getParentObjectEntryFolderId());
+
+					itemsCount +=
+						_objectEntryLocalService.
+							getObjectEntryFolderObjectEntriesCount(
+								objectEntryFolder.getGroupId(),
+								objectEntryFolder.getObjectEntryFolderId());
+
+					return itemsCount;
+				}
+			).put(
 				"type", "FOLDER"
 			).build());
 		bulkActionItem.setClassName(objectEntryFolder::getModelClassName);

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -138,8 +138,8 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 
 	@Override
 	public Page<BulkActionItem> postBulkActionItemPreviewPage(
-			String search, Filter filter, Pagination pagination, Sort[] sorts,
-			BulkAction bulkAction)
+			Boolean fetchChildren, String search, Filter filter,
+			Pagination pagination, Sort[] sorts, BulkAction bulkAction)
 		throws Exception {
 
 		if (!FeatureFlagManagerUtil.isEnabled(
@@ -151,6 +151,28 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 		}
 
 		BulkActionItem[] bulkActionItems = bulkAction.getBulkActionItems();
+
+		if (GetterUtil.getBoolean(fetchChildren)) {
+			if (ArrayUtil.isEmpty(bulkActionItems)) {
+				return Page.of(Collections.emptyList());
+			}
+
+			BulkActionItem bulkActionItem = bulkActionItems[0];
+
+			if ((bulkActionItems.length > 1) ||
+				!Objects.equals(
+					bulkActionItem.getClassName(),
+					ObjectEntryFolder.class.getName())) {
+
+				throw new BadRequestException(
+					"\"fetchChildren\" is only supported with a single folder");
+			}
+
+			return _getBulkActionItemPreviewPage(
+				_getObjectEntryFolderBulkActionItems(
+					bulkActionItem.getClassPK()),
+				pagination, search, sorts);
+		}
 
 		if (ArrayUtil.isEmpty(bulkActionItems) &&
 			!GetterUtil.getBoolean(bulkAction.getSelectAll())) {
@@ -686,6 +708,31 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 		return "custom-structure";
 	}
 
+	private List<BulkActionItem> _getObjectEntryFolderBulkActionItems(
+			long objectObjectEntryFolderId)
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.getObjectEntryFolder(
+				objectObjectEntryFolderId);
+
+		List<BulkActionItem> bulkActionItems = transform(
+			_objectEntryLocalService.getObjectEntryFolderObjectEntries(
+				objectEntryFolder.getGroupId(), objectObjectEntryFolderId,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+			this::_toBulkActionItem);
+
+		bulkActionItems.addAll(
+			transform(
+				_objectEntryFolderLocalService.getObjectEntryFolders(
+					objectEntryFolder.getGroupId(),
+					objectEntryFolder.getCompanyId(), objectObjectEntryFolderId,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+				this::_toBulkActionItem));
+
+		return bulkActionItems;
+	}
+
 	private String _getTaskItemDelegateName(String className) throws Exception {
 		if (StringUtil.equals(
 				"com.liferay.object.model.ObjectEntryFolder", className)) {
@@ -741,46 +788,58 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 	}
 
 	private BulkActionItem _toBulkActionItem(long classPK) {
-		BulkActionItem bulkActionItem = new BulkActionItem();
-
-		bulkActionItem.setClassPK(() -> classPK);
-
 		ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
 			classPK);
 
 		if (objectEntry != null) {
-			ObjectDefinition objectDefinition =
-				_objectDefinitionLocalService.fetchObjectDefinition(
-					objectEntry.getObjectDefinitionId());
-
-			bulkActionItem.setAttributes(
-				() -> HashMapBuilder.<String, Object>put(
-					"deletionType",
-					() -> _getDeletionType(objectEntry.getGroupId())
-				).put(
-					"mimeType", _getMimeType(objectDefinition, objectEntry)
-				).put(
-					"type", "ASSET"
-				).put(
-					"usages",
-					_getUsagesCount(
-						objectDefinition.getClassName(),
-						objectDefinition.getObjectDefinitionId(),
-						objectEntry.getObjectEntryId())
-				).build());
-			bulkActionItem.setClassName(objectDefinition::getClassName);
-
-			bulkActionItem.setClassExternalReferenceCode(
-				objectEntry::getExternalReferenceCode);
-			bulkActionItem.setName(
-				() -> objectEntry.getTitleValue(
-					LocaleUtil.toLanguageId(contextUser.getLocale()), true));
-
-			return bulkActionItem;
+			return _toBulkActionItem(objectEntry);
 		}
 
-		ObjectEntryFolder objectEntryFolder =
-			_objectEntryFolderLocalService.fetchObjectEntryFolder(classPK);
+		return _toBulkActionItem(
+			_objectEntryFolderLocalService.fetchObjectEntryFolder(classPK));
+	}
+
+	private BulkActionItem _toBulkActionItem(ObjectEntry objectEntry) {
+		BulkActionItem bulkActionItem = new BulkActionItem();
+
+		bulkActionItem.setClassPK(objectEntry::getObjectEntryId);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				objectEntry.getObjectDefinitionId());
+
+		bulkActionItem.setAttributes(
+			() -> HashMapBuilder.<String, Object>put(
+				"deletionType", () -> _getDeletionType(objectEntry.getGroupId())
+			).put(
+				"mimeType", _getMimeType(objectDefinition, objectEntry)
+			).put(
+				"type", "ASSET"
+			).put(
+				"usages",
+				_getUsagesCount(
+					objectDefinition.getClassName(),
+					objectDefinition.getObjectDefinitionId(),
+					objectEntry.getObjectEntryId())
+			).build());
+
+		bulkActionItem.setClassName(objectDefinition::getClassName);
+
+		bulkActionItem.setClassExternalReferenceCode(
+			objectEntry::getExternalReferenceCode);
+		bulkActionItem.setName(
+			() -> objectEntry.getTitleValue(
+				LocaleUtil.toLanguageId(contextUser.getLocale()), true));
+
+		return bulkActionItem;
+	}
+
+	private BulkActionItem _toBulkActionItem(
+		ObjectEntryFolder objectEntryFolder) {
+
+		BulkActionItem bulkActionItem = new BulkActionItem();
+
+		bulkActionItem.setClassPK(objectEntryFolder::getObjectEntryFolderId);
 
 		bulkActionItem.setAttributes(
 			() -> HashMapBuilder.<String, Object>put(

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BulkActionResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BulkActionResourceTest.java
@@ -395,7 +395,8 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 
 		Page<BulkActionItem> page =
 			bulkActionResource.postBulkActionItemPreviewPage(
-				null, null, Pagination.of(1, 10), "name:desc", bulkAction);
+				false, null, null, Pagination.of(1, 10), "name:desc",
+				bulkAction);
 
 		Assert.assertEquals(2, page.getTotalCount());
 
@@ -429,7 +430,7 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 		bulkAction.setSelectAll(true);
 
 		page = bulkActionResource.postBulkActionItemPreviewPage(
-			objectEntryFolder2.getName(),
+			false, objectEntryFolder2.getName(),
 			"folderId eq " + objectEntryFolder1.getObjectEntryFolderId(),
 			Pagination.of(1, 10), null, bulkAction);
 
@@ -442,6 +443,38 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 			items.get(0), objectEntryFolder2.getObjectEntryFolderId(),
 			expectedDeletionType, null, objectEntryFolder2.getName(), "FOLDER",
 			null);
+
+		bulkAction.setBulkActionItems(
+			new BulkActionItem[] {_toBulkActionItem(objectEntryFolder1)});
+
+		page = bulkActionResource.postBulkActionItemPreviewPage(
+			true, null, null, Pagination.of(1, 10), null, bulkAction);
+
+		items = ListUtil.fromCollection(page.getItems());
+
+		Assert.assertEquals(items.toString(), 2, items.size());
+		Assert.assertEquals(items.toString(), 2, page.getTotalCount());
+
+		if (name.compareTo(objectEntryFolder2.getName()) < 0) {
+			_assertBulkActionItem(
+				items.get(0), objectEntryFolder2.getObjectEntryFolderId(),
+				expectedDeletionType, null, objectEntryFolder2.getName(),
+				"FOLDER", null);
+			_assertBulkActionItem(
+				items.get(1), objectEntry.getObjectEntryId(),
+				expectedDeletionType, "basic-web-content",
+				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
+		}
+		else {
+			_assertBulkActionItem(
+				items.get(0), objectEntry.getObjectEntryId(),
+				expectedDeletionType, "basic-web-content",
+				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
+			_assertBulkActionItem(
+				items.get(1), objectEntryFolder2.getObjectEntryFolderId(),
+				expectedDeletionType, null, objectEntryFolder2.getName(),
+				"FOLDER", null);
+		}
 	}
 
 	private void _testPostBulkActionWithTypeDefaultPermission()

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BulkActionResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BulkActionResourceTest.java
@@ -383,19 +383,81 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 
 		BulkAction bulkAction = new DeleteBulkAction();
 
+		bulkAction.setType(BulkAction.Type.DELETE_BULK_ACTION);
+
+		_testPostBulkActionItemPreviewPageWithBulkActionItems(
+			bulkAction, expectedDeletionType, objectEntry, objectEntryFolder2);
+
+		_testPostBulkActionItemPreviewPageWithSelectAllAndFilter(
+			bulkAction, expectedDeletionType, objectEntryFolder1,
+			objectEntryFolder2);
+
+		_testPostBulkActionItemPreviewPageWithFetchChildrenEnabled(
+			bulkAction, expectedDeletionType, objectEntry, objectEntryFolder1,
+			objectEntryFolder2);
+	}
+
+	private void _testPostBulkActionItemPreviewPageWithBulkActionItems(
+			BulkAction bulkAction, String expectedDeletionType,
+			ObjectEntry objectEntry, ObjectEntryFolder objectEntryFolder)
+		throws Exception {
+
 		bulkAction.setBulkActionItems(
 			new BulkActionItem[] {
 				_toBulkActionItem(
 					_basicWebContentObjectDefinition.getClassName(),
 					objectEntry),
-				_toBulkActionItem(objectEntryFolder2)
+				_toBulkActionItem(objectEntryFolder)
 			});
 		bulkAction.setSelectAll(false);
-		bulkAction.setType(BulkAction.Type.DELETE_BULK_ACTION);
 
 		Page<BulkActionItem> page =
 			bulkActionResource.postBulkActionItemPreviewPage(
 				false, null, null, Pagination.of(1, 10), "name:desc",
+				bulkAction);
+
+		Assert.assertEquals(2, page.getTotalCount());
+
+		List<BulkActionItem> items = ListUtil.fromCollection(page.getItems());
+
+		Assert.assertEquals(items.toString(), 2, items.size());
+
+		String name = objectEntry.getTitleValue(_LANGUAGE_ID);
+
+		if (name.compareTo(objectEntryFolder.getName()) < 0) {
+			_assertBulkActionItem(
+				items.get(0), objectEntryFolder.getObjectEntryFolderId(),
+				expectedDeletionType, null, objectEntryFolder.getName(),
+				"FOLDER", null);
+			_assertBulkActionItem(
+				items.get(1), objectEntry.getObjectEntryId(),
+				expectedDeletionType, "basic-web-content",
+				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
+		}
+		else {
+			_assertBulkActionItem(
+				items.get(0), objectEntry.getObjectEntryId(),
+				expectedDeletionType, "basic-web-content",
+				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
+			_assertBulkActionItem(
+				items.get(1), objectEntryFolder.getObjectEntryFolderId(),
+				expectedDeletionType, null, objectEntryFolder.getName(),
+				"FOLDER", null);
+		}
+	}
+
+	private void _testPostBulkActionItemPreviewPageWithFetchChildrenEnabled(
+			BulkAction bulkAction, String expectedDeletionType,
+			ObjectEntry objectEntry, ObjectEntryFolder objectEntryFolder1,
+			ObjectEntryFolder objectEntryFolder2)
+		throws Exception {
+
+		bulkAction.setBulkActionItems(
+			new BulkActionItem[] {_toBulkActionItem(objectEntryFolder1)});
+
+		Page<BulkActionItem> page =
+			bulkActionResource.postBulkActionItemPreviewPage(
+				true, null, null, Pagination.of(1, 10), "name:desc",
 				bulkAction);
 
 		Assert.assertEquals(2, page.getTotalCount());
@@ -426,55 +488,32 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 				expectedDeletionType, null, objectEntryFolder2.getName(),
 				"FOLDER", null);
 		}
+	}
+
+	private void _testPostBulkActionItemPreviewPageWithSelectAllAndFilter(
+			BulkAction bulkAction, String expectedDeletionType,
+			ObjectEntryFolder objectEntryFolder1,
+			ObjectEntryFolder objectEntryFolder2)
+		throws Exception {
 
 		bulkAction.setSelectAll(true);
 
-		page = bulkActionResource.postBulkActionItemPreviewPage(
-			false, objectEntryFolder2.getName(),
-			"folderId eq " + objectEntryFolder1.getObjectEntryFolderId(),
-			Pagination.of(1, 10), null, bulkAction);
+		Page<BulkActionItem> page =
+			bulkActionResource.postBulkActionItemPreviewPage(
+				false, objectEntryFolder2.getName(),
+				"folderId eq " + objectEntryFolder1.getObjectEntryFolderId(),
+				Pagination.of(1, 10), null, bulkAction);
 
-		items = ListUtil.fromCollection(page.getItems());
+		Assert.assertEquals(1, page.getTotalCount());
+
+		List<BulkActionItem> items = ListUtil.fromCollection(page.getItems());
 
 		Assert.assertEquals(items.toString(), 1, items.size());
-		Assert.assertEquals(items.toString(), 1, page.getTotalCount());
 
 		_assertBulkActionItem(
 			items.get(0), objectEntryFolder2.getObjectEntryFolderId(),
 			expectedDeletionType, null, objectEntryFolder2.getName(), "FOLDER",
 			null);
-
-		bulkAction.setBulkActionItems(
-			new BulkActionItem[] {_toBulkActionItem(objectEntryFolder1)});
-
-		page = bulkActionResource.postBulkActionItemPreviewPage(
-			true, null, null, Pagination.of(1, 10), null, bulkAction);
-
-		items = ListUtil.fromCollection(page.getItems());
-
-		Assert.assertEquals(items.toString(), 2, items.size());
-		Assert.assertEquals(items.toString(), 2, page.getTotalCount());
-
-		if (name.compareTo(objectEntryFolder2.getName()) < 0) {
-			_assertBulkActionItem(
-				items.get(0), objectEntryFolder2.getObjectEntryFolderId(),
-				expectedDeletionType, null, objectEntryFolder2.getName(),
-				"FOLDER", null);
-			_assertBulkActionItem(
-				items.get(1), objectEntry.getObjectEntryId(),
-				expectedDeletionType, "basic-web-content",
-				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
-		}
-		else {
-			_assertBulkActionItem(
-				items.get(0), objectEntry.getObjectEntryId(),
-				expectedDeletionType, "basic-web-content",
-				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
-			_assertBulkActionItem(
-				items.get(1), objectEntryFolder2.getObjectEntryFolderId(),
-				expectedDeletionType, null, objectEntryFolder2.getName(),
-				"FOLDER", null);
-		}
 	}
 
 	private void _testPostBulkActionWithTypeDefaultPermission()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-64766

## Goal

Allow retrieving a preview of what will happen with items inside a folder marked for deletion.

## How

By changing the existing endpoint that provides bulk action previews

### Images

These changes provide data for the following case (see [figma file](https://www.figma.com/design/IeYGhyy3lIJZ2qfe0id9LE/LPD-48123---Prevent-Broken-Links?node-id=1939-69465&t=51m7Ie0QR2UkEWJI-0))


<img width="1728" height="1117" alt="png(4)" src="https://github.com/user-attachments/assets/3f655f45-8369-40fc-bb55-c35fb8d51ea4" />

<img width="1728" height="1117" alt="png(5)" src="https://github.com/user-attachments/assets/4f0eb15f-681d-4ec4-98fa-0d52b2450d0c" />
