### PR TITLE
LPD-84627

### DIFF
--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/AnalyticsDXPEntityBatchExporterImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/AnalyticsDXPEntityBatchExporterImpl.java
@@ -17,7 +17,15 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -153,18 +161,39 @@ public class AnalyticsDXPEntityBatchExporterImpl
 		}
 	}
 
+	private User _addAnalyticsAdmin(long companyId) throws Exception {
+		Company company = _companyLocalService.getCompany(companyId);
+
+		Role role = _roleLocalService.getRole(
+			companyId, "Analytics Administrator");
+
+		User user = _userLocalService.addUser(
+			0, companyId, true, null, null, false,
+			AnalyticsSecurityConstants.SCREEN_NAME_ANALYTICS_ADMIN,
+			"analytics.administrator@" + company.getMx(),
+			LocaleUtil.getDefault(), "Analytics", "", "Administrator", 0, 0,
+			true, 0, 1, 1970, "", UserConstants.TYPE_REGULAR, null, null,
+			new long[] {role.getRoleId()}, null, false, new ServiceContext());
+
+		return _userLocalService.updateUser(user);
+	}
+
 	private DispatchTrigger _addDispatchTrigger(
 			long companyId, String dispatchTriggerName,
 			LocalDateTime localDateTime)
 		throws Exception {
 
+		User user = _userLocalService.fetchUserByScreenName(
+			companyId, AnalyticsSecurityConstants.SCREEN_NAME_ANALYTICS_ADMIN);
+
+		if (user == null) {
+			user = _addAnalyticsAdmin(companyId);
+		}
+
 		DispatchTrigger dispatchTrigger =
 			_dispatchTriggerLocalService.addDispatchTrigger(
-				null,
-				_userLocalService.getUserIdByScreenName(
-					companyId,
-					AnalyticsSecurityConstants.SCREEN_NAME_ANALYTICS_ADMIN),
-				dispatchTriggerName, null, dispatchTriggerName, false);
+				null, user.getUserId(), dispatchTriggerName, null,
+				dispatchTriggerName, false);
 
 		return _dispatchTriggerLocalService.updateDispatchTrigger(
 			dispatchTrigger.getDispatchTriggerId(), true, _CRON_EXPRESSION,
@@ -180,6 +209,9 @@ public class AnalyticsDXPEntityBatchExporterImpl
 		AnalyticsDXPEntityBatchExporterImpl.class);
 
 	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
 	private DispatchLogLocalService _dispatchLogLocalService;
 
 	@Reference
@@ -187,6 +219,9 @@ public class AnalyticsDXPEntityBatchExporterImpl
 
 	@Reference
 	private MessageBus _messageBus;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/AnalyticsDXPEntityBatchExporterImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/AnalyticsDXPEntityBatchExporterImpl.java
@@ -9,6 +9,8 @@ import com.liferay.analytics.batch.exportimport.AnalyticsDXPEntityBatchExporter;
 import com.liferay.analytics.settings.security.constants.AnalyticsSecurityConstants;
 import com.liferay.dispatch.constants.DispatchConstants;
 import com.liferay.dispatch.executor.DispatchTaskClusterMode;
