### PR TITLE
LPD-86011

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/display/context/AnnouncementsDisplayContext.java
@@ -162,8 +162,7 @@ public class AnnouncementsDisplayContext {
 					_segmentsEntryRetriever.getSegmentsEntryIds(
 						_announcementsRequestHelper.getScopeGroupId(),
 						_themeDisplay.getUserId(),
-						_requestContextMapper.map(_httpServletRequest),
-						new long[0]);
+						_requestContextMapper.map(_httpServletRequest));
 
 				for (long segmentsEntryId : segmentsEntryIds) {
 					List<SegmentsEntryRole> segmentsEntryRoles =

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -2427,8 +2427,7 @@ public class AssetPublisherDisplayContext {
 			_themeDisplay.getScopeGroupId(), _themeDisplay.getUserId(),
 			_requestContextMapper.map(
 				_portal.getOriginalServletRequest(
-					_portal.getHttpServletRequest(_portletRequest))),
-			new long[0]);
+					_portal.getHttpServletRequest(_portletRequest))));
 
 		return TransformUtil.transformToLongArray(
 			_assetListEntrySegmentsEntryRelLocalService.

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -118,6 +118,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.rss.util.RSSUtil;
 import com.liferay.segments.SegmentsEntryRetriever;
+import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.context.RequestContextMapper;
 
@@ -2422,19 +2423,30 @@ public class AssetPublisherDisplayContext {
 	}
 
 	private long[] _getSegmentsEntryIds(AssetListEntry assetListEntry) {
-		return _segmentsEntryRetriever.getSegmentsEntryIds(
+		long[] segmentsEntryIds = _segmentsEntryRetriever.getSegmentsEntryIds(
 			_themeDisplay.getScopeGroupId(), _themeDisplay.getUserId(),
 			_requestContextMapper.map(
 				_portal.getOriginalServletRequest(
 					_portal.getHttpServletRequest(_portletRequest))),
-			ArrayUtil.toLongArray(
-				TransformUtil.transform(
-					_assetListEntrySegmentsEntryRelLocalService.
-						getAssetListEntrySegmentsEntryRels(
-							assetListEntry.getAssetListEntryId(),
-							QueryUtil.ALL_POS, QueryUtil.ALL_POS),
-					assetListEntrySegmentsEntryRel ->
-						assetListEntrySegmentsEntryRel.getSegmentsEntryId())));
+			new long[0]);
+
+		return TransformUtil.transformToLongArray(
+			_assetListEntrySegmentsEntryRelLocalService.
+				getAssetListEntrySegmentsEntryRels(
+					assetListEntry.getAssetListEntryId(), QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS),
+			assetListEntrySegmentsEntryRel -> {
+				long segmentsEntryId =
+					assetListEntrySegmentsEntryRel.getSegmentsEntryId();
+
+				if ((segmentsEntryId == SegmentsEntryConstants.ID_DEFAULT) ||
+					ArrayUtil.contains(segmentsEntryIds, segmentsEntryId)) {
+
+					return segmentsEntryId;
+				}
+
+				return null;
+			});
 	}
 
 	private boolean _isShowRelatedAssets() {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -1248,8 +1248,7 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 		return _segmentsEntryRetriever.getSegmentsEntryIds(
 			themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
 			_requestContextMapper.map(
-				_portal.getHttpServletRequest(portletRequest)),
-			new long[0]);
+				_portal.getHttpServletRequest(portletRequest)));
 	}
 
 	private long[] _getSiteGroupIds(long[] groupIds) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SegmentResourceImpl.java
