### PR TITLE
LPD-63231 add support for sorting BulkAction preview items by "usages"

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/odata/entity/v1_0/BulkActionEntityModel.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/odata/entity/v1_0/BulkActionEntityModel.java
@@ -80,7 +80,8 @@ public class BulkActionEntityModel implements EntityModel {
 							LocaleUtil.toLanguageId(locale)));
 
 					return sortableFieldName.concat(".keyword_lowercase");
-				}));
+				}),
+			new StringEntityField("usages", locale -> "usages"));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/headless/headless-cms/headless-cms-impl/src/main/java/com/liferay/headless/cms/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -150,6 +150,23 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			throw new UnsupportedOperationException();
 		}
 
+		if (ArrayUtil.isNotEmpty(sorts)) {
+			Sort sort = sorts[0];
+
+			String fieldName = sort.getFieldName();
+
+			if ((!StringUtil.equalsIgnoreCase(fieldName, "name") &&
+				 !StringUtil.equalsIgnoreCase(fieldName, "usages")) ||
+				(sorts.length > 1)) {
+
+				throw new BadRequestException(
+					"Only the fields \"name\" and \"usages\" are sortable");
+			}
+		}
+		else {
+			sorts = new Sort[] {new Sort("usages", true)};
+		}
+
 		BulkActionItem[] bulkActionItems = bulkAction.getBulkActionItems();
 
 		if (GetterUtil.getBoolean(fetchChildren)) {
@@ -171,7 +188,7 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			return _getBulkActionItemPreviewPage(
 				_getObjectEntryFolderBulkActionItems(
 					bulkActionItem.getClassPK()),
-				pagination, search, sorts);
+				pagination, search, sorts[0]);
 		}
 
 		if (ArrayUtil.isEmpty(bulkActionItems) &&
@@ -180,23 +197,14 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			return Page.of(Collections.emptyList());
 		}
 
-		if (ArrayUtil.isNotEmpty(sorts)) {
-			Sort sort = sorts[0];
-
-			if (!StringUtil.equalsIgnoreCase(sort.getFieldName(), "name") ||
-				(sorts.length > 1)) {
-
-				throw new BadRequestException(
-					"Only the field \"name\" is sortable");
-			}
-		}
-
 		if (!GetterUtil.getBoolean(bulkAction.getSelectAll())) {
 			return _getBulkActionItemPreviewPage(
-				ListUtil.fromArray(bulkActionItems), pagination, search, sorts);
+				ListUtil.fromArray(bulkActionItems), pagination, search,
+				sorts[0]);
 		}
 
