### PR TITLE
LPD-88620 Fix uncaught TypeError on missing A/B click goalTarget

### DIFF
--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
@@ -30,9 +30,13 @@ SegmentsExperiment segmentsExperiment = (SegmentsExperiment)request.getAttribute
 			});
 		}
 		else {
-			elements.push(
-				document.querySelector('<%= segmentsExperiment.getGoalTarget() %>')
+			var goalTargetElement = document.querySelector(
+				'<%= segmentsExperiment.getGoalTarget() %>'
 			);
+
+			if (goalTargetElement) {
+				elements.push(goalTargetElement);
+			}
 		}
 
 		if (elements.length) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88620

## What is being fixed

When an A/B test (Segments Experiment) with a Click goal is running on a page and the configured `goalTarget` selector does not resolve to any element in the rendered DOM, the inline script injected by `top_head.jsp` throws an uncaught `TypeError: Cannot read properties of null (reading 'addEventListener')`. The error breaks subsequent script execution on the page. In the customer scenario reported under LPP-63825, this prevents the SAML SP from completing the redirect to the configured Identity Provider, leaving the user stranded on the SP — but any other inline or deferred JavaScript on the same page would be aborted in the same way.

## How it is being fixed

In the `else` branch of `top_head.jsp`, the result of `document.querySelector(goalTarget)` is now captured in a local and only pushed into the `elements` array when it is non-null. The subsequent `forEach` therefore can never dereference `null`. When the target element is absent, the script silently no-ops, which is the correct behavior since there is nothing to attach a listener to.

## Why are there no tests?

The change is a three-line null guard inside an inline `<aui:script>` block in `top_head.jsp`. The module's existing JS test surface (`segments-experiment-web/test/js/`) covers React components, not server-rendered inline scripts; there is no current Playwright coverage for click-goal runtime tracking either. Adding a meaningful automated test would require either extracting the inline script into an importable ES module or building Playwright infrastructure for an active A/B experiment with a deliberately mismatched `goalTarget` — both significantly broader than this hotfix. The behavior change is locally provable: a `null` is no longer pushed into the `elements` array, so the subsequent `forEach` cannot dereference it. A follow-up to refactor the script for testability can be tracked separately.