### PR TITLE
LPD-86211

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/util/AnalyticsAttributesUtil.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/util/AnalyticsAttributesUtil.java
@@ -335,15 +335,14 @@ public class AnalyticsAttributesUtil {
 				return null;
 			}
 
-			Object infoItem = infoItemObjectProvider.getInfoItem(
-				new ClassPKInfoItemIdentifier(
-					objectEntry.getObjectDefinitionId()));
+			ObjectDefinition objectDefinition =
+				infoItemObjectProvider.getInfoItem(
+					new ClassPKInfoItemIdentifier(
+						objectEntry.getObjectDefinitionId()));
 
-			if (infoItem == null) {
+			if (objectDefinition == null) {
 				return null;
 			}
-
-			ObjectDefinition objectDefinition = (ObjectDefinition)infoItem;
 
 			return objectDefinition.getName();
 		}

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/util/AnalyticsAttributesUtil.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/util/AnalyticsAttributesUtil.java
@@ -39,7 +39,10 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -91,12 +94,43 @@ public class AnalyticsAttributesUtil {
 			).build();
 		}
 
-		return _getAnalyticsAttributes(
-			fragmentEntryProcessorContext, fragmentEntryProcessorHelper,
-			infoDisplaysFieldValues,
+		InfoItemFieldMapped infoItemFieldMapped =
 			fragmentEntryProcessorHelper.getInfoItemFieldMapped(
-				editableValueJSONObject, fragmentEntryProcessorContext),
-			infoItemServiceRegistry);
+				editableValueJSONObject, fragmentEntryProcessorContext);
+
+		if (infoItemFieldMapped == null) {
+			return Collections.emptyMap();
+		}
+
+		InfoItemIdentifier infoItemIdentifier =
+			infoItemFieldMapped.getInfoItemIdentifier();
+
+		if (!(infoItemIdentifier instanceof
+				ClassPKInfoItemIdentifier classPKInfoItemIdentifier)) {
+
+			return Collections.emptyMap();
+		}
+
+		InfoItemFieldValues infoItemFieldValues = infoDisplaysFieldValues.get(
+			infoItemFieldMapped.getInfoItemReference());
+
+		return HashMapBuilder.<String, Object>put(
+			"analytics-asset-action",
+			_getAnalyticsAssetAction(infoItemFieldMapped, infoItemFieldValues)
+		).put(
+			"analytics-asset-field", infoItemFieldMapped.getFieldName()
+		).put(
+			"analytics-asset-mime-type",
+			_getAnalyticsAssetMimeType(
+				fragmentEntryProcessorHelper, infoItemFieldMapped,
+				infoItemFieldValues, fragmentEntryProcessorContext.getLocale())
+		).putAll(
+			_getAnalyticsAttributes(
+				classPKInfoItemIdentifier, fragmentEntryProcessorContext,
+				infoItemFieldMapped, infoItemFieldValues,
+				infoItemServiceRegistry,
+				fragmentEntryProcessorContext.getLocale())
+		).build();
 	}
 
 	private static String _getAnalyticsAssetAction(
@@ -221,47 +255,53 @@ public class AnalyticsAttributesUtil {
 	}
 
 	private static Map<String, Object> _getAnalyticsAttributes(
+		ClassPKInfoItemIdentifier classPKInfoItemIdentifier,
 		FragmentEntryProcessorContext fragmentEntryProcessorContext,
-		FragmentEntryProcessorHelper fragmentEntryProcessorHelper,
-		Map<InfoItemReference, InfoItemFieldValues> infoDisplaysFieldValues,
 		InfoItemFieldMapped infoItemFieldMapped,
-		InfoItemServiceRegistry infoItemServiceRegistry) {
+		InfoItemFieldValues infoItemFieldValues,
+		InfoItemServiceRegistry infoItemServiceRegistry, Locale locale) {
 
-		if (infoItemFieldMapped == null) {
-			return Collections.emptyMap();
+		HttpServletRequest httpServletRequest =
+			fragmentEntryProcessorContext.getHttpServletRequest();
+
+		if (httpServletRequest == null) {
+			return _getAnalyticsAttributes(
+				classPKInfoItemIdentifier, infoItemFieldMapped,
+				infoItemFieldValues, infoItemServiceRegistry, locale);
 		}
 
-		InfoItemIdentifier infoItemIdentifier =
-			infoItemFieldMapped.getInfoItemIdentifier();
+		Map<InfoItemReference, Map<String, Object>>
+			assetAnalyticsAttributesMap =
+				(Map<InfoItemReference, Map<String, Object>>)
+					httpServletRequest.getAttribute(_ANALYTICS_ATTRIBUTES_MAP);
 
-		if (!(infoItemIdentifier instanceof
-				ClassPKInfoItemIdentifier classPKInfoItemIdentifier)) {
+		if (assetAnalyticsAttributesMap == null) {
+			assetAnalyticsAttributesMap = new HashMap<>();
 
-			return Collections.emptyMap();
+			httpServletRequest.setAttribute(
+				_ANALYTICS_ATTRIBUTES_MAP, assetAnalyticsAttributesMap);
 		}
 
-		InfoItemFieldValues infoItemFieldValues = infoDisplaysFieldValues.get(
-			infoItemFieldMapped.getInfoItemReference());
+		return assetAnalyticsAttributesMap.computeIfAbsent(
+			infoItemFieldMapped.getInfoItemReference(),
+			key -> _getAnalyticsAttributes(
+				classPKInfoItemIdentifier, infoItemFieldMapped,
+				infoItemFieldValues, infoItemServiceRegistry, locale));
+	}
+
+	private static Map<String, Object> _getAnalyticsAttributes(
+		ClassPKInfoItemIdentifier classPKInfoItemIdentifier,
+		InfoItemFieldMapped infoItemFieldMapped,
+		InfoItemFieldValues infoItemFieldValues,
+		InfoItemServiceRegistry infoItemServiceRegistry, Locale locale) {
 
 		return HashMapBuilder.<String, Object>put(
-			"analytics-asset-action",
-			() -> _getAnalyticsAssetAction(
-				infoItemFieldMapped, infoItemFieldValues)
-		).put(
 			"analytics-asset-categories",
 			() -> _getAnalyticsAssetCategories(
-				classPKInfoItemIdentifier, infoItemFieldMapped,
-				fragmentEntryProcessorContext.getLocale())
-		).put(
-			"analytics-asset-field", infoItemFieldMapped::getFieldName
+				classPKInfoItemIdentifier, infoItemFieldMapped, locale)
 		).put(
 			"analytics-asset-id",
 			String.valueOf(classPKInfoItemIdentifier.getClassPK())
-		).put(
-			"analytics-asset-mime-type",
-			() -> _getAnalyticsAssetMimeType(
-				fragmentEntryProcessorHelper, infoItemFieldMapped,
-				infoItemFieldValues, fragmentEntryProcessorContext.getLocale())
 		).put(
 			"analytics-asset-subtype",
 			() -> _getAnalyticsSubtype(
@@ -272,16 +312,14 @@ public class AnalyticsAttributesUtil {
 				classPKInfoItemIdentifier, infoItemFieldMapped)
 		).put(
 			"analytics-asset-title",
-			() -> _getAnalyticsTitle(
-				infoItemFieldValues, fragmentEntryProcessorContext.getLocale())
+			() -> _getAnalyticsTitle(infoItemFieldValues, locale)
 		).put(
 			"analytics-asset-type",
 			_getAnalyticsAssetType(infoItemFieldMapped.getClassName())
 		).put(
 			"analytics-external-reference-code",
 			() -> _getAnalyticsExternalReferenceCode(
-				infoItemFieldMapped, infoItemFieldValues,
-				fragmentEntryProcessorContext.getLocale())
+				infoItemFieldMapped, infoItemFieldValues, locale)
 		).put(
 			"analytics-object-definition-name",
 			() -> {
@@ -386,6 +424,9 @@ public class AnalyticsAttributesUtil {
 
 		return String.valueOf(infoFieldValue.getValue(locale));
 	}
+
+	private static final String _ANALYTICS_ATTRIBUTES_MAP =
+		"ANALYTICS_ATTRIBUTES_MAP";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AnalyticsAttributesUtil.class);

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/util/AnalyticsAttributesUtil.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/util/AnalyticsAttributesUtil.java
@@ -27,7 +27,6 @@ import com.liferay.info.item.provider.InfoItemObjectVariationProvider;
 import com.liferay.info.type.WebImage;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -36,17 +35,15 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Supplier;
-
-import org.jsoup.nodes.Element;
 
 /**
  * @author Eudaldo Alonso
@@ -59,8 +56,8 @@ public class AnalyticsAttributesUtil {
 
 	public static final String ACTION_VIEW = "view";
 
-	public static void addAnalyticsAttributes(
-		JSONObject editableValueJSONObject, Element element,
+	public static Map<String, Object> getAnalyticsAttributes(
+		JSONObject editableValueJSONObject,
 		FragmentEntryProcessorContext fragmentEntryProcessorContext,
 		FragmentEntryProcessorHelper fragmentEntryProcessorHelper,
 		Map<InfoItemReference, InfoItemFieldValues> infoDisplaysFieldValues,
@@ -74,116 +71,32 @@ public class AnalyticsAttributesUtil {
 				configJSONObject.getString("fieldId"),
 				"FileEntry_downloadURL")) {
 
-			ElementAttributeBuilder.of(
-				element
-			).attr(
-				"data-analytics-asset-action", ACTION_DOWNLOAD
-			).attr(
-				"data-analytics-asset-field",
+			return HashMapBuilder.<String, Object>put(
+				"analytics-asset-action", ACTION_DOWNLOAD
+			).put(
+				"analytics-asset-field",
 				() -> configJSONObject.getString("fieldId")
-			).attr(
-				"data-analytics-asset-id",
+			).put(
+				"analytics-asset-id",
 				() -> configJSONObject.getString("classPK")
-			).attr(
-				"data-analytics-asset-subtype",
+			).put(
+				"analytics-asset-subtype",
 				() -> configJSONObject.getString("itemSubtype")
-			).attr(
-				"data-analytics-asset-title",
+			).put(
+				"analytics-asset-title",
 				() -> configJSONObject.getString("title")
-			).attr(
-				"data-analytics-asset-type",
-				() -> _getAnalyticsAssetType(FileEntry.class.getName())
-			);
-
-			return;
+			).put(
+				"analytics-asset-type",
+				_getAnalyticsAssetType(FileEntry.class.getName())
+			).build();
 		}
 
-		_addAnalyticsAttributes(
-			element, fragmentEntryProcessorContext,
-			fragmentEntryProcessorHelper, infoDisplaysFieldValues,
+		return _getAnalyticsAttributes(
+			fragmentEntryProcessorContext, fragmentEntryProcessorHelper,
+			infoDisplaysFieldValues,
 			fragmentEntryProcessorHelper.getInfoItemFieldMapped(
 				editableValueJSONObject, fragmentEntryProcessorContext),
 			infoItemServiceRegistry);
-	}
-
-	private static void _addAnalyticsAttributes(
-		Element element,
-		FragmentEntryProcessorContext fragmentEntryProcessorContext,
-		FragmentEntryProcessorHelper fragmentEntryProcessorHelper,
-		Map<InfoItemReference, InfoItemFieldValues> infoDisplaysFieldValues,
-		InfoItemFieldMapped infoItemFieldMapped,
-		InfoItemServiceRegistry infoItemServiceRegistry) {
-
-		if (infoItemFieldMapped == null) {
-			return;
-		}
-
-		InfoItemIdentifier infoItemIdentifier =
-			infoItemFieldMapped.getInfoItemIdentifier();
-
-		if (!(infoItemIdentifier instanceof
-				ClassPKInfoItemIdentifier classPKInfoItemIdentifier)) {
-
-			return;
-		}
-
-		InfoItemFieldValues infoItemFieldValues = infoDisplaysFieldValues.get(
-			infoItemFieldMapped.getInfoItemReference());
-
-		ElementAttributeBuilder.of(
-			element
-		).attr(
-			"data-analytics-asset-action",
-			() -> _getAnalyticsAssetAction(
-				infoItemFieldMapped, infoItemFieldValues)
-		).attr(
-			"data-analytics-external-reference-code",
-			() -> _getAnalyticsExternalReferenceCode(
-				infoItemFieldMapped, infoItemFieldValues,
-				fragmentEntryProcessorContext.getLocale())
-		).attr(
-			"data-analytics-asset-categories",
-			() -> _getAnalyticsAssetCategories(
-				classPKInfoItemIdentifier, infoItemFieldMapped,
-				fragmentEntryProcessorContext.getLocale())
-		).attr(
-			"data-analytics-asset-field", infoItemFieldMapped.getFieldName()
-		).attr(
-			"data-analytics-asset-id",
-			String.valueOf(classPKInfoItemIdentifier.getClassPK())
-		).attr(
-			"data-analytics-asset-mime-type",
-			() -> _getAnalyticsAssetMimeType(
-				fragmentEntryProcessorHelper, infoItemFieldMapped,
-				infoItemFieldValues, fragmentEntryProcessorContext.getLocale())
-		).attr(
-			"data-analytics-asset-subtype",
-			() -> _getAnalyticsSubtype(
-				infoItemFieldMapped, infoItemServiceRegistry)
-		).attr(
-			"data-analytics-asset-tags",
-			() -> _getAnalyticsAssetTags(
-				classPKInfoItemIdentifier, infoItemFieldMapped)
-		).attr(
-			"data-analytics-asset-title",
-			() -> _getAnalyticsTitle(
-				infoItemFieldValues, fragmentEntryProcessorContext.getLocale())
-		).attr(
-			"data-analytics-asset-type",
-			() -> _getAnalyticsAssetType(infoItemFieldMapped.getClassName())
-		).attr(
-			"data-analytics-object-definition-name",
-			() -> {
-				Object object = infoItemFieldMapped.getObject();
-
-				if (object instanceof ObjectEntry) {
-					return _getAnalyticsObjectDefinitionName(
-						infoItemServiceRegistry, (ObjectEntry)object);
-				}
-
-				return StringPool.BLANK;
-			}
-		);
 	}
 
 	private static String _getAnalyticsAssetAction(
@@ -233,7 +146,7 @@ public class AnalyticsAttributesUtil {
 			return jsonArray.toString();
 		}
 
-		return StringPool.BLANK;
+		return null;
 	}
 
 	private static String _getAnalyticsAssetMimeType(
@@ -246,7 +159,7 @@ public class AnalyticsAttributesUtil {
 				infoItemFieldMapped.getFieldName());
 
 		if (infoFieldValue == null) {
-			return StringPool.BLANK;
+			return null;
 		}
 
 		Object value = infoFieldValue.getValue(locale);
@@ -260,7 +173,7 @@ public class AnalyticsAttributesUtil {
 					fileEntryId);
 
 				if (fileEntry == null) {
-					return StringPool.BLANK;
+					return null;
 				}
 
 				return fileEntry.getMimeType();
@@ -272,7 +185,7 @@ public class AnalyticsAttributesUtil {
 			}
 		}
 
-		return StringPool.BLANK;
+		return null;
 	}
 
 	private static String _getAnalyticsAssetTags(
@@ -296,7 +209,7 @@ public class AnalyticsAttributesUtil {
 			return jsonArray.toString();
 		}
 
-		return StringPool.BLANK;
+		return null;
 	}
 
 	private static String _getAnalyticsAssetType(String className) {
@@ -305,6 +218,83 @@ public class AnalyticsAttributesUtil {
 		}
 
 		return className;
+	}
+
+	private static Map<String, Object> _getAnalyticsAttributes(
+		FragmentEntryProcessorContext fragmentEntryProcessorContext,
+		FragmentEntryProcessorHelper fragmentEntryProcessorHelper,
+		Map<InfoItemReference, InfoItemFieldValues> infoDisplaysFieldValues,
+		InfoItemFieldMapped infoItemFieldMapped,
+		InfoItemServiceRegistry infoItemServiceRegistry) {
+
+		if (infoItemFieldMapped == null) {
+			return Collections.emptyMap();
+		}
+
+		InfoItemIdentifier infoItemIdentifier =
+			infoItemFieldMapped.getInfoItemIdentifier();
+
+		if (!(infoItemIdentifier instanceof
+				ClassPKInfoItemIdentifier classPKInfoItemIdentifier)) {
+
+			return Collections.emptyMap();
+		}
+
+		InfoItemFieldValues infoItemFieldValues = infoDisplaysFieldValues.get(
+			infoItemFieldMapped.getInfoItemReference());
+
+		return HashMapBuilder.<String, Object>put(
+			"analytics-asset-action",
+			() -> _getAnalyticsAssetAction(
+				infoItemFieldMapped, infoItemFieldValues)
+		).put(
+			"analytics-asset-categories",
+			() -> _getAnalyticsAssetCategories(
+				classPKInfoItemIdentifier, infoItemFieldMapped,
+				fragmentEntryProcessorContext.getLocale())
+		).put(
+			"analytics-asset-field", infoItemFieldMapped::getFieldName
+		).put(
+			"analytics-asset-id",
+			String.valueOf(classPKInfoItemIdentifier.getClassPK())
+		).put(
+			"analytics-asset-mime-type",
+			() -> _getAnalyticsAssetMimeType(
+				fragmentEntryProcessorHelper, infoItemFieldMapped,
+				infoItemFieldValues, fragmentEntryProcessorContext.getLocale())
+		).put(
+			"analytics-asset-subtype",
+			() -> _getAnalyticsSubtype(
+				infoItemFieldMapped, infoItemServiceRegistry)
+		).put(
+			"analytics-asset-tags",
+			() -> _getAnalyticsAssetTags(
+				classPKInfoItemIdentifier, infoItemFieldMapped)
+		).put(
+			"analytics-asset-title",
+			() -> _getAnalyticsTitle(
+				infoItemFieldValues, fragmentEntryProcessorContext.getLocale())
+		).put(
+			"analytics-asset-type",
+			_getAnalyticsAssetType(infoItemFieldMapped.getClassName())
+		).put(
+			"analytics-external-reference-code",
+			() -> _getAnalyticsExternalReferenceCode(
+				infoItemFieldMapped, infoItemFieldValues,
+				fragmentEntryProcessorContext.getLocale())
+		).put(
+			"analytics-object-definition-name",
+			() -> {
+				if (infoItemFieldMapped.getObject() instanceof
+						ObjectEntry objectEntry) {
+
+					return _getAnalyticsObjectDefinitionName(
+						infoItemServiceRegistry, objectEntry);
+				}
+
+				return null;
+			}
+		).build();
 	}
 
 	private static String _getAnalyticsExternalReferenceCode(
@@ -318,14 +308,14 @@ public class AnalyticsAttributesUtil {
 		}
 
 		if (infoItemFieldValues == null) {
-			return StringPool.BLANK;
+			return null;
 		}
 
 		InfoFieldValue<?> infoFieldValue =
 			infoItemFieldValues.getInfoFieldValue("externalReferenceCode");
 
 		if (infoFieldValue == null) {
-			return StringPool.BLANK;
+			return null;
 		}
 
 		return String.valueOf(infoFieldValue.getValue(locale));
@@ -342,7 +332,7 @@ public class AnalyticsAttributesUtil {
 					ObjectDefinition.class.getName());
 
 			if (infoItemObjectProvider == null) {
-				return StringPool.BLANK;
+				return null;
 			}
 
 			Object infoItem = infoItemObjectProvider.getInfoItem(
@@ -350,7 +340,7 @@ public class AnalyticsAttributesUtil {
 					objectEntry.getObjectDefinitionId()));
 
 			if (infoItem == null) {
-				return StringPool.BLANK;
+				return null;
 			}
 
 			ObjectDefinition objectDefinition = (ObjectDefinition)infoItem;
@@ -361,7 +351,7 @@ public class AnalyticsAttributesUtil {
 			_log.error(exception);
 		}
 
-		return StringPool.BLANK;
+		return null;
 	}
 
 	private static String _getAnalyticsSubtype(
@@ -374,7 +364,7 @@ public class AnalyticsAttributesUtil {
 				infoItemFieldMapped.getClassName());
 
 		if (infoItemObjectVariationProvider == null) {
-			return StringPool.BLANK;
+			return null;
 		}
 
 		return infoItemObjectVariationProvider.getInfoItemFormVariationKey(
@@ -385,14 +375,14 @@ public class AnalyticsAttributesUtil {
 		InfoItemFieldValues infoItemFieldValues, Locale locale) {
 
 		if (infoItemFieldValues == null) {
-			return StringPool.BLANK;
+			return null;
 		}
 
 		InfoFieldValue<?> infoFieldValue =
 			infoItemFieldValues.getInfoFieldValue("title");
 
 		if (infoFieldValue == null) {
-			return StringPool.BLANK;
+			return null;
 		}
 
 		return String.valueOf(infoFieldValue.getValue(locale));
@@ -400,39 +390,5 @@ public class AnalyticsAttributesUtil {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AnalyticsAttributesUtil.class);
-
-	private static class ElementAttributeBuilder {
-
-		public static ElementAttributeBuilder of(Element element) {
-			return new ElementAttributeBuilder(element);
-		}
-
-		public ElementAttributeBuilder attr(String name, String value) {
-			if (Validator.isNotNull(value)) {
-				_element.attr(name, value);
-			}
-
-			return this;
-		}
-
-		public ElementAttributeBuilder attr(
-			String name, Supplier<String> supplier) {
-
-			String value = supplier.get();
-
-			if (Validator.isNotNull(value)) {
-				_element.attr(name, value);
-			}
-
-			return this;
-		}
-
-		private ElementAttributeBuilder(Element element) {
-			_element = element;
-		}
-
-		private final Element _element;
-
-	}
 
 }

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-background-image/build.gradle
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-background-image/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "org.jsoup", name: "jsoup", version: "1.15.3"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:analytics:analytics-settings-rest-api")
 	compileOnly project(":apps:asset:asset-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:fragment:fragment-api")

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-background-image/src/main/java/com/liferay/fragment/entry/processor/background/image/BackgroundImageDocumentFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-background-image/src/main/java/com/liferay/fragment/entry/processor/background/image/BackgroundImageDocumentFragmentEntryProcessor.java
@@ -5,6 +5,7 @@
 
 package com.liferay.fragment.entry.processor.background.image;
 
+import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
@@ -79,6 +80,9 @@ public class BackgroundImageDocumentFragmentEntryProcessor
 
 		Map<InfoItemReference, InfoItemFieldValues> infoDisplaysFieldValues =
 			new HashMap<>();
+
+		boolean analyticsEnabled = _isAnalyticsEnabled(
+			fragmentEntryLink.getCompanyId());
 
 		for (Element element :
 				document.getElementsByAttribute(
@@ -176,7 +180,9 @@ public class BackgroundImageDocumentFragmentEntryProcessor
 				element.removeAttr("data-lfr-background-image-id");
 			}
 
-			if (fragmentEntryProcessorContext.isViewMode()) {
+			if (analyticsEnabled &&
+				fragmentEntryProcessorContext.isViewMode()) {
+
 				AnalyticsAttributesUtil.addAnalyticsAttributes(
 					editableValueJSONObject, element,
 					fragmentEntryProcessorContext,
@@ -252,8 +258,24 @@ public class BackgroundImageDocumentFragmentEntryProcessor
 		return String.valueOf(fieldValue);
 	}
 
+	private boolean _isAnalyticsEnabled(long companyId) {
+		try {
+			return _analyticsSettingsManager.isAnalyticsEnabled(companyId);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return false;
+		}
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		BackgroundImageDocumentFragmentEntryProcessor.class);
+
+	@Reference
+	private AnalyticsSettingsManager _analyticsSettingsManager;
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-background-image/src/main/java/com/liferay/fragment/entry/processor/background/image/BackgroundImageDocumentFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-background-image/src/main/java/com/liferay/fragment/entry/processor/background/image/BackgroundImageDocumentFragmentEntryProcessor.java
@@ -183,11 +183,12 @@ public class BackgroundImageDocumentFragmentEntryProcessor
 			if (analyticsEnabled &&
 				fragmentEntryProcessorContext.isViewMode()) {
 
-				AnalyticsAttributesUtil.addAnalyticsAttributes(
-					editableValueJSONObject, element,
-					fragmentEntryProcessorContext,
-					_fragmentEntryProcessorHelper, infoDisplaysFieldValues,
-					_infoItemServiceRegistry);
+				_setAnalyticsAttributes(
+					element,
+					AnalyticsAttributesUtil.getAnalyticsAttributes(
+						editableValueJSONObject, fragmentEntryProcessorContext,
+						_fragmentEntryProcessorHelper, infoDisplaysFieldValues,
+						_infoItemServiceRegistry));
 			}
 		}
 	}
@@ -268,6 +269,26 @@ public class BackgroundImageDocumentFragmentEntryProcessor
 			}
 
 			return false;
+		}
+	}
+
+	private void _setAnalyticsAttributes(
+		Element element, Map<String, Object> analyticsAttributes) {
+
+		for (Map.Entry<String, Object> entry : analyticsAttributes.entrySet()) {
+			Object value = entry.getValue();
+
+			if (value == null) {
+				continue;
+			}
+
+			String stringValue = String.valueOf(value);
+
+			if (Validator.isNull(stringValue)) {
+				continue;
+			}
+
+			element.attr("data-" + entry.getKey(), stringValue);
 		}
 	}
 

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/build.gradle
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-rest-test-util")
 	testIntegrationImplementation project(":apps:object:object-test-util")
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:segments:segments-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/src/testIntegration/java/com/liferay/fragment/entry/processor/editable/test/EditableFragmentEntryProcessorTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/src/testIntegration/java/com/liferay/fragment/entry/processor/editable/test/EditableFragmentEntryProcessorTest.java
@@ -74,6 +74,7 @@ import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -104,6 +105,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -185,10 +187,28 @@ public class EditableFragmentEntryProcessorTest {
 				_company, _group, _layout));
 
 		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+
+		_companyConfigurationTemporarySwapper =
+			new CompanyConfigurationTemporarySwapper(
+				_company.getCompanyId(),
+				"com.liferay.analytics.settings.configuration." +
+					"AnalyticsConfiguration",
+				HashMapDictionaryBuilder.<String, Object>put(
+					"liferayAnalyticsDataSourceId",
+					RandomTestUtil.randomString()
+				).put(
+					"liferayAnalyticsFaroBackendSecuritySignature",
+					RandomTestUtil.randomString()
+				).put(
+					"liferayAnalyticsFaroBackendURL",
+					"http://" + RandomTestUtil.randomString()
+				).build());
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDown() throws Exception {
+		_companyConfigurationTemporarySwapper.close();
+
 		LocaleThreadLocal.setSiteDefaultLocale(_originalSiteDefaultLocale);
 		LocaleThreadLocal.setThemeDisplayLocale(
 			_originalThemeDisplayDefaultLocale);
@@ -2600,6 +2620,8 @@ public class EditableFragmentEntryProcessorTest {
 	private static DDMFormDeserializer _jsonDDMFormDeserializer;
 
 	private Company _company;
+	private CompanyConfigurationTemporarySwapper
+		_companyConfigurationTemporarySwapper;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/build.gradle
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "org.jsoup", name: "jsoup", version: "1.15.3"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:analytics:analytics-settings-rest-api")
 	compileOnly project(":apps:asset:asset-api")
 	compileOnly project(":apps:asset:asset-info-display-api")
 	compileOnly project(":apps:document-library:document-library-api")

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/EditableDocumentFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/EditableDocumentFragmentEntryProcessor.java
@@ -5,6 +5,7 @@
 
 package com.liferay.fragment.entry.processor.editable;
 
+import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
 import com.liferay.fragment.entry.processor.editable.mapper.EditableElementMapper;
 import com.liferay.fragment.entry.processor.editable.parser.EditableElementParser;
@@ -24,6 +25,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
@@ -89,6 +92,9 @@ public class EditableDocumentFragmentEntryProcessor
 
 		Map<InfoItemReference, InfoItemFieldValues> infoDisplaysFieldValues =
 			new HashMap<>();
+
+		boolean analyticsEnabled = _isAnalyticsEnabled(
+			fragmentEntryLink.getCompanyId());
 
 		Elements elements = Collector.collect(
 			new Evaluator() {
@@ -228,7 +234,9 @@ public class EditableDocumentFragmentEntryProcessor
 				element.removeAttr("view-tag-name");
 			}
 
-			if (fragmentEntryProcessorContext.isViewMode()) {
+			if (analyticsEnabled &&
+				fragmentEntryProcessorContext.isViewMode()) {
+
 				AnalyticsAttributesUtil.addAnalyticsAttributes(
 					editableValueJSONObject, element,
 					fragmentEntryProcessorContext,
@@ -308,6 +316,25 @@ public class EditableDocumentFragmentEntryProcessor
 
 		return _editableElementParserServiceTrackerMap.getService(type);
 	}
+
+	private boolean _isAnalyticsEnabled(long companyId) {
+		try {
+			return _analyticsSettingsManager.isAnalyticsEnabled(companyId);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return false;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		EditableDocumentFragmentEntryProcessor.class);
+
+	@Reference
+	private AnalyticsSettingsManager _analyticsSettingsManager;
 
 	private ServiceTrackerMap<String, EditableElementMapper>
 		_editableElementMapperServiceTrackerMap;

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/EditableDocumentFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/EditableDocumentFragmentEntryProcessor.java
@@ -237,11 +237,12 @@ public class EditableDocumentFragmentEntryProcessor
 			if (analyticsEnabled &&
 				fragmentEntryProcessorContext.isViewMode()) {
 
-				AnalyticsAttributesUtil.addAnalyticsAttributes(
-					editableValueJSONObject, element,
-					fragmentEntryProcessorContext,
-					_fragmentEntryProcessorHelper, infoDisplaysFieldValues,
-					_infoItemServiceRegistry);
+				_setAnalyticsAttributes(
+					element,
+					AnalyticsAttributesUtil.getAnalyticsAttributes(
+						editableValueJSONObject, fragmentEntryProcessorContext,
+						_fragmentEntryProcessorHelper, infoDisplaysFieldValues,
+						_infoItemServiceRegistry));
 			}
 		}
 
@@ -327,6 +328,26 @@ public class EditableDocumentFragmentEntryProcessor
 			}
 
 			return false;
+		}
+	}
+
+	private void _setAnalyticsAttributes(
+		Element element, Map<String, Object> analyticsAttributes) {
+
+		for (Map.Entry<String, Object> entry : analyticsAttributes.entrySet()) {
+			Object value = entry.getValue();
+
+			if (value == null) {
+				continue;
+			}
+
+			String stringValue = String.valueOf(value);
+
+			if (Validator.isNull(stringValue)) {
+				continue;
+			}
+
+			element.attr("data-" + entry.getKey(), stringValue);
 		}
 	}
 

--- a/modules/apps/fragment/fragment-impl/build.gradle
+++ b/modules/apps/fragment/fragment-impl/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "org.jsoup", name: "jsoup", version: "1.15.3"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:analytics:analytics-settings-rest-api")
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:asset:asset-info-display-api")
 	compileOnly project(":apps:asset:asset-taglib")

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentObjectFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentObjectFragmentRenderer.java
@@ -5,6 +5,7 @@
 
 package com.liferay.fragment.internal.renderer;
 
+import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
@@ -231,7 +232,9 @@ public class ContentObjectFragmentRenderer implements FragmentRenderer {
 
 		long classPK = _getClassPK(infoItemReference, jsonObject);
 
-		if (!fragmentRendererContext.isViewMode() || (classPK <= 0)) {
+		if (!fragmentRendererContext.isViewMode() || (classPK <= 0) ||
+			!_isAnalyticsEnabled(httpServletRequest)) {
+
 			_render(
 				displayObject, httpServletRequest, httpServletResponse,
 				(InfoItemRenderer<Object>)tuple.getObject(0), tuple);
@@ -545,6 +548,24 @@ public class ContentObjectFragmentRenderer implements FragmentRenderer {
 		return true;
 	}
 
+	private boolean _isAnalyticsEnabled(HttpServletRequest httpServletRequest) {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		try {
+			return _analyticsSettingsManager.isAnalyticsEnabled(
+				themeDisplay.getCompanyId());
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return false;
+		}
+	}
+
 	private void _render(
 		Object displayObject, HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse,
@@ -572,6 +593,9 @@ public class ContentObjectFragmentRenderer implements FragmentRenderer {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ContentObjectFragmentRenderer.class);
+
+	@Reference
+	private AnalyticsSettingsManager _analyticsSettingsManager;
 
 	@Reference
 	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/renderer/test/ContentObjectFragmentRendererTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/renderer/test/ContentObjectFragmentRendererTest.java
@@ -31,6 +31,7 @@ import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.layout.util.LayoutServiceContextHelper;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -57,6 +58,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -131,27 +133,56 @@ public class ContentObjectFragmentRendererTest {
 	public void testRenderAssertAnalyticsAttributesInViewMode()
 		throws Exception {
 
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						"com.liferay.analytics.settings.configuration." +
+							"AnalyticsConfiguration",
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsDataSourceId",
+							RandomTestUtil.randomString()
+						).put(
+							"liferayAnalyticsFaroBackendSecuritySignature",
+							RandomTestUtil.randomString()
+						).put(
+							"liferayAnalyticsFaroBackendURL",
+							"http://" + RandomTestUtil.randomString()
+						).build())) {
+
+			String content = _render(
+				_addFragmentEntryLink(), FragmentEntryLinkConstants.VIEW);
+
+			Assert.assertTrue(
+				content.contains("data-analytics-asset-action=\"view\""));
+			Assert.assertTrue(
+				content.contains(
+					"data-analytics-asset-id=\"" +
+						_journalArticle.getResourcePrimKey() + "\""));
+			Assert.assertTrue(
+				content.contains(
+					"data-analytics-asset-subtype=\"" +
+						_journalArticle.getDDMStructureId() + "\""));
+			Assert.assertTrue(
+				content.contains(
+					"data-analytics-asset-title=\"" +
+						_journalArticle.getTitle(LocaleUtil.US) + "\""));
+			Assert.assertTrue(
+				content.contains(
+					"data-analytics-asset-type=\"" +
+						JournalArticle.class.getName() + "\""));
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-86211")
+	public void testRenderAssertAnalyticsAttributesNotInViewModeWhenAnalyticsDisabled()
+		throws Exception {
+
 		String content = _render(
 			_addFragmentEntryLink(), FragmentEntryLinkConstants.VIEW);
 
-		Assert.assertTrue(
-			content.contains("data-analytics-asset-action=\"view\""));
-		Assert.assertTrue(
-			content.contains(
-				"data-analytics-asset-id=\"" +
-					_journalArticle.getResourcePrimKey() + "\""));
-		Assert.assertTrue(
-			content.contains(
-				"data-analytics-asset-subtype=\"" +
-					_journalArticle.getDDMStructureId() + "\""));
-		Assert.assertTrue(
-			content.contains(
-				"data-analytics-asset-title=\"" +
-					_journalArticle.getTitle(LocaleUtil.US) + "\""));
-		Assert.assertTrue(
-			content.contains(
-				"data-analytics-asset-type=\"" +
-					JournalArticle.class.getName() + "\""));
+		Assert.assertFalse(content.contains("data-analytics-asset-action"));
 	}
 
 	@Test


### PR DESCRIPTION
Motivation
----
Fix Possible regression in the Object test case from the benchmark tool.

This PR introduces several improvements to the analytics attributes handling and caching strategy, with the goal of making the implementation more efficient, consistent, and easier to maintain.

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-86211)

Proposed Solution
----

- The logic has been **adapted to cache immutable fields using `InfoItemIdentifier`**, improving performance by avoiding unnecessary recomputation of stable data.
- The implementation has been **simplified**, reducing complexity and improving readability.
- References to **jsoup have been removed from `AnalyticsAttributesUtil`**, helping to reduce external dependencies and keep the utility focused.
- **Tests have been updated accordingly** to reflect the changes in behavior and ensure continued reliability.
- `data-analytics` attributes are now **only added when `isAnalyticsEnabled` is true**, ensuring that analytics-related metadata is applied conditionally and not in all scenarios.