-		return _getBulkActionItemPreviewPage(filter, pagination, search, sorts);
+		return _getBulkActionItemPreviewPage(
+			filter, pagination, search, sorts[0]);
 	}
 
 	private BulkActionTask _addBulkActionTask(String type) throws Exception {
@@ -385,7 +393,7 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 	}
 
 	private Page<BulkActionItem> _getBulkActionItemPreviewPage(
-			Filter filter, Pagination pagination, String search, Sort[] sorts)
+			Filter filter, Pagination pagination, String search, Sort sort)
 		throws Exception {
 
 		if (filter == null) {
@@ -413,16 +421,15 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 				contextUser
 			).build();
 
-		if (ArrayUtil.isNotEmpty(sorts)) {
-			Sort sort = sorts[0];
-
+		if (StringUtil.equalsIgnoreCase(sort.getFieldName(), "name")) {
 			sort.setFieldName(
 				Field.getSortableFieldName(
 					"localized_title_".concat(contextUser.getLanguageId())));
 		}
 
 		Page<SearchResult> searchPage = searchResultResource.getSearchPage(
-			null, true, null, null, search, filter, pagination, sorts);
+			null, true, null, null, search, filter, pagination,
+			new Sort[] {sort});
 
 		for (SearchResult searchResult : searchPage.getItems()) {
 			JSONObject jsonObject = _jsonFactory.createJSONObject(
@@ -431,23 +438,20 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			bulkActionItems.add(_toBulkActionItem(jsonObject.getLong("id")));
 		}
 
+		if (StringUtil.equalsIgnoreCase(sort.getFieldName(), "usages")) {
+			bulkActionItems = _sortBulkActionItems(bulkActionItems, sort);
+		}
+
 		return Page.of(bulkActionItems, pagination, searchPage.getTotalCount());
 	}
 
 	private Page<BulkActionItem> _getBulkActionItemPreviewPage(
-			List<BulkActionItem> bulkActionItems1, Pagination pagination,
-			String search, Sort[] sorts)
-		throws Exception {
+		List<BulkActionItem> bulkActionItems1, Pagination pagination,
+		String search, Sort sort) {
 
 		List<BulkActionItem> bulkActionItems2 = new ArrayList<>();
 
 		long totalCount = bulkActionItems1.size();
-
-		if (Validator.isNull(search) && ArrayUtil.isEmpty(sorts)) {
-			bulkActionItems1 = ListUtil.subList(
-				bulkActionItems1, pagination.getStartPosition(),
-				pagination.getEndPosition());
-		}
 
 		for (BulkActionItem bulkActionItem : bulkActionItems1) {
 			bulkActionItems2.add(
@@ -464,25 +468,9 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 			totalCount = bulkActionItems2.size();
 		}
 
-		if (ArrayUtil.isNotEmpty(sorts)) {
-			Sort sort = sorts[0];
-
-			bulkActionItems2 = ListUtil.sort(
-				bulkActionItems2,
-				(bulkActionItem1, bulkActionItem2) -> {
-					String name = bulkActionItem1.getName();
-
-					int value = name.compareTo(bulkActionItem2.getName());
-
-					if (!sort.isReverse()) {
-						return value;
-					}
-
-					return -value;
-				});
-		}
-
-		return Page.of(bulkActionItems2, pagination, totalCount);
+		return Page.of(
+			_sortBulkActionItems(bulkActionItems2, sort), pagination,
+			totalCount);
 	}
 
 	private long _getBulkActionTaskItemObjectDefinitionId() throws Exception {
@@ -800,6 +788,43 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 		}
 
 		return usagesCount;
+	}
+
+	private List<BulkActionItem> _sortBulkActionItems(
+		List<BulkActionItem> bulkActionItems, Sort sort) {
+
+		return ListUtil.sort(
+			bulkActionItems,
+			(bulkActionItem1, bulkActionItem2) -> {
+				if (StringUtil.equalsIgnoreCase(sort.getFieldName(), "name")) {
+					String name = bulkActionItem1.getName();
+
+					int value = name.compareTo(bulkActionItem2.getName());
+
+					if (!sort.isReverse()) {
+						return value;
+					}
+
+					return -value;
+				}
+
+				Map<String, Object> attributes1 =
+					bulkActionItem1.getAttributes();
+
+				Long usages = GetterUtil.getLong(attributes1.get("usages"));
+
+				Map<String, Object> attributes2 =
+					bulkActionItem2.getAttributes();
+
+				int value = usages.compareTo(
+					GetterUtil.getLong(attributes2.get("usages")));
+
+				if (!sort.isReverse()) {
+					return value;
+				}
+
+				return -value;
+			});
 	}
 
 	private BulkActionItem _toBulkActionItem(long classPK) {

--- a/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BulkActionResourceTest.java
+++ b/modules/apps/headless/headless-cms/headless-cms-test/src/testIntegration/java/com/liferay/headless/cms/resource/v1_0/test/BulkActionResourceTest.java
@@ -409,39 +409,59 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 			});
 		bulkAction.setSelectAll(false);
 
-		Page<BulkActionItem> page =
+		Page<BulkActionItem> page1 =
 			bulkActionResource.postBulkActionItemPreviewPage(
 				false, null, null, Pagination.of(1, 10), "name:desc",
 				bulkAction);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(2, page1.getTotalCount());
 
-		List<BulkActionItem> items = ListUtil.fromCollection(page.getItems());
+		List<BulkActionItem> items1 = ListUtil.fromCollection(page1.getItems());
 