@@ -59,8 +59,7 @@ public class SegmentResourceImpl extends BaseSegmentResourceImpl {
 				ArrayUtil.toArray(
 					_segmentsEntryProviderRegistry.getSegmentsEntryIds(
 						siteId, user.getModelClassName(), user.getPrimaryKey(),
-						_requestContextMapper.map(contextHttpServletRequest),
-						new long[0])),
+						_requestContextMapper.map(contextHttpServletRequest))),
 				segmentsEntryId -> _toSegment(
 					_segmentsEntryService.getSegmentsEntry(segmentsEntryId))));
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentSetElementResourceImpl.java
@@ -162,7 +162,7 @@ public class ContentSetElementResourceImpl
 
 		long[] segmentsEntryIds = _segmentsEntryRetriever.getSegmentsEntryIds(
 			assetListEntry.getGroupId(), contextUser.getUserId(),
-			_requestContextMapper.map(contextHttpServletRequest), new long[0]);
+			_requestContextMapper.map(contextHttpServletRequest));
 
 		InfoPage<AssetEntry> infoPage =
 			_assetListAssetEntryProvider.getAssetEntriesInfoPage(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -629,8 +629,7 @@ public class SitePageResourceImpl
 					layout.getPlid(),
 					_segmentsEntryRetriever.getSegmentsEntryIds(
 						layout.getGroupId(), contextUser.getUserId(),
-						_requestContextMapper.map(httpServletRequest),
-						new long[0]));
+						_requestContextMapper.map(httpServletRequest)));
 
 		if (ArrayUtil.isEmpty(segmentsExperienceIds)) {
 			return _segmentsExperienceLocalService.fetchSegmentsExperience(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/ContentManagerImpl.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/ContentManagerImpl.java
@@ -892,7 +892,7 @@ public class ContentManagerImpl implements ContentManager {
 				_segmentsEntryRetriever.getSegmentsEntryIds(
 					_portal.getScopeGroupId(httpServletRequest),
 					_portal.getUserId(httpServletRequest),
-					_requestContextMapper.map(httpServletRequest), new long[0]),
+					_requestContextMapper.map(httpServletRequest)),
 				StringPool.BLANK);
 
 		long[] allTagIds = assetEntryQuery.getAllTagIds();

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddCollectionItemMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddCollectionItemMVCActionCommand.java
@@ -95,7 +95,7 @@ public class AddCollectionItemMVCActionCommand extends BaseMVCActionCommand {
 		return _segmentsEntryRetriever.getSegmentsEntryIds(
 			_portal.getScopeGroupId(httpServletRequest),
 			_portal.getUserId(httpServletRequest),
-			_requestContextMapper.map(httpServletRequest), new long[0]);
+			_requestContextMapper.map(httpServletRequest));
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/EvaluateLayoutStructureRulesStrutsAction.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/EvaluateLayoutStructureRulesStrutsAction.java
@@ -85,8 +85,7 @@ public class EvaluateLayoutStructureRulesStrutsAction implements StrutsAction {
 				layoutStructureRules, themeDisplay.getPermissionChecker(),
 				_segmentsEntryRetriever.getSegmentsEntryIds(
 					themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
-					_requestContextMapper.map(httpServletRequest),
-					new long[0]));
+					_requestContextMapper.map(httpServletRequest)));
 
 		ServletResponseUtil.write(httpServletResponse, jsonArray.toString());
 

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderCollectionLayoutStructureItemDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderCollectionLayoutStructureItemDisplayContext.java
@@ -711,7 +711,7 @@ public class RenderCollectionLayoutStructureItemDisplayContext {
 
 		_segmentsEntryIds = segmentsEntryRetriever.getSegmentsEntryIds(
 			_themeDisplay.getScopeGroupId(), _themeDisplay.getUserId(),
-			requestContextMapper.map(_httpServletRequest), new long[0]);
+			requestContextMapper.map(_httpServletRequest));
 
 		_segmentsEntryIds = _filterSegmentsEntryIds(
 			layoutListRetriever, listObjectReference, _segmentsEntryIds);

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -1123,7 +1123,7 @@ public class RenderLayoutStructureDisplayContext {
 
 			_segmentsEntryIds = segmentsEntryRetriever.getSegmentsEntryIds(
 				_themeDisplay.getScopeGroupId(), _themeDisplay.getUserId(),
-				requestContextMapper.map(_httpServletRequest), new long[0]);
+				requestContextMapper.map(_httpServletRequest));
 		}
 
 		return _segmentsEntryIds;

--- a/modules/apps/segments/segments-api/bnd.bnd
+++ b/modules/apps/segments/segments-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Segments API
 Bundle-SymbolicName: com.liferay.segments.api
