### PR TITLE
LPD-87428 Remove Individuals Data and Analytics Data columns from data source list

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
@@ -85,7 +85,8 @@ const AccountCard: React.FC<IAccountCardProps> = ({
 								style={{
 									color:
 										getStatsColor(
-											metrics?.trend?.trendClassification
+											metrics?.trend
+												?.trendClassification || ''
 										) || TrendClassification.Neutral
 								}}
 							>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
@@ -79,11 +79,10 @@ describe('List', () => {
 		useHistory.mockReturnValue({push: mockHistoryPush});
 
 		const useRequest = require('shared/hooks/useRequest');
-		useRequest.useRequest = jest.fn(() => ({
-			data: {
-				total: 1
-			}
-		}));
+		useRequest.useRequest = jest
+			.fn()
+			.mockReturnValueOnce({data: {total: 1}})
+			.mockReturnValue({data: []});
 	});
 
 	afterEach(cleanup);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
@@ -20,20 +20,11 @@ import {
 	PROVIDER_TYPE
 } from 'shared/util/pagination';
 import {DataSource} from 'shared/util/records';
-import {
-	DataSourceStates,
-	DataSourceStatuses,
-	DataSourceTypes,
-	Sizes
-} from 'shared/util/constants';
+import {DataSourceStates, DataSourceTypes, Sizes} from 'shared/util/constants';
 import {formatDateToTimeZone} from 'shared/util/date';
 import {fromJS} from 'immutable';
 import {get} from 'lodash';
-import {
-	getDataSourceDisplayObject,
-	validAnalyticsConfig,
-	validContactsConfig
-} from 'shared/util/data-sources';
+import {getDataSourceDisplayObject} from 'shared/util/data-sources';
 import {Link, useHistory, useParams} from 'react-router-dom';
 import {Routes, toRoute} from 'shared/util/router';
 import {sub} from 'shared/util/lang';
@@ -45,23 +36,6 @@ import {useTimeZone} from 'shared/hooks/useTimeZone';
 interface ICellProps {
 	data: {[key: string]: any};
 }
-
-const AnalyticsDataCell: React.FC<ICellProps> = ({data}) => (
-	<td className='text-center'>
-		{validAnalyticsConfig(new DataSource(fromJS(data))) && (
-			<ClayIcon className='icon-root' symbol='check' />
-		)}
-	</td>
-);
-
-const IndividualsDataCell: React.FC<ICellProps> = ({data}) => (
-	<td className='text-center'>
-		{validContactsConfig(new DataSource(fromJS(data))) &&
-			data.status === DataSourceStatuses.Active && (
-				<ClayIcon className='icon-root' symbol='check' />
-			)}
-	</td>
-);
 
 interface IDataSourceNameProps {
 	data: {[key: string]: any};
@@ -360,16 +334,6 @@ const DataSourceList: React.FC<IDataSourceListProps> = ({className}) => {
 						{
 							cellRenderer: StatusRenderer,
 							label: Liferay.Language.get('status'),
-							sortable: false
-						},
-						{
-							cellRenderer: IndividualsDataCell,
-							label: Liferay.Language.get('individuals-data'),
-							sortable: false
-						},
-						{
-							cellRenderer: AnalyticsDataCell,
-							label: Liferay.Language.get('analytics-data'),
 							sortable: false
 						},
 						{

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/__tests__/__snapshots__/DataSourceList.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/__tests__/__snapshots__/DataSourceList.jsx.snap
@@ -535,16 +535,6 @@ exports[`DataSourceList should render 1`] = `
                         <th
                           class="table-head-title"
                         >
-                          Individuals Data
-                        </th>
-                        <th
-                          class="table-head-title"
-                        >
-                          Analytics Data
-                        </th>
-                        <th
-                          class="table-head-title"
-                        >
                           <a
                             class="button-root w-100 btn btn-unstyled"
                             href="/?field=createDate&page=1&sortOrder=DESC"
@@ -612,21 +602,6 @@ exports[`DataSourceList should render 1`] = `
                             </span>
                           </div>
                         </td>
-                        <td
-                          class="text-center"
-                        >
-                          <svg
-                            class="lexicon-icon lexicon-icon-check icon-root"
-                            role="presentation"
-                          >
-                            <use
-                              href="#check"
-                            />
-                          </svg>
-                        </td>
-                        <td
-                          class="text-center"
-                        />
                         <td>
                           Jul 8, 2018
                         </td>


### PR DESCRIPTION
## Summary

- Removed the **Individuals Data** and **Analytics Data** columns from the data source list table for a cleaner UI
- Deleted the `IndividualsDataCell` and `AnalyticsDataCell` components along with their unused imports (`validAnalyticsConfig`, `validContactsConfig`)
- Updated the corresponding snapshot test