### PR TITLE
LPD-86441 Remove apiHelpers.headlessSite calls for Analytics Cloud

### DIFF
--- a/modules/test/playwright/tests/analytics-client-js/main/events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/events.spec.ts
@@ -27,14 +27,16 @@ let site;
 const siteName = getRandomString();
 
 test.beforeEach(async ({apiHelpers}) => {
-	site = await apiHelpers.headlessSite.createSite({
+	site = await apiHelpers.headlessAdminSite.postSite({
 		name: siteName,
 	});
 });
 
 test.afterEach(async ({apiHelpers}) => {
 	await test.step('Delete site on de DXP side', async () => {
-		await apiHelpers.headlessSite.deleteSite(site.id);
+		await apiHelpers.headlessAdminSite.deleteSite(
+			site.externalReferenceCode
+		);
 	});
 });
 

--- a/modules/test/playwright/tests/analytics-settings-web/main/connection-information.spec.ts
+++ b/modules/test/playwright/tests/analytics-settings-web/main/connection-information.spec.ts
@@ -40,11 +40,9 @@ test(
 		tag: '@LRAC-11044',
 	},
 	async ({apiHelpers, page}) => {
-		const site1 = await apiHelpers.headlessSite.createSite({
+		const site1 = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site1.externalReferenceCode, type: 'site'});
 
 		const commerceChannel1 =
 			await apiHelpers.headlessCommerceAdminChannel.postChannel({
@@ -62,11 +60,9 @@ test(
 			siteName: site1.name,
 		});
 
-		const site2 = await apiHelpers.headlessSite.createSite({
+		const site2 = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site2.externalReferenceCode, type: 'site'});
 
 		const commerceChannel2 =
 			await apiHelpers.headlessCommerceAdminChannel.postChannel({
@@ -127,11 +123,9 @@ test(
 		tag: '@LPD-69652',
 	},
 	async ({apiHelpers, page}) => {
-		const site1 = await apiHelpers.headlessSite.createSite({
+		const site1 = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site1.externalReferenceCode, type: 'site'});
 
 		const channelName1 = getRandomString();
 
@@ -147,11 +141,9 @@ test(
 			stepName: 'Properties',
 		});
 
-		const site2 = await apiHelpers.headlessSite.createSite({
+		const site2 = await apiHelpers.headlessAdminSite.postSite({
 			name: getRandomString(),
 		});
-
-		apiHelpers.data.push({id: site2.externalReferenceCode, type: 'site'});
 
 		const channelName2 = getRandomString();
 

--- a/modules/test/playwright/tests/analytics-settings-web/main/recommendations.spec.ts
+++ b/modules/test/playwright/tests/analytics-settings-web/main/recommendations.spec.ts
@@ -10,7 +10,6 @@ import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginAnalyticsCloudTest} from '../../../fixtures/loginAnalyticsCloudTest';
 import {loginTest} from '../../../fixtures/loginTest';
-import {liferayConfig} from '../../../liferay.config';
 import getRandomString from '../../../utils/getRandomString';
 import {createChannel} from '../../osb-faro-web/main/utils/channel';
 import {createDataSource} from '../../osb-faro-web/main/utils/data-source';
@@ -59,13 +58,8 @@ test.describe('Test All Recommendation Job', () => {
 			apiHelpers,
 			page,
 		}) => {
-			const site = await apiHelpers.headlessSite.createSite({
+			const site = await apiHelpers.headlessAdminSite.postSite({
 				name: getRandomString(),
-			});
-
-			apiHelpers.data.push({
-				id: site.externalReferenceCode,
-				type: 'site',
 			});
 
 			const channelName = 'My Property - ' + getRandomString();
@@ -158,15 +152,11 @@ test.describe('Test All Recommendation Job', () => {
 
 			expect(await toggleElement.isChecked()).toBeFalsy();
 
-			await test.step('Delete channel and delete site on the DXP side', async () => {
+			await test.step('Delete channel', async () => {
 				await apiHelpers.jsonWebServicesOSBFaro.deleteChannel(
 					`[${channel.id}]`,
 					project.groupId
 				);
-
-				await page.goto(liferayConfig.environment.baseUrl);
-
-				await apiHelpers.headlessSite.deleteSite(String(site.id));
 			});
 		});
 	});

--- a/modules/test/playwright/tests/osb-faro-web/main/ab-test.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/ab-test.spec.ts
@@ -24,11 +24,7 @@ import {
 } from '../../segment-experiment-web/main/utils/ab-test';
 import {checkEmptyStateOnACSide, clickOnActionButton} from './utils/ab-test';
 import {ACPage, navigateTo, navigateToACPageViaURL} from './utils/navigation';
-import {
-	createSitePage,
-	navigateToDXPandDeleteSite,
-	navigateToSitePage,
-} from './utils/portal';
+import {createSitePage, navigateToSitePage} from './utils/portal';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -49,7 +45,7 @@ test(
 	async ({apiHelpers, page}) => {
 		const siteName = getRandomString();
 
-		const site = await apiHelpers.headlessSite.createSite({
+		await apiHelpers.headlessAdminSite.postSite({
 			name: siteName,
 		});
 
@@ -126,10 +122,6 @@ test(
 				project.groupId
 			);
 		});
-
-		await test.step('delete site on DXP side', async () => {
-			await navigateToDXPandDeleteSite({apiHelpers, page, site});
-		});
 	}
 );
 
@@ -141,7 +133,7 @@ test(
 	async ({apiHelpers, page}) => {
 		const siteName = getRandomString();
 
-		const site = await apiHelpers.headlessSite.createSite({
+		await apiHelpers.headlessAdminSite.postSite({
 			name: siteName,
 		});
 
@@ -223,10 +215,6 @@ test(
 				project.groupId
 			);
 		});
-
-		await test.step('delete site on DXP side', async () => {
-			await navigateToDXPandDeleteSite({apiHelpers, page, site});
-		});
 	}
 );
 
@@ -238,7 +226,7 @@ test(
 	async ({apiHelpers, page, pageEditorPage}) => {
 		const siteName = getRandomString();
 
-		await apiHelpers.headlessSite.createSite({
+		await apiHelpers.headlessAdminSite.postSite({
 			name: siteName,
 		});
 
@@ -335,7 +323,7 @@ test(
 	async ({apiHelpers, page, pageEditorPage}) => {
 		const siteName = getRandomString();
 
-		await apiHelpers.headlessSite.createSite({
+		await apiHelpers.headlessAdminSite.postSite({
 			name: siteName,
 		});
 
@@ -442,7 +430,7 @@ test(
 	async ({apiHelpers, page, pageEditorPage}) => {
 		const siteName = getRandomString();
 
-		await apiHelpers.headlessSite.createSite({
+		await apiHelpers.headlessAdminSite.postSite({
 			name: siteName,
 		});
 
@@ -541,7 +529,7 @@ test(
 	async ({apiHelpers, page}) => {
 		const siteName = getRandomString();
 
-		const site = await apiHelpers.headlessSite.createSite({
+		await apiHelpers.headlessAdminSite.postSite({
 			name: siteName,
 		});
 
@@ -627,10 +615,6 @@ test(
 				`[${channel.id}]`,
 				project.groupId
 			);
-		});
-
-		await test.step('delete site on DXP side', async () => {
-			await navigateToDXPandDeleteSite({apiHelpers, page, site});
 		});
 	}
 );

--- a/modules/test/playwright/tests/osb-faro-web/main/emptyStateConnectedToDXP.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/emptyStateConnectedToDXP.spec.ts
@@ -10,7 +10,6 @@ import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginAnalyticsCloudTest} from '../../../fixtures/loginAnalyticsCloudTest';
 import {loginTest} from '../../../fixtures/loginTest';
-import {liferayConfig} from '../../../liferay.config';
 import getRandomString from '../../../utils/getRandomString';
 import {syncAnalyticsCloud} from '../../analytics-settings-web/main/utils/analytics-settings';
 import {switchChannel} from './utils/channel';
@@ -39,10 +38,9 @@ const siteName = 'My Site ' + randomString;
 
 let channel;
 let project;
-let site;
 
 test.beforeEach(async ({apiHelpers, page}) => {
-	site = await apiHelpers.headlessSite.createSite({
+	await apiHelpers.headlessAdminSite.postSite({
 		name: siteName,
 	});
 
@@ -57,18 +55,12 @@ test.beforeEach(async ({apiHelpers, page}) => {
 	project = result.project;
 });
 
-test.afterEach(async ({apiHelpers, page}) => {
+test.afterEach(async ({apiHelpers}) => {
 	await test.step('Delete channel', async () => {
 		await apiHelpers.jsonWebServicesOSBFaro.deleteChannel(
 			`[${channel.id}]`,
 			project.groupId
 		);
-	});
-
-	await test.step('Delete site on DXP side', async () => {
-		await page.goto(liferayConfig.environment.baseUrl);
-
-		await apiHelpers.headlessSite.deleteSite(String(site.id));
 	});
 });
 

--- a/modules/test/playwright/tests/osb-faro-web/main/individual.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/individual.spec.ts
@@ -9,7 +9,6 @@ import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginAnalyticsCloudTest} from '../../../fixtures/loginAnalyticsCloudTest';
 import {loginTest} from '../../../fixtures/loginTest';
-import {liferayConfig} from '../../../liferay.config';
 import getRandomString from '../../../utils/getRandomString';
 import {syncAnalyticsCloud} from '../../analytics-settings-web/main/utils/analytics-settings';
 import {
@@ -35,10 +34,9 @@ const siteName = 'My Site ' + randomString;
 
 let channel;
 let project;
-let site;
 
 test.beforeEach(async ({apiHelpers, page}) => {
-	site = await apiHelpers.headlessSite.createSite({
+	await apiHelpers.headlessAdminSite.postSite({
 		name: siteName,
 	});
 
@@ -59,16 +57,12 @@ test.beforeEach(async ({apiHelpers, page}) => {
 	project = result.project;
 });
 
-test.afterEach(async ({apiHelpers, page}) => {
-	await test.step('Delete channel and delete site on the DXP side', async () => {
+test.afterEach(async ({apiHelpers}) => {
+	await test.step('Delete channel', async () => {
 		await apiHelpers.jsonWebServicesOSBFaro.deleteChannel(
 			`[${channel.id}]`,
 			project.groupId
 		);
-
-		await page.goto(liferayConfig.environment.baseUrl);
-
-		await apiHelpers.headlessSite.deleteSite(String(site.id));
 	});
 });
 

--- a/modules/test/playwright/tests/osb-faro-web/main/utils/portal.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/utils/portal.ts
@@ -61,7 +61,7 @@ export async function navigateToDXPandDeleteSite({
 }) {
 	await page.goto(liferayConfig.environment.baseUrl);
 
-	await apiHelpers.headlessSite.deleteSite(String(site.id));
+	await apiHelpers.headlessAdminSite.deleteSite(site.externalReferenceCode);
 }
 
 export async function navigateToSitePage({

--- a/modules/test/playwright/tests/segment-experiment-web/main/ab-test.spec.ts
+++ b/modules/test/playwright/tests/segment-experiment-web/main/ab-test.spec.ts
@@ -79,7 +79,7 @@ test(
 
 		const siteName = 'My Site ' + getRandomString();
 
-		const site = await apiHelpers.headlessSite.createSite({
+		const site = await apiHelpers.headlessAdminSite.postSite({
 			name: siteName,
 		});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86441

### Summary
Standardized Playwright tests by replacing legacy `apiHelpers.headlessSite` with `apiHelpers.headlessAdminSite`.

### Site Cleanup
- Automated: Manual `deleteSite` calls were removed when using `dataApiHelpersTest`, as cleanup is now handled automatically through `ApiHelpers.clearData`.
- Manual: Explicit deletion remains for tests using `apiHelpersTest` (which lacks the automatic registry) or where immediate cleanup is required for state validation.

If you encounter any failures or flakiness related to these changes, please let me know.