### PR TITLE
LPD-89746 Return data source access token in project creation response

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceController.java
@@ -40,6 +40,7 @@ import com.liferay.osb.faro.engine.client.model.provider.SalesforceProvider;
 import com.liferay.osb.faro.engine.client.util.EngineServiceURLUtil;
 import com.liferay.osb.faro.engine.client.util.OrderByField;
 import com.liferay.osb.faro.model.FaroProject;
+import com.liferay.osb.faro.util.FaroPropsValues;
 import com.liferay.osb.faro.web.internal.annotations.PATCH;
 import com.liferay.osb.faro.web.internal.annotations.Unauthenticated;
 import com.liferay.osb.faro.web.internal.antivirus.ClamAVScanner;
@@ -65,6 +66,7 @@ import com.liferay.osb.faro.web.internal.util.ContactsCSVHelper;
 import com.liferay.osb.faro.web.internal.util.FieldMappingUtil;
 import com.liferay.osb.faro.web.internal.util.OAuthUtil;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -414,6 +416,21 @@ public class DataSourceController extends BaseFaroController {
 		faroProject.setDataSourceConnected(false);
 
 		faroProjectLocalService.updateFaroProject(faroProject);
+	}
+
+	public String generateDataSourceAccessToken(
+		long groupId, long faroProjectId) {
+
+		String json = JSONUtil.put(
+			"token", _tokenManager.getToken(null, faroProjectId)
+		).put(
+			"url",
+			StringBundler.concat(
+				FaroPropsValues.FARO_URL, "/o/faro/contacts/", groupId,
+				"/data_source/connect")
+		).toString();
+
+		return Base64.encode(json.getBytes(StandardCharsets.UTF_8));
 	}
 
 	@GET

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectController.java
@@ -37,6 +37,7 @@ import com.liferay.osb.faro.util.DateUtil;
 import com.liferay.osb.faro.util.FaroPropsValues;
 import com.liferay.osb.faro.web.internal.annotations.Unauthenticated;
 import com.liferay.osb.faro.web.internal.controller.BaseFaroController;
+import com.liferay.osb.faro.web.internal.controller.contacts.DataSourceController;
 import com.liferay.osb.faro.web.internal.controller.contacts.FieldMappingController;
 import com.liferay.osb.faro.web.internal.exception.FaroException;
 import com.liferay.osb.faro.web.internal.exception.FaroValidationException;
@@ -319,7 +320,13 @@ public class ProjectController extends BaseFaroController {
 				faroProject.getWeDeployKey());
 		}
 
-		return new ProjectDisplay(faroProject);
+		ProjectDisplay projectDisplay = new ProjectDisplay(faroProject);
+
+		projectDisplay.setDataSourceAccessToken(
+			_dataSourceController.generateDataSourceAccessToken(
+				faroProject.getGroupId(), faroProject.getFaroProjectId()));
+
+		return projectDisplay;
 	}
 
 	@Path("/trial")
@@ -1130,7 +1137,14 @@ public class ProjectController extends BaseFaroController {
 				faroProject.getWeDeployKey());
 		}
 