+import com.liferay.dispatch.executor.DispatchTaskExecutor;
+import com.liferay.dispatch.executor.DispatchTaskExecutorRegistry;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchLogLocalService;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
@@ -183,6 +185,14 @@ public class AnalyticsDXPEntityBatchExporterImpl
 			LocalDateTime localDateTime)
 		throws Exception {
 
+		DispatchTaskExecutor dispatchTaskExecutor =
+			_dispatchTaskExecutorRegistry.fetchDispatchTaskExecutor(
+				dispatchTriggerName);
+
+		if (dispatchTaskExecutor == null) {
+			return null;
+		}
+
 		User user = _userLocalService.fetchUserByScreenName(
 			companyId, AnalyticsSecurityConstants.SCREEN_NAME_ANALYTICS_ADMIN);
 
@@ -192,8 +202,8 @@ public class AnalyticsDXPEntityBatchExporterImpl
 
 		DispatchTrigger dispatchTrigger =
 			_dispatchTriggerLocalService.addDispatchTrigger(
-				null, user.getUserId(), dispatchTriggerName, null,
-				dispatchTriggerName, false);
+				null, user.getUserId(), dispatchTaskExecutor,
+				dispatchTriggerName, null, dispatchTriggerName, false);
 
 		return _dispatchTriggerLocalService.updateDispatchTrigger(
 			dispatchTrigger.getDispatchTriggerId(), true, _CRON_EXPRESSION,
@@ -213,6 +223,9 @@ public class AnalyticsDXPEntityBatchExporterImpl
 
 	@Reference
 	private DispatchLogLocalService _dispatchLogLocalService;
+
+	@Reference
+	private DispatchTaskExecutorRegistry _dispatchTaskExecutorRegistry;
 
 	@Reference
 	private DispatchTriggerLocalService _dispatchTriggerLocalService;

--- a/modules/apps/analytics/analytics-batch-export-import-test/build.gradle
+++ b/modules/apps/analytics/analytics-batch-export-import-test/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
+	testIntegrationImplementation project(":apps:analytics:analytics-batch-export-import-api")
 	testIntegrationImplementation project(":apps:analytics:analytics-dxp-entity-rest-api")
 	testIntegrationImplementation project(":apps:analytics:analytics-settings-api")
 	testIntegrationImplementation project(":apps:batch-engine:batch-engine-api")
+	testIntegrationImplementation project(":apps:dispatch:dispatch-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/analytics/analytics-batch-export-import-test/src/testIntegration/java/com/liferay/analytics/batch/exportimport/internal/test/AnalyticsDXPEntityBatchExporterTest.java
+++ b/modules/apps/analytics/analytics-batch-export-import-test/src/testIntegration/java/com/liferay/analytics/batch/exportimport/internal/test/AnalyticsDXPEntityBatchExporterTest.java
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.batch.exportimport.internal.test;
+
+import com.liferay.analytics.batch.exportimport.AnalyticsDXPEntityBatchExporter;
+import com.liferay.analytics.batch.exportimport.constants.AnalyticsDXPEntityBatchExporterConstants;
+import com.liferay.analytics.settings.security.constants.AnalyticsSecurityConstants;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@RunWith(Arquillian.class)
+public class AnalyticsDXPEntityBatchExporterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testScheduleExportTriggersCreatesAnalyticsAdminWhenMissing()
+		throws Exception {
+
+		User existingUser = _userLocalService.fetchUserByScreenName(
+			TestPropsValues.getCompanyId(),
+			AnalyticsSecurityConstants.SCREEN_NAME_ANALYTICS_ADMIN);
+
+		if (existingUser != null) {
+			_userLocalService.deleteUser(existingUser);
+		}
+
+		_analyticsDXPEntityBatchExporter.scheduleExportTriggers(
+			TestPropsValues.getCompanyId(),
+			new String[] {
+				AnalyticsDXPEntityBatchExporterConstants.
+					DISPATCH_TRIGGER_NAME_DXP_ENTITIES
+			});
+
+		Assert.assertNotNull(
+			_userLocalService.fetchUserByScreenName(
+				TestPropsValues.getCompanyId(),
+				AnalyticsSecurityConstants.SCREEN_NAME_ANALYTICS_ADMIN));
+		Assert.assertNotNull(
+			_dispatchTriggerLocalService.fetchDispatchTrigger(
+				TestPropsValues.getCompanyId(),
+				AnalyticsDXPEntityBatchExporterConstants.
+					DISPATCH_TRIGGER_NAME_DXP_ENTITIES));
+	}
+
+	@Inject
+	private AnalyticsDXPEntityBatchExporter _analyticsDXPEntityBatchExporter;
+
+	@Inject
+	private DispatchTriggerLocalService _dispatchTriggerLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}


### PR DESCRIPTION
Motivation
----
Fix for Configuration error after upgrade

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-84627)

Proposed Solution
----
This PR improves the robustness of the analytics dispatch trigger flow by preventing the creation of dispatch triggers when the corresponding dispatch task executor is not available or has not been registered yet. This helps avoid potential race conditions during startup or deployment scenarios.

Additionally, the changes ensure that the analytics user is automatically created when it does not already exist, improving reliability and reducing manual intervention requirements.

To support these updates, new test coverage has been added to verify the user creation flow and validate the new behavior.