-Bundle-Version: 32.0.1
+Bundle-Version: 33.0.0
 Export-Package:\
 	com.liferay.segments,\
 	com.liferay.segments.configuration,\

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/SegmentsEntryRetriever.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/SegmentsEntryRetriever.java
@@ -15,6 +15,6 @@ import com.liferay.segments.context.Context;
 public interface SegmentsEntryRetriever {
 
 	public long[] getSegmentsEntryIds(
-		long groupId, long userId, Context context, long[] segmentEntryIds);
+		long groupId, long userId, Context context);
 
 }

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/provider/SegmentsEntryProviderRegistry.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/provider/SegmentsEntryProviderRegistry.java
@@ -27,13 +27,11 @@ public interface SegmentsEntryProviderRegistry {
 			long groupId, String className, long classPK)
 		throws PortalException {
 
-		return getSegmentsEntryIds(
-			groupId, className, classPK, null, new long[0]);
+		return getSegmentsEntryIds(groupId, className, classPK, null);
 	}
 
 	public long[] getSegmentsEntryIds(
-			long groupId, String className, long classPK, Context context,
-			long[] segmentEntryIds)
+			long groupId, String className, long classPK, Context context)
 		throws PortalException;
 
 	public SegmentsEntryProvider getSegmentsEntryProvider(String source);