-		return new ProjectDisplay(faroProject, friendlyURL);
+		ProjectDisplay projectDisplay = new ProjectDisplay(
+			faroProject, friendlyURL);
+
+		projectDisplay.setDataSourceAccessToken(
+			_dataSourceController.generateDataSourceAccessToken(
+				faroProject.getGroupId(), faroProject.getFaroProjectId()));
+
+		return projectDisplay;
 	}
 
 	private String _getDeletionFailedErrorMessage(User user) {
@@ -1686,6 +1700,9 @@ public class ProjectController extends BaseFaroController {
 	@Reference
 	private ContactsLayoutTemplateLocalService
 		_contactsLayoutTemplateLocalService;
+
+	@Reference
+	private DataSourceController _dataSourceController;
 
 	@Reference
 	private FaroNotificationLocalService _faroNotificationLocalService;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectController.java
@@ -384,7 +384,19 @@ public class ProjectController extends BaseFaroController {
 				corpProjectUuid);
 
 		if (faroProject != null) {
-			return new ProjectDisplay(faroProject);
+			ProjectDisplay projectDisplay = new ProjectDisplay(faroProject);
+
+			if (Objects.equals(
+					faroProject.getState(),
+					FaroProjectConstants.STATE_NOT_READY)) {
+
+				projectDisplay.setDataSourceAccessToken(
+					_dataSourceController.generateDataSourceAccessToken(
+						faroProject.getGroupId(),
+						faroProject.getFaroProjectId()));
+			}
+
+			return projectDisplay;
 		}
 
 		return _createUnprovisioned(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/ProjectDisplay.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/ProjectDisplay.java
@@ -90,12 +90,20 @@ public class ProjectDisplay {
 		return _corpProjectUuid;
 	}
 
+	public String getDataSourceAccessToken() {
+		return _dataSourceAccessToken;
+	}
+
 	public FaroSubscriptionDisplay getFaroSubscriptionDisplay() {
 		return _faroSubscriptionDisplay;
 	}
 
 	public String getState() {
 		return _state;
+	}
+
+	public void setDataSourceAccessToken(String dataSourceAccessToken) {
+		_dataSourceAccessToken = dataSourceAccessToken;
 	}
 
 	public void setFriendlyURL(String friendlyURL) {
@@ -124,6 +132,7 @@ public class ProjectDisplay {
 	private String _accountName;
 	private String _corpProjectName;
 	private String _corpProjectUuid;
+	private String _dataSourceAccessToken;
 	private FaroSubscriptionDisplay _faroSubscriptionDisplay;
 	private String _friendlyURL;
 	private long _groupId;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceControllerTest.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceControllerTest.java
@@ -13,16 +13,23 @@ import com.liferay.osb.faro.engine.client.model.FieldMapping;
 import com.liferay.osb.faro.engine.client.model.Results;
 import com.liferay.osb.faro.model.FaroProject;
 import com.liferay.osb.faro.service.FaroProjectLocalService;
+import com.liferay.osb.faro.util.FaroPropsValues;
 import com.liferay.osb.faro.web.internal.model.display.contacts.DataSourceMappingDisplay;
 import com.liferay.osb.faro.web.internal.util.ContactsCSVHelper;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.nio.charset.StandardCharsets;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -177,6 +184,34 @@ public class DataSourceControllerTest {
 		ReflectionTestUtils.setField(
 			_dataSourceController, "faroProjectLocalService",
 			_faroProjectLocalService);
+	}
+
+	@Test
+	public void testGenerateDataSourceAccessToken() throws Exception {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+
+		ReflectionTestUtil.setFieldValue(
+			FaroPropsValues.class, "FARO_URL", "https://faro.test");
+
+		String dataSourceAccessToken =
+			_dataSourceController.generateDataSourceAccessToken(12345L, 67890L);
+
+		Assert.assertNotNull(dataSourceAccessToken);
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			new String(
+				Base64.decode(dataSourceAccessToken), StandardCharsets.UTF_8));
+
+		Assert.assertEquals(
+			"https://faro.test/o/faro/contacts/12345/data_source/connect",
+			jsonObject.getString("url"));
+
+		String token = jsonObject.getString("token");
+
+		Assert.assertNotNull(token);
+		Assert.assertFalse(token.isEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
Motivation
----
Return data source access token in project creation response

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-89746)

Proposed Solution
----
This PR improves the project provisioning flow by ensuring the data source access token is consistently generated, stored, and returned across different project creation scenarios.

### Changes included:
- Added a new `_dataSourceAccessToken` field, including its corresponding getter and setter.
- Introduced a new `generateDataSourceAccessToken()` method responsible for generating both the token and its associated URL.
- Updated `createProvisioned()` and `_createUnprovisioned()` to properly set the data source access token during project creation.
- Fixed the `createUnprovisioned()` flow to return the data source access token when reusing an existing project that is not yet ready.
- Added test coverage to validate the new behavior and avoid regressions.