### PR TITLE
faro-v4.15.x | LPD-86065

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
@@ -177,7 +177,7 @@
 		"format": "eslint --fix \"src/main/js/**/*.+(js|ts)?(x)\"",
 		"lint": "eslint \"src/main/js/**/*.+(js|ts)?(x)\"",
 		"start": "cross-env FARO_ENVIRONMENT_NAME=local webpack-dev-server --config webpack.dev.js",
-		"test": "cross-env TZ=Etc/GMT jest --coverage=false --maxWorkers=4",
+		"test": "cross-env TZ=Etc/GMT LC_ALL=en_US.UTF-8 jest --coverage=false --maxWorkers=4",
 		"webpack": "webpack --config webpack.prod.js",
 		"webpack:dev": "webpack --config webpack.dev.js"
 	},

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/__tests__/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/__tests__/List.tsx
@@ -1,4 +1,4 @@
-import List from '../pages/List';
+import List from 'assets/pages/List';
 import mockStore from 'test/mock-store';
 import React from 'react';
 import {ChannelContext} from 'shared/context/channel';
@@ -14,24 +14,28 @@ jest.unmock('react-dom');
 jest.mock('shared/hooks/useFrontendDataSet', () => ({
 	useFrontendDataSet: () => {
 		const FakeDataSet = ({
+			filters,
 			id,
 			itemsActions
 		}: {
+			filters?: any[];
 			id: string;
 			itemsActions?: Array<{onClick?: (item: any) => void}>;
 		}) => (
 			<div data-testid='fds-component' id={id}>
+				<div data-testid='fds-filters'>{JSON.stringify(filters)}</div>
+
 				<button
 					data-testid='trigger-info-panel'
 					onClick={() =>
 						itemsActions?.[0]?.onClick?.({
 							itemData: {
 								assetCategories: [],
-								assetMimeType: 'blog',
 								assetTags: [],
 								assetTitle: 'Test Asset Title',
 								assetType: 'blog',
-								id: 'asset-id-1'
+								id: 'asset-id-1',
+								mimeType: 'blog'
 							}
 						})
 					}
@@ -62,10 +66,10 @@ jest.mock('shared/hooks/useFrontendDataSet', () => ({
 						itemsActions?.[0]?.onClick?.({
 							itemData: {
 								assetCategories: [],
-								assetMimeType: 'folder',
 								assetTags: [],
 								assetType: 'folder',
-								id: 'fallback-id-3'
+								id: 'fallback-id-3',
+								mimeType: 'folder'
 							}
 						})
 					}
@@ -82,11 +86,11 @@ jest.mock('shared/hooks/useFrontendDataSet', () => ({
 									{id: 'cat-1', name: 'Category One'},
 									{id: 'cat-2', name: 'Category Two'}
 								],
-								assetMimeType: 'basic-web-content',
 								assetTags: [{id: 'tag-1', name: 'Tag One'}],
 								assetTitle: 'Rich Asset',
 								assetType: 'webContent',
-								id: 'asset-id-4'
+								id: 'asset-id-4',
+								mimeType: 'basic-web-content'
 							}
 						})
 					}
@@ -231,6 +235,22 @@ describe('List', () => {
 				'id',
 				'assetTable'
 			);
+		});
+
+		it('should pass the mimeType filter to FrontendDataSet', () => {
+			renderList();
+
+			const filters = JSON.parse(
+				screen.getByTestId('fds-filters').textContent
+			);
+
+			const mimeTypeFilter = filters.find(
+				filter => filter.id === 'mimeType'
+			);
+
+			expect(mimeTypeFilter).toBeDefined();
+			expect(mimeTypeFilter.label).toBe('MIME Type');
+			expect(mimeTypeFilter.apiURL).toContain('asset-summary-mime-types');
 		});
 
 		it('should render the DropdownRangeKey', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
@@ -94,6 +94,11 @@ exports[`List rendering should match the snapshot 1`] = `
           data-testid="fds-component"
           id="assetTable"
         >
+          <div
+            data-testid="fds-filters"
+          >
+            [{"apiURL":"/o/faro/contacts/23/asset-summary-types?channelId=123&rangeKey=30","entityFieldType":"string","id":"assetType","itemKey":"name","itemLabel":"name","label":"Type","multiple":true,"searchable":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-tags?channelId=123&rangeKey=30","entityFieldType":"string","id":"tags/id","itemKey":"id","itemLabel":"name","label":"Tags","multiple":true,"searchable":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-categories?channelId=123&rangeKey=30","entityFieldType":"string","id":"categories/id","itemKey":"id","itemLabel":"name","label":"Categories","multiple":true,"searchable":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-mime-types?channelId=123&rangeKey=30","entityFieldType":"string","id":"mimeType","itemKey":"id","itemLabel":"name","label":"MIME Type","multiple":true,"searchable":true,"type":"selection"}]
+          </div>
           <button
             data-testid="trigger-info-panel"
           >

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/components/InfoPanel.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/components/InfoPanel.tsx
@@ -15,7 +15,7 @@ interface IInfoPanelProps {
 	data: {
 		itemData: {
 			assetCategories?: {id: string; name: string}[];
-			assetMimeType?: string;
+			mimeType?: string;
 			assetTags?: {id: string; name: string}[];
 			assetTitle: string;
 			assetType: string;
@@ -31,7 +31,7 @@ const InfoPanel: React.FC<IInfoPanelProps> = ({data, onClose}) => {
 
 	const mimeType = getMimeType({
 		assetType: data?.itemData?.assetType,
-		mimeType: data?.itemData?.assetMimeType
+		mimeType: data?.itemData?.mimeType
 	});
 
 	return (

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/components/mime-type/__tests__/index.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/components/mime-type/__tests__/index.ts
@@ -1,0 +1,73 @@
+import {getMimeType} from '../index';
+import {STRUCTURES_MAP} from '../constants';
+
+describe('getMimeType', () => {
+	it('should return correct mapping for assetType when mimeType is missing', () => {
+		expect(getMimeType({assetType: 'blog'})).toEqual(STRUCTURES_MAP.blog);
+		expect(getMimeType({assetType: 'document'})).toEqual(
+			STRUCTURES_MAP.document
+		);
+	});
+
+	it('should return fallback for unknown assetType when mimeType is missing', () => {
+		expect(getMimeType({assetType: 'unknown'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentDefault
+		);
+	});
+
+	it('should return CMSDocumentDefault if both assetType and mimeType are missing', () => {
+		expect(getMimeType({})).toEqual(STRUCTURES_MAP.CMSDocumentDefault);
+	});
+
+	it('should return mapping for exact mimeType match', () => {
+		expect(getMimeType({mimeType: 'application/pdf'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentVector
+		);
+		expect(getMimeType({mimeType: 'text/plain'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentText
+		);
+	});
+
+	it('should return mapping based on mimeType prefix (image)', () => {
+		expect(getMimeType({mimeType: 'image/png'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentImage
+		);
+		expect(getMimeType({mimeType: 'image/jpeg'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentImage
+		);
+		expect(getMimeType({mimeType: 'image/gif'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentImage
+		);
+	});
+
+	it('should return mapping based on mimeType prefix (audio)', () => {
+		expect(getMimeType({mimeType: 'audio/mpeg'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentMultimedia
+		);
+		expect(getMimeType({mimeType: 'audio/wav'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentMultimedia
+		);
+	});
+
+	it('should return mapping based on mimeType prefix (video)', () => {
+		expect(getMimeType({mimeType: 'video/mp4'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentMultimedia
+		);
+		expect(getMimeType({mimeType: 'video/webm'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentMultimedia
+		);
+	});
+
+	it('should return default mapping for unknown mimeType and unknown prefix', () => {
+		expect(getMimeType({mimeType: 'unknown/type'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentDefault
+		);
+	});
+
+	it('should handle mimeType without slash by using it as prefix', () => {
+		// Even if it's not a standard mime type, the logic uses the first part.
+		expect(getMimeType({mimeType: 'image'})).toEqual(
+			STRUCTURES_MAP.CMSDocumentImage
+		);
+	});
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/pages/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/pages/List.tsx
@@ -83,7 +83,7 @@ const columns = {
 
 		const mimeType = getMimeType({
 			assetType: itemData?.assetType,
-			mimeType: itemData?.assetMimeType
+			mimeType: itemData?.mimeType
 		});
 
 		return (
@@ -143,6 +143,7 @@ const List = () => {
 				itemLabel: 'name',
 				label: Liferay.Language.get('type'),
 				multiple: true,
+				searchable: true,
 				type: 'selection'
 			},
 			{
@@ -153,6 +154,7 @@ const List = () => {
 				itemLabel: 'name',
 				label: Liferay.Language.get('tags'),
 				multiple: true,
+				searchable: true,
 				type: 'selection'
 			},
 			{
@@ -163,6 +165,18 @@ const List = () => {
 				itemLabel: 'name',
 				label: Liferay.Language.get('categories'),
 				multiple: true,
+				searchable: true,
+				type: 'selection'
+			},
+			{
+				apiURL: `/o/faro/contacts/${groupId}/asset-summary-mime-types?channelId=${channelId}&${rangeSelectorParams}`,
+				entityFieldType: 'string',
+				id: 'mimeType',
+				itemKey: 'id',
+				itemLabel: 'name',
+				label: Liferay.Language.get('mime-type'),
+				multiple: true,
+				searchable: true,
 				type: 'selection'
 			}
 		],

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language.properties
@@ -932,6 +932,7 @@ metric=Metric
 metrics-overview=Metrics Overview
 metrics-will-show-once-there-are-visitors-to-your-variants=Metrics will show once there are visitors to your variants.
 middle-name=Middle Name
+mime-type=MIME Type
 minimum-fix-pack-version-required-for-full-functionality=Minimum Fix Pack Version Required for Full Functionality
 minutes=Minutes
 mobile=Mobile


### PR DESCRIPTION
Backport of LPD-86065 commits onto faro-v4.15.x.

Cherry-picked commits:
- fd5dd46 LPD-86065 Fix test locale environment and add mime-type language key
- 3e7d742 LPD-86065 Implement MIME type filtering and info panel integration
- c471125 LPD-86065 Update asset list tests and add MIME type utility tests