-		Assert.assertEquals(items.toString(), 2, items.size());
+		Assert.assertEquals(items1.toString(), 2, items1.size());
 
 		String name = objectEntry.getTitleValue(_LANGUAGE_ID);
 
 		if (name.compareTo(objectEntryFolder.getName()) < 0) {
 			_assertBulkActionItem(
-				items.get(0), objectEntryFolder.getObjectEntryFolderId(),
+				items1.get(0), objectEntryFolder.getObjectEntryFolderId(),
 				expectedDeletionType, null, objectEntryFolder.getName(),
 				"FOLDER", null);
 			_assertBulkActionItem(
-				items.get(1), objectEntry.getObjectEntryId(),
+				items1.get(1), objectEntry.getObjectEntryId(),
 				expectedDeletionType, "basic-web-content",
 				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
 		}
 		else {
 			_assertBulkActionItem(
-				items.get(0), objectEntry.getObjectEntryId(),
+				items1.get(0), objectEntry.getObjectEntryId(),
 				expectedDeletionType, "basic-web-content",
 				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
 			_assertBulkActionItem(
-				items.get(1), objectEntryFolder.getObjectEntryFolderId(),
+				items1.get(1), objectEntryFolder.getObjectEntryFolderId(),
 				expectedDeletionType, null, objectEntryFolder.getName(),
 				"FOLDER", null);
 		}
+
+		Page<BulkActionItem> page2 =
+			bulkActionResource.postBulkActionItemPreviewPage(
+				false, null, null, Pagination.of(1, 10), "usages:asc",
+				bulkAction);
+
+		Assert.assertEquals(2, page2.getTotalCount());
+
+		List<BulkActionItem> items2 = ListUtil.fromCollection(page2.getItems());
+
+		Assert.assertEquals(items2.toString(), 2, items2.size());
+
+		_assertBulkActionItem(
+			items2.get(0), objectEntryFolder.getObjectEntryFolderId(),
+			expectedDeletionType, null, objectEntryFolder.getName(), "FOLDER",
+			null);
+		_assertBulkActionItem(
+			items2.get(1), objectEntry.getObjectEntryId(), expectedDeletionType,
+			"basic-web-content", objectEntry.getTitleValue(_LANGUAGE_ID),
+			"ASSET", 1L);
 	}
 
 	private void _testPostBulkActionItemPreviewPageWithFetchChildrenEnabled(
@@ -453,39 +473,59 @@ public class BulkActionResourceTest extends BaseBulkActionResourceTestCase {
 		bulkAction.setBulkActionItems(
 			new BulkActionItem[] {_toBulkActionItem(objectEntryFolder1)});
 
-		Page<BulkActionItem> page =
+		Page<BulkActionItem> page1 =
 			bulkActionResource.postBulkActionItemPreviewPage(
 				true, null, null, Pagination.of(1, 10), "name:desc",
 				bulkAction);
 
-		Assert.assertEquals(2, page.getTotalCount());
+		Assert.assertEquals(2, page1.getTotalCount());
 
-		List<BulkActionItem> items = ListUtil.fromCollection(page.getItems());
+		List<BulkActionItem> items1 = ListUtil.fromCollection(page1.getItems());
 
-		Assert.assertEquals(items.toString(), 2, items.size());
+		Assert.assertEquals(items1.toString(), 2, items1.size());
 
 		String name = objectEntry.getTitleValue(_LANGUAGE_ID);
 
 		if (name.compareTo(objectEntryFolder2.getName()) < 0) {
 			_assertBulkActionItem(
-				items.get(0), objectEntryFolder2.getObjectEntryFolderId(),
+				items1.get(0), objectEntryFolder2.getObjectEntryFolderId(),
 				expectedDeletionType, null, objectEntryFolder2.getName(),
 				"FOLDER", null);
 			_assertBulkActionItem(
-				items.get(1), objectEntry.getObjectEntryId(),
+				items1.get(1), objectEntry.getObjectEntryId(),
 				expectedDeletionType, "basic-web-content",
 				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
 		}
 		else {
 			_assertBulkActionItem(
-				items.get(0), objectEntry.getObjectEntryId(),
+				items1.get(0), objectEntry.getObjectEntryId(),
 				expectedDeletionType, "basic-web-content",
 				objectEntry.getTitleValue(_LANGUAGE_ID), "ASSET", 1L);
 			_assertBulkActionItem(
-				items.get(1), objectEntryFolder2.getObjectEntryFolderId(),
+				items1.get(1), objectEntryFolder2.getObjectEntryFolderId(),
 				expectedDeletionType, null, objectEntryFolder2.getName(),
 				"FOLDER", null);
 		}
+
+		Page<BulkActionItem> page2 =
+			bulkActionResource.postBulkActionItemPreviewPage(
+				true, null, null, Pagination.of(1, 10), "usages:desc",
+				bulkAction);
+
+		Assert.assertEquals(2, page2.getTotalCount());
+
+		List<BulkActionItem> items2 = ListUtil.fromCollection(page2.getItems());
+
+		Assert.assertEquals(items2.toString(), 2, items2.size());
+
+		_assertBulkActionItem(
+			items2.get(0), objectEntry.getObjectEntryId(), expectedDeletionType,
+			"basic-web-content", objectEntry.getTitleValue(_LANGUAGE_ID),
+			"ASSET", 1L);
+		_assertBulkActionItem(
+			items2.get(1), objectEntryFolder2.getObjectEntryFolderId(),
+			expectedDeletionType, null, objectEntryFolder2.getName(), "FOLDER",
+			null);
 	}
 
 	private void _testPostBulkActionItemPreviewPageWithSelectAllAndFilter(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-63231

This PR adds additional support for the 'usages' property for when previewing a bulk action. 

The BulkActionResourceImpl.java class has grown way faster than anticipated (this is a shared CMS module). **A refactor for the module** will come soon to account for different types of BulkActions and preview.

