### PR TITLE
LPD-88580 Restrict accounts and lifecycle routes to LDP customers

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/sidebar/__tests__/Sidebar.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/sidebar/__tests__/Sidebar.jsx
@@ -60,4 +60,30 @@ describe('Sidebar', () => {
 			container.querySelector('.sidebar-item-root.active').firstChild
 		).toHaveAttribute('href', activePathName);
 	});
+
+	it('should render lifecycle and accounts items when LDP is enabled', () => {
+		const {queryByText} = render(
+			<Provider store={mockStore(mockStoreDataLDP)}>
+				<StaticRouter>
+					<Sidebar {...defaultProps} />
+				</StaticRouter>
+			</Provider>
+		);
+
+		expect(queryByText('Lifecycles')).toBeTruthy();
+		expect(queryByText('Accounts')).toBeTruthy();
+	});
+
+	it('should not render lifecycle and accounts items when LDP is not enabled', () => {
+		const {queryByText} = render(
+			<Provider store={mockStore()}>
+				<StaticRouter>
+					<Sidebar {...defaultProps} />
+				</StaticRouter>
+			</Provider>
+		);
+
+		expect(queryByText('Lifecycles')).toBeNull();
+		expect(queryByText('Accounts')).toBeNull();
+	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/sidebar/__tests__/Sidebar.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/sidebar/__tests__/Sidebar.jsx
@@ -1,4 +1,4 @@
-import mockStore from 'test/mock-store';
+import mockStore, {mockStoreDataLDP} from 'test/mock-store';
 import React from 'react';
 import Sidebar from '../index';
 import {Provider} from 'react-redux';
@@ -18,7 +18,7 @@ jest.unmock('react-dom');
 describe('Sidebar', () => {
 	it('should render', () => {
 		const {container} = render(
-			<Provider store={mockStore()}>
+			<Provider store={mockStore(mockStoreDataLDP)}>
 				<StaticRouter>
 					<Sidebar {...defaultProps} />
 				</StaticRouter>
@@ -30,7 +30,7 @@ describe('Sidebar', () => {
 
 	it('should render as collapsed', () => {
 		const {container} = render(
-			<Provider store={mockStore()}>
+			<Provider store={mockStore(mockStoreDataLDP)}>
 				<StaticRouter>
 					<Sidebar {...defaultProps} collapsed />
 				</StaticRouter>
@@ -46,7 +46,7 @@ describe('Sidebar', () => {
 		const activePathName = '/workspace/23/123/contacts/individuals';
 
 		const {container} = render(
-			<Provider store={mockStore()}>
+			<Provider store={mockStore(mockStoreDataLDP)}>
 				<StaticRouter>
 					<Sidebar
 						{...defaultProps}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/sidebar/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/sidebar/index.tsx
@@ -8,6 +8,7 @@ import UserDropdown, {Menus} from 'shared/components/user-dropdown';
 import {ACCOUNTS, Routes, SEGMENTS, toRoute} from 'shared/util/router';
 import {DEVELOPER_MODE, LANGUAGES} from 'shared/util/constants';
 import {Link, matchPath} from 'react-router-dom';
+import {useLDPEnabled} from 'shared/hooks/useLDPEnabled';
 import {User} from 'shared/util/records';
 
 interface ISidebarProps {
@@ -31,10 +32,12 @@ const Sidebar: React.FC<ISidebarProps> = ({
 	groupId,
 	onToggle
 }) => {
+	const LDPEnabled = useLDPEnabled({groupId});
+
 	const sidebarSections = [
 		{
 			items: [
-				{
+				LDPEnabled && {
 					icon: 'polls',
 					label: Liferay.Language.get('lifecycles'),
 					route: Routes.LIFECYCLE,
@@ -64,7 +67,7 @@ const Sidebar: React.FC<ISidebarProps> = ({
 						groupId
 					})
 				}
-			],
+			].filter(Boolean) as [],
 			label: Liferay.Language.get('touchpoints')
 		},
 		{
@@ -79,7 +82,7 @@ const Sidebar: React.FC<ISidebarProps> = ({
 						type: SEGMENTS
 					})
 				},
-				{
+				LDPEnabled && {
 					icon: 'ac_account',
 					label: Liferay.Language.get('accounts'),
 					route: Routes.CONTACTS_LIST_ACCOUNT,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/pages/AppSidebarRoutes.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/pages/AppSidebarRoutes.jsx
@@ -178,16 +178,6 @@ const CommerceDashboard = lazy(() =>
 
 const ROUTES = [
 	{
-		data: AccountsList,
-		path: Routes.CONTACTS_LIST_ACCOUNT
-	},
-	{
-		data: AccountProfileRoutes,
-		exact: false,
-		path: Routes.CONTACTS_ACCOUNT
-	},
-
-	{
 		data: SegmentsList,
 		path: Routes.CONTACTS_LIST_SEGMENT
 	},
@@ -289,11 +279,6 @@ const ROUTES = [
 		destructured: false,
 		path: Routes.CHANNEL
 	},
-	{
-		data: LifecycleDashboard,
-		destructured: false,
-		path: Routes.LIFECYCLE
-	},
 	DEVELOPER_MODE && {
 		data: CommerceDashboard,
 		destructured: false,
@@ -356,6 +341,31 @@ export default class AppSidebarRoutes extends React.PureComponent {
 								destructured={false}
 								exact={false}
 								path={Routes.CONTACTS_INDIVIDUALS}
+							/>
+						)}
+
+						{LDPEnabled && (
+							<BundleRouter
+								data={AccountsList}
+								exact
+								path={Routes.CONTACTS_LIST_ACCOUNT}
+							/>
+						)}
+
+						{LDPEnabled && (
+							<BundleRouter
+								data={AccountProfileRoutes}
+								exact={false}
+								path={Routes.CONTACTS_ACCOUNT}
+							/>
+						)}
+
+						{LDPEnabled && (
+							<BundleRouter
+								data={LifecycleDashboard}
+								destructured={false}
+								exact
+								path={Routes.LIFECYCLE}
 							/>
 						)}
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/test/mock-store.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/test/mock-store.jsx
@@ -163,6 +163,11 @@ export const mockStoreData = fromJS({
 	}
 });
 
+export const mockStoreDataLDP = mockStoreData.setIn(
+	['projects', '23', 'data', 'faroSubscription'],
+	fromJS({name: 'Liferay Data Platform'})
+);
+
 export default function mockStore(
 	initialState = mockStoreData,
 	reducer = reducers


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88580

## What is being fixed

The Sidebar showed the Lifecycles and Accounts items, and AppSidebarRoutes
registered the corresponding /lifecycle, accounts list, and account profile
routes, for every workspace — including non-LDP customers. These features are
exclusive to Liferay Data Platform subscribers and should not be reachable
from other plans.

## How it is being fixed

The Sidebar now calls the existing useLDPEnabled hook with the current
groupId. The Lifecycles item under Touchpoints and the Accounts item under
People are only included in the section list when LDPEnabled is true; the
falsy entries are filtered out before render. AppSidebarRoutes moves the
AccountsList, AccountProfileRoutes, and LifecycleDashboard routes out of the
static ROUTES array and renders them through BundleRouter only when its
existing LDPEnabled prop (provided by the withLDPEnabled HOC) is true, so the
routes are not mounted for non-LDP customers. The shared test mock store gains
a mockStoreDataLDP helper that injects an LDP faroSubscription, the existing
Sidebar tests are updated to use it, and new tests assert that the Lifecycles
and Accounts items render only when LDP is enabled.