### PR TITLE
LPD-88808 Include DSR Room object definition in analytics SitesTab classNameIds filter

### DIFF
--- a/modules/apps/analytics/analytics-settings-rest-impl/build.gradle
+++ b/modules/apps/analytics/analytics-settings-rest-impl/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	compileOnly project(":apps:analytics:analytics-settings-rest-api")
 	compileOnly project(":apps:dispatch:dispatch-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-api")
+	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/SiteResourceImpl.java
@@ -12,6 +12,8 @@ import com.liferay.analytics.settings.rest.internal.client.model.AnalyticsChanne
 import com.liferay.analytics.settings.rest.internal.dto.v1_0.converter.SiteDTOConverterContext;
 import com.liferay.analytics.settings.rest.internal.util.SortUtil;
 import com.liferay.analytics.settings.rest.resource.v1_0.SiteResource;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -19,6 +21,7 @@ import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -64,11 +67,13 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 				analyticsChannel.getId(), analyticsChannel.getName());
 		}
 
+		long[] classNameIds = _getClassNameIds(contextCompany.getCompanyId());
+
 		return Page.of(
 			transform(
 				_groupService.search(
-					contextCompany.getCompanyId(), _classNameIdsSupplier.get(),
-					keywords, _getParams(), pagination.getStartPosition(),
+					contextCompany.getCompanyId(), classNameIds, keywords,
+					_getParams(), pagination.getStartPosition(),
 					pagination.getEndPosition(),
 					SortUtil.getIgnoreCaseOrderByComparator(
 						contextAcceptLanguage.getPreferredLocale(), sorts)),
@@ -80,8 +85,8 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 					group)),
 			pagination,
 			_groupService.searchCount(
-				contextCompany.getCompanyId(), _classNameIdsSupplier.get(),
-				keywords, _getParams()));
+				contextCompany.getCompanyId(), classNameIds, keywords,
+				_getParams()));
 	}
 
 	@Activate
@@ -89,6 +94,22 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 		_analyticsCloudClient = new AnalyticsCloudClient(_http);
 		_classNameIdsSupplier = _classNameLocalService.getClassNameIdsSupplier(
 			new String[] {Group.class.getName(), Organization.class.getName()});
