### PR TITLE
LPD-77745 Refactor metric-card and add Apollo cache typePolicies

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
@@ -93,7 +93,7 @@ const AccountCard: React.FC<IAccountCardProps> = ({
 									color:
 										getStatsColor(
 											metrics?.trend
-												?.trendClassification || ''
+												?.trendClassification ?? ''
 										) || TrendClassification.Neutral
 								}}
 							>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
@@ -6,7 +6,8 @@ import {cleanup, render, screen} from '@testing-library/react';
 import {createMemoryHistory} from 'history';
 import {mockChannelContext} from 'test/mock-channel-context';
 import {Provider} from 'react-redux';
-import {Router} from 'react-router-dom';
+import {Router, useHistory} from 'react-router-dom';
+import {useRequest} from 'shared/hooks/useRequest';
 import {waitForLoadingToBeRemoved} from 'test/helpers';
 
 jest.unmock('react-dom');
@@ -21,7 +22,9 @@ jest.mock('shared/hooks/useFrontendDataSet', () => ({
 	}
 }));
 
-jest.mock('shared/hooks/useRequest');
+jest.mock('shared/hooks/useRequest', () => ({
+	useRequest: jest.fn()
+}));
 
 jest.mock('shared/util/breadcrumbs', () => ({
 	getHome: jest.fn(({label}: {label?: string} = {}) => ({
@@ -39,7 +42,8 @@ jest.mock('react-router-dom', () => ({
 	})
 }));
 
-// Default push spy shared across tests, reset in beforeEach.
+const mockedUseHistory = useHistory as jest.Mock;
+const mockedUseRequest = useRequest as jest.Mock;
 
 const mockHistoryPush = jest.fn();
 
@@ -53,7 +57,35 @@ const buildHistory = (path = '/workspace/23/123/accounts') => {
 
 const store = mockStore();
 
-// Helper: wrap List in the minimum context providers it needs.
+// `useRequest` is consumed by both `List` (data source search, expects an
+// object with `total`) and `TotalAccounts` (account metrics, expects an array
+// of `IAccountMetric`). Differentiate by `variables.delta`, which is only
+// present in the data source search call.
+
+const accountMetricsMock = [
+	{
+		metricType: 'totalCount',
+		trend: {percentage: 0, trendClassification: 'NEUTRAL'},
+		value: 0
+	},
+	{
+		metricType: 'newCount',
+		trend: {percentage: 0, trendClassification: 'NEUTRAL'},
+		value: 0
+	},
+	{
+		metricType: 'activeCount',
+		trend: {percentage: 0, trendClassification: 'NEUTRAL'},
+		value: 0
+	}
+];
+
+const useRequestImpl =
+	({total = 1}: {total?: number} = {}) =>
+	({variables}: {variables: {[key: string]: any}}) =>
+		variables?.delta !== undefined
+			? {data: {total}}
+			: {data: accountMetricsMock};
 
 const renderList = (
 	{queryString = ''}: {queryString?: string} = {},
@@ -69,20 +101,12 @@ const renderList = (
 		</Provider>
 	);
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const {useHistory} = require('react-router-dom');
-
 describe('List', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 
-		useHistory.mockReturnValue({push: mockHistoryPush});
-
-		const useRequest = require('shared/hooks/useRequest');
-		useRequest.useRequest = jest
-			.fn()
-			.mockReturnValueOnce({data: {total: 1}})
-			.mockReturnValue({data: []});
+		mockedUseHistory.mockReturnValue({push: mockHistoryPush});
+		mockedUseRequest.mockImplementation(useRequestImpl());
 	});
 
 	afterEach(cleanup);
@@ -101,13 +125,7 @@ describe('List', () => {
 		});
 
 		it('should render the empty state when there are no data sources connected', () => {
-			const useRequest = require('shared/hooks/useRequest');
-
-			useRequest.useRequest.mockReturnValue({
-				data: {
-					total: 0
-				}
-			});
+			mockedUseRequest.mockImplementation(useRequestImpl({total: 0}));
 
 			renderList();
 		});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
@@ -56,6 +56,9 @@ exports[`List rendering should match the snapshot 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="embedded-alert-list-root notification-alert-list-root"
+      />
     </header>
     <div
       class="body-root page-container"

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/cache.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/cache.js
@@ -1,3 +1,33 @@
 import {InMemoryCache} from '@apollo/client';
 
-export default new InMemoryCache();
+/*
+ * `merge: true` instructs InMemoryCache to shallow-merge incoming writes into
+ * the existing cached object instead of replacing it, so the two queries
+ * coexist in a single cache entry. See:
+ * https://www.apollographql.com/docs/react/caching/cache-field-behavior#merging-non-normalized-objects
+ *
+ * This is a client-side workaround. The canonical fix is server-side: each
+ * root metric type should expose a stable, deterministic `id` derived from the
+ * resolver arguments, so InMemoryCache can normalize them automatically. Once
+ * the backend ships that change, this typePolicies block can be removed and
+ * the metric-card queries should select the new `id` field. Tracking ticket:
+ * <add backend ticket id here once filed>.
+ */
+
+const metricRootMerge = {
+	blog: {merge: true},
+	document: {merge: true},
+	form: {merge: true},
+	journal: {merge: true},
+	objectEntry: {merge: true},
+	page: {merge: true},
+	site: {merge: true}
+};
+
+export default new InMemoryCache({
+	typePolicies: {
+		Query: {
+			fields: metricRootMerge
+		}
+	}
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/client.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/client.js
@@ -2,6 +2,7 @@ import cache from './cache';
 import {ApolloClient, from, HttpLink} from '@apollo/client';
 import {DEVELOPER_MODE} from 'shared/util/constants';
 import {get} from 'lodash';
+import {loadDevMessages, loadErrorMessages} from '@apollo/client/dev';
 import {onError} from '@apollo/client/link/error';
 import {reloadPage} from 'shared/util/router';
 import {resolvers} from './resolvers/resolvers';
@@ -62,5 +63,11 @@ const client = new ApolloClient({
 		Query: DEVELOPER_MODE ? resolvers : {}
 	}
 });
+
+if (DEVELOPER_MODE) {
+	// Adds messages only in a dev environment
+	loadDevMessages();
+	loadErrorMessages();
+}
 
 export default client;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/MetricChart.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/MetricChart.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck - Fix it at this LRAC-13388
-
 import Checkbox from 'shared/components/Checkbox';
 import ClayLink from '@clayui/link';
 import ComposedChartWithEmptyState from 'shared/components/ComposedChartWithEmptyState';
@@ -26,23 +24,37 @@ import {
 	XAxis,
 	YAxis
 } from 'recharts';
+import {
+	CHART_DATA_PREVIOUS,
+	getActiveItem,
+	getMetricData,
+	getMetricName,
+	METRIC_TOOLTIP_LABEL_MAP
+} from './util';
 import {formatXAxisDate} from 'shared/util/charts';
-import {getActiveItem, getMetricData, getMetricName} from './util';
 import {ICommonMetricProps, useActions, useData} from './MetricBaseCard';
+import {Interval, RangeSelectors} from 'shared/types';
 import {useMetricQuery} from './hooks';
 import {useRetentionPeriod} from 'shared/hooks/useRetentionPeriod';
 
-export const CHART_DATA_PREVIOUS = 'data_previous';
-export const METRIC_TOOLTIP_LABEL_MAP = {
-	bounceRateMetric: Liferay.Language.get('avg-bounce')
+export {CHART_DATA_PREVIOUS, METRIC_TOOLTIP_LABEL_MAP};
+
+type TChartSeries = {
+	color?: string;
+	data: any;
+	dataName?: string;
+	id: string;
+	name?: string;
+	tooltipTitle?: string;
+	type?: string;
 };
 
 interface IMetricChartProps extends Partial<ICommonMetricProps> {
-	// @deprecated. It is used only on CustomAsset
-	onCompareToPreviousChange?: (compareToPrevious: boolean) => void;
 	chartHeight?: number;
 	compareToPrevious: boolean;
 	data: any;
+	// @deprecated. It is used only on CustomAsset
+	onCompareToPreviousChange?: (compareToPrevious: boolean) => void;
 }
 
 export const MetricChart: React.FC<IMetricChartProps> = ({
@@ -55,8 +67,10 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 }) => {
 	const {changeCompareToPrevious} = useActions();
 
-	const [hoveredLegendItem, setHoveredLegendItem] = useState(null);
-	const [hoverIndex, setHoverIndex] = useState(-1);
+	const [hoveredLegendItem, setHoveredLegendItem] = useState<string | null>(
+		null
+	);
+	const [hoverIndex, setHoverIndex] = useState<number>(-1);
 
 	const {
 		chartData,
@@ -71,14 +85,14 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 		[compareToPrevious, data]
 	);
 
-	const dataIds = chartData.map(item => item.id);
+	const dataIds: string[] = chartData.map((item: TChartSeries) => item.id);
 
 	let yAxisWidth = 40;
 
 	const combinedData = useMemo(
 		() =>
-			timeline.data.map((date, i) =>
-				dataIds.reduce(
+			timeline.data.map((date: number, i: number) =>
+				dataIds.reduce<Record<string, any>>(
 					(acc, item, j) => {
 						acc[item] = chartData[j].data[i];
 
@@ -96,8 +110,8 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 						date,
 						dateString: formatXAxisDate(
 							date,
-							rangeSelectors.rangeKey,
-							interval,
+							rangeSelectors!.rangeKey,
+							interval as Interval,
 							dateKeysIMap
 						)
 					}
@@ -106,11 +120,13 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 		[timeline, dataIds, chartData]
 	);
 
-	const barData = chartData.filter(item => item.type === 'bar');
+	const barData = chartData.filter(
+		(item: TChartSeries) => item.type === 'bar'
+	);
 
-	const lineData = chartData.filter(item => {
+	const lineData = chartData.filter((item: TChartSeries) => {
 		if (!compareToPrevious && item.id === CHART_DATA_PREVIOUS) {
-			return;
+			return false;
 		}
 
 		return item.type !== 'bar';
@@ -129,17 +145,15 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 					/>
 
 					<XAxis
-						axisLine={{
-							stroke: AXIS.borderStroke
-						}}
+						axisLine={{stroke: AXIS.borderStroke}}
 						dataKey='date'
 						interval='preserveStart'
 						stroke={AXIS.gridStroke}
-						tick={getAxisTickText('x', int =>
+						tick={getAxisTickText('x', (int: number | string) =>
 							formatXAxisDate(
 								int,
-								rangeSelectors.rangeKey,
-								interval,
+								rangeSelectors!.rangeKey,
+								interval as Interval,
 								dateKeysIMap
 							)
 						)}
@@ -149,9 +163,7 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 					/>
 
 					<XAxis
-						axisLine={{
-							stroke: AXIS.borderStroke
-						}}
+						axisLine={{stroke: AXIS.borderStroke}}
 						dataKey='date'
 						orientation='top'
 						stroke={AXIS.gridStroke}
@@ -161,9 +173,7 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 					/>
 
 					<YAxis
-						axisLine={{
-							stroke: AXIS.borderStroke
-						}}
+						axisLine={{stroke: AXIS.borderStroke}}
 						label={getYAxisLabel(
 							METRIC_TOOLTIP_LABEL_MAP[name] || title,
 							'left',
@@ -176,9 +186,7 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 					/>
 
 					<YAxis
-						axisLine={{
-							stroke: AXIS.borderStroke
-						}}
+						axisLine={{stroke: AXIS.borderStroke}}
 						orientation='right'
 						stroke={AXIS.gridStroke}
 						tick={false}
@@ -188,12 +196,14 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 					/>
 
 					<Tooltip
-						content={props => (
+						content={(props: any) => (
 							<MetricTooltip
 								compareToPrevious={compareToPrevious}
 								data={data}
-								interval={interval}
-								rangeSelectors={rangeSelectors}
+								interval={interval as Interval}
+								rangeSelectors={
+									rangeSelectors as RangeSelectors
+								}
 								retentionPeriod={retentionPeriod}
 								{...props}
 							/>
@@ -203,31 +213,32 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 
 					<Legend
 						align='right'
-						formatter={(label, {dataKey}) => {
+						formatter={(label: string, {dataKey}: any) => {
 							if (
 								compositeContent &&
-								dataKey !== 'data_previous'
+								dataKey !== CHART_DATA_PREVIOUS
 							) {
-								const {dataName} = barData.find(
-									({id}) => id === dataKey
+								const barItem = barData.find(
+									({id}: TChartSeries) => id === dataKey
 								);
+								const dataName = barItem?.dataName;
 
-								const {value} = compositeContent[dataName];
+								if (dataName && compositeContent[dataName]) {
+									const {value} = compositeContent[dataName];
 
-								return (
-									<>
+									return (
 										<span className='legend-text-color'>
 											{label}
 											<b className='ml-1'>{value}</b>
 										</span>
-									</>
-								);
+									);
+								}
 							}
 
 							return label;
 						}}
 						iconSize={8}
-						onMouseEnter={({dataKey}) =>
+						onMouseEnter={({dataKey}: any) =>
 							setHoveredLegendItem(dataKey)
 						}
 						onMouseLeave={() => setHoveredLegendItem(null)}
@@ -240,7 +251,7 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 						}}
 					/>
 
-					{barData.map(item => (
+					{barData.map((item: TChartSeries) => (
 						<Bar
 							animationDuration={ANIMATION_DURATION.bar}
 							dataKey={item.id}
@@ -254,11 +265,13 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 							key={item.id}
 							legendType='circle'
 							name={item.name}
-							onMouseEnter={(e, index) => setHoverIndex(index)}
+							onMouseEnter={(_e: unknown, index: number) =>
+								setHoverIndex(index)
+							}
 							onMouseLeave={() => setHoverIndex(-1)}
 							stackId='a'
 						>
-							{item.data.map((entry, index) => (
+							{item.data.map((_entry: unknown, index: number) => (
 								<Cell
 									fill={item.color}
 									key={`cell-${index}`}
@@ -268,7 +281,7 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 						</Bar>
 					))}
 
-					{lineData.map(item => (
+					{lineData.map((item: TChartSeries) => (
 						<Line
 							animationDuration={ANIMATION_DURATION.line}
 							dataKey={item.id}
@@ -277,8 +290,6 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 							key={item.id}
 							legendType='plainline'
 							name={item.name}
-							onMouseEnter={(e, index) => setHoverIndex(index)}
-							onMouseLeave={() => setHoverIndex(-1)}
 							stroke={item.color}
 							strokeDasharray={
 								item.id === CHART_DATA_PREVIOUS
@@ -305,61 +316,27 @@ export const MetricChart: React.FC<IMetricChartProps> = ({
 					onChange={() => {
 						changeCompareToPrevious(!compareToPrevious);
 
-						onCompareToPreviousChange &&
-							onCompareToPreviousChange(!compareToPrevious);
+						onCompareToPreviousChange?.(!compareToPrevious);
 					}}
 				/>
 			</div>
 
 			<div
 				data-qa-is-chart-populated={data.data[0].data.some(
-					value => value
+					(value: number) => value
 				)}
 			/>
 		</>
 	);
 };
 
-interface IMetricChartRendererProps extends ICommonMetricProps {}
-
-const MetricChartRenderer: React.FC<IMetricChartRendererProps> = ({
-	emptyDescription,
-	emptyTitle,
-	experienceId,
-	filters,
-	interval,
-	rangeSelectors
-}) => {
-	const {activeItemIndex, metrics, queries, variables} = useData();
-
-	const metricName = getMetricName(activeItemIndex, metrics);
-
-	const {data, error, loading} = useMetricQuery({
-		experienceId,
-		filters,
-		interval,
-		Query: queries.MetricQuery(metricName),
-		rangeSelectors,
-		variables
-	});
-
-	return (
-		<MetricStateRenderer error={error} loading={loading}>
-			<MetricChartWrapper
-				data={data}
-				emptyDescription={emptyDescription}
-				emptyTitle={emptyTitle}
-				interval={interval}
-				metricName={metricName}
-				rangeSelectors={rangeSelectors}
-			/>
-		</MetricStateRenderer>
-	);
-};
-
-interface IMetricChartWrapperProps extends Partial<IMetricChartRendererProps> {
+interface IMetricChartWrapperProps {
 	data: any;
+	emptyDescription?: string | React.ReactElement;
+	emptyTitle?: string;
+	interval: Interval;
 	metricName: string;
+	rangeSelectors: RangeSelectors;
 }
 
 const MetricChartWrapper: React.FC<IMetricChartWrapperProps> = ({
@@ -389,7 +366,7 @@ const MetricChartWrapper: React.FC<IMetricChartWrapperProps> = ({
 	const {chartDataMapFn, compareToPrevious, metrics, queries} = useData();
 
 	const {compositeMetrics, name, title, tooltipTitle, type} = metrics.find(
-		({name}) => metricName === name
+		({name}: {name: string}) => name === metricName
 	);
 
 	const formattedData = useMemo(
@@ -428,6 +405,43 @@ const MetricChartWrapper: React.FC<IMetricChartWrapperProps> = ({
 				/>
 			</ComposedChartWithEmptyState>
 		</div>
+	);
+};
+
+const MetricChartRenderer: React.FC<ICommonMetricProps> = ({
+	emptyDescription,
+	emptyTitle,
+	experienceId,
+	filters,
+	interval,
+	rangeSelectors
+}) => {
+	const {activeItemIndex, metrics, queries, variables} = useData();
+
+	const metricName = getMetricName(activeItemIndex, metrics);
+
+	const {data, error, loading} = useMetricQuery({
+		experienceId,
+		filters,
+		interval,
+		Query: queries.MetricQuery(metricName),
+		rangeSelectors,
+		variables
+	});
+
+	return (
+		<MetricStateRenderer error={error} loading={loading}>
+			<MetricChartWrapper
+				data={data}
+				emptyDescription={
+					emptyDescription as string | React.ReactElement | undefined
+				}
+				emptyTitle={emptyTitle}
+				interval={interval}
+				metricName={metricName}
+				rangeSelectors={rangeSelectors}
+			/>
+		</MetricStateRenderer>
 	);
 };
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/MetricTabs.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/MetricTabs.tsx
@@ -3,17 +3,43 @@ import MetricStateRenderer from './MetricStateRenderer';
 import React from 'react';
 import {buildTabs, getMetricCardTabsData} from './util';
 import {ICommonMetricProps, useActions, useData} from './MetricBaseCard';
+import {Metric} from './metrics';
 import {useMetricQuery} from './hooks';
 
-interface IMetricTabsRendererProps extends ICommonMetricProps {}
+interface IMetricTabsViewProps {
+	activeItemIndex: number;
+	changeActiveItemIndex: (index: number) => void;
+	data: any;
+	metrics: Metric[];
+	queryName: string;
+}
 
-const MetricTabsRenderer: React.FC<IMetricTabsRendererProps> = ({
+const MetricTabsView: React.FC<IMetricTabsViewProps> = React.memo(
+	({activeItemIndex, changeActiveItemIndex, data, metrics, queryName}) => {
+		const items = getMetricCardTabsData(data[queryName], metrics);
+
+		return (
+			<CardTabs
+				activeTabId={activeItemIndex}
+				className='analytics-metrics-tabs'
+				tabs={buildTabs({
+					activeItemIndex,
+					items,
+					onActiveItemIndexChange: changeActiveItemIndex
+				})}
+			/>
+		);
+	}
+);
+
+const MetricTabsRenderer: React.FC<ICommonMetricProps> = ({
 	experienceId,
 	filters,
 	interval,
 	rangeSelectors
 }) => {
-	const {queries, variables} = useData();
+	const {activeItemIndex, metrics, queries, variables} = useData();
+	const {changeActiveItemIndex} = useActions();
 
 	const {data, error, loading} = useMetricQuery({
 		experienceId,
@@ -26,30 +52,14 @@ const MetricTabsRenderer: React.FC<IMetricTabsRendererProps> = ({
 
 	return (
 		<MetricStateRenderer error={error} loading={loading} spacer>
-			<MetricTabs data={data} />
+			<MetricTabsView
+				activeItemIndex={activeItemIndex}
+				changeActiveItemIndex={changeActiveItemIndex}
+				data={data}
+				metrics={metrics}
+				queryName={queries.name}
+			/>
 		</MetricStateRenderer>
-	);
-};
-
-interface IMetricTabsProps extends Partial<IMetricTabsRendererProps> {
-	data: any;
-}
-
-const MetricTabs: React.FC<IMetricTabsProps> = ({data}) => {
-	const {activeItemIndex, metrics, queries} = useData();
-	const {changeActiveItemIndex} = useActions();
-	const items = getMetricCardTabsData(data[queries.name], metrics);
-
-	return (
-		<CardTabs
-			activeTabId={activeItemIndex}
-			className='analytics-metrics-tabs'
-			tabs={buildTabs({
-				activeItemIndex,
-				items,
-				onActiveItemIndexChange: changeActiveItemIndex
-			})}
-		/>
 	);
 };
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/MetricTooltip.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/MetricTooltip.tsx
@@ -3,17 +3,20 @@ import ChartTooltip, {
 	Weights
 } from 'shared/components/chart-tooltip';
 import React, {useMemo} from 'react';
-import {CHART_DATA_PREVIOUS, METRIC_TOOLTIP_LABEL_MAP} from './MetricChart';
+import {
+	CHART_DATA_ID_1,
+	CHART_DATA_ID_2,
+	CHART_DATA_PREVIOUS,
+	getActiveItem,
+	getPreviousValueFromCompositeData,
+	METRIC_TOOLTIP_LABEL_MAP
+} from './util';
 import {find, get} from 'lodash';
-import {getActiveItem, getPreviousValueFromCompositeData} from './util';
 import {getDateTitle} from 'shared/util/charts';
 import {Interval, RangeSelectors} from 'shared/types';
 import {RangeKeyTimeRanges} from 'shared/util/constants';
 import {sub} from 'shared/util/lang';
 import {useData} from './MetricBaseCard';
-
-const CHART_DATA_ID_1 = 'data_1';
-const CHART_DATA_ID_2 = 'data_2';
 
 type TTooltipPayloadItem = {
 	dataKey?: string;
@@ -21,7 +24,7 @@ type TTooltipPayloadItem = {
 	value: number;
 };
 
-const useMetricTooltip = ({
+const useMetricTooltipRows = ({
 	data,
 	interval,
 	payload,
@@ -29,39 +32,47 @@ const useMetricTooltip = ({
 }: {
 	data: any;
 	interval: Interval;
-	payload: TTooltipPayloadItem[];
+	payload: TTooltipPayloadItem[] | undefined;
 	rangeSelectors: RangeSelectors;
 }) => {
 	const {compareToPrevious} = useData();
 
-	const {
-		asymmetricComparison,
-		chartData,
-		compositeData,
-		content: {name, title},
-		dateKeysIMap,
-		format,
-		prevDateKeysIMap
-	} = useMemo(
+	const activeItem = useMemo(
 		() => getActiveItem(data, compareToPrevious),
 		[compareToPrevious, data]
 	);
 
-	const showCurrentPeriod =
-		compareToPrevious && asymmetricComparison ? payload.length > 1 : true;
+	return useMemo(() => {
+		if (!payload?.length) {
+			return null;
+		}
 
-	const [header, rows] = useMemo(() => {
+		const {
+			asymmetricComparison,
+			chartData,
+			compositeData,
+			content: {name, title},
+			dateKeysIMap,
+			format,
+			prevDateKeysIMap
+		} = activeItem;
+
+		const showCurrentPeriod =
+			compareToPrevious && asymmetricComparison
+				? payload.length > 1
+				: true;
+
 		const dateKey = payload[0].payload.date;
 
 		const dataOneItemData = find(
 			chartData,
-			({id}) => id === CHART_DATA_ID_1
+			({id}: {id: string}) => id === CHART_DATA_ID_1
 		);
 		const dataOneValue = payload[0].value;
 
 		const dataTwoItemData = find(
 			chartData,
-			({id}) => id === CHART_DATA_ID_2
+			({id}: {id: string}) => id === CHART_DATA_ID_2
 		);
 		const dataTwoValue = payload[1] && payload[1].value;
 
@@ -96,7 +107,7 @@ const useMetricTooltip = ({
 
 		const getDataRowName = (itemData: unknown) =>
 			get(itemData, 'tooltipTitle') ||
-			(METRIC_TOOLTIP_LABEL_MAP as Record<string, string>)[name] ||
+			METRIC_TOOLTIP_LABEL_MAP[name] ||
 			get(itemData, 'name');
 
 		const header = [
@@ -120,9 +131,7 @@ const useMetricTooltip = ({
 		const rows = [
 			{
 				columns: [
-					{
-						label: getDataRowName(dataOneItemData)
-					},
+					{label: getDataRowName(dataOneItemData)},
 					compareToPrevious && {
 						align: Alignments.Right,
 						label: format(dataOnePreviousValue)
@@ -135,9 +144,7 @@ const useMetricTooltip = ({
 			},
 			compositeData && {
 				columns: [
-					{
-						label: getDataRowName(dataTwoItemData)
-					},
+					{label: getDataRowName(dataTwoItemData)},
 					compareToPrevious && {
 						align: Alignments.Right,
 						label: format(dataTwoPreviousValue)
@@ -150,9 +157,7 @@ const useMetricTooltip = ({
 			},
 			compositeData && {
 				columns: [
-					{
-						label: Liferay.Language.get('total')
-					},
+					{label: Liferay.Language.get('total')},
 					compareToPrevious && {
 						align: Alignments.Right,
 						label: format(
@@ -167,21 +172,11 @@ const useMetricTooltip = ({
 			}
 		].filter(Boolean);
 
-		return [header, rows];
-	}, [showCurrentPeriod, interval, payload, rangeSelectors]);
-
-	return [header, rows];
+		return {header, rows};
+	}, [activeItem, compareToPrevious, interval, payload, rangeSelectors]);
 };
 
-const MetricTooltip = ({
-	active,
-	compareToPrevious,
-	data,
-	interval,
-	payload,
-	rangeSelectors,
-	retentionPeriod
-}: {
+interface IMetricTooltipProps {
 	active?: boolean;
 	compareToPrevious: boolean;
 	data: any;
@@ -189,46 +184,55 @@ const MetricTooltip = ({
 	payload?: TTooltipPayloadItem[];
 	rangeSelectors: RangeSelectors;
 	retentionPeriod?: number;
+}
+
+const MetricTooltip: React.FC<IMetricTooltipProps> = ({
+	active,
+	compareToPrevious,
+	data,
+	interval,
+	payload,
+	rangeSelectors,
+	retentionPeriod
 }) => {
-	if (active && payload?.length) {
-		const [header, rows] = useMetricTooltip({
-			data,
-			interval,
-			payload,
-			rangeSelectors
-		});
+	const tooltipRows = useMetricTooltipRows({
+		data,
+		interval,
+		payload,
+		rangeSelectors
+	});
 
-		let description = '';
+	if (!active || !tooltipRows) {
+		return null;
+	}
 
-		if (
-			(compareToPrevious &&
-				rangeSelectors.rangeKey === RangeKeyTimeRanges.Last180Days) ||
-			(retentionPeriod === 13 &&
-				rangeSelectors.rangeKey === RangeKeyTimeRanges.LastYear)
-		) {
-			description = sub(
+	const showRetentionWarning =
+		(compareToPrevious &&
+			rangeSelectors.rangeKey === RangeKeyTimeRanges.Last180Days) ||
+		(retentionPeriod === 13 &&
+			rangeSelectors.rangeKey === RangeKeyTimeRanges.LastYear);
+
+	const description = showRetentionWarning
+		? (sub(
 				Liferay.Language.get(
 					'there-is-no-data-available-for-dates-prior-to-x-months-due-to-your-workspaces-data-retention-period'
 				),
 				[retentionPeriod]
-			) as string;
-		}
+		  ) as string)
+		: '';
 
-		return (
-			<div
-				className='bb-tooltip-container'
-				style={{maxWidth: 400, position: 'static'}}
-			>
-				<ChartTooltip
-					description={description}
-					header={header}
-					rows={rows}
-				/>
-			</div>
-		);
-	}
-
-	return null;
+	return (
+		<div
+			className='bb-tooltip-container'
+			style={{maxWidth: 400, position: 'static'}}
+		>
+			<ChartTooltip
+				description={description}
+				header={tooltipRows.header}
+				rows={tooltipRows.rows}
+			/>
+		</div>
+	);
 };
 
 export default MetricTooltip;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/__tests__/MetricBaseCard.network.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/__tests__/MetricBaseCard.network.tsx
@@ -1,0 +1,219 @@
+import BasePage from 'shared/components/base-page';
+import MetricBaseCard from '../MetricBaseCard';
+import React from 'react';
+import {
+	BounceRateMetric,
+	CompositeMetric,
+	Metric,
+	SessionDurationMetric,
+	SessionsPerVisitorMetric
+} from '../metrics';
+import {getSiteMetricsChartData} from 'shared/components/metric-card/util';
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MockedProvider} from '@apollo/client/testing';
+import {RangeKeyTimeRanges} from 'shared/util/constants';
+import {render, waitFor} from '@testing-library/react';
+import {SitesMetricQuery, SitesTabsQuery} from '../queries';
+
+jest.unmock('react-dom');
+
+jest.mock('shared/hooks/useRequest', () => ({
+	useRequest: jest.fn(() => ({
+		data: 13,
+		loading: false
+	}))
+}));
+
+const metrics: Metric[] = [
+	CompositeMetric,
+	SessionsPerVisitorMetric,
+	SessionDurationMetric,
+	BounceRateMetric
+];
+
+const sharedRequestVariables = {
+	channelId: '456',
+	devices: 'Any',
+	interval: 'D',
+	location: 'Any',
+	rangeEnd: null,
+	rangeKey: parseInt(RangeKeyTimeRanges.Last30Days),
+	rangeStart: null
+};
+
+const tabsResult = {
+	site: {
+		__typename: 'SiteMetric',
+		bounceRateMetric: {
+			__typename: 'Metric',
+			previousValue: null,
+			trend: {
+				__typename: 'Trend',
+				percentage: null,
+				trendClassification: 'NEUTRAL'
+			},
+			value: 0
+		},
+		sessionDurationMetric: {
+			__typename: 'Metric',
+			previousValue: null,
+			trend: {
+				__typename: 'Trend',
+				percentage: null,
+				trendClassification: 'NEUTRAL'
+			},
+			value: 0
+		},
+		sessionsPerVisitorMetric: {
+			__typename: 'Metric',
+			previousValue: null,
+			trend: {
+				__typename: 'Trend',
+				percentage: null,
+				trendClassification: 'NEUTRAL'
+			},
+			value: 0
+		},
+		visitorsMetric: {
+			__typename: 'Metric',
+			previousValue: null,
+			trend: {
+				__typename: 'Trend',
+				percentage: null,
+				trendClassification: 'NEUTRAL'
+			},
+			value: 0
+		}
+	}
+};
+
+const compositeMetricResult = {
+	site: {
+		__typename: 'SiteMetric',
+		anonymousVisitorsMetric: {
+			__typename: 'HistogramMetric',
+			histogram: {
+				__typename: 'Histogram',
+				asymmetricComparison: false,
+				metrics: []
+			},
+			previousValue: null,
+			trend: {
+				__typename: 'Trend',
+				percentage: null,
+				trendClassification: 'NEUTRAL'
+			},
+			value: 0
+		},
+		knownVisitorsMetric: {
+			__typename: 'HistogramMetric',
+			histogram: {
+				__typename: 'Histogram',
+				asymmetricComparison: false,
+				metrics: []
+			},
+			previousValue: null,
+			trend: {
+				__typename: 'Trend',
+				percentage: null,
+				trendClassification: 'NEUTRAL'
+			},
+			value: 0
+		},
+		visitorsMetric: {
+			__typename: 'HistogramMetric',
+			histogram: {
+				__typename: 'Histogram',
+				asymmetricComparison: false,
+				metrics: []
+			},
+			previousValue: null,
+			trend: {
+				__typename: 'Trend',
+				percentage: null,
+				trendClassification: 'NEUTRAL'
+			},
+			value: 0
+		}
+	}
+};
+
+const buildMocks = (counter: {tabs: number; metric: number}) => [
+	{
+		newData: () => {
+			counter.tabs += 1;
+			return {data: tabsResult};
+		},
+		request: {
+			query: SitesTabsQuery,
+			variables: sharedRequestVariables
+		}
+	},
+	{
+		newData: () => {
+			counter.metric += 1;
+			return {data: compositeMetricResult};
+		},
+		request: {
+			query: SitesMetricQuery('visitorsMetric'),
+			variables: sharedRequestVariables
+		}
+	}
+];
+
+const renderWithProviders = (
+	mocks: ReturnType<typeof buildMocks>,
+	{visible = true}: {visible?: boolean} = {}
+) =>
+	render(
+		<MockedProvider addTypename={false} mocks={mocks}>
+			<BasePage.Context.Provider
+				value={{
+					filters: {},
+					router: {
+						params: {channelId: '456', groupId: '2000'},
+						query: {rangeKey: RangeKeyTimeRanges.Last30Days}
+					}
+				}}
+			>
+				<MemoryRouter
+					initialEntries={[
+						`/workspace/2000/456/sites?rangeKey=${RangeKeyTimeRanges.Last30Days}`
+					]}
+				>
+					<Route path='/workspace/:groupId/:channelId/sites'>
+						{visible && (
+							<MetricBaseCard
+								chartDataMapFn={getSiteMetricsChartData}
+								label='Visitors Behavior'
+								metrics={metrics}
+								queries={{
+									MetricQuery: SitesMetricQuery,
+									name: 'site',
+									TabsQuery: SitesTabsQuery
+								}}
+								variables={() => ({
+									...sharedRequestVariables
+								})}
+							/>
+						)}
+					</Route>
+				</MemoryRouter>
+			</BasePage.Context.Provider>
+		</MockedProvider>
+	);
+
+describe('MetricBaseCard network behavior', () => {
+	it('fires only one TabsQuery on initial mount', async () => {
+		const counter = {metric: 0, tabs: 0};
+
+		renderWithProviders(buildMocks(counter));
+
+		await waitFor(() => {
+			expect(counter.tabs).toBeGreaterThan(0);
+		});
+
+		expect(counter.tabs).toBe(1);
+		expect(counter.metric).toBe(1);
+	});
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/hooks.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/hooks.ts
@@ -35,14 +35,28 @@ export const useAssetVariables = (variables: ICommonVariables) => {
 	};
 };
 
-type TMetricQuery = {
-	filters: RawFilters;
+type TMetricQueryParams = {
 	experienceId?: string;
+	filters: RawFilters;
 	interval: Interval;
 	Query: DocumentNode;
 	rangeSelectors: RangeSelectors;
 	variables: (commonVariables: ICommonVariables) => any;
 };
+
+const buildQueryVariables = ({
+	experienceId,
+	filters,
+	interval,
+	rangeSelectors,
+	variables
+}: Omit<TMetricQueryParams, 'Query'>) =>
+	variables({
+		interval,
+		...getFilters(filters),
+		...getSafeRangeSelectors(rangeSelectors),
+		...(experienceId && {experienceId})
+	});
 
 export const useMetricQuery = ({
 	Query,
@@ -51,14 +65,15 @@ export const useMetricQuery = ({
 	interval,
 	rangeSelectors,
 	variables
-}: TMetricQuery) => {
+}: TMetricQueryParams) => {
 	const {data, error, loading} = useQuery(Query, {
 		fetchPolicy: fetchPolicyDefinition(rangeSelectors),
-		variables: variables({
+		variables: buildQueryVariables({
+			experienceId,
+			filters,
 			interval,
-			...getFilters(filters),
-			...getSafeRangeSelectors(rangeSelectors),
-			...(experienceId && {experienceId})
+			rangeSelectors,
+			variables
 		})
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/metrics.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/metrics.ts
@@ -10,48 +10,50 @@ export enum MetricType {
 export type Metric = {
 	compositeMetrics?: Metric[];
 	name: MetricName;
+	sortField?: MetricName;
 	title: string;
 	tooltipTitle?: string;
 	type: MetricType;
-	sortField?: MetricName;
 };
 
-export const AbandonmentsMetric: Metric = {
+const metric = (metric: Metric): Metric => metric;
+
+export const AbandonmentsMetric = metric({
 	name: MetricName.Abandonments,
 	sortField: MetricName.Abandonments,
 	title: Liferay.Language.get('abandonment'),
 	type: MetricType.Percentage
-};
+});
 
-export const AvgTimeOnPageMetric: Metric = {
+export const AvgTimeOnPageMetric = metric({
 	name: MetricName.AvgTimeOnPage,
 	sortField: MetricName.AvgTimeOnPage,
 	title: Liferay.Language.get('time-on-page'),
 	type: MetricType.Time
-};
+});
 
-export const BounceRateMetric: Metric = {
+export const BounceRateMetric = metric({
 	name: MetricName.BounceRate,
 	sortField: MetricName.BounceRate,
 	title: Liferay.Language.get('bounce-rate'),
 	type: MetricType.Percentage
-};
+});
 
-export const CommentsMetric: Metric = {
+export const CommentsMetric = metric({
 	name: MetricName.Comments,
 	sortField: MetricName.Comments,
 	title: Liferay.Language.get('comments'),
 	type: MetricType.Number
-};
+});
 
-export const CompletionTimeMetric: Metric = {
+export const CompletionTimeMetric = metric({
 	name: MetricName.CompletionTime,
 	sortField: MetricName.CompletionTime,
 	title: Liferay.Language.get('completion-time'),
 	type: MetricType.Time
-};
+});
 
-export const CompositeMetric: Metric = {
+export const CompositeMetric = metric({
 	compositeMetrics: [
 		{
 			name: MetricName.AnonymousVisitors,
@@ -69,79 +71,81 @@ export const CompositeMetric: Metric = {
 	name: MetricName.Visitors,
 	title: Liferay.Language.get('unique-visitors'),
 	type: MetricType.Number
-};
+});
 
-export const DownloadsMetric: Metric = {
+export const DownloadsMetric = metric({
 	name: MetricName.Downloads,
 	sortField: MetricName.Downloads,
 	title: Liferay.Language.get('downloads'),
 	type: MetricType.Number
-};
-export const EntrancesMetric: Metric = {
+});
+
+export const EntrancesMetric = metric({
 	name: MetricName.Entrances,
 	sortField: MetricName.Entrances,
 	title: Liferay.Language.get('entrances'),
 	type: MetricType.Number
-};
+});
 
-export const ExitRateMetric: Metric = {
+export const ExitRateMetric = metric({
 	name: MetricName.ExitRate,
 	sortField: MetricName.ExitRate,
 	title: Liferay.Language.get('exit-rate'),
 	type: MetricType.Percentage
-};
-export const ImpressionMadeMetric: Metric = {
+});
+
+export const ImpressionMadeMetric = metric({
 	name: MetricName.Impressions,
 	sortField: MetricName.Impressions,
 	title: Liferay.Language.get('impressions'),
 	type: MetricType.Number
-};
+});
 
-export const RatingsMetric: Metric = {
+export const RatingsMetric = metric({
 	name: MetricName.Ratings,
 	sortField: MetricName.Ratings,
 	title: Liferay.Language.get('rating'),
 	type: MetricType.Ratings
-};
+});
 
-export const ReadingTimeMetric: Metric = {
+export const ReadingTimeMetric = metric({
 	name: MetricName.ReadingTime,
 	sortField: MetricName.ReadingTime,
 	title: Liferay.Language.get('reading-time'),
 	type: MetricType.Time
-};
+});
 
-export const SessionDurationMetric: Metric = {
+export const SessionDurationMetric = metric({
 	name: MetricName.SessionsDuration,
 	title: Liferay.Language.get('session-duration'),
 	tooltipTitle: Liferay.Language.get('avg-duration'),
 	type: MetricType.Time
-};
+});
 
-export const SessionsPerVisitorMetric: Metric = {
+export const SessionsPerVisitorMetric = metric({
 	name: MetricName.SessionsPerVisitor,
 	title: Liferay.Language.get('sessions-visitor'),
 	tooltipTitle: Liferay.Language.get('avg-sessions'),
 	type: MetricType.Number
-};
+});
 
-export const SubmissionsMetric: Metric = {
+export const SubmissionsMetric = metric({
 	name: MetricName.Submissions,
 	sortField: MetricName.Submissions,
 	title: Liferay.Language.get('submissions'),
 	type: MetricType.Number
-};
+});
 
-export const ViewsMetric: Metric = {
+export const ViewsMetric = metric({
 	name: MetricName.Views,
 	sortField: MetricName.Views,
 	title: Liferay.Language.get('views'),
 	type: MetricType.Number
-};
+});
 
-export const VisitorsMetric: Metric = {
+export const VisitorsMetric = metric({
 	name: MetricName.Visitors,
 	sortField: MetricName.Visitors,
 	title: Liferay.Language.get('unique-visitors'),
 	type: MetricType.Number
-};
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/queries.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/queries.ts
@@ -5,29 +5,19 @@ import {
 	METRIC_TABS_FRAGMENT
 } from 'shared/queries/fragments';
 
-const assetMetricFragment = (metrics: Metric[]) => {
-	let fragment = '';
-
-	for (let i = 0; i < metrics.length; i++) {
-		fragment += `${metrics[i].name} {
-			...TabsFragment
-		}`;
-	}
-
-	return fragment;
-};
-
-const capitalizeFirstLetter = (str: string): string =>
+const capitalize = (str: string): string =>
 	str.charAt(0).toUpperCase() + str.slice(1);
 
-const queryTabsName = (str: string): string =>
-	`${capitalizeFirstLetter(str)}MetricTabsQuery`;
+const tabsOperationName = (name: string) =>
+	`${capitalize(name)}MetricTabsQuery`;
 
-const queryMetricName = (str: string): string =>
-	`${capitalizeFirstLetter(str)}MetricQuery`;
+const metricOperationName = (name: string) => `${capitalize(name)}MetricQuery`;
+
+const buildAssetTabsBody = (metrics: Metric[]) =>
+	metrics.map(({name}) => `${name} { ...TabsFragment }`).join('\n\t\t\t\t');
 
 export const AssetTabsQuery = (metrics: Metric[], name: string) => gql`
-	query ${queryTabsName(name)}(
+	query ${tabsOperationName(name)}(
 		$assetId: String!
 		$channelId: String
 		$devices: String
@@ -49,7 +39,7 @@ export const AssetTabsQuery = (metrics: Metric[], name: string) => gql`
 			rangeStart: $rangeStart
 			title: $title
 		) {
-			${assetMetricFragment(metrics)}
+			${buildAssetTabsBody(metrics)}
 		}
 	}
 
@@ -58,7 +48,7 @@ export const AssetTabsQuery = (metrics: Metric[], name: string) => gql`
 
 export const AssetMetricQuery = (queryName: string) => (metricName: string) =>
 	gql`
-	query ${queryMetricName(queryName)}(
+	query ${metricOperationName(queryName)}(
 		$assetId: String!
 		$channelId: String
 		$devices: String
@@ -122,7 +112,7 @@ export const SitesTabsQuery = gql`
 	${METRIC_TABS_FRAGMENT}
 `;
 
-const GenericMetricQuery = (metricName: string) => gql`
+const SitesGenericMetricQuery = (metricName: string) => gql`
 	query SitesMetricQuery(
 		$channelId: String
 		$interval: String!
@@ -146,7 +136,7 @@ const GenericMetricQuery = (metricName: string) => gql`
 	${METRIC_HISTOGRAM_FRAGMENT}
 `;
 
-const CompositeMetricQuery = gql`
+const SitesCompositeMetricQuery = gql`
 	query SitesMetricQuery(
 		$channelId: String
 		$interval: String!
@@ -176,13 +166,10 @@ const CompositeMetricQuery = gql`
 	${METRIC_HISTOGRAM_FRAGMENT}
 `;
 
-export const SitesMetricQuery = (metricName: string) => {
-	if (metricName === 'visitorsMetric') {
-		return CompositeMetricQuery;
-	}
-
-	return GenericMetricQuery(metricName);
-};
+export const SitesMetricQuery = (metricName: string) =>
+	metricName === 'visitorsMetric'
+		? SitesCompositeMetricQuery
+		: SitesGenericMetricQuery(metricName);
 
 export const PageMetricQuery = (metricName: string) => gql`
 	query PageMetricQuery(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/util.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/metric-card/util.tsx
@@ -1,14 +1,14 @@
 import MetricValue from './MetricValue';
 import React, {Fragment} from 'react';
 import Trend from 'shared/components/Trend';
-import {CHART_COLOR_NAMES} from 'shared/util/charts';
-import {get, last} from 'lodash';
 import {
+	CHART_COLOR_NAMES,
 	getAxisFormatter,
 	getDataFormatter,
 	getIntervals,
 	getMetricFormatter
 } from 'shared/util/charts';
+import {get, last} from 'lodash';
 import {getIcon, getStatsColor} from 'shared/util/metrics';
 import {Interval, RangeSelectors} from 'shared/types';
 import {INTERVAL_KEY_MAP} from 'shared/util/time';
@@ -16,16 +16,42 @@ import {Metric, MetricType} from './metrics';
 import {toRounded} from 'shared/util/numbers';
 import {toUnix} from 'shared/util/date';
 
+export const CHART_DATA_ID_1 = 'data_1';
+export const CHART_DATA_ID_2 = 'data_2';
+export const CHART_DATA_PREVIOUS = 'data_previous';
+
+const PREVIOUS_PERIOD_VISITORS_COLOR = '#393A4A';
+
+export const METRIC_TOOLTIP_LABEL_MAP: Record<string, string> = {
+	bounceRateMetric: Liferay.Language.get('avg-bounce')
+};
+
+const {
+	martell: CHART_GREEN,
+	martellL2: CHART_GREEN_L2,
+	mormont: CHART_ORANGE,
+	stark: CHART_BLUE,
+	starkL2: CHART_BLUE_L2
+} = CHART_COLOR_NAMES;
+
+export const Icons = {
+	negative: 'caret-bottom-l',
+	neutral: undefined,
+	positive: 'caret-top-l'
+};
+
+type THistogramItem = {
+	key: string;
+	previousValue: number;
+	previousValueKey: string;
+	value: number;
+	valueKey: string;
+};
+
 type TMetricResultItem = {
 	histogram: {
 		asymmetricComparison?: boolean;
-		metrics: Array<{
-			key: string;
-			previousValue: number;
-			previousValueKey: string;
-			value: number;
-			valueKey: string;
-		}>;
+		metrics: THistogramItem[];
 	};
 	trend: {
 		percentage: number;
@@ -46,64 +72,47 @@ type TChartDataSet = {
 	type?: string;
 };
 
-const CHART_DATA_ID_1 = 'data_1';
-const CHART_DATA_ID_2 = 'data_2';
-const CHART_DATA_PREVIOUS = 'data_previous';
-const METRIC_TOOLTIP_LABEL_MAP = {
-	bounceRateMetric: Liferay.Language.get('avg-bounce')
+type TTabContent = {
+	details: {
+		color: string;
+		icon?: string;
+		label: string;
+	};
+	name: string;
+	title: string;
+	type: MetricType;
+	value: string;
 };
 
-const {
-	martell: CHART_GREEN,
-	martellL2: CHART_GREEN_L2,
-	mormont: CHART_ORANGE,
-	stark: CHART_BLUE,
-	starkL2: CHART_BLUE_L2
-} = CHART_COLOR_NAMES;
-
-export const Icons = {
-	negative: 'caret-bottom-l',
-	neutral: undefined,
-	positive: 'caret-top-l'
+type TTabItem = {
+	content: TTabContent;
 };
 
-const PREVIOUS_PERIOD_VISITORS_COLOR = '#393A4A';
-
-type TBuildTabs = (props: {
-	activeItemIndex: number;
-	items: {
-		content: {
-			details: {
-				color: string;
-				icon?: string;
-				label: string;
-			};
-			title: string;
-			type: MetricType;
-			value: string;
-		};
-	}[];
-	onActiveItemIndexChange: (index: number) => void;
-}) => {
-	onClick: () => void | ((index: number) => void);
+type TTab = {
+	onClick: () => void;
 	secondaryInfo: React.ReactElement;
-}[];
+	tabId: number;
+	title: string;
+};
 
-export const buildTabs: TBuildTabs = ({
+export const buildTabs = ({
 	activeItemIndex,
 	items,
 	onActiveItemIndexChange
-}) =>
+}: {
+	activeItemIndex: number;
+	items: TTabItem[];
+	onActiveItemIndexChange: (index: number) => void;
+}): TTab[] =>
 	items.map(({content}, index) => {
 		const {details, title, type, value} = content;
 		const {color, icon, label} = details;
 
 		return {
 			onClick: () => {
-				if (activeItemIndex !== index && !onActiveItemIndexChange)
-					return () => {};
-
-				return onActiveItemIndexChange(index);
+				if (activeItemIndex !== index) {
+					onActiveItemIndexChange(index);
+				}
 			},
 			secondaryInfo: (
 				<span>
@@ -155,10 +164,7 @@ export const getActiveItem = (retVal: any, compareToPrevious: boolean) => {
 				...retVal,
 				compositeData: compositeDataKeys.reduce(
 					(acc: Record<string, any>, val) => {
-						acc = {
-							...acc,
-							[val]: retVal.compositeData[val].slice(1)
-						};
+						acc[val] = retVal.compositeData[val].slice(1);
 
 						return acc;
 					},
@@ -172,7 +178,7 @@ export const getActiveItem = (retVal: any, compareToPrevious: boolean) => {
 			chartData: chartData.map((dataSet: TChartDataSet) => ({
 				...dataSet,
 				data:
-					dataSet.id !== 'data_previous'
+					dataSet.id !== CHART_DATA_PREVIOUS
 						? [null, ...dataSet.data.slice(1)]
 						: dataSet.data
 			})),
@@ -202,50 +208,39 @@ export const getPreviousValueFromCompositeData = (
 	}
 };
 
-export const getRegexType = (type: MetricType): RegExp => {
-	if (type === MetricType.Ratings) {
-		return /([/][0-9]+)/g;
-	} else {
-		return /([a-zA-Z%])+/g;
-	}
-};
+export const getRegexType = (type: MetricType): RegExp =>
+	type === MetricType.Ratings ? /([/][0-9]+)/g : /([a-zA-Z%])+/g;
 
 export const formatValue = (
 	value: string,
 	regex: RegExp
-): React.ReactElement[] => {
-	const items = value.split(' ');
-
-	return items.map((item, i) => {
-		const [value, unit] = item.split(regex);
+): React.ReactElement[] =>
+	value.split(' ').map((item, i) => {
+		const [head, unit] = item.split(regex);
 
 		return (
 			<Fragment key={i}>
-				{value}
+				{head}
 
 				<span className='metric-value-letter'>{unit}</span>
 			</Fragment>
 		);
 	});
-};
 
 export const getMetricCardTabsData = (
 	result: TMetricsResult,
 	metrics: Metric[]
-) =>
+): TTabItem[] =>
 	metrics.map(({name, title, type}) => {
 		const metricFormatter = getMetricFormatter(type);
+		const {percentage, trendClassification} = result[name].trend;
 
 		return {
 			content: {
 				details: {
-					color: getStatsColor(
-						result[name].trend.trendClassification
-					),
-					icon: getIcon(result[name].trend.percentage),
-					label: `${toRounded(
-						Math.abs(result[name].trend.percentage)
-					)}%`
+					color: getStatsColor(trendClassification),
+					icon: getIcon(percentage),
+					label: `${toRounded(Math.abs(percentage))}%`
 				},
 				name,
 				title,
@@ -254,68 +249,6 @@ export const getMetricCardTabsData = (
 			}
 		};
 	});
-
-export const getMetricsData = (
-	result: TMetricsResult,
-	metrics: Metric[],
-	rangeSelectors: Partial<RangeSelectors> = {},
-	chartDataMapFn: (...args: any[]) => any = getMetricsChartData,
-	interval: string = INTERVAL_KEY_MAP.day
-) =>
-	metrics.map(({compositeMetrics, name, title, tooltipTitle, type}) =>
-		getMetricData({
-			chartDataMapFn,
-			compositeMetrics,
-			interval,
-			name,
-			rangeSelectors,
-			result,
-			title,
-			tooltipTitle,
-			type
-		})
-	);
-
-export const getMetricsChartData = ({
-	histogram,
-	name,
-	title,
-	tooltipTitle,
-	type
-}: {
-	histogram: Array<{
-		key: string;
-		previousValue: number;
-		value: number;
-	}>;
-	name: string;
-	title: string;
-	tooltipTitle?: string;
-	type: MetricType;
-}) => [
-	{
-		color: CHART_BLUE,
-		data: getDataFormatter(type)(histogram.map(({value}) => value)),
-		id: CHART_DATA_ID_1,
-		name:
-			tooltipTitle ||
-			(METRIC_TOOLTIP_LABEL_MAP as Record<string, string>)[name] ||
-			title,
-		tooltipTitle
-	},
-	{
-		color: CHART_BLUE_L2,
-		data: getDataFormatter(type)(
-			histogram.map(({previousValue}) => previousValue)
-		),
-		id: CHART_DATA_PREVIOUS,
-		name: Liferay.Language.get('previous-period')
-	},
-	{
-		data: histogram.map(({key}) => key),
-		id: 'x'
-	}
-];
 
 export const convertHistogramKeysToDate = ({
 	key,
@@ -333,6 +266,84 @@ export const convertHistogramKeysToDate = ({
 	valueKey: valueKey.split('/').map(toUnix),
 	...otherParams
 });
+
+export const getMetricsChartData = ({
+	histogram,
+	name,
+	title,
+	tooltipTitle,
+	type
+}: {
+	histogram: Array<{
+		key: string;
+		previousValue: number;
+		value: number;
+	}>;
+	name: string;
+	title: string;
+	tooltipTitle?: string;
+	type: MetricType;
+}): TChartDataSet[] => {
+	const formatter = getDataFormatter(type);
+
+	return [
+		{
+			color: CHART_BLUE,
+			data: formatter(histogram.map(({value}) => value)),
+			id: CHART_DATA_ID_1,
+			name: tooltipTitle || METRIC_TOOLTIP_LABEL_MAP[name] || title,
+			tooltipTitle
+		},
+		{
+			color: CHART_BLUE_L2,
+			data: formatter(histogram.map(({previousValue}) => previousValue)),
+			id: CHART_DATA_PREVIOUS,
+			name: Liferay.Language.get('previous-period')
+		},
+		{
+			data: histogram.map(({key}) => key),
+			id: 'x'
+		}
+	];
+};
+
+const buildCompositeData = (
+	compositeMetrics: Metric[],
+	result: TMetricsResult
+) => {
+	const compositeContent = compositeMetrics.reduce(
+		(acc: Record<string, any>, {name, title, type}) => {
+			const metricFormatter = getMetricFormatter(type);
+			const {percentage, trendClassification} = result[name].trend;
+
+			acc[name] = {
+				details: {
+					color: getStatsColor(trendClassification),
+					icon: getIcon(percentage),
+					label: `${toRounded(Math.abs(percentage))}%`
+				},
+				name,
+				title,
+				type,
+				value: metricFormatter(result[name].value)
+			};
+
+			return acc;
+		},
+		{}
+	);
+
+	const compositeData = compositeMetrics.reduce(
+		(acc: Record<string, any>, {name}) => {
+			acc[name] = result[name].histogram.metrics;
+
+			return acc;
+		},
+		{}
+	);
+
+	return {compositeContent, compositeData};
+};
 
 export const getMetricData = ({
 	chartDataMapFn = getMetricsChartData,
@@ -361,69 +372,24 @@ export const getMetricData = ({
 		convertHistogramKeysToDate
 	);
 
-	const compositeData = compositeMetrics
-		? {
-				compositeContent: compositeMetrics.reduce(
-					(
-						acc: Record<string, any>,
-						{
-							name: compositeMetricName,
-							title: compositeMetricTitle,
-							type: compositeMetricType
-						}
-					) => {
-						acc[compositeMetricName] = {
-							details: {
-								color: getStatsColor(
-									result[compositeMetricName].trend
-										.trendClassification
-								),
-								icon: getIcon(
-									result[compositeMetricName].trend.percentage
-								),
-								label: `${toRounded(
-									Math.abs(
-										result[compositeMetricName].trend
-											.percentage
-									)
-								)}%`
-							},
-							name: compositeMetricName,
-							title: compositeMetricTitle,
-							type: compositeMetricType,
-							value: metricFormatter(
-								result[compositeMetricName].value
-							)
-						};
-
-						return acc;
-					},
-					{}
-				),
-				compositeData: compositeMetrics.reduce(
-					(acc: Record<string, any>, {name: compositeMetricName}) => {
-						acc[compositeMetricName] =
-							result[compositeMetricName].histogram.metrics;
-
-						return acc;
-					},
-					{}
-				)
-		  }
+	const compositeMeta = compositeMetrics
+		? buildCompositeData(compositeMetrics, result)
 		: {};
 
 	const dateKeysIMap = new Map(
 		histogram.map(({key, valueKey}) => [key, valueKey])
 	);
 
+	const {percentage, trendClassification} = result[name].trend;
+
 	return {
-		...compositeData,
+		...compositeMeta,
 		asymmetricComparison: result[name].histogram.asymmetricComparison,
 		content: {
 			details: {
-				color: getStatsColor(result[name].trend.trendClassification),
-				icon: getIcon(result[name].trend.percentage),
-				label: `${toRounded(Math.abs(result[name].trend.percentage))}%`
+				color: getStatsColor(trendClassification),
+				icon: getIcon(percentage),
+				label: `${toRounded(Math.abs(percentage))}%`
 			},
 			name,
 			title,
@@ -431,7 +397,7 @@ export const getMetricData = ({
 			value: metricFormatter(result[name].value)
 		},
 		data: chartDataMapFn({
-			...compositeData,
+			...compositeMeta,
 			histogram,
 			name,
 			title,
@@ -452,6 +418,27 @@ export const getMetricData = ({
 	};
 };
 
+export const getMetricsData = (
+	result: TMetricsResult,
+	metrics: Metric[],
+	rangeSelectors: Partial<RangeSelectors> = {},
+	chartDataMapFn: (...args: any[]) => any = getMetricsChartData,
+	interval: string = INTERVAL_KEY_MAP.day
+) =>
+	metrics.map(({compositeMetrics, name, title, tooltipTitle, type}) =>
+		getMetricData({
+			chartDataMapFn,
+			compositeMetrics,
+			interval,
+			name,
+			rangeSelectors,
+			result,
+			title,
+			tooltipTitle,
+			type
+		})
+	);
+
 export const getSiteMetricsChartData = ({
 	compositeData,
 	histogram,
@@ -470,58 +457,62 @@ export const getSiteMetricsChartData = ({
 	title: string;
 	tooltipTitle?: string;
 	type: MetricType;
-}) =>
-	name === 'visitorsMetric'
-		? [
-				{
-					color: CHART_BLUE,
-					data: getDataFormatter(type)(
-						compositeData.knownVisitorsMetric.map(
-							({value}: {value: number}) => value
-						)
-					),
-					dataName: 'knownVisitorsMetric',
-					id: CHART_DATA_ID_1,
-					name: Liferay.Language.get('known-visitors'),
-					tooltipTitle: Liferay.Language.get('known'),
-					type: 'bar'
-				},
-				{
-					color: CHART_ORANGE,
-					data: getDataFormatter(type)(
-						compositeData.anonymousVisitorsMetric.map(
-							({value}: {value: number}) => value
-						)
-					),
-					dataName: 'anonymousVisitorsMetric',
-					id: CHART_DATA_ID_2,
-					name: Liferay.Language.get('anonymous-visitors'),
-					tooltipTitle: Liferay.Language.get('anonymous'),
-					type: 'bar'
-				},
-				{
-					color: PREVIOUS_PERIOD_VISITORS_COLOR,
-					data: getDataFormatter(type)(
-						histogram.map(({previousValue}) => previousValue)
-					),
-					id: CHART_DATA_PREVIOUS,
-					name: Liferay.Language.get('previous-period'),
-					type: 'line'
-				},
-				{
-					data: histogram.map(({key}) => key),
-					id: 'x'
-				}
-		  ]
-		: getMetricsChartData({histogram, name, title, tooltipTitle, type}).map(
-				data =>
-					[CHART_DATA_ID_1, CHART_DATA_PREVIOUS].includes(data.id)
-						? {
-								...data,
-								color:
-									data.id === CHART_DATA_PREVIOUS
-										? CHART_GREEN_L2
-										: CHART_GREEN
-						  }
-						: data
-		  );
+}): TChartDataSet[] => {
+	if (name !== 'visitorsMetric') {
+		return getMetricsChartData({
+			histogram,
+			name,
+			title,
+			tooltipTitle,
+			type
+		}).map(data =>
+			[CHART_DATA_ID_1, CHART_DATA_PREVIOUS].includes(data.id)
+				? {
+						...data,
+						color:
+							data.id === CHART_DATA_PREVIOUS
+								? CHART_GREEN_L2
+								: CHART_GREEN
+				  }
+				: data
+		);
+	}
+
+	const formatter = getDataFormatter(type);
+
+	return [
+		{
+			color: CHART_BLUE,
+			data: formatter(
+				compositeData.knownVisitorsMetric.map(({value}) => value)
+			),
+			dataName: 'knownVisitorsMetric',
+			id: CHART_DATA_ID_1,
+			name: Liferay.Language.get('known-visitors'),
+			tooltipTitle: Liferay.Language.get('known'),
+			type: 'bar'
+		},
+		{
+			color: CHART_ORANGE,
+			data: formatter(
+				compositeData.anonymousVisitorsMetric.map(({value}) => value)
+			),
+			dataName: 'anonymousVisitorsMetric',
+			id: CHART_DATA_ID_2,
+			name: Liferay.Language.get('anonymous-visitors'),
+			tooltipTitle: Liferay.Language.get('anonymous'),
+			type: 'bar'
+		},
+		{
+			color: PREVIOUS_PERIOD_VISITORS_COLOR,
+			data: formatter(histogram.map(({previousValue}) => previousValue)),
+			id: CHART_DATA_PREVIOUS,
+			name: Liferay.Language.get('previous-period'),
+			type: 'line'
+		},
+		{
+			data: histogram.map(({key}) => key),
+			id: 'x'
+		}
+	];
+};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-77745

**What is being fixed:** The shared `metric-card` component had grown into a tangle of overlapping concerns — chart rendering, tooltip composition, tab wiring, metric resolution, and data-shape utilities were all interleaved across `MetricChart`, `MetricTabs`, `MetricTooltip`, and `util.tsx`, making it hard to follow and to extend. On top of that, two recurring runtime issues affected the cards in production: Apollo's `InMemoryCache` was overwriting cached data when sibling root metric queries (blog, document, form, journal, objectEntry, page, site) wrote into the same root field, and `TotalAccounts` could throw when `trendClassification` was missing from the response.

**How it is being fixed:** The bulk of the change is a refactor of `metric-card` — `MetricChart`, `MetricTabs`, `MetricTooltip`, `hooks`, `metrics`, `queries`, and `util` were reorganized so each module owns a single concern, with types tightened along the way and a new `MetricBaseCard.network` test covering the integrated render and data-fetch path. To stop the cache thrash, `shared/apollo/cache.js` now declares `typePolicies` with `merge: true` for every metric root type so concurrent writes coalesce into a single normalized entry; this is documented as a client-side workaround until the backend exposes a stable `id` on those root resolvers. `TotalAccounts` switches to nullish coalescing when reading `trendClassification` so a missing field no longer crashes the cell, and the `List` tests are updated to mock the new TotalAccounts data shape so the suite still validates the page. Finally, the Apollo client now loads `loadDevMessages` and `loadErrorMessages` when `DEVELOPER_MODE` is on, surfacing the full Apollo error text during local development.