### PR TITLE
LPD-87708 Pin @babel/runtime ^7.26.10 to fix security vulnerability

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
@@ -7,6 +7,8 @@
 	"dependencies": {
 		"@apollo/client": "^3.8.0",
 		"@apollo/react-hoc": "^4.0.0",
+		"@babel/runtime": "^7.26.10",
+		"@babel/runtime-corejs3": "^7.26.10",
 		"@clayui/alert": "^3.161.0",
 		"@clayui/autocomplete": "^3.161.0",
 		"@clayui/badge": "^3.161.0",

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/yarn.lock
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/yarn.lock
@@ -1003,7 +1003,14 @@
     "@babel/plugin-transform-react-jsx-development" "^7.27.1"
     "@babel/plugin-transform-react-pure-annotations" "^7.27.1"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.28.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime-corejs3@^7.26.10":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz#cb86ad06e7a1d39224afb12a874301085e071846"
+  integrity sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==
+  dependencies:
+    core-js-pure "^3.48.0"
+
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.26.10", "@babel/runtime@^7.28.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
@@ -4203,6 +4210,11 @@ core-js-compat@^3.48.0:
   integrity sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==
   dependencies:
     browserslist "^4.28.1"
+
+core-js-pure@^3.48.0:
+  version "3.49.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.49.0.tgz#ff8436b7251a3832f5fdbbe3e10f7f2e58e51fb1"
+  integrity sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==
 
 core-js@^2.4.0, core-js@^2.5.7:
   version "2.6.12"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87708

**What is being fixed:** Parent bug LPD-71165 flagged @babel/runtime 7.25.6 as vulnerable to CVE-2025-27789, an issue where untrusted input passed to .replace() with named capture groups can produce unsafe output. In osb-faro-web the package was being resolved transitively only, so a future dependency change could regress the version below the fix line.

**How it is being fixed:** Adding @babel/runtime and @babel/runtime-corejs3 as direct dependencies in package.json pinned to ^7.26.10. After yarn install, both resolve to 7.29.2, which keeps every transitive consumer (Clay UI and others) on a non-vulnerable version. No code changes were needed; the babel toolchain in this module does not use plugin-transform-runtime, so this is purely a version pin.