### PR TITLE
LPD-88191 Flatten Demandbase account message payload

### DIFF
--- a/modules/apps/analytics/analytics-client-js/src/demandbase.ts
+++ b/modules/apps/analytics/analytics-client-js/src/demandbase.ts
@@ -127,9 +127,9 @@ class Demandbase {
 			const {emailAddressHashed} = this.analyticsInstance.config.identity;
 
 			const messageHash = hash({
-				companyProfile: profile,
 				emailAddressHashed,
 				userId,
+				webSite: profile.web_site,
 			});
 			const storedHash = getItem<string>(
 				AnalyticsType.Keys.DemandbaseAccount
@@ -143,7 +143,7 @@ class Demandbase {
 
 			this.analyticsInstance[AnalyticsType.Queues.AccountMessage].addItem(
 				{
-					companyProfile: profile,
+					...profile,
 					emailAddressHashed,
 					id: messageHash,
 					userId,

--- a/modules/apps/analytics/analytics-client-js/src/types.ts
+++ b/modules/apps/analytics/analytics-client-js/src/types.ts
@@ -48,10 +48,10 @@ export namespace Analytics {
 	}
 
 	export type AccountMessage = {
-		companyProfile: {[key: string]: unknown};
 		emailAddressHashed: string;
 		id: string;
 		userId: string;
+		[key: string]: unknown;
 	};
 
 	export type Config = {

--- a/modules/apps/analytics/analytics-client-js/test/analytics.ts
+++ b/modules/apps/analytics/analytics-client-js/test/analytics.ts
@@ -313,7 +313,7 @@ describe('Analytics', () => {
 
 			expect(items.length).toBe(1);
 			expect(items[0].userId).toBe(getItem(AnalyticsType.Keys.UserId));
-			expect(items[0].companyProfile).toEqual(COMPANY_PROFILE);
+			expect(items[0]).toMatchObject(COMPANY_PROFILE);
 			expect(items[0].emailAddressHashed).toBe(
 				Analytics.config.identity.emailAddressHashed
 			);

--- a/modules/apps/analytics/analytics-client-js/test/queues/accountMessageQueue.ts
+++ b/modules/apps/analytics/analytics-client-js/test/queues/accountMessageQueue.ts
@@ -35,7 +35,7 @@ describe('AccountMessageQueue', () => {
 
 	it('posts to the demandbase-account endpoint', async () => {
 		accountMessageQueue.addItem({
-			companyProfile: {company_name: 'Acme'},
+			company_name: 'Acme',
 			emailAddressHashed: 'hashed-email',
 			id: 'hash-1',
 			userId: 'user-1',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88191

**What is being fixed:** The publisher's `DemandbaseAccountRestController` reads `web_site` at the top level of the JSON body via `jsonObject.optString("web_site", ...)`. The `analytics-client-js` was sending the Demandbase company profile nested under a `companyProfile` key, so the publisher resolved the ID to `null` and silently discarded every account message with a debug log. No Demandbase data ever reached the message bus or BigQuery.

**How it is being fixed:** Flatten the payload in the SDK before enqueuing the account message — spread the Demandbase profile fields at the top level alongside `userId`, `id`, and `emailAddressHashed` instead of nesting them under a `companyProfile` key. This matches the shape expected by both `DemandbaseAccountRestController` (publisher) and `DemandbaseAccountNanite` (stream-curator), which both read fields from the top level. Update the `Analytics.AccountMessage` type and the corresponding tests to reflect the flat shape.