### PR TITLE
LPD-83747 Add FDS snapshots support to Assets List

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/List.tsx
@@ -9,7 +9,7 @@ import getCN from 'classnames';
 import React, {useMemo, useRef, useState} from 'react';
 import {AssetIcon} from './components/AssetsIcon';
 import {ClayButtonWithIcon} from '@clayui/button';
-import {columns, pagination} from 'shared/util/frontend-data-set';
+import {columns, pagination, useSnapshots} from 'shared/util/frontend-data-set';
 import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
 import {Heading, Text} from '@clayui/core';
 import {pickBy} from 'lodash';
@@ -35,13 +35,11 @@ const List = () => {
 
 	const [infoPanel, setInfoPanel] = useState(null);
 
+	const snapshots = useSnapshots('assetTable');
+
 	const FrontendDataSet = useFrontendDataSet();
 
 	const sidePanelRef = useRef(null);
-
-	// Disable fetch filter interceptor for now.
-
-	// useEffect(() => createFetchFilterInterceptor(), []);
 
 	let rangeSelectorParams = `rangeKey=${rangeSelectors.rangeKey}`;
 
@@ -154,8 +152,6 @@ const List = () => {
 							}}
 							filters={filters}
 							id='assetTable'
-							// Trick to restart FDS every time the rangeSelectors changes.
-
 							itemsActions={[
 								{
 									data: {
@@ -168,18 +164,23 @@ const List = () => {
 									onClick: setInfoPanel
 								}
 							]}
+							// Trick to restart FDS every time the rangeSelectors changes.
+
 							key={Object.values(rangeSelectors).join()}
 							pagination={pagination}
 							showPagination
+							snapshots={snapshots}
+							snapshotsEnabled
 							views={[
 								{
 									contentRenderer: 'table',
-									default: false,
-									label: 'table',
+									default: true,
+									label: Liferay.Language.get('default-view'),
 									name: 'table',
 									schema: {
 										fields: [
 											{
+												_key: 'assetTitle',
 												contentRenderer:
 													'assetTitleRenderer',
 												fieldName: 'assetTitle',
@@ -192,6 +193,7 @@ const List = () => {
 												truncate: true
 											},
 											{
+												_key: 'assetTypeMetric',
 												fieldName: 'assetType',
 												label: Liferay.Language.get(
 													'type'
@@ -199,6 +201,7 @@ const List = () => {
 												sortable: true
 											},
 											{
+												_key: 'viewsMetric',
 												contentRenderer:
 													'assetMetricRenderer',
 												fieldName: 'viewsMetric',
@@ -208,6 +211,7 @@ const List = () => {
 												sortable: true
 											},
 											{
+												_key: 'impressionsMetric',
 												contentRenderer:
 													'assetMetricRenderer',
 												fieldName: 'impressionsMetric',
@@ -217,6 +221,7 @@ const List = () => {
 												sortable: true
 											},
 											{
+												_key: 'downloadsMetric',
 												contentRenderer:
 													'assetMetricRenderer',
 												fieldName: 'downloadsMetric',

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/custom-types/liferay.d.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/custom-types/liferay.d.ts
@@ -1,5 +1,11 @@
 declare namespace Liferay {
+	const FeatureFlags: Record<string, boolean>;
+
 	namespace Language {
 		function get(languageKey: string);
+	}
+
+	namespace Util {
+		function fetch(url: string, options?: any): Promise<any>;
 	}
 }

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/frontend-data-set.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/frontend-data-set.tsx
@@ -1,6 +1,6 @@
 import ClayLink from '@clayui/link';
 import FaroConstants from 'shared/util/constants';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {AssetIcon, MimeTypes} from 'assets/components/AssetsIcon';
 import {Routes, toRoute} from './router';
 import {Text} from '@clayui/core';
@@ -66,52 +66,38 @@ export const columns = {
 	}
 };
 
-/**
- * Patches window.fetch to base64-encode the `filter` query parameter on every
- * outgoing request. This is necessary because Cloud Armor blocks requests whose
- * filter strings contain OData expressions with parentheses, quotes, and spaces
- * (e.g. "(assetType in ('CMSBasicWebContent')) and (assetTags in ('tag 01'))").
- * Encoding the value with btoa() makes the payload opaque to the WAF rules.
- *
- * The function returns a cleanup callback that restores the original fetch,
- * intended to be used as the return value of a useEffect call.
- *
- * The backend must decode the filter parameter from base64 before processing it.
- */
-export function createFetchFilterInterceptor() {
-	const originalFetch = window.fetch;
+export function useSnapshots(fdsName: string) {
+	if (
+		!Liferay.FeatureFlags['LPD-34594'] ||
+		!Liferay.FeatureFlags['LPS-164563']
+	) {
+		return [];
+	}
 
-	window.fetch = function (input: any, init: any): Promise<Response> {
-		try {
-			const rawUrl =
-				typeof input === 'string'
-					? input
-					: input instanceof URL
-					? input.href
-					: (input as Request).url;
+	const [snapshots, setSnapshots] = useState([]);
 
-			const urlObj = new URL(rawUrl, window.location.origin);
-			const filterParam = urlObj.searchParams.get('filter');
+	useEffect(() => {
+		Liferay.Util.fetch(
+			`/o/data-set-admin/snapshots?filter=fdsName eq '${fdsName}'`,
+			{headers: {'Content-Type': 'application/json'}, method: 'GET'}
+		)
+			.then(res => res.json())
+			.then(data => {
+				const formattedSnapshots = data.items.map(
+					(item: {
+						externalReferenceCode: any;
+						label: any;
+						viewConfig: any;
+					}) => ({
+						configuration: item.viewConfig,
+						erc: item.externalReferenceCode,
+						label: item.label
+					})
+				);
 
-			if (filterParam) {
-				urlObj.searchParams.set('filter', btoa(filterParam));
+				setSnapshots(formattedSnapshots);
+			});
+	}, [fdsName]);
 
-				if (typeof input === 'string') {
-					input = urlObj.toString();
-				} else if (input instanceof URL) {
-					input = new URL(urlObj.toString());
-				} else {
-					input = new Request(urlObj.toString(), input as Request);
-				}
-			}
-		} catch (_) {
-			// proceed with original input if URL parsing fails
-		}
-
-		return originalFetch.call(this, input, init);
-	};
-
-	return () => {
-		window.fetch = originalFetch;
-	};
+	return snapshots;
 }


### PR DESCRIPTION
## Summary

- Replace `createFetchFilterInterceptor` with `useSnapshots` hook that fetches snapshots from the data-set-admin API behind feature flags (`LPD-34594`, `LPS-164563`)
- Pass `snapshots` and `snapshotsEnabled` props to `FrontendDataSet` component in Assets List
- Add `_key` fields to schema columns and set default view to `true`
- Add `Liferay.FeatureFlags` and `Liferay.Util.fetch` type declarations