+	}
+
+	private long[] _getClassNameIds(long companyId) {
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					"L_DSR_ROOM", companyId);
+
+		if (objectDefinition == null) {
+			return _classNameIdsSupplier.get();
+		}
+
+		return ArrayUtil.append(
+			_classNameIdsSupplier.get(),
+			_classNameLocalService.getClassNameId(
+				objectDefinition.getClassName()));
 	}
 
 	private LinkedHashMap<String, Object> _getParams() {
@@ -113,6 +134,9 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 
 	@Reference
 	private Http _http;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference(
 		target = "(component.name=com.liferay.analytics.settings.rest.internal.dto.v1_0.converter.SiteDTOConverter)"

--- a/modules/test/playwright/helpers/HeadlessDigitalSalesRoomApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDigitalSalesRoomApiHelper.ts
@@ -14,6 +14,31 @@ export class HeadlessDigitalSalesRoomApiHelper {
 		this.basePath = 'digital-sales-room';
 	}
 
+	async addRoom({
+		accountEntryId,
+		friendlyURL,
+		name,
+		siteTemplateKey = 'L_DSR_LAYOUT_SET_PROTOTYPE',
+	}: {
+		accountEntryId: number;
+		friendlyURL?: string;
+		name: string;
+		siteTemplateKey?: string;
+	}) {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/rooms/`,
+			{
+				data: {
+					friendlyURL: friendlyURL || `/${name.toLowerCase()}`,
+					name,
+					r_accountToDSRRooms_accountEntryId: accountEntryId,
+					siteTemplateKey,
+				},
+				failOnStatusCode: true,
+			}
+		);
+	}
+
 	async getRooms() {
 		return this.apiHelpers.get(
 			`${this.apiHelpers.baseUrl}${this.basePath}/rooms`

--- a/modules/test/playwright/tests/analytics-settings-web/main/sitesTabDsrRoom.spec.ts
+++ b/modules/test/playwright/tests/analytics-settings-web/main/sitesTabDsrRoom.spec.ts
@@ -1,0 +1,111 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginAnalyticsCloudTest} from '../../../fixtures/loginAnalyticsCloudTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {getRandomInt} from '../../../utils/getRandomInt';
+import getRandomString from '../../../utils/getRandomString';
+import {createChannel} from '../../osb-faro-web/main/utils/channel';
+import {createDataSource} from '../../osb-faro-web/main/utils/data-source';
+import {acceptsCookiesBanner} from '../../osb-faro-web/main/utils/portal';
+import {
+	connectToAnalyticsCloud,
+	disconnectFromAnalyticsCloud,
+	findChannel,
+	goToAnalyticsCloudInstanceSettings,
+} from './utils/analytics-settings';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-35443': {enabled: true},
+		'LPD-66359': {enabled: true},
+	}),
+	loginAnalyticsCloudTest(),
+	loginTest()
+);
+
+test.afterEach(async ({apiHelpers}) => {
+	const rooms = await apiHelpers.headlessDigitalSalesRoom.getRooms();
+
+	for (const room of rooms.items) {
+		await apiHelpers.headlessDigitalSalesRoom.deleteRoom(room.id);
+	}
+});
+
+test(
+	'Digital Sales Room appears in the analytics property Sites tab',
+	{tag: '@LPD-88808'},
+	async ({apiHelpers, page}) => {
+		const account = await apiHelpers.headlessAdminUser.postAccount({
+			type: 'business',
+		});
+
+		const roomName = `Room${getRandomInt()}`;
+
+		await apiHelpers.headlessDigitalSalesRoom.addRoom({
+			accountEntryId: account.id,
+			name: roomName,
+		});
+
+		const channelName = 'My Property - ' + getRandomString();
+
+		const {channel, project} = await createChannel({
+			apiHelpers,
+			channelName,
+		});
+
+		const {token} = await createDataSource(page);
+
+		await goToAnalyticsCloudInstanceSettings(page);
+
+		await acceptsCookiesBanner(page);
+
+		await disconnectFromAnalyticsCloud(page);
+
+		await connectToAnalyticsCloud(page, {token});
+
+		const channelRow = await findChannel({channelName, page});
+
+		await channelRow.locator('button').click();
+
+		await page.getByRole('tab', {name: 'Sites'}).click();
+
+		await page
+			.getByText(
+				'Sites can only be assigned to a single property at a time'
+			)
+			.waitFor({state: 'visible'});
+
+		await page.locator('.active').getByPlaceholder('Search').fill(roomName);
+
+		await page
+			.locator('.active')
+			.getByRole('button', {name: 'Search'})
+			.click();
+
+		await expect(page.locator('span[data-testid="loading"]')).toBeHidden();
+
+		await expect(
+			page.locator('[data-testid="sites"]').getByRole('cell', {
+				exact: true,
+				name: roomName,
+			})
+		).toBeVisible();
+
+		await test.step('Delete channel', async () => {
+			await apiHelpers.jsonWebServicesOSBFaro.deleteChannel(
+				`[${channel.id}]`,
+				project.groupId
+			);
+		});
+	}
+);


### PR DESCRIPTION
Motivation
----
Include DSR Room object definition in analytics SitesTab classNameIds filter

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-88808)

Proposed Solution
----
This PR updates the analytics site selection filtering to include the DSR Room object definition in the `SitesTab` `classNameIds` filter, ensuring DSR Rooms are correctly displayed in the AC configuration site selection list.

Additionally, a new Playwright test has been added to validate the expected behavior and help prevent regressions by covering the full functionality end-to-end.