--- a/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/packageinfo
+++ b/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/provider/packageinfo
+++ b/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/provider/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/SegmentsEntryRetrieverImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/SegmentsEntryRetrieverImpl.java
@@ -37,7 +37,7 @@ public class SegmentsEntryRetrieverImpl implements SegmentsEntryRetriever {
 
 	@Override
 	public long[] getSegmentsEntryIds(
-		long groupId, long userId, Context context, long[] segmentEntryIds) {
+		long groupId, long userId, Context context) {
 
 		try {
 			if (!_segmentsConfigurationProvider.isSegmentationEnabled(
@@ -53,8 +53,7 @@ public class SegmentsEntryRetrieverImpl implements SegmentsEntryRetriever {
 		return ArrayUtil.toLongArray(
 			SetUtil.fromArray(
 				ArrayUtil.append(
-					_getSegmentEntryIds(
-						groupId, userId, context, segmentEntryIds),
+					_getSegmentEntryIds(groupId, userId, context),
 					SegmentsEntryConstants.ID_DEFAULT)));
 	}
 
@@ -73,7 +72,7 @@ public class SegmentsEntryRetrieverImpl implements SegmentsEntryRetriever {
 	}
 
 	private long[] _getSegmentEntryIds(
-		long groupId, long userId, Context context, long[] segmentEntryIds) {
+		long groupId, long userId, Context context) {
 
 		long segmentsEntryId = _getSegmentsEntryId();
 
@@ -83,8 +82,7 @@ public class SegmentsEntryRetrieverImpl implements SegmentsEntryRetriever {
 
 		try {
 			return _segmentsEntryProviderRegistry.getSegmentsEntryIds(
-				groupId, User.class.getName(), userId, context,
-				segmentEntryIds);
+				groupId, User.class.getName(), userId, context);
 		}
 		catch (PortalException portalException) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/events/SegmentsServicePreAction.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/events/SegmentsServicePreAction.java
@@ -117,8 +117,7 @@ public class SegmentsServicePreAction extends Action {
 				long[] userSegmentsEntryIds =
 					_segmentsEntryRetriever.getSegmentsEntryIds(
 						groupId, userId,
-						_requestContextMapper.map(httpServletRequest),
-						new long[0]);
+						_requestContextMapper.map(httpServletRequest));
 
 				segmentsEntryIds = TransformUtil.transformToLongArray(
 					segmentsExperienceIdsSegmentsEntryIds,

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/events/SegmentsServicePreAction.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/events/SegmentsServicePreAction.java
@@ -6,6 +6,7 @@
 package com.liferay.segments.internal.events;
 
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.events.Action;
 import com.liferay.portal.kernel.events.ActionException;
 import com.liferay.portal.kernel.events.LifecycleAction;
@@ -113,12 +114,25 @@ public class SegmentsServicePreAction extends Action {
 				segmentsEntryIds = cachedSegmentsEntryIds;
 			}
 			else {
-				segmentsEntryIds = _segmentsEntryRetriever.getSegmentsEntryIds(
-					groupId, userId,
-					_requestContextMapper.map(httpServletRequest),
-					ArrayUtil.toArray(
-						segmentsExperienceIdsSegmentsEntryIds.toArray(
-							new Long[0])));
+				long[] userSegmentsEntryIds =
+					_segmentsEntryRetriever.getSegmentsEntryIds(
+						groupId, userId,
+						_requestContextMapper.map(httpServletRequest),
+						new long[0]);
+
+				segmentsEntryIds = TransformUtil.transformToLongArray(
+					segmentsExperienceIdsSegmentsEntryIds,
+					segmentsEntryId -> {
+						if ((segmentsEntryId ==
+								SegmentsEntryConstants.ID_DEFAULT) ||
+							ArrayUtil.contains(
+								userSegmentsEntryIds, segmentsEntryId)) {
+
+							return segmentsEntryId;
+						}
+
+						return null;
+					});
 			}
 
 			httpServletRequest.setAttribute(

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserGroupRoleModelListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/model/listener/UserGroupRoleModelListener.java
@@ -36,8 +36,8 @@ public class UserGroupRoleModelListener
 		try {
 			long[] segmentsEntryIds =
 				_segmentsEntryRetriever.getSegmentsEntryIds(
-					userGroupRole.getGroupId(), userGroupRole.getUserId(), null,
-					new long[0]);
+					userGroupRole.getGroupId(), userGroupRole.getUserId(),
+					null);
 
 			for (long segmentsEntryId : segmentsEntryIds) {
 				_deleteSegmentsEntryId(userGroupRole, segmentsEntryId);

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/SegmentsEntryProviderRegistryImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/SegmentsEntryProviderRegistryImpl.java
@@ -113,8 +113,7 @@ public class SegmentsEntryProviderRegistryImpl
 
 	@Override
 	public long[] getSegmentsEntryIds(
-			long groupId, String className, long classPK, Context context,
-			long[] segmentEntryIds)
+			long groupId, String className, long classPK, Context context)
 		throws PortalException {
 
 		String cacheKey = _generateCacheKey(classPK, context);
@@ -134,7 +133,7 @@ public class SegmentsEntryProviderRegistryImpl
 			finalSegmentsEntryIds = ArrayUtil.append(
 				finalSegmentsEntryIds,
 				segmentsEntryProvider.getSegmentsEntryIds(
-					groupId, className, classPK, context, segmentEntryIds,
+					groupId, className, classPK, context, new long[0],
 					finalSegmentsEntryIds));
 		}
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/security/permission/contributor/SegmentsEntryRoleContributor.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/security/permission/contributor/SegmentsEntryRoleContributor.java
@@ -111,7 +111,7 @@ public class SegmentsEntryRoleContributor implements RoleContributor {
 
 		long[] segmentsEntryIds = _segmentsEntryRetriever.getSegmentsEntryIds(
 			roleCollection.getGroupId(), user.getUserId(),
-			_requestContextMapper.map(httpServletRequest), new long[0]);
+			_requestContextMapper.map(httpServletRequest));
 
 		if ((segmentsEntryIds.length > 0) && _log.isDebugEnabled()) {
 			_log.debug(

--- a/modules/apps/segments/segments-service/src/test/java/com/liferay/segments/internal/provider/SegmentsEntryProviderRegistryTest.java
+++ b/modules/apps/segments/segments-service/src/test/java/com/liferay/segments/internal/provider/SegmentsEntryProviderRegistryTest.java
@@ -186,7 +186,7 @@ public class SegmentsEntryProviderRegistryTest {
 
 		long[] actualSegmentsEntryIds =
 			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
-				groupId, className, classPK, context, new long[0]);
+				groupId, className, classPK, context);
 
 		Arrays.sort(actualSegmentsEntryIds);
 

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/ReferredSegmentsEntryProviderTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/ReferredSegmentsEntryProviderTest.java
@@ -275,7 +275,7 @@ public class ReferredSegmentsEntryProviderTest {
 		long[] segmentsEntryIds =
 			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
 				_group.getGroupId(), User.class.getName(), _user1.getUserId(),
-				new Context(), new long[0]);
+				new Context());
 
 		Assert.assertEquals(
 			StringUtil.merge(segmentsEntryIds, StringPool.COMMA), 1,
@@ -314,7 +314,7 @@ public class ReferredSegmentsEntryProviderTest {
 		long[] segmentsEntryIds =
 			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
 				_group.getGroupId(), User.class.getName(), _user1.getUserId(),
-				new Context(), new long[0]);
+				new Context());
 
 		Assert.assertEquals(
 			StringUtil.merge(segmentsEntryIds, StringPool.COMMA), 2,
@@ -369,7 +369,7 @@ public class ReferredSegmentsEntryProviderTest {
 		long[] segmentsEntryIds =
 			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
 				_group.getGroupId(), User.class.getName(), _user1.getUserId(),
-				context, new long[0]);
+				context);
 
 		Assert.assertEquals(
 			StringUtil.merge(segmentsEntryIds, StringPool.COMMA), 2,
@@ -423,7 +423,7 @@ public class ReferredSegmentsEntryProviderTest {
 		long[] segmentsEntryIds =
 			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
 				_group.getGroupId(), User.class.getName(), _user1.getUserId(),
-				context, new long[0]);
+				context);
 
 		Assert.assertEquals(
 			StringUtil.merge(segmentsEntryIds, StringPool.COMMA), 2,

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/SegmentsEntryProviderRegistryTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/SegmentsEntryProviderRegistryTest.java
@@ -66,8 +66,7 @@ public class SegmentsEntryProviderRegistryTest {
 		long[] segmentsEntryIds =
 			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
 				_group.getGroupId(), User.class.getName(),
-				TestPropsValues.getUserId(), new Context(),
-				new long[] {segmentsEntry1.getSegmentsEntryId()});
+				TestPropsValues.getUserId(), new Context());
 
 		Assert.assertEquals(
 			Arrays.toString(segmentsEntryIds), 1, segmentsEntryIds.length);
@@ -80,8 +79,7 @@ public class SegmentsEntryProviderRegistryTest {
 
 		segmentsEntryIds = _segmentsEntryProviderRegistry.getSegmentsEntryIds(
 			_group.getGroupId(), User.class.getName(),
-			TestPropsValues.getUserId(), new Context(),
-			new long[] {segmentsEntry2.getSegmentsEntryId()});
+			TestPropsValues.getUserId(), new Context());
 
 		Assert.assertEquals(
 			Arrays.toString(segmentsEntryIds), 1, segmentsEntryIds.length);

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/SegmentsEntryProviderRegistryTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/SegmentsEntryProviderRegistryTest.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.segments.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.segments.context.Context;
+import com.liferay.segments.criteria.Criteria;
+import com.liferay.segments.criteria.CriteriaSerializer;
+import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
+import com.liferay.segments.model.SegmentsEntry;
+import com.liferay.segments.provider.SegmentsEntryProviderRegistry;
+import com.liferay.segments.test.util.SegmentsTestUtil;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@RunWith(Arquillian.class)
+@Sync
+public class SegmentsEntryProviderRegistryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testGetSegmentsEntryIds() throws Exception {
+		SegmentsEntry segmentsEntry1 = _addSegmentsEntry(
+			RandomTestUtil.randomString());
+
+		User user = TestPropsValues.getUser();
+
+		SegmentsEntry segmentsEntry2 = _addSegmentsEntry(user.getFirstName());
+
+		long[] segmentsEntryIds =
+			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
+				_group.getGroupId(), User.class.getName(),
+				TestPropsValues.getUserId(), new Context(),
+				new long[] {segmentsEntry1.getSegmentsEntryId()});
+
+		Assert.assertEquals(
+			Arrays.toString(segmentsEntryIds), 1, segmentsEntryIds.length);
+		Assert.assertFalse(
+			ArrayUtil.contains(
+				segmentsEntryIds, segmentsEntry1.getSegmentsEntryId()));
+		Assert.assertTrue(
+			ArrayUtil.contains(
+				segmentsEntryIds, segmentsEntry2.getSegmentsEntryId()));
+
+		segmentsEntryIds = _segmentsEntryProviderRegistry.getSegmentsEntryIds(
+			_group.getGroupId(), User.class.getName(),
+			TestPropsValues.getUserId(), new Context(),
+			new long[] {segmentsEntry2.getSegmentsEntryId()});
+
+		Assert.assertEquals(
+			Arrays.toString(segmentsEntryIds), 1, segmentsEntryIds.length);
+		Assert.assertFalse(
+			ArrayUtil.contains(
+				segmentsEntryIds, segmentsEntry1.getSegmentsEntryId()));
+		Assert.assertTrue(
+			ArrayUtil.contains(
+				segmentsEntryIds, segmentsEntry2.getSegmentsEntryId()));
+	}
+
+	private SegmentsEntry _addSegmentsEntry(String firstName) throws Exception {
+		Criteria criteria = new Criteria();
+
+		_userSegmentsCriteriaContributor.contribute(
+			criteria, String.format("(firstName eq '%s')", firstName),
+			Criteria.Conjunction.AND);
+
+		return SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId(), CriteriaSerializer.serialize(criteria));
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private SegmentsEntryProviderRegistry _segmentsEntryProviderRegistry;
+
+	@Inject(
+		filter = "segments.criteria.contributor.key=user",
+		type = SegmentsCriteriaContributor.class
+	)
+	private SegmentsCriteriaContributor _userSegmentsCriteriaContributor;
+
+}

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/test/SegmentsEntryRetrieverTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/test/SegmentsEntryRetrieverTest.java
@@ -76,7 +76,7 @@ public class SegmentsEntryRetrieverTest {
 
 			long[] segmentsEntryIds =
 				_segmentsEntryRetriever.getSegmentsEntryIds(
-					_group.getGroupId(), _user.getUserId(), null, new long[0]);
+					_group.getGroupId(), _user.getUserId(), null);
 
 			Assert.assertEquals(
 				Arrays.toString(segmentsEntryIds), 2, segmentsEntryIds.length);
@@ -123,7 +123,7 @@ public class SegmentsEntryRetrieverTest {
 	@Test
 	public void testGetSegmentsEntryIdsWithoutSegmentsEntry() throws Exception {
 		long[] segmentsEntryIds = _segmentsEntryRetriever.getSegmentsEntryIds(
-			_group.getGroupId(), _user.getUserId(), null, new long[0]);
+			_group.getGroupId(), _user.getUserId(), null);
 
 		Assert.assertEquals(
 			Arrays.toString(segmentsEntryIds), 1, segmentsEntryIds.length);
@@ -175,7 +175,7 @@ public class SegmentsEntryRetrieverTest {
 
 		try {
 			return _segmentsEntryRetriever.getSegmentsEntryIds(
-				_group.getGroupId(), _user.getUserId(), null, new long[0]);
+				_group.getGroupId(), _user.getUserId(), null);
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/contributor/UserSXPParameterContributor.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/blueprint/parameter/contributor/UserSXPParameterContributor.java
@@ -452,8 +452,7 @@ public class UserSXPParameterContributor implements SXPParameterContributor {
 							_language.getLanguageId(searchContext.getLocale()));
 						put(Context.SIGNED_IN, !user.isGuestUser());
 					}
-				},
-				new long[0]);
+				});
 
 			segmentsEntryIds = ArrayUtil.filter(
 				segmentsEntryIds, segmentsEntryId -> segmentsEntryId > 0);

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/parameter/contributor/UserSXPParameterContributorTest.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/test/java/com/liferay/search/experiences/internal/blueprint/parameter/contributor/UserSXPParameterContributorTest.java
@@ -1087,7 +1087,7 @@ public class UserSXPParameterContributorTest {
 		).when(
 			segmentsEntryRetriever
 		).getSegmentsEntryIds(
-			Mockito.anyLong(), Mockito.anyLong(), Mockito.any(), Mockito.any()
+			Mockito.anyLong(), Mockito.anyLong(), Mockito.any()
 		);
 
 		return segmentsEntryRetriever;


### PR DESCRIPTION
Motivation
----
Fix for Assets are not correctly displayed when several Asset Publishers within the same page are configured with Collections containing different Variations

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-86011)

Proposed Solution
----
In this PR, we’ve updated how segment entry IDs are handled to better align with the recent caching behavior and avoid incorrect results.

Specifically, we removed the `segmentEntryIds` parameter from the method, since segment entry IDs are now cached. Passing this parameter could lead to inconsistent results when the same cached context is reused with different values. Instead, we now retrieve the user’s segment entry IDs directly from `segmentsEntryRetriever.getSegmentsEntryIds` and apply filtering locally to keep only those that match the relevant variations.

Additionally, we’ve added tests to clearly expose and validate the issue caused by the previous approach, ensuring the new behavior is properly covered and preventing regressions in the future.