### PR TITLE
LPD-86103

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/BaseSegmentsEntryProvider.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/BaseSegmentsEntryProvider.java
@@ -8,6 +8,7 @@ package com.liferay.segments.internal.provider;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.expando.kernel.model.ExpandoColumn;
+import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.expando.kernel.model.ExpandoTable;
 import com.liferay.expando.kernel.model.ExpandoTableConstants;
 import com.liferay.expando.kernel.model.ExpandoValue;
@@ -380,7 +381,7 @@ public abstract class BaseSegmentsEntryProvider
 	}
 
 	private Map<String, Object> _getUserAttributes(User user) throws Exception {
-		Map<String, String> expandoValues = new HashMap<>();
+		Map<String, Object> expandoValues = new HashMap<>();
 
 		ExpandoTable expandoTable = expandoTableLocalService.fetchTable(
 			user.getCompanyId(),
@@ -407,7 +408,14 @@ public abstract class BaseSegmentsEntryProvider
 						CharPool.SPACE, CharPool.UNDERLINE));
 
 				if (expandoValue != null) {
-					expandoValues.put(key, expandoValue.getData());
+					if (expandoColumn.getType() ==
+							ExpandoColumnConstants.BOOLEAN) {
+
+						expandoValues.put(key, expandoValue.getBoolean());
+					}
+					else {
+						expandoValues.put(key, expandoValue.getData());
+					}
 				}
 				else {
 					expandoValues.put(key, StringPool.BLANK);

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/DefaultSegmentsEntryProviderTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/DefaultSegmentsEntryProviderTest.java
@@ -8,6 +8,13 @@ package com.liferay.segments.provider.test;
 import com.fasterxml.jackson.databind.util.ISO8601Utils;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.expando.kernel.model.ExpandoColumn;
+import com.liferay.expando.kernel.model.ExpandoColumnConstants;
+import com.liferay.expando.kernel.model.ExpandoTable;
+import com.liferay.expando.kernel.service.ExpandoTableLocalService;
+import com.liferay.expando.kernel.service.ExpandoValueLocalService;
+import com.liferay.expando.test.util.ExpandoTestUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -29,6 +36,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.odata.normalizer.Normalizer;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.segments.constants.SegmentsEntryConstants;
@@ -183,6 +191,43 @@ public class DefaultSegmentsEntryProviderTest {
 			new long[] {_user1.getUserId()},
 			_segmentsEntryProvider.getSegmentsEntryClassPKs(
 				segmentsEntry.getSegmentsEntryId(), 0, 1));
+	}
+
+	@Test
+	@TestInfo("LPD-86103")
+	public void testGetSegmentsEntryIdsWithBooleanCustomField()
+		throws Exception {
+
+		ExpandoTable expandoTable = _expandoTableLocalService.addDefaultTable(
+			TestPropsValues.getCompanyId(), User.class.getName());
+
+		ExpandoColumn expandoColumn = ExpandoTestUtil.addColumn(
+			expandoTable, RandomTestUtil.randomString(),
+			ExpandoColumnConstants.BOOLEAN);
+
+		_expandoValueLocalService.addValue(
+			TestPropsValues.getCompanyId(), User.class.getName(),
+			expandoTable.getName(), expandoColumn.getName(),
+			TestPropsValues.getUserId(), true);
+
+		Criteria criteria = new Criteria();
+
+		_userSegmentsCriteriaContributor.contribute(
+			criteria,
+			StringBundler.concat(
+				"(customField/_", expandoColumn.getColumnId(), "_",
+				Normalizer.normalizeIdentifier(expandoColumn.getName()),
+				" eq true)"),
+			Criteria.Conjunction.AND);
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId(), CriteriaSerializer.serialize(criteria));
+
+		Assert.assertArrayEquals(
+			new long[] {segmentsEntry.getSegmentsEntryId()},
+			_segmentsEntryProvider.getSegmentsEntryIds(
+				_group.getGroupId(), User.class.getName(),
+				TestPropsValues.getUserId(), new Context()));
 	}
 
 	@Test
@@ -972,6 +1017,12 @@ public class DefaultSegmentsEntryProviderTest {
 		type = SegmentsCriteriaContributor.class
 	)
 	private SegmentsCriteriaContributor _contextSegmentsCriteriaContributor;
+
+	@Inject
+	private ExpandoTableLocalService _expandoTableLocalService;
+
+	@Inject
+	private ExpandoValueLocalService _expandoValueLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
Motivation
----
Fix for Variations related to Segments with Boolean Custom Fields are not honored in Asset Publishers

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-86103)

Proposed Solution
----
If the column type is boolean, we need to pass the value as a boolean instead of a string because segment validation isn’t working properly.