### PR TITLE
LPD-89651 Stop metric-card refetch cascade via deep cache merge

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/__tests__/cache.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/__tests__/cache.js
@@ -1,0 +1,85 @@
+import {deepMergeMetric} from '../cache';
+
+describe('Apollo cache deepMergeMetric', () => {
+	it('fuses sibling sub-fields written by different queries under the same parent', () => {
+		const fromLocationsQuery = {
+			__typename: 'Site',
+			sessionsMetric: {
+				__typename: 'Metric',
+				geolocation: [{value: 100, valueKey: 'BR'}]
+			}
+		};
+
+		const fromDevicesQuery = {
+			__typename: 'Site',
+			sessionsMetric: {
+				__typename: 'Metric',
+				browser: [{value: 10, valueKey: 'Chrome'}],
+				device: [{value: 8, valueKey: 'Desktop'}],
+				value: 50
+			}
+		};
+
+		expect(deepMergeMetric(fromLocationsQuery, fromDevicesQuery)).toEqual({
+			__typename: 'Site',
+			sessionsMetric: {
+				__typename: 'Metric',
+				browser: [{value: 10, valueKey: 'Chrome'}],
+				device: [{value: 8, valueKey: 'Desktop'}],
+				geolocation: [{value: 100, valueKey: 'BR'}],
+				value: 50
+			}
+		});
+	});
+
+	it('preserves both sides regardless of which query writes first', () => {
+		const locations = {sessionsMetric: {geolocation: ['L']}};
+		const devices = {sessionsMetric: {browser: ['D']}};
+
+		expect(deepMergeMetric(locations, devices)).toEqual({
+			sessionsMetric: {browser: ['D'], geolocation: ['L']}
+		});
+
+		expect(deepMergeMetric(devices, locations)).toEqual({
+			sessionsMetric: {browser: ['D'], geolocation: ['L']}
+		});
+	});
+
+	it('replaces arrays wholesale rather than concatenating', () => {
+		const existing = {sessionsMetric: {geolocation: ['old']}};
+		const incoming = {sessionsMetric: {geolocation: ['new1', 'new2']}};
+
+		expect(deepMergeMetric(existing, incoming)).toEqual({
+			sessionsMetric: {geolocation: ['new1', 'new2']}
+		});
+	});
+
+	it('overwrites primitive values with the incoming value', () => {
+		expect(deepMergeMetric({a: 1}, {a: 2})).toEqual({a: 2});
+		expect(deepMergeMetric({a: 'old'}, {a: 'new'})).toEqual({a: 'new'});
+	});
+
+	it('preserves existing fields when incoming omits them', () => {
+		expect(deepMergeMetric({a: 1, b: 2}, {a: 99})).toEqual({a: 99, b: 2});
+	});
+
+	it('returns incoming when existing is null or undefined', () => {
+		expect(deepMergeMetric(null, {a: 1})).toEqual({a: 1});
+		expect(deepMergeMetric(undefined, {a: 1})).toEqual({a: 1});
+	});
+
+	it('returns incoming when incoming is not a plain object (replace semantics)', () => {
+		expect(deepMergeMetric({a: 1}, null)).toBeNull();
+		expect(deepMergeMetric({a: 1}, 'string')).toBe('string');
+		expect(deepMergeMetric({a: 1}, [1, 2])).toEqual([1, 2]);
+	});
+
+	it('merges deeply nested objects', () => {
+		const existing = {a: {b: {c: 1}}};
+		const incoming = {a: {b: {d: 2}}};
+
+		expect(deepMergeMetric(existing, incoming)).toEqual({
+			a: {b: {c: 1, d: 2}}
+		});
+	});
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/cache.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/cache.js
@@ -1,27 +1,61 @@
 import {InMemoryCache} from '@apollo/client';
 
 /*
- * `merge: true` instructs InMemoryCache to shallow-merge incoming writes into
- * the existing cached object instead of replacing it, so the two queries
- * coexist in a single cache entry. See:
- * https://www.apollographql.com/docs/react/caching/cache-field-behavior#merging-non-normalized-objects
+ * Custom merge function for the root metric fields (`site`, `blog`, ...).
  *
- * This is a client-side workaround. The canonical fix is server-side: each
- * root metric type should expose a stable, deterministic `id` derived from the
- * resolver arguments, so InMemoryCache can normalize them automatically. Once
- * the backend ships that change, this typePolicies block can be removed and
- * the metric-card queries should select the new `id` field. Tracking ticket:
+ * Each of these fields is selected by multiple metric-card queries that
+ * share the same arguments but request different sub-fields of the same
+ * nested `*Metric` object (one query selects `geolocation`, another
+ * selects `browser`/`device`/`value`, etc.). Because the root metric
+ * objects are not normalized (no stable `id` selected today), they share
+ * a single cache entry — and Apollo's default `merge: true` only does a
+ * shallow merge, so the second write would replace the first's nested
+ * `*Metric` instead of fusing it. The losing query's cached data would
+ * then be incomplete, and Apollo would refetch it as soon as the broadcast
+ * after the second write reached its watcher (the symptom: a second
+ * network request that only starts after the first one completes).
+ *
+ * A recursive merge fuses sibling sub-fields under the same nested object
+ * so both queries' data coexist after their writes, suppressing the
+ * cascade refetch.
+ *
+ * The canonical fix is server-side: each root metric type should expose
+ * a stable, deterministic `id` derived from the resolver arguments so
+ * InMemoryCache can normalize them automatically. Once the backend ships
+ * that change, this typePolicies block can be removed and the metric-card
+ * queries should select the new `id` field. Tracking ticket:
  * <add backend ticket id here once filed>.
  */
 
+const isPlainObject = value =>
+	value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const deepMergeMetric = (existing, incoming) => {
+	if (!isPlainObject(existing) || !isPlainObject(incoming)) {
+		return incoming;
+	}
+
+	const merged = {...existing};
+
+	for (const key of Object.keys(incoming)) {
+		merged[key] = deepMergeMetric(existing[key], incoming[key]);
+	}
+
+	return merged;
+};
+
+export {deepMergeMetric};
+
+const metricRootField = {merge: deepMergeMetric};
+
 const metricRootMerge = {
-	blog: {merge: true},
-	document: {merge: true},
-	form: {merge: true},
-	journal: {merge: true},
-	objectEntry: {merge: true},
-	page: {merge: true},
-	site: {merge: true}
+	blog: metricRootField,
+	document: metricRootField,
+	form: metricRootField,
+	journal: metricRootField,
+	objectEntry: metricRootField,
+	page: metricRootField,
+	site: metricRootField
 };
 
 export default new InMemoryCache({


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89651

## What is being fixed

On the Sites overview, the **Session by location** and **Session by technology** cards trigger sequential GraphQL refetches instead of running cleanly in parallel. After the two initial `SiteMetrics` requests complete, a third one fires as a refetch of the Locations data, surfacing in production as serialized network activity.

The root cause: both queries select different sub-fields of the same path `Query.site.sessionsMetric`. The InMemoryCache `typePolicy` on `Query.site` was `merge: true` (shallow), so the second write overwrote the nested `sessionsMetric` object instead of fusing the fields. Apollo's cache broadcast then saw the LocationsCard query's cached data as incomplete and refetched it.

## How it is being fixed

Replace `merge: true` with a recursive merge function (`deepMergeMetric`) applied to every metric root field (`site`, `blog`, `document`, `form`, `journal`, `objectEntry`, `page`). The function fuses plain objects recursively and lets primitives, arrays, and non-objects replace wholesale — so sibling sub-fields written by different queries coexist under the same parent and neither side is invalidated when the other writes. The Apollo broadcast then sees both queries' data as complete and no refetch is triggered.

The canonical fix (exposing a stable `id` on each metric root type so InMemoryCache can normalize them) is tracked separately under [LPD-89653](https://liferay.atlassian.net/browse/LPD-89653) along with its frontend and backend subtasks.