### PR TITLE
LPD-89863 Fix Connector Overview status alerts and entity chip

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorEntities.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorEntities.tsx
@@ -3,16 +3,18 @@ import ClayList from '@clayui/list';
 import ClaySticker from '@clayui/sticker';
 import Label from '@clayui/label';
 import React from 'react';
-import {ConnectorEntityDescriptor} from './types';
+import {ConnectorEntityDescriptor, ConnectorStatus} from './types';
 import {getEntityDisplay} from './getEntityDisplay';
 import {sub} from 'shared/util/lang';
 
 interface IConnectorEntitiesProps {
+	connectorStatus?: ConnectorStatus;
 	entities: ConnectorEntityDescriptor[];
 	syncedCounts: {[entity: string]: number | undefined};
 }
 
 const ConnectorEntities: React.FC<IConnectorEntitiesProps> = ({
+	connectorStatus,
 	entities,
 	syncedCounts
 }) => (
@@ -21,7 +23,10 @@ const ConnectorEntities: React.FC<IConnectorEntitiesProps> = ({
 			{entities.map(({entity}) => {
 				const {icon, label} = getEntityDisplay(entity);
 				const count = syncedCounts[entity];
-				const configured = typeof count === 'number' && count > 0;
+				const configured =
+					connectorStatus !== ConnectorStatus.Disconnected &&
+					typeof count === 'number' &&
+					count > 0;
 
 				return (
 					<ClayList.Item flex key={entity}>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
@@ -27,6 +27,7 @@ import {getConnectorAvailableDataAlert} from './getConnectorAvailableDataAlert';
 import {getConnectorConnectionStatusAlert} from './getConnectorConnectionStatusAlert';
 import {getConnectorStatus} from './getConnectorStatus';
 import {getConnectorStatusDisplay} from './getConnectorStatusDisplay';
+import {revoke} from 'shared/api/api-tokens';
 import {Text} from '@clayui/core';
 import {useCurrentUser} from 'shared/hooks/useCurrentUser';
 import {useDisconnectDataSource} from '../data-source/utils';
@@ -54,20 +55,15 @@ const ConnectorOverview: React.FC<IConnectorOverviewProps> = ({
 	dataSource: initialDataSource,
 	open
 }) => {
-	const getDataSourceToken = (ds: DataSource) =>
-		(ds.credentials?.get('privateKey') as string) ?? '';
-
 	const [loading, setLoading] = useState(false);
 	const [dataSource, setDataSource] = useState(initialDataSource);
-	const [token, setToken] = useState(getDataSourceToken(initialDataSource));
+	const [token, setToken] = useState('');
 
 	const {groupId = '', id = ''} = useParams<{
 		groupId: string;
 		id: string;
 	}>();
 	const currentUser = useCurrentUser();
-
-	const dataSourceActive = dataSource.status === DataSourceStatuses.Active;
 
 	const endpointURL = `${window.location.origin}${config.endpointPath}`;
 
@@ -96,19 +92,7 @@ const ConnectorOverview: React.FC<IConnectorOverviewProps> = ({
 	const connectorStatus = getConnectorStatus(dataSource);
 
 	useEffect(() => {
-		const dataSourceToken = getDataSourceToken(dataSource);
-
-		if (dataSourceToken) {
-			setToken(dataSourceToken);
-		}
-	}, [dataSource]);
-
-	useEffect(() => {
-		if (
-			token ||
-			dataSourceActive ||
-			connectorStatus === ConnectorStatus.Disconnected
-		) {
+		if (connectorStatus === ConnectorStatus.Disconnected) {
 			return;
 		}
 
@@ -132,7 +116,7 @@ const ConnectorOverview: React.FC<IConnectorOverviewProps> = ({
 		};
 
 		fetchConnectorTokenForGroup();
-	}, [config.slug, connectorStatus, dataSourceActive, groupId, token]);
+	}, [config.slug, connectorStatus, groupId]);
 
 	const handleGenerateToken = async () => {
 		try {
@@ -164,9 +148,9 @@ const ConnectorOverview: React.FC<IConnectorOverviewProps> = ({
 	const {handleDisconnect} = useDisconnectDataSource({
 		addAlert,
 		beforeSubmit: async () => {
-			// This endpoint is returning 500 status and need to be fixed to enable the line below.
-			// Token should be revoke and generate a new one after clicking to generate token.
-			// await revoke({groupId, token});
+			if (token) {
+				await revoke({groupId, token});
+			}
 		},
 		close,
 		groupId,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
@@ -436,6 +436,7 @@ const ConnectorEntityList: React.FC<IConnectorEntityListProps> = ({
 				)}
 
 				<ConnectorEntities
+					connectorStatus={getConnectorStatus(dataSource)}
 					entities={config.entities}
 					syncedCounts={syncedCounts}
 				/>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
@@ -16,6 +16,10 @@ import {Card} from 'shared/components/revamping/Card';
 import {close, open} from 'shared/actions/modals';
 import {compose} from 'redux';
 import {connect, ConnectedProps} from 'react-redux';
+import {
+	ConnectorAvailableDataAlertKind,
+	getConnectorAvailableDataAlert
+} from './getConnectorAvailableDataAlert';
 import {ConnectorConfig, ConnectorStatus} from './types';
 import {CopyInputValue} from '../CopyInputValue';
 import {DataSource} from 'shared/util/records';
@@ -23,7 +27,6 @@ import {DataSourceEditableTitle} from '../data-source/DataSourceEditableTitle';
 import {DataSourceStatuses} from 'shared/util/constants';
 import {fetch} from 'shared/api/data-source';
 import {generateConnectorToken, updateConnector} from 'shared/api/connector';
-import {getConnectorAvailableDataAlert} from './getConnectorAvailableDataAlert';
 import {getConnectorConnectionStatusAlert} from './getConnectorConnectionStatusAlert';
 import {getConnectorStatus} from './getConnectorStatus';
 import {getConnectorStatusDisplay} from './getConnectorStatusDisplay';
@@ -335,26 +338,49 @@ interface IConnectorEntityListProps {
 	groupId: string;
 }
 
-const getSyncingAlertStorageKey = (dataSourceId: string) =>
-	`connector-overview:syncing-alert-dismissed:${dataSourceId}`;
+const getAvailableDataAlertStorageKey = (
+	kind: ConnectorAvailableDataAlertKind,
+	dataSourceId: string
+) => `connector-overview:${kind}-alert-dismissed:${dataSourceId}`;
 
 const ConnectorEntityList: React.FC<IConnectorEntityListProps> = ({
 	config,
 	dataSource,
 	groupId
 }) => {
-	const syncingAlertStorageKey = getSyncingAlertStorageKey(
-		dataSource.id ?? ''
-	);
+	const dataSourceId = dataSource.id ?? '';
 
 	const [syncingAlertDismissed, setSyncingAlertDismissed] = useState(
-		() => window.localStorage.getItem(syncingAlertStorageKey) === 'true'
+		() =>
+			window.localStorage.getItem(
+				getAvailableDataAlertStorageKey('syncing', dataSourceId)
+			) === 'true'
 	);
 
-	const handleDismissSyncingAlert = () => {
-		window.localStorage.setItem(syncingAlertStorageKey, 'true');
+	const [previouslySyncedAlertDismissed, setPreviouslySyncedAlertDismissed] =
+		useState(
+			() =>
+				window.localStorage.getItem(
+					getAvailableDataAlertStorageKey(
+						'previously-synced',
+						dataSourceId
+					)
+				) === 'true'
+		);
 
-		setSyncingAlertDismissed(true);
+	const handleDismissAvailableDataAlert = (
+		kind: ConnectorAvailableDataAlertKind
+	) => {
+		window.localStorage.setItem(
+			getAvailableDataAlertStorageKey(kind, dataSourceId),
+			'true'
+		);
+
+		if (kind === 'syncing') {
+			setSyncingAlertDismissed(true);
+		} else {
+			setPreviouslySyncedAlertDismissed(true);
+		}
 	};
 
 	const countResponse = useRequest({
@@ -431,15 +457,15 @@ const ConnectorEntityList: React.FC<IConnectorEntityListProps> = ({
 				/>
 
 				{availableDataAlert &&
-					!(
-						availableDataAlert.dismissible && syncingAlertDismissed
-					) && (
+					!(availableDataAlert.kind === 'syncing'
+						? syncingAlertDismissed
+						: previouslySyncedAlertDismissed) && (
 						<ClayAlert
 							displayType={availableDataAlert.displayType}
-							onClose={
-								availableDataAlert.dismissible
-									? handleDismissSyncingAlert
-									: undefined
+							onClose={() =>
+								handleDismissAvailableDataAlert(
+									availableDataAlert.kind
+								)
 							}
 						>
 							{availableDataAlert.message}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
@@ -351,11 +351,28 @@ interface IConnectorEntityListProps {
 	groupId: string;
 }
 
+const getSyncingAlertStorageKey = (dataSourceId: string) =>
+	`connector-overview:syncing-alert-dismissed:${dataSourceId}`;
+
 const ConnectorEntityList: React.FC<IConnectorEntityListProps> = ({
 	config,
 	dataSource,
 	groupId
 }) => {
+	const syncingAlertStorageKey = getSyncingAlertStorageKey(
+		dataSource.id ?? ''
+	);
+
+	const [syncingAlertDismissed, setSyncingAlertDismissed] = useState(
+		() => window.localStorage.getItem(syncingAlertStorageKey) === 'true'
+	);
+
+	const handleDismissSyncingAlert = () => {
+		window.localStorage.setItem(syncingAlertStorageKey, 'true');
+
+		setSyncingAlertDismissed(true);
+	};
+
 	const countResponse = useRequest({
 		dataSourceFn: async (params: {[key: string]: any}) => {
 			const entries = await Promise.all(
@@ -429,11 +446,21 @@ const ConnectorEntityList: React.FC<IConnectorEntityListProps> = ({
 					title={Liferay.Language.get('available-data')}
 				/>
 
-				{availableDataAlert && (
-					<ClayAlert displayType={availableDataAlert.displayType}>
-						{availableDataAlert.message}
-					</ClayAlert>
-				)}
+				{availableDataAlert &&
+					!(
+						availableDataAlert.dismissible && syncingAlertDismissed
+					) && (
+						<ClayAlert
+							displayType={availableDataAlert.displayType}
+							onClose={
+								availableDataAlert.dismissible
+									? handleDismissSyncingAlert
+									: undefined
+							}
+						>
+							{availableDataAlert.message}
+						</ClayAlert>
+					)}
 
 				<ConnectorEntities
 					connectorStatus={getConnectorStatus(dataSource)}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorEntities.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorEntities.tsx
@@ -2,7 +2,7 @@ jest.unmock('react-dom');
 
 import ConnectorEntities from '../ConnectorEntities';
 import React from 'react';
-import {Entity} from '../types';
+import {ConnectorStatus, Entity} from '../types';
 import {render} from '@testing-library/react';
 
 describe('ConnectorEntities', () => {
@@ -82,6 +82,42 @@ describe('ConnectorEntities', () => {
 		);
 
 		expect(getByText('Unconfigured')).toBeTruthy();
+	});
+
+	it('renders the Unconfigured label when connector status is Disconnected even with count greater than zero', () => {
+		const {getByText} = render(
+			<ConnectorEntities
+				connectorStatus={ConnectorStatus.Disconnected}
+				entities={[{entity: Entity.Accounts}]}
+				syncedCounts={{[Entity.Accounts]: 5}}
+			/>
+		);
+
+		expect(getByText('Unconfigured')).toBeTruthy();
+	});
+
+	it('renders the Configured label when connector status is Active and count is greater than zero', () => {
+		const {getByText} = render(
+			<ConnectorEntities
+				connectorStatus={ConnectorStatus.Active}
+				entities={[{entity: Entity.Accounts}]}
+				syncedCounts={{[Entity.Accounts]: 5}}
+			/>
+		);
+
+		expect(getByText('Configured')).toBeTruthy();
+	});
+
+	it('renders the Configured label when connector status is Inactive and count is greater than zero', () => {
+		const {getByText} = render(
+			<ConnectorEntities
+				connectorStatus={ConnectorStatus.Inactive}
+				entities={[{entity: Entity.Accounts}]}
+				syncedCounts={{[Entity.Accounts]: 5}}
+			/>
+		);
+
+		expect(getByText('Configured')).toBeTruthy();
 	});
 
 	it('renders nothing inside the list when no entities are provided', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorOverview.tsx
@@ -670,7 +670,7 @@ describe('ConnectorOverview', () => {
 	});
 
 	describe('Synced Data card — Connection Status alert', () => {
-		it('ACTIVE with zero accounts: success / "successfully connected" message', () => {
+		it('ACTIVE with zero accounts: warning / "successfully connected" message', () => {
 			mockEntityCount(0);
 
 			const {getByText} = renderOverview({

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorOverview.tsx
@@ -174,6 +174,8 @@ const mockEntityCount = (count: number | undefined) =>
 
 describe('ConnectorOverview', () => {
 	beforeEach(() => {
+		window.localStorage.clear();
+
 		(generateConnectorToken as jest.Mock).mockClear();
 		(updateConnector as jest.Mock).mockClear();
 		(fetch as jest.Mock).mockClear();
@@ -770,6 +772,84 @@ describe('ConnectorOverview', () => {
 					'Your data may take some time to appear as syncing completes.'
 				)
 			).toBeTruthy();
+		});
+
+		it('ACTIVE with accounts: syncing alert can be dismissed and the dismissal is persisted in localStorage', () => {
+			mockEntityCount(7);
+
+			const {container, queryByText} = renderOverview({
+				dataSource: buildDataSource(DataSourceStatuses.Active)
+			});
+
+			const closeButton = container.querySelector(
+				'.alert .close'
+			) as HTMLButtonElement;
+
+			expect(closeButton).toBeTruthy();
+
+			fireEvent.click(closeButton);
+
+			expect(
+				queryByText(
+					'Your data may take some time to appear as syncing completes.'
+				)
+			).toBeNull();
+
+			expect(
+				window.localStorage.getItem(
+					'connector-overview:syncing-alert-dismissed:ds-1'
+				)
+			).toBe('true');
+		});
+
+		it('ACTIVE with accounts: syncing alert is hidden on re-render when localStorage flag is set', () => {
+			window.localStorage.setItem(
+				'connector-overview:syncing-alert-dismissed:ds-1',
+				'true'
+			);
+
+			mockEntityCount(7);
+
+			const {queryByText} = renderOverview({
+				dataSource: buildDataSource(DataSourceStatuses.Active)
+			});
+
+			expect(
+				queryByText(
+					'Your data may take some time to appear as syncing completes.'
+				)
+			).toBeNull();
+		});
+
+		it('ACTIVE with accounts: dismissal of one data source does not hide the alert for another data source', () => {
+			window.localStorage.setItem(
+				'connector-overview:syncing-alert-dismissed:other-ds',
+				'true'
+			);
+
+			mockEntityCount(7);
+
+			const {getByText} = renderOverview({
+				dataSource: buildDataSource(DataSourceStatuses.Active)
+			});
+
+			expect(
+				getByText(
+					'Your data may take some time to appear as syncing completes.'
+				)
+			).toBeTruthy();
+		});
+
+		it('DISCONNECTED with data: previously-synced alert does not render a close button', () => {
+			mockEntityCount(7);
+
+			const {container} = renderOverview({
+				dataSource: buildDataSource(DataSourceStatuses.Inactive, {
+					state: DataSourceStates.Disconnected
+				})
+			});
+
+			expect(container.querySelector('.alert .close')).toBeNull();
 		});
 
 		it('INACTIVE without data: no alert', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorOverview.tsx
@@ -852,16 +852,76 @@ describe('ConnectorOverview', () => {
 			).toBeTruthy();
 		});
 
-		it('DISCONNECTED with data: previously-synced alert does not render a close button', () => {
+		it('DISCONNECTED with data: previously-synced alert can be dismissed and the dismissal is persisted in localStorage', () => {
 			mockEntityCount(7);
 
-			const {container} = renderOverview({
+			const {container, queryByText} = renderOverview({
 				dataSource: buildDataSource(DataSourceStatuses.Inactive, {
 					state: DataSourceStates.Disconnected
 				})
 			});
 
-			expect(container.querySelector('.alert .close')).toBeNull();
+			const closeButton = container.querySelector(
+				'.alert .close'
+			) as HTMLButtonElement;
+
+			expect(closeButton).toBeTruthy();
+
+			fireEvent.click(closeButton);
+
+			expect(
+				queryByText(
+					'Previously synced data remains available. Reconnect or check your data source connection to resume data syncing.'
+				)
+			).toBeNull();
+
+			expect(
+				window.localStorage.getItem(
+					'connector-overview:previously-synced-alert-dismissed:ds-1'
+				)
+			).toBe('true');
+		});
+
+		it('DISCONNECTED with data: previously-synced alert is hidden on re-render when localStorage flag is set', () => {
+			window.localStorage.setItem(
+				'connector-overview:previously-synced-alert-dismissed:ds-1',
+				'true'
+			);
+
+			mockEntityCount(7);
+
+			const {queryByText} = renderOverview({
+				dataSource: buildDataSource(DataSourceStatuses.Inactive, {
+					state: DataSourceStates.Disconnected
+				})
+			});
+
+			expect(
+				queryByText(
+					'Previously synced data remains available. Reconnect or check your data source connection to resume data syncing.'
+				)
+			).toBeNull();
+		});
+
+		it('dismissing the syncing alert does not hide the previously-synced alert, and vice versa', () => {
+			window.localStorage.setItem(
+				'connector-overview:syncing-alert-dismissed:ds-1',
+				'true'
+			);
+
+			mockEntityCount(7);
+
+			const {getByText} = renderOverview({
+				dataSource: buildDataSource(DataSourceStatuses.Inactive, {
+					state: DataSourceStates.Disconnected
+				})
+			});
+
+			expect(
+				getByText(
+					'Previously synced data remains available. Reconnect or check your data source connection to resume data syncing.'
+				)
+			).toBeTruthy();
 		});
 
 		it('INACTIVE without data: no alert', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorOverview.tsx
@@ -374,45 +374,61 @@ describe('ConnectorOverview', () => {
 	});
 
 	describe('Token state and auto-fetch', () => {
-		it('initializes the token from dataSource.credentials.privateKey when present', () => {
-			const {getAllByTestId} = renderOverview({
-				dataSource: buildDataSource(DataSourceStatuses.Active, {
-					credentials: {privateKey: 'stored-token'}
-				})
+		it.each([
+			['Active', DataSourceStatuses.Active],
+			['Inactive', DataSourceStatuses.Inactive]
+		])(
+			'fetches the OAuth2 token for status %s by calling generateConnectorToken with the connector slug',
+			async (_, status) => {
+				renderOverview({
+					dataSource: buildDataSource(status)
+				});
+
+				await waitFor(() =>
+					expect(generateConnectorToken).toHaveBeenCalledWith({
+						groupId: '23',
+						type: 'acme'
+					})
+				);
+			}
+		);
+
+		it('renders the fetched token in the Token copy input', async () => {
+			(generateConnectorToken as jest.Mock).mockResolvedValueOnce({
+				token: 'fetched-token'
 			});
 
-			const values = getAllByTestId('copy-input-value').map(
-				node => node.textContent
-			);
-
-			expect(values).toContain('stored-token');
-		});
-
-		it('starts with an empty token when credentials.privateKey is missing', () => {
 			const {getAllByTestId} = renderOverview({
 				dataSource: buildDataSource(DataSourceStatuses.Active)
 			});
 
-			const tokenValue = getAllByTestId('copy-input').find(node =>
-				node
-					.querySelector('[data-testid="copy-input-title"]')
-					?.textContent?.match(/^Token$/)
-			);
+			await waitFor(() => {
+				const values = getAllByTestId('copy-input-value').map(
+					node => node.textContent
+				);
 
-			expect(
-				tokenValue?.querySelector('[data-testid="copy-input-value"]')
-					?.textContent
-			).toBe('');
+				expect(values).toContain('fetched-token');
+			});
 		});
 
-		it('syncs the token when dataSource is refetched with a new privateKey', async () => {
-			(fetch as jest.Mock).mockResolvedValueOnce({
-				credentials: {privateKey: 'refreshed-token'},
-				id: 'ds-1',
-				status: DataSourceStatuses.Active
+		it('does not auto-fetch a token when the data source is disconnected (user mints a new one via Generate Token)', async () => {
+			renderOverview({
+				dataSource: buildDataSource(DataSourceStatuses.Inactive, {
+					state: DataSourceStates.Disconnected
+				})
 			});
 
-			const {getAllByTestId, getByLabelText} = renderOverview({
+			await Promise.resolve();
+
+			expect(generateConnectorToken).not.toHaveBeenCalled();
+		});
+
+		it('on Generate Token click: stores the freshly minted token in state', async () => {
+			(generateConnectorToken as jest.Mock).mockResolvedValueOnce({
+				token: 'freshly-minted-token'
+			});
+
+			const {getByLabelText} = renderOverview({
 				dataSource: buildDataSource(DataSourceStatuses.Inactive, {
 					state: DataSourceStates.Disconnected
 				})
@@ -420,48 +436,12 @@ describe('ConnectorOverview', () => {
 
 			fireEvent.click(getByLabelText('Generate Token'));
 
-			await waitFor(() => {
-				const values = getAllByTestId('copy-input-value').map(
-					node => node.textContent
-				);
-
-				expect(values).toContain('refreshed-token');
-			});
-		});
-
-		it('skips the auto-fetch when the token is already set from credentials', async () => {
-			renderOverview({
-				dataSource: buildDataSource(DataSourceStatuses.Inactive, {
-					credentials: {privateKey: 'stored-token'}
-				})
-			});
-
-			await Promise.resolve();
-
-			expect(generateConnectorToken).not.toHaveBeenCalled();
-		});
-
-		it('auto-fetches a token for INACTIVE data sources without a credentials privateKey', async () => {
-			renderOverview({
-				dataSource: buildDataSource(DataSourceStatuses.Inactive)
-			});
-
 			await waitFor(() =>
 				expect(generateConnectorToken).toHaveBeenCalledWith({
 					groupId: '23',
 					type: 'acme'
 				})
 			);
-		});
-
-		it('does not auto-fetch a token when the data source is already active', async () => {
-			renderOverview({
-				dataSource: buildDataSource(DataSourceStatuses.Active)
-			});
-
-			await Promise.resolve();
-
-			expect(generateConnectorToken).not.toHaveBeenCalled();
 		});
 	});
 
@@ -510,60 +490,89 @@ describe('ConnectorOverview', () => {
 			expect(handleDisconnect).toHaveBeenCalled();
 		});
 
-		// TODO: Re-enable this test once the OAuth2 revoke endpoint is
-		// fixed on the backend (currently returns 500 with "Unable to
-		// revoke OAuth2 authorization") and the `revoke({groupId, token})`
-		// call is uncommented in ConnectorOverview's beforeSubmit.
-		it.skip('disconnect: passes a beforeSubmit that revokes the current token (so revoke runs before the disconnect endpoint)', async () => {
-			renderOverview({
-				dataSource: buildDataSource(DataSourceStatuses.Active, {
-					credentials: {privateKey: 'stored-token'}
-				})
+		it('disconnect: passes a beforeSubmit that revokes the fetched OAuth2 token (so revoke runs before the disconnect endpoint)', async () => {
+			(generateConnectorToken as jest.Mock).mockResolvedValueOnce({
+				token: 'fetched-token'
 			});
 
-			const {beforeSubmit} = useDisconnectDataSourceMock.mock.calls[0][0];
+			const {getAllByTestId} = renderOverview({
+				dataSource: buildDataSource(DataSourceStatuses.Active)
+			});
+
+			await waitFor(() => {
+				const values = getAllByTestId('copy-input-value').map(
+					node => node.textContent
+				);
+
+				expect(values).toContain('fetched-token');
+			});
+
+			const {beforeSubmit} =
+				useDisconnectDataSourceMock.mock.calls[
+					useDisconnectDataSourceMock.mock.calls.length - 1
+				][0];
 
 			await beforeSubmit();
 
 			expect(revoke).toHaveBeenCalledWith({
 				groupId: '23',
-				token: 'stored-token'
+				token: 'fetched-token'
 			});
 		});
 
-		it('disconnect: beforeSubmit is a no-op when there is no token to revoke', async () => {
+		it('disconnect: beforeSubmit is a no-op when the auto-fetch did not produce a token', async () => {
+			(generateConnectorToken as jest.Mock).mockResolvedValueOnce({});
+
 			renderOverview({
 				dataSource: buildDataSource(DataSourceStatuses.Active)
 			});
 
-			const {beforeSubmit} = useDisconnectDataSourceMock.mock.calls[0][0];
+			await waitFor(() =>
+				expect(generateConnectorToken).toHaveBeenCalled()
+			);
+
+			const {beforeSubmit} =
+				useDisconnectDataSourceMock.mock.calls[
+					useDisconnectDataSourceMock.mock.calls.length - 1
+				][0];
 
 			await beforeSubmit();
 
 			expect(revoke).not.toHaveBeenCalled();
 		});
 
-		// TODO: Re-enable this test once the OAuth2 revoke endpoint is
-		// fixed on the backend and the `revoke({groupId, token})` call
-		// is uncommented in ConnectorOverview's beforeSubmit.
-		it.skip('disconnect: beforeSubmit swallows revoke failures so the disconnect can still proceed', async () => {
+		it('disconnect: beforeSubmit propagates revoke failures so the shared hook can show its error alert', async () => {
+			(generateConnectorToken as jest.Mock).mockResolvedValueOnce({
+				token: 'fetched-token'
+			});
 			(revoke as jest.Mock).mockRejectedValueOnce(
 				new Error('Unable to revoke OAuth2 authorization')
 			);
 
-			renderOverview({
-				dataSource: buildDataSource(DataSourceStatuses.Active, {
-					credentials: {privateKey: 'stored-token'}
-				})
+			const {getAllByTestId} = renderOverview({
+				dataSource: buildDataSource(DataSourceStatuses.Active)
 			});
 
-			const {beforeSubmit} = useDisconnectDataSourceMock.mock.calls[0][0];
+			await waitFor(() => {
+				const values = getAllByTestId('copy-input-value').map(
+					node => node.textContent
+				);
 
-			await expect(beforeSubmit()).resolves.toBeUndefined();
+				expect(values).toContain('fetched-token');
+			});
+
+			const {beforeSubmit} =
+				useDisconnectDataSourceMock.mock.calls[
+					useDisconnectDataSourceMock.mock.calls.length - 1
+				][0];
+
+			await expect(beforeSubmit()).rejects.toThrow(
+				'Unable to revoke OAuth2 authorization'
+			);
 
 			expect(revoke).toHaveBeenCalledWith({
 				groupId: '23',
-				token: 'stored-token'
+				token: 'fetched-token'
 			});
 		});
 
@@ -572,7 +581,10 @@ describe('ConnectorOverview', () => {
 				dataSource: buildDataSource(DataSourceStatuses.Active)
 			});
 
-			const {onSubmit} = useDisconnectDataSourceMock.mock.calls[0][0];
+			const {onSubmit} =
+				useDisconnectDataSourceMock.mock.calls[
+					useDisconnectDataSourceMock.mock.calls.length - 1
+				][0];
 
 			await onSubmit();
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/getConnectorAvailableDataAlert.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/getConnectorAvailableDataAlert.ts
@@ -21,12 +21,12 @@ describe('getConnectorAvailableDataAlert', () => {
 			).toBeNull();
 		});
 
-		it('with data: dismissible info / "Your data may take some time to appear" message', () => {
+		it('with data: syncing kind / "Your data may take some time to appear" message', () => {
 			expect(
 				getConnectorAvailableDataAlert(activeDataSource, true)
 			).toEqual({
-				dismissible: true,
 				displayType: 'info',
+				kind: 'syncing',
 				message: SYNCING_COMPLETES_MESSAGE
 			});
 		});
@@ -44,12 +44,12 @@ describe('getConnectorAvailableDataAlert', () => {
 			).toBeNull();
 		});
 
-		it('with data (90d): non-dismissible info / "Previously synced data remains available" message', () => {
+		it('with data (90d): previously-synced kind / "Previously synced data remains available" message', () => {
 			expect(
 				getConnectorAvailableDataAlert(inactiveDataSource, true)
 			).toEqual({
-				dismissible: false,
 				displayType: 'info',
+				kind: 'previously-synced',
 				message: PREVIOUSLY_SYNCED_MESSAGE
 			});
 		});
@@ -61,22 +61,22 @@ describe('getConnectorAvailableDataAlert', () => {
 			status: DataSourceStatuses.Inactive
 		});
 
-		it('with data: non-dismissible info / "Previously synced data remains available" message', () => {
+		it('with data: previously-synced kind / "Previously synced data remains available" message', () => {
 			expect(
 				getConnectorAvailableDataAlert(disconnectedDataSource, true)
 			).toEqual({
-				dismissible: false,
 				displayType: 'info',
+				kind: 'previously-synced',
 				message: PREVIOUSLY_SYNCED_MESSAGE
 			});
 		});
 
-		it('without data: still shows non-dismissible / "Previously synced data remains available" message', () => {
+		it('without data: still shows previously-synced kind / "Previously synced data remains available" message', () => {
 			expect(
 				getConnectorAvailableDataAlert(disconnectedDataSource, false)
 			).toEqual({
-				dismissible: false,
 				displayType: 'info',
+				kind: 'previously-synced',
 				message: PREVIOUSLY_SYNCED_MESSAGE
 			});
 		});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/getConnectorAvailableDataAlert.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/getConnectorAvailableDataAlert.ts
@@ -21,10 +21,11 @@ describe('getConnectorAvailableDataAlert', () => {
 			).toBeNull();
 		});
 
-		it('with data: info / "Your data may take some time to appear" message', () => {
+		it('with data: dismissible info / "Your data may take some time to appear" message', () => {
 			expect(
 				getConnectorAvailableDataAlert(activeDataSource, true)
 			).toEqual({
+				dismissible: true,
 				displayType: 'info',
 				message: SYNCING_COMPLETES_MESSAGE
 			});
@@ -43,10 +44,11 @@ describe('getConnectorAvailableDataAlert', () => {
 			).toBeNull();
 		});
 
-		it('with data (90d): info / "Previously synced data remains available" message', () => {
+		it('with data (90d): non-dismissible info / "Previously synced data remains available" message', () => {
 			expect(
 				getConnectorAvailableDataAlert(inactiveDataSource, true)
 			).toEqual({
+				dismissible: false,
 				displayType: 'info',
 				message: PREVIOUSLY_SYNCED_MESSAGE
 			});
@@ -59,19 +61,21 @@ describe('getConnectorAvailableDataAlert', () => {
 			status: DataSourceStatuses.Inactive
 		});
 
-		it('with data: info / "Previously synced data remains available" message', () => {
+		it('with data: non-dismissible info / "Previously synced data remains available" message', () => {
 			expect(
 				getConnectorAvailableDataAlert(disconnectedDataSource, true)
 			).toEqual({
+				dismissible: false,
 				displayType: 'info',
 				message: PREVIOUSLY_SYNCED_MESSAGE
 			});
 		});
 
-		it('without data: still shows "Previously synced data remains available" message', () => {
+		it('without data: still shows non-dismissible / "Previously synced data remains available" message', () => {
 			expect(
 				getConnectorAvailableDataAlert(disconnectedDataSource, false)
 			).toEqual({
+				dismissible: false,
 				displayType: 'info',
 				message: PREVIOUSLY_SYNCED_MESSAGE
 			});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/getConnectorConnectionStatusAlert.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/getConnectorConnectionStatusAlert.ts
@@ -9,11 +9,11 @@ describe('getConnectorConnectionStatusAlert', () => {
 			status: DataSourceStatuses.Active
 		});
 
-		it('with zero accounts: success / "successfully connected" message', () => {
+		it('with zero accounts: warning / "successfully connected" message', () => {
 			expect(
 				getConnectorConnectionStatusAlert(activeDataSource, 0)
 			).toEqual({
-				displayType: 'success',
+				displayType: 'warning',
 				message:
 					'You have successfully connected to your data source. Complete your data source configuration to start syncing data.'
 			});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorAvailableDataAlert.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorAvailableDataAlert.ts
@@ -2,9 +2,11 @@ import {ConnectorStatus} from './types';
 import {DataSource} from 'shared/util/records';
 import {getConnectorStatus} from './getConnectorStatus';
 
+export type ConnectorAvailableDataAlertKind = 'previously-synced' | 'syncing';
+
 export interface ConnectorAvailableDataAlert {
-	dismissible: boolean;
 	displayType: 'info';
+	kind: ConnectorAvailableDataAlertKind;
 	message: string;
 }
 
@@ -16,8 +18,8 @@ export function getConnectorAvailableDataAlert(
 
 	if (status === ConnectorStatus.Disconnected) {
 		return {
-			dismissible: false,
 			displayType: 'info',
+			kind: 'previously-synced',
 			message: Liferay.Language.get(
 				'previously-synced-data-remains-available-reconnect-or-check-your-data-source-connection-to-resume-data-syncing'
 			)
@@ -26,8 +28,8 @@ export function getConnectorAvailableDataAlert(
 
 	if (status === ConnectorStatus.Inactive && hasData) {
 		return {
-			dismissible: false,
 			displayType: 'info',
+			kind: 'previously-synced',
 			message: Liferay.Language.get(
 				'previously-synced-data-remains-available-reconnect-or-check-your-data-source-connection-to-resume-data-syncing'
 			)
@@ -36,8 +38,8 @@ export function getConnectorAvailableDataAlert(
 
 	if (status === ConnectorStatus.Active && hasData) {
 		return {
-			dismissible: true,
 			displayType: 'info',
+			kind: 'syncing',
 			message: Liferay.Language.get(
 				'your-data-may-take-some-time-to-appear-as-syncing-completes'
 			)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorAvailableDataAlert.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorAvailableDataAlert.ts
@@ -3,6 +3,7 @@ import {DataSource} from 'shared/util/records';
 import {getConnectorStatus} from './getConnectorStatus';
 
 export interface ConnectorAvailableDataAlert {
+	dismissible: boolean;
 	displayType: 'info';
 	message: string;
 }
@@ -15,6 +16,7 @@ export function getConnectorAvailableDataAlert(
 
 	if (status === ConnectorStatus.Disconnected) {
 		return {
+			dismissible: false,
 			displayType: 'info',
 			message: Liferay.Language.get(
 				'previously-synced-data-remains-available-reconnect-or-check-your-data-source-connection-to-resume-data-syncing'
@@ -24,6 +26,7 @@ export function getConnectorAvailableDataAlert(
 
 	if (status === ConnectorStatus.Inactive && hasData) {
 		return {
+			dismissible: false,
 			displayType: 'info',
 			message: Liferay.Language.get(
 				'previously-synced-data-remains-available-reconnect-or-check-your-data-source-connection-to-resume-data-syncing'
@@ -33,6 +36,7 @@ export function getConnectorAvailableDataAlert(
 
 	if (status === ConnectorStatus.Active && hasData) {
 		return {
+			dismissible: true,
 			displayType: 'info',
 			message: Liferay.Language.get(
 				'your-data-may-take-some-time-to-appear-as-syncing-completes'

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorConnectionStatusAlert.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorConnectionStatusAlert.ts
@@ -23,16 +23,20 @@ export function getConnectorConnectionStatusAlert(
 	}
 
 	if (status === ConnectorStatus.Active) {
+		if (entityCount > 0) {
+			return {
+				displayType: 'success',
+				message: Liferay.Language.get(
+					'all-data-coming-from-this-data-source-is-up-to-date.-there-are-no-errors-to-report'
+				)
+			};
+		}
+
 		return {
-			displayType: 'success',
-			message:
-				entityCount > 0
-					? Liferay.Language.get(
-							'all-data-coming-from-this-data-source-is-up-to-date.-there-are-no-errors-to-report'
-					  )
-					: Liferay.Language.get(
-							'you-have-successfully-connected-to-your-data-source-complete-your-data-source-configuration-to-start-syncing-data'
-					  )
+			displayType: 'warning',
+			message: Liferay.Language.get(
+				'you-have-successfully-connected-to-your-data-source-complete-your-data-source-configuration-to-start-syncing-data'
+			)
 		};
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89863

## What is being fixed

Four issues uncovered in the Connector Overview after the initial status-type implementation:

1. The entity chip kept showing "Configured" for a manually disconnected data source whenever the previously synced count was still greater than zero, contradicting the disconnected state.
2. The Connection Status alert displayed a `success` indicator for data sources that were technically ACTIVE but had not synced any data yet, misleading users into thinking the integration was complete.
3. The Synced Data card's available-data alerts ("Your data may take some time to appear…" and "Previously synced data remains available…") stayed pinned forever with no way to acknowledge them.
4. Manual disconnects were not revoking the OAuth2 token before calling the disconnect endpoint, leaving stale credentials in the backend (companion fix from LPD-89275).

## How it is being fixed

The disconnected case now drives the chip directly: when the connector status resolves to Disconnected, the chip renders as "Unconfigured" regardless of count. The Connection Status alert distinguishes ACTIVE with zero data (warning) from ACTIVE with data (success). The available-data alerts gained a close button each, and each kind persists its own dismissal flag per data source in localStorage so that dismissing the syncing alert does not hide a later previously-synced alert when the data source transitions to disconnected. The disconnect flow runs a token revoke before the backend disconnect call through the `beforeSubmit` hook on the shared disconnect helper.