### PR TITLE
LPD-89141 Use channelId to create account profile URL

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -103,6 +103,7 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 						value: string;
 					}) =>
 						columns.nameAndLinkRenderer({
+							channelId,
 							groupId,
 							itemData,
 							route: Routes.CONTACTS_ACCOUNT,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -19,9 +19,26 @@ type FakeFilter = {
 	};
 };
 
+type FakeCustomDataRenderers = {
+	accountNameRenderer: (props: {
+		itemData: {id: string | number};
+		value: string;
+	}) => React.ReactElement;
+};
+
+let lastCustomDataRenderers: FakeCustomDataRenderers | undefined;
 let lastFilters: FakeFilter[] | undefined;
 
-const FakeDataSet = ({filters, id}: {filters: FakeFilter[]; id: string}) => {
+const FakeDataSet = ({
+	customDataRenderers,
+	filters,
+	id
+}: {
+	customDataRenderers: FakeCustomDataRenderers;
+	filters: FakeFilter[];
+	id: string;
+}) => {
+	lastCustomDataRenderers = customDataRenderers;
 	lastFilters = filters;
 
 	return <div data-testid='fds-component' id={id} />;
@@ -30,6 +47,7 @@ const FakeDataSet = ({filters, id}: {filters: FakeFilter[]; id: string}) => {
 describe('AccountsDataSet', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		lastCustomDataRenderers = undefined;
 		lastFilters = undefined;
 		useFrontendDataSetMock.mockReturnValue(FakeDataSet);
 	});
@@ -116,5 +134,21 @@ describe('AccountsDataSet', () => {
 			exclude: false,
 			selectedItems: [{label: 'At Risk', value: 'atRisk'}]
 		});
+	});
+
+	it('should render the account name link with channelId in the href', () => {
+		render(<AccountsDataSet channelId='123' groupId='23' />);
+
+		const {container} = render(
+			lastCustomDataRenderers!.accountNameRenderer({
+				itemData: {id: 'abc'},
+				value: 'Acme Corp'
+			})
+		);
+
+		expect(container.querySelector('a')).toHaveAttribute(
+			'href',
+			'/workspace/23/123/contacts/accounts/abc'
+		);
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/frontend-data-set.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/frontend-data-set.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {columns} from '../frontend-data-set';
 import {render, screen} from '@testing-library/react';
 import {Routes} from '../router';

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/frontend-data-set.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/frontend-data-set.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {columns} from '../frontend-data-set';
+import {render, screen} from '@testing-library/react';
+import {Routes} from '../router';
+
+jest.unmock('react-dom');
+
+describe('columns.nameAndLinkRenderer', () => {
+	it('should generate an href that includes the channelId path segment', () => {
+		render(
+			columns.nameAndLinkRenderer({
+				channelId: '123',
+				groupId: '23',
+				itemData: {id: 'abc'},
+				route: Routes.CONTACTS_ACCOUNT,
+				value: 'Acme Corp'
+			})
+		);
+
+		expect(screen.getByRole('link')).toHaveAttribute(
+			'href',
+			'/workspace/23/123/contacts/accounts/abc'
+		);
+	});
+
+	it('should use value as the link text when provided', () => {
+		render(
+			columns.nameAndLinkRenderer({
+				channelId: '123',
+				groupId: '23',
+				itemData: {id: 'abc'},
+				route: Routes.CONTACTS_ACCOUNT,
+				value: 'Acme Corp'
+			})
+		);
+
+		expect(screen.getByRole('link')).toHaveTextContent('Acme Corp');
+	});
+
+	it('should fall back to itemData.id as the link text when value is empty', () => {
+		render(
+			columns.nameAndLinkRenderer({
+				channelId: '123',
+				groupId: '23',
+				itemData: {id: 'abc'},
+				route: Routes.CONTACTS_ACCOUNT,
+				value: ''
+			})
+		);
+
+		expect(screen.getByRole('link')).toHaveTextContent('abc');
+	});
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/frontend-data-set.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/frontend-data-set.tsx
@@ -37,11 +37,13 @@ export const columns = {
 		<div>{value && formatUTCDate(value, CUSTOM_DATE_FORMAT)}</div>
 	),
 	nameAndLinkRenderer: ({
+		channelId,
 		groupId,
 		itemData,
 		route,
 		value
 	}: {
+		channelId: string;
 		groupId: string;
 		itemData: {id: string | number};
 		route: string;
@@ -53,6 +55,7 @@ export const columns = {
 			<ClayLink
 				className='font-weight-semi-bold text-dark'
 				href={toRoute(route, {
+					channelId,
 					groupId,
 					id: itemData.id
 				})}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89141

## What is being fixed

Clicking an account in the accounts list navigated to an account profile URL that lacked the `channelId` path segment, causing the property context to be lost.

## How it is being fixed

The `channelId` is now threaded through `nameAndLinkRenderer` in `frontend-data-set` and forwarded by the `accountNameRenderer` in `AccountsDataSet`, so the generated href includes the channel segment (`/workspace/:groupId/:channelId/contacts/accounts/:id`). Unit tests cover both the renderer in isolation and the integration through `AccountsDataSet`.