### PR TITLE
LPD-89507 Fix some playwright tests

### DIFF
--- a/modules/test/playwright/tests/analytics-client-js/main/events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/events.spec.ts
@@ -6,20 +6,20 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
-import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginAnalyticsCloudTest} from '../../../fixtures/loginAnalyticsCloudTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
+import {syncAnalyticsCloud} from '../../analytics-settings-web/main/utils/analytics-settings';
 import getFragmentDefinition from '../../layout-content-page-editor-web/main/utils/getFragmentDefinition';
 import getPageDefinition from '../../layout-content-page-editor-web/main/utils/getPageDefinition';
-import {Analytics, Event} from './utils/analytics';
 
 const test = mergeTests(
 	apiHelpersTest,
-	featureFlagsTest({
-		'LPS-178052': {enabled: true},
-	}),
+	dataApiHelpersTest,
 	isolatedSiteTest,
+	loginAnalyticsCloudTest(),
 	loginTest()
 );
 
@@ -29,6 +29,13 @@ test(
 		tag: '@LPD-56895',
 	},
 	async ({apiHelpers, page, site}) => {
+		await syncAnalyticsCloud({
+			apiHelpers,
+			channelName: 'My Property - ' + getRandomString(),
+			page,
+			siteName: site.name,
+		});
+
 		const layout1 = await apiHelpers.headlessDelivery.createSitePage({
 			pageDefinition: getPageDefinition([
 				getFragmentDefinition({
@@ -51,36 +58,57 @@ test(
 			title: 'MyPage 2',
 		});
 
+		const pageViewedTitles: string[] = [];
+
+		page.on('request', (request) => {
+			if (request.method() !== 'POST') {
+				return;
+			}
+
+			const postData = request.postData();
+
+			if (!postData || !postData.includes('"eventId":"pageViewed"')) {
+				return;
+			}
+
+			try {
+				const eventBucket = JSON.parse(postData);
+
+				const title = eventBucket.context?.title;
+
+				if (typeof title === 'string') {
+					pageViewedTitles.push(title);
+				}
+			}
+			catch {
+
+				// Ignore non-JSON bodies; only analytics POSTs are valid here.
+
+			}
+		});
+
 		await test.step('Go to My Page 1', async () => {
 			await page.goto(
 				`/web${site.friendlyUrlPath}${layout1.friendlyUrlPath}`
 			);
-		});
 
-		await test.step('Check the pageViewed event on My Page 1', async () => {
-			const analytics = new Analytics(page);
-
-			const pageViewedEvent = (await analytics.getEvents(
-				'pageViewed'
-			)) as Event;
-
-			expect(pageViewedEvent).toBeTruthy();
+			await expect
+				.poll(() =>
+					pageViewedTitles.some((t) => t.includes('MyPage 1'))
+				)
+				.toBe(true);
 		});
 
 		await test.step('Go to My Page 2', async () => {
 			await page.goto(
 				`/web${site.friendlyUrlPath}${layout2.friendlyUrlPath}`
 			);
-		});
 
-		await test.step('Check the pageViewed event on My Page 2', async () => {
-			const analytics = new Analytics(page);
-
-			const pageViewedEvent = (await analytics.getEvents(
-				'pageViewed'
-			)) as Event;
-
-			expect(pageViewedEvent).toBeTruthy();
+			await expect
+				.poll(() =>
+					pageViewedTitles.some((t) => t.includes('MyPage 2'))
+				)
+				.toBe(true);
 		});
 	}
 );

--- a/modules/test/playwright/tests/analytics-client-js/main/events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/events.spec.ts
@@ -7,12 +7,11 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import getRandomString from '../../../utils/getRandomString';
-import {
-	createSitePage,
-	navigateToSitePage,
-} from '../../osb-faro-web/main/utils/portal';
+import getFragmentDefinition from '../../layout-content-page-editor-web/main/utils/getFragmentDefinition';
+import getPageDefinition from '../../layout-content-page-editor-web/main/utils/getPageDefinition';
 import {Analytics, Event} from './utils/analytics';
 
 const test = mergeTests(
@@ -20,84 +19,68 @@ const test = mergeTests(
 	featureFlagsTest({
 		'LPS-178052': {enabled: true},
 	}),
+	isolatedSiteTest,
 	loginTest()
 );
-
-let site;
-const siteName = getRandomString();
-
-test.beforeEach(async ({apiHelpers}) => {
-	site = await apiHelpers.headlessAdminSite.postSite({
-		name: siteName,
-	});
-});
-
-test.afterEach(async ({apiHelpers}) => {
-	await test.step('Delete site on de DXP side', async () => {
-		await apiHelpers.headlessAdminSite.deleteSite(
-			site.externalReferenceCode
-		);
-	});
-});
 
 test(
 	'Verify events after navigating by SPA',
 	{
 		tag: '@LPD-56895',
 	},
-	async ({apiHelpers, page}) => {
-		await test.step('test', async () => {
-			const pageTitle1 = 'MyPage 1';
+	async ({apiHelpers, page, site}) => {
+		const layout1 = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: 'MyPage 1',
+		});
 
-			await test.step('Create My Page 1', async () => {
-				await createSitePage({
-					apiHelpers,
-					pageTitle: pageTitle1,
-					siteName,
-				});
-			});
+		const layout2 = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: 'MyPage 2',
+		});
 
-			const pageTitle2 = 'MyPage 2';
+		await test.step('Go to My Page 1', async () => {
+			await page.goto(
+				`/web${site.friendlyUrlPath}${layout1.friendlyUrlPath}`
+			);
+		});
 
-			await test.step('Create My Page 2', async () => {
-				await createSitePage({
-					apiHelpers,
-					pageTitle: pageTitle2,
-					siteName,
-				});
-			});
+		await test.step('Check the pageViewed event on My Page 1', async () => {
+			const analytics = new Analytics(page);
 
-			await test.step('Go to My Page 1', async () => {
-				await navigateToSitePage({
-					page,
-					pageName: pageTitle1,
-					siteName,
-				});
-			});
+			const pageViewedEvent = (await analytics.getEvents(
+				'pageViewed'
+			)) as Event;
 
-			await test.step('Check the pageViewed event on My Page 1', async () => {
-				const analytics = new Analytics(page);
+			expect(pageViewedEvent).toBeTruthy();
+		});
 
-				const pageViewedEvent = (await analytics.getEvents(
-					'pageViewed'
-				)) as Event;
+		await test.step('Go to My Page 2', async () => {
+			await page.goto(
+				`/web${site.friendlyUrlPath}${layout2.friendlyUrlPath}`
+			);
+		});
 
-				expect(pageViewedEvent).toBeTruthy();
-			});
+		await test.step('Check the pageViewed event on My Page 2', async () => {
+			const analytics = new Analytics(page);
 
-			await test.step('Go to My Page 2', async () => {
-				await page.getByRole('menuitem', {name: 'MyPage 2'}).click();
-			});
+			const pageViewedEvent = (await analytics.getEvents(
+				'pageViewed'
+			)) as Event;
 
-			await test.step('Check the pageViewed event on My Page 2', async () => {
-				const analytics = new Analytics(page);
-
-				const pageViewedEvent = (await analytics.getEvents(
-					'pageViewed'
-				)) as Event;
-
-				expect(pageViewedEvent).toBeTruthy();
-			});
+			expect(pageViewedEvent).toBeTruthy();
 		});
 	}
 );

--- a/modules/test/playwright/tests/analytics-settings-web/main/utils/analytics-settings.ts
+++ b/modules/test/playwright/tests/analytics-settings-web/main/utils/analytics-settings.ts
@@ -7,7 +7,9 @@ import {Page, expect} from '@playwright/test';
 
 import {ApiHelpers} from '../../../../helpers/ApiHelpers';
 import {liferayConfig} from '../../../../liferay.config';
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
+import {waitForAlert} from '../../../../utils/waitForAlert';
 import {createChannel} from '../../../osb-faro-web/main/utils/channel';
 import {createDataSource} from '../../../osb-faro-web/main/utils/data-source';
 import {acceptsCookiesBanner} from '../../../osb-faro-web/main/utils/portal';
@@ -80,9 +82,7 @@ export async function disconnectFromAnalyticsCloud(page: Page) {
 
 		await confirmationButton.click();
 
-		await expect(
-			page.getByText('Success:Workspace disconnected.')
-		).toBeVisible();
+		await waitForAlert(page, 'Workspace disconnected.');
 	}
 }
 
@@ -332,15 +332,9 @@ export async function syncCommerce({
 
 	await checkbox.check();
 
-	const submitButton = await page.$(
-		'.modal .modal-item-last button.btn-primary'
-	);
+	await page.locator('.modal .modal-item-last button.btn-primary').click();
 
-	await submitButton.click();
-
-	await expect(
-		page.getByText('Success:Properties settings have been saved.')
-	).toBeVisible();
+	await waitForAlert(page, 'Properties settings have been saved.');
 }
 
 export async function toggleSiteSync({
@@ -356,9 +350,10 @@ export async function toggleSiteSync({
 }) {
 	const channel = await findChannel({channelName, page});
 
-	const assignButton = await channel.locator('button');
-
-	await assignButton.click();
+	await clickAndExpectToBeVisible({
+		target: page.getByRole('dialog'),
+		trigger: channel.locator('button'),
+	});
 
 	await switchToTab({page, tabName: TabName.Sites});
 
@@ -385,15 +380,9 @@ export async function toggleSiteSync({
 		await checkbox.uncheck();
 	}
 
-	const submitButton = await page.$(
-		'.modal .modal-item-last button.btn-primary'
-	);
+	await page.locator('.modal .modal-item-last button.btn-primary').click();
 
-	await submitButton.click();
-
-	await expect(
-		page.getByText('Success:Properties settings have been saved.')
-	).toBeVisible();
+	await waitForAlert(page, 'Properties settings have been saved.');
 }
 
 export async function goNextStep(page) {

--- a/modules/test/playwright/tests/analytics-settings-web/main/utils/analytics-settings.ts
+++ b/modules/test/playwright/tests/analytics-settings-web/main/utils/analytics-settings.ts
@@ -45,7 +45,7 @@ export async function connectToAnalyticsCloud(
 ) {
 	await page.getByPlaceholder('Paste token here.').fill(token);
 
-	await page.getByRole('button', {name: 'Connect'}).click();
+	await page.getByRole('button', {name: 'Connect'}).last().click();
 }
 
 export async function connectToAnalyticsCloudWithNoSiteSynced(page: Page) {

--- a/modules/test/playwright/tests/analytics-settings-web/main/utils/analytics-settings.ts
+++ b/modules/test/playwright/tests/analytics-settings-web/main/utils/analytics-settings.ts
@@ -125,11 +125,9 @@ export async function findChannel({
 	channelName: string;
 	page: Page;
 }): Promise<any> {
-	const managementBar = page
-		.locator('.management-bar')
-		.filter({
-			has: page.locator('input[placeholder="Search"]:not([disabled])'),
-		});
+	const managementBar = page.locator('.management-bar').filter({
+		has: page.locator('input[placeholder="Search"]:not([disabled])'),
+	});
 
 	await managementBar.getByPlaceholder('Search').fill(channelName);
 

--- a/modules/test/playwright/tests/analytics-settings-web/main/utils/analytics-settings.ts
+++ b/modules/test/playwright/tests/analytics-settings-web/main/utils/analytics-settings.ts
@@ -125,11 +125,15 @@ export async function findChannel({
 	channelName: string;
 	page: Page;
 }): Promise<any> {
-	await page.waitForSelector('[data-testid="properties"]');
+	const managementBar = page
+		.locator('.management-bar')
+		.filter({
+			has: page.locator('input[placeholder="Search"]:not([disabled])'),
+		});
 
-	await page.getByPlaceholder('Search').first().fill(channelName);
+	await managementBar.getByPlaceholder('Search').fill(channelName);
 
-	await page.getByRole('button', {name: 'Search'}).first().click();
+	await managementBar.getByRole('button', {name: 'Search'}).click();
 
 	await expect(page.getByRole('cell', {name: channelName})).toBeVisible({
 		timeout: 100 * 1000,
@@ -370,9 +374,11 @@ export async function toggleSiteSync({
 
 	expect(sitesTable).toBeVisible();
 
-	const checkbox = sitesTable.locator(
-		'tbody tr:first-child input[type="checkbox"]'
-	);
+	const siteRow = sitesTable.locator('tbody tr').filter({hasText: siteName});
+
+	await expect(siteRow).toBeVisible();
+
+	const checkbox = siteRow.locator('input[type="checkbox"]');
 
 	if (synced) {
 		await checkbox.check();

--- a/modules/test/playwright/tests/osb-faro-web/main/blog.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/blog.spec.ts
@@ -89,7 +89,7 @@ test('View all blogs in the property in assets', async ({apiHelpers, page}) => {
 	});
 
 	await test.step('Go to Analytics Cloud asset page', async () => {
-		navigateToACPageViaURL({
+		await navigateToACPageViaURL({
 			acPage: ACPage.assetPage,
 			channelID: channel.id,
 			page,

--- a/modules/test/playwright/tests/osb-faro-web/main/disconnection.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/disconnection.spec.ts
@@ -19,6 +19,7 @@ import {
 import {createChannel} from './utils/channel';
 import {
 	checkDataSourceStatus,
+	createDataSource,
 	findDataSource,
 	renameDataSource,
 } from './utils/data-source';
@@ -47,29 +48,7 @@ test(
 			channelName,
 		});
 
-		let token;
-
-		await test.step('Go to Analytics Cloud settings and add a Data Source', async () => {
-			await navigateToACSettingsViaURL({
-				acPage: ACPage.dataSourcePage,
-				page,
-				projectID: project.groupId,
-			});
-
-			await page.getByRole('button', {name: 'Add Data Source'}).click();
-
-			await page
-				.getByRole('menuitem', {name: 'Liferay DXP Site'})
-				.click();
-
-			await page.waitForTimeout(1000);
-
-			token = await page
-				.locator('.onboarding-modal-root input')
-				.getAttribute('value');
-
-			await page.getByRole('link', {name: 'Done'}).click();
-		});
+		const {token} = await createDataSource(page);
 
 		await test.step('Go to DXP --> Instance Settings --> Analytics Cloud and disconnect the workspace', async () => {
 			await goToAnalyticsCloudInstanceSettings(page);

--- a/modules/test/playwright/tests/osb-faro-web/main/document.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/document.spec.ts
@@ -125,7 +125,7 @@ test('Documents visitor behavior card shows expected amount of views', async ({
 	});
 
 	await test.step('Go to Analytics Cloud asset page', async () => {
-		navigateToACPageViaURL({
+		await navigateToACPageViaURL({
 			acPage: ACPage.assetPage,
 			channelID: channel.id,
 			page,

--- a/modules/test/playwright/tests/osb-faro-web/main/forms.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/forms.spec.ts
@@ -112,7 +112,7 @@ test('Forms visitor behavior card shows expected amount of views', async ({
 		]);
 
 		await test.step('Go to Analytics Cloud asset page', async () => {
-			navigateToACPageViaURL({
+			await navigateToACPageViaURL({
 				acPage: ACPage.assetPage,
 				channelID: channel.id,
 				page,

--- a/modules/test/playwright/tests/osb-faro-web/main/segment.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/segment.spec.ts
@@ -149,17 +149,12 @@ test(
 				page,
 			});
 
-			await page.waitForTimeout(3000);
+			const dropdownItems = page.locator(
+				'.dropdown-menu.dropdown-menu-select.show .dropdown-item'
+			);
 
-			const dropdownItems = await page
-				.locator(
-					'.dropdown-menu.dropdown-menu-select.show .dropdown-item'
-				)
-				.all();
-
-			expect(dropdownItems.length).toBe(1);
-
-			expect(await dropdownItems[0].textContent()).toBe(
+			await expect(dropdownItems).toHaveCount(1);
+			await expect(dropdownItems).toHaveText(
 				`${individualName}@liferay.com`
 			);
 		});

--- a/modules/test/playwright/tests/osb-faro-web/main/segment.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/segment.spec.ts
@@ -76,7 +76,7 @@ let channelName;
 let project;
 
 test(
-	'Add a dynamic segment using an individual property',
+	'Add a Batch segment using an individual property',
 	{
 		tag: '@LRAC-11460',
 	},

--- a/modules/test/playwright/tests/osb-faro-web/main/segment.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/segment.spec.ts
@@ -39,6 +39,7 @@ import {
 	addNestedSegmentField,
 	addSegmentField,
 	addStaticMember,
+	createBatchSegment,
 	createDynamicSegment,
 	createStaticSegment,
 	editCriteriaAttributeValue,
@@ -128,11 +129,11 @@ test(
 			projectID: project.groupId,
 		});
 
-		await createDynamicSegment(page);
+		await createBatchSegment(page);
 
 		await test.step('Add email criteria and fill in', async () => {
 			await addSegmentField({
-				criterionName: 'email',
+				criterionName: 'Email Address',
 				criterionType: 'Individual Attributes',
 				page,
 			});

--- a/modules/test/playwright/tests/osb-faro-web/main/utils/segments.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/utils/segments.ts
@@ -39,8 +39,13 @@ export async function addSegmentField({
 	criterionType: string;
 	page: Page;
 }) {
-	await page.locator('button.dropdown-toggle.btn-outline-secondary').click();
-	await page.getByRole('menuitem', {name: criterionType}).click();
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: page.getByRole('menuitem', {name: criterionType}),
+		trigger: page
+			.locator('.criteria-sidebar-root .sidebar-header')
+			.getByRole('button'),
+	});
 
 	await dragAndDropCriteriaItem({
 		page,

--- a/modules/test/playwright/tests/osb-faro-web/main/utils/segments.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/utils/segments.ts
@@ -133,7 +133,9 @@ export async function dragAndDropCriteriaItem({
 		target = page.locator('.display-value').getByText(nestedSegmentField);
 	}
 	else {
-		target = page.locator('div.drop-zone-target').last();
+		target = page
+			.locator('.empty-drop-zone-target, div.drop-zone-target')
+			.last();
 	}
 
 	return await source.dragTo(target);

--- a/modules/test/playwright/tests/osb-faro-web/main/utils/segments.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/utils/segments.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page, expect} from '@playwright/test';
 
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import {SegmentConditions} from './selectors';
 import {searchByTerm} from './utils';
 
@@ -70,6 +71,16 @@ export async function addStaticMember({
 	}
 
 	await page.getByRole('button', {exact: true, name: 'Add'}).click();
+}
+
+export async function createBatchSegment(page: Page) {
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: page.getByRole('menuitem', {name: 'Batch'}),
+		trigger: page
+			.getByRole('button', {name: 'Menu'})
+			.filter({hasText: 'New Segment'}),
+	});
 }
 
 export async function createDynamicSegment(page: Page) {


### PR DESCRIPTION
Motivation
-----
This PR improves the stability, readability, and maintainability of the Analytics Cloud Playwright tests by migrating several tests to the `isolatedSiteTest` fixture and updating assertions to rely on real AC behavior instead of arbitrary waits.

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-89507)

Proposed Solution
-----


### Main improvements included

- Migrated `events.spec.ts` to use `isolatedSiteTest` and updated assertions to better reflect real Analytics Cloud behavior.
- Replaced several `waitForTimeout` usages with state-based `expect` assertions to reduce test flakiness and improve reliability.
- Added missing `await` in `navigateToACPageViaURL` to ensure proper async handling.
- Updated interactions in the events flow to click the actual form `Connect` button instead of the wizard step indicator.
- Scoped `findChannel` and `toggleSiteSync` helpers to properly disambiguate rows during test execution.
- Added support for empty drop zones in `dragAndDropCriteriaItem`.
- Updated `addSegmentField` to use `clickAndExpectToBeVisible` after the Clay dropdown refactor.
- Added a reusable `createBatchSegment` helper and updated `segment.spec.ts` to use it.
- Reused shared utilities such as `createDataSource` in `disconnection.spec.ts` and additional common utils to reduce duplication.
- Renamed the “Add a Batch segment” test to better reflect the current behavior and intent of the test.