### PR TITLE
LPD-86335

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/BaseSegmentsEntryProvider.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/BaseSegmentsEntryProvider.java
@@ -15,10 +15,8 @@ import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
 import com.liferay.expando.kernel.service.ExpandoValueLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -42,6 +40,7 @@ import com.liferay.segments.criteria.Criteria;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
 import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributorRegistry;
 import com.liferay.segments.internal.checker.UserSegmentsEntryMembershipChecker;
+import com.liferay.segments.internal.odata.entity.EntityModelFieldMapper;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsEntryRel;
 import com.liferay.segments.odata.matcher.ODataMatcher;
@@ -338,6 +337,9 @@ public abstract class BaseSegmentsEntryProvider
 	protected ClassNameLocalService classNameLocalService;
 
 	@Reference
+	protected EntityModelFieldMapper entityModelFieldMapper;
+
+	@Reference
 	protected ExpandoColumnLocalService expandoColumnLocalService;
 
 	@Reference
@@ -396,15 +398,11 @@ public abstract class BaseSegmentsEntryProvider
 					expandoTable.getTableId(), expandoColumn.getColumnId(),
 					user.getUserId());
 
-				String expandoColumnName = expandoColumn.getName();
+				String encodedName =
+					entityModelFieldMapper.getExpandoColumnEntityFieldName(
+						expandoColumn);
 
-				String key = StringBundler.concat(
-					"customField/_", expandoColumn.getColumnId(),
-					StringPool.UNDERLINE,
-					StringUtil.replace(
-						expandoColumnName.replaceAll(
-							":|;|'|\"", StringPool.BLANK),
-						CharPool.SPACE, CharPool.UNDERLINE));
+				String key = "customField/" + encodedName;
 
 				if (expandoValue != null) {
 					expandoValues.put(key, expandoValue.getData());

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/DefaultSegmentsEntryProviderTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/DefaultSegmentsEntryProviderTest.java
@@ -878,6 +878,42 @@ public class DefaultSegmentsEntryProviderTest {
 	}
 
 	@Test
+	@TestInfo("LPD-86335")
+	public void testGetSegmentsEntryIdsWithSpecialCharactersInCustomFieldName()
+		throws Exception {
+
+		ExpandoTable expandoTable = _expandoTableLocalService.addDefaultTable(
+			TestPropsValues.getCompanyId(), User.class.getName());
+
+		ExpandoColumn expandoColumn = ExpandoTestUtil.addColumn(
+			expandoTable, "custom-field", ExpandoColumnConstants.STRING);
+
+		_expandoValueLocalService.addValue(
+			TestPropsValues.getCompanyId(), User.class.getName(),
+			expandoTable.getName(), expandoColumn.getName(),
+			TestPropsValues.getUserId(), "test");
+
+		Criteria criteria = new Criteria();
+
+		_userSegmentsCriteriaContributor.contribute(
+			criteria,
+			StringBundler.concat(
+				"(customField/_", expandoColumn.getColumnId(), "_",
+				Normalizer.normalizeIdentifier(expandoColumn.getName()),
+				" eq 'test')"),
+			Criteria.Conjunction.AND);
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId(), CriteriaSerializer.serialize(criteria));
+
+		Assert.assertArrayEquals(
+			new long[] {segmentsEntry.getSegmentsEntryId()},
+			_segmentsEntryProvider.getSegmentsEntryIds(
+				_group.getGroupId(), User.class.getName(),
+				TestPropsValues.getUserId(), new Context()));
+	}
+
+	@Test
 	public void testGetSegmentsEntryIdsWithUserDateModifiedCriterion()
 		throws Exception {
 


### PR DESCRIPTION
Motivation
----
Fix for Asset Publishers do not display contents related to segments with Custom Fields whose name contains hyphens

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-86335)

Proposed Solution
----
This PR introduces a new test to help reproduce and better understand the underlying issue.

Additionally, it updates the implementation to use `EntityModelFieldMapper` for retrieving the `expandoColumnEntityFieldName`. This ensures consistency with how the value is generated and used when adding segments through the UI, as well as within the `filterString` query.

By aligning these behaviors, we reduce the risk of mismatches and improve the reliability of segment-related filtering.