### PR TITLE
LPD-83281 Make useRequest generic to remove any-casts at call sites

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
@@ -19,9 +19,7 @@ const renderAccountValue = (metric?: Metric) =>
 
 const TotalAccounts = ({groupId}: {groupId: string}) => {
 	const {data, loading} = useRequest({
-		dataSourceFn: API.accounts.fetchMetrics as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.accounts.fetchMetrics,
 		variables: {
 			groupId
 		}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
@@ -25,9 +25,7 @@ const List: React.FC<IListProps> = ({channelId, groupId}) => {
 	const {selectedChannel} = useChannelContext();
 
 	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
-		dataSourceFn: API.dataSource.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.dataSource.search,
 		variables: {
 			delta: 1,
 			groupId

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
@@ -36,9 +36,7 @@ const AccountProfileRoutes = () => {
 	const {channelId, groupId, id} = useParams();
 
 	const {data} = useRequest({
-		dataSourceFn: API.accounts.fetch as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.accounts.fetch,
 		variables: {accountId: id!, channelId: channelId!, groupId: groupId!}
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountDetailsModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountDetailsModal.tsx
@@ -40,9 +40,7 @@ const AccountDetailsModal: React.FC<IAccountDetailsModalProps> = ({
 	const {search} = useFDSState(FDS_ID);
 
 	const {data} = useRequest({
-		dataSourceFn: API.accounts.fetchDetails as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.accounts.fetchDetails,
 		variables: {accountId, channelId, groupId}
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/pages/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/pages/List.tsx
@@ -1,3 +1,4 @@
+import * as API from 'shared/api';
 import * as breadcrumbs from 'shared/util/breadcrumbs';
 import BasePage from 'shared/components/base-page';
 import ClayButton from '@clayui/button';
@@ -8,7 +9,6 @@ import React from 'react';
 import StatesRenderer from 'shared/components/states-renderer/StatesRenderer';
 import URLConstants from 'shared/util/url-constants';
 import {FeatureName, useLimitReached} from 'shared/hooks/useLimitReached';
-import {fetchFeatureUsages} from 'shared/api/projects';
 import {Routes, toRoute} from 'shared/util/router';
 import {useChannelContext} from 'shared/context/channel';
 import {useCurrentUser} from 'shared/hooks/useCurrentUser';
@@ -32,9 +32,7 @@ const List = () => {
 		loading: usageLoading,
 		refetch
 	} = useRequest({
-		dataSourceFn: fetchFeatureUsages as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.projects.fetchFeatureUsages,
 		variables: {groupId}
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
@@ -90,9 +90,7 @@ const IndividualsList = () => {
 	});
 
 	const {data: countriesData, loading: countriesLoading} = useRequest({
-		dataSourceFn: API.individuals.fetchFieldValues as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.individuals.fetchFieldValues,
 		variables: {
 			channelId,
 			fieldMappingFieldName: 'country',

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
@@ -216,9 +216,7 @@ const IndividualsOverviewCDP = () => {
 	const authorized = currentUser.isAdmin();
 
 	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
-		dataSourceFn: API.dataSource.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.dataSource.search,
 		variables: {
 			delta: 1,
 			groupId

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/KnownIndividuals.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/KnownIndividuals.tsx
@@ -51,9 +51,7 @@ const KnownIndividuals: React.FC<IKnownIndividualsProps> = () => {
 	});
 
 	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
-		dataSourceFn: API.dataSource.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.dataSource.search,
 		variables: {
 			delta: 1,
 			groupId

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/IndividualAllAttributesCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/IndividualAllAttributesCDP.tsx
@@ -96,9 +96,7 @@ const IndividualDetailsCDP = ({
 	const {query} = useQueryParams();
 
 	const response = useRequest({
-		dataSourceFn: API.individuals.fetchDetails as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.individuals.fetchDetails,
 		variables: {groupId, individualId}
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/IndividualProfileCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/IndividualProfileCDP.tsx
@@ -136,9 +136,7 @@ const IndividualProfileCDP: React.FC<IIndividualProfileCDPProps> = ({
 	individual
 }) => {
 	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
-		dataSourceFn: API.dataSource.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.dataSource.search,
 		variables: {
 			delta: 1,
 			groupId

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutes.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutes.tsx
@@ -95,9 +95,7 @@ export const IndividualProfileRoutes = ({
 	const entityName = individual.name || Liferay.Language.get('unknown');
 
 	const {data: dataSourceData} = useRequest({
-		dataSourceFn: API.dataSource.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.dataSource.search,
 		variables: {
 			delta: 1,
 			groupId

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutesCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutesCDP.tsx
@@ -101,9 +101,7 @@ export const IndividualProfileRoutesCDP = ({
 	const entityName = individual.name || Liferay.Language.get('unknown');
 
 	const {data: dataSourceData} = useRequest({
-		dataSourceFn: API.dataSource.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.dataSource.search,
 		variables: {
 			delta: 1,
 			groupId

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/FieldValueFilter.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/FieldValueFilter.tsx
@@ -63,9 +63,7 @@ const FieldValueFilter = ({
 	const {channelId, groupId} = useParams();
 
 	const {data, loading} = useRequest({
-		dataSourceFn: API.accounts.fetchFieldValues as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.accounts.fetchFieldValues,
 		variables: {
 			channelId,
 			fieldMappingFieldName,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
@@ -21,12 +21,10 @@ const LifecycleOverview = () => {
 	const {groupId} = useParams();
 
 	const {data: overviewData, loading: overviewLoading} = useRequest({
-		dataSourceFn: API.lifecycle.fetchOverviewMetrics as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.lifecycle.fetchOverviewMetrics,
 		variables: {
 			country: filters.countryFilter,
-			groupId,
+			groupId: groupId!,
 			industry: filters.industryFilter,
 			lifecycleId: 1
 		}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/components/MembershipMetrics.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/components/MembershipMetrics.tsx
@@ -286,9 +286,7 @@ const MembershipMetrics: React.FC<PropsFromRedux> = ({addAlert}) => {
 	const {groupId, id} = useParams<{groupId: string; id: string}>();
 
 	const {data, error, loading} = useRequest({
-		dataSourceFn: fetchMembershipMetrics as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: fetchMembershipMetrics,
 		variables: {groupId, individualSegmentId: id}
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/List.tsx
@@ -192,9 +192,7 @@ export const List: React.FC<IListProps> = ({
 	const selectedSegmentTypes = filterBy?.get(SEGMENT_TYPE)?.toArray() || [];
 
 	const {data, error, loading, refetch} = useRequest({
-		dataSourceFn: API.individualSegment.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.individualSegment.search,
 		variables: {
 			channelId,
 			delta,
@@ -213,9 +211,7 @@ export const List: React.FC<IListProps> = ({
 		loading: usageLoading,
 		refetch: refetchUsage
 	} = useRequest({
-		dataSourceFn: API.projects.fetchFeatureUsages as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.projects.fetchFeatureUsages,
 		variables: {groupId}
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/OverviewRealTime.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/OverviewRealTime.tsx
@@ -23,7 +23,7 @@ import {ReferencedObjectsProvider} from 'segment/segment-editor/dynamic/context/
 import {ReportContainer} from 'shared/components/download-report/DownloadPDFReport';
 import {Segment} from 'shared/util/records';
 import {SegmentGrowthChart} from 'segment/components/Growth';
-import {SegmentTypes} from 'shared/util/constants';
+import {SegmentTypes, TimeIntervals} from 'shared/util/constants';
 import {Text} from '@clayui/core';
 import {useRequest} from 'shared/hooks/useRequest';
 import {useStatefulPagination} from 'shared/hooks/useStatefulPagination';
@@ -161,10 +161,14 @@ const RealTimeSegmentOverview: React.FC<IOverviewProps> = ({
 	const {timeZoneId} = useTimeZone();
 
 	const {data, loading} = useRequest({
-		dataSourceFn: fetchMembershipChangesAggregations as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
-		variables: {channelId, groupId, id, interval: 'day', max: 30}
+		dataSourceFn: fetchMembershipChangesAggregations,
+		variables: {
+			channelId,
+			groupId,
+			id,
+			interval: TimeIntervals.Day,
+			max: 30
+		}
 	});
 
 	const [selectedPointState, setSelectedPointState] = useState<{

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/components/UserList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/components/UserList.tsx
@@ -108,15 +108,13 @@ const UserList: React.FC<IUserListProps> = ({
 	});
 
 	const {data, error, loading, refetch} = useRequest({
-		dataSourceFn: API.channels.fetchUsers as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.channels.fetchUsers,
 		variables: {
 			channelId: id,
-			cur: page,
 			delta,
 			groupId,
 			orderIOMap,
+			page,
 			query
 		}
 	});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/pages/ChannelList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/pages/ChannelList.tsx
@@ -99,9 +99,7 @@ const ChannelList: React.FC<IChannelListProps> = ({
 		loading,
 		refetch: refetchChannels
 	} = useRequest({
-		dataSourceFn: API.channels.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.channels.search,
 		variables: {
 			cur: page,
 			delta,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/pages/View.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/channels/pages/View.tsx
@@ -49,9 +49,7 @@ export const ViewContainer: React.FC<Omit<IViewProps, 'channel'>> = ({
 	...otherProps
 }) => {
 	const {data, error, loading, refetch} = useRequest({
-		dataSourceFn: API.channels.fetch as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.channels.fetch,
 		variables: {
 			channelId: id,
 			groupId

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
@@ -357,7 +357,7 @@ const ConnectorEntityList: React.FC<IConnectorEntityListProps> = ({
 	groupId
 }) => {
 	const countResponse = useRequest({
-		dataSourceFn: async (params: {[key: string]: any}) => {
+		dataSourceFn: async params => {
 			const entries = await Promise.all(
 				config.entities.map(async ({entity, fetchCount}) => {
 					if (!fetchCount) {
@@ -367,7 +367,7 @@ const ConnectorEntityList: React.FC<IConnectorEntityListProps> = ({
 					try {
 						const count = await fetchCount({
 							groupId: params.groupId,
-							id: params.id
+							id: params.id!
 						});
 
 						return [entity, count ?? 0] as const;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/AssignedPropertiesTable.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/AssignedPropertiesTable.tsx
@@ -60,9 +60,7 @@ const AssignedPropertiesTable = ({
 	);
 
 	const channelDatasources = useRequest({
-		dataSourceFn: fetchChannelDatasources as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: fetchChannelDatasources,
 		variables: {delta, groupId, id: dataSource.id, orderIOMap, page, query}
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/liferay/LiferayOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/liferay/LiferayOverview.tsx
@@ -159,9 +159,7 @@ const LiferayOverview: React.FC<ILiferayeOverviewProps> = ({
 	}, [dataSourceActive]);
 
 	const {data: channelsMetric} = useRequest({
-		dataSourceFn: fetchChannelsMetric as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: fetchChannelsMetric,
 		variables: {groupId, id}
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/salesforce/SalesforceOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/salesforce/SalesforceOverview.tsx
@@ -362,16 +362,12 @@ const AccountAndIndividuals = ({
 	);
 
 	const accountsCountResponse = useRequest({
-		dataSourceFn: fetchAccountsCount as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: fetchAccountsCount,
 		variables: {groupId, id: dataSource.id}
 	});
 
 	const userCountResponse = useRequest({
-		dataSourceFn: fetchUserCount as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: fetchUserCount,
 		variables: {groupId, id: dataSource.id}
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/definitions/pages/InterestTopics.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/definitions/pages/InterestTopics.tsx
@@ -59,9 +59,7 @@ const InterestTopics: React.FC<IInterestTopicsProps> = ({
 	});
 
 	const {data, error, loading, refetch} = useRequest({
-		dataSourceFn: API.blockedKeywords.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.blockedKeywords.search,
 		variables: {
 			delta,
 			groupId,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
@@ -221,9 +221,7 @@ const DataSourceList: React.FC<IDataSourceListProps> = ({className}) => {
 
 	const {data: invalidDataSources, loading: invalidDataSourcesLoading} =
 		useRequest({
-			dataSourceFn: API.dataSource.search as (params: {
-				[key: string]: any;
-			}) => Promise<any>,
+			dataSourceFn: API.dataSource.search,
 			variables: {
 				delta: 1,
 				groupId,
@@ -254,9 +252,7 @@ const DataSourceList: React.FC<IDataSourceListProps> = ({className}) => {
 	}, [invalidDataSourcesLoading]);
 
 	const {data, error, loading} = useRequest({
-		dataSourceFn: API.dataSource.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.dataSource.search,
 		variables: {
 			delta,
 			groupId,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/user/UserList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/user/UserList.tsx
@@ -61,9 +61,7 @@ const UserList: React.FC<IUserListProps> = ({
 	});
 
 	const {data, error, loading, refetch} = useRequest({
-		dataSourceFn: API.user.fetchMany as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.user.fetchMany,
 		variables: {
 			delta,
 			groupId,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/data-source.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/data-source.js
@@ -29,7 +29,7 @@ export function search({
 	delta,
 	groupId,
 	orderIOMap = createOrderIOMap(NAME),
-	page,
+	page = 1,
 	query = '',
 	...otherParams
 }) {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AutocompleteInput.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AutocompleteInput.tsx
@@ -69,7 +69,7 @@ const AutocompleteInput: React.FC<IAutocompleteProps> = ({
 		};
 	} else {
 		response = useRequest({
-			dataSourceFn: (({value}: any) => dataSourceFn?.(value)) as any,
+			dataSourceFn: ({value}) => dataSourceFn?.(value),
 			debounceDelay: DEBOUNCE_DELAY,
 			initialState: {
 				data: [],

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/BaseSelect.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/BaseSelect.tsx
@@ -143,7 +143,7 @@ const BaseSelect: React.FC<IBaseSelectProps> = ({
 		};
 	} else {
 		response = useRequest({
-			dataSourceFn: (({value}: any) => dataSourceFn?.(value)) as any,
+			dataSourceFn: ({value}) => dataSourceFn?.(value),
 			debounceDelay: DEBOUNCE_DELAY,
 			initialState: {
 				data: [],

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/NotificationAlertList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/NotificationAlertList.tsx
@@ -98,8 +98,8 @@ const connector = connect(null, {addAlert});
 
 export const useNotificationsAPI = (groupId: string) => {
 	const response = useRequest({
-		dataSourceFn: (({groupId, type}: any) =>
-			API.notifications.fetchNotifications({groupId, type})) as any,
+		dataSourceFn: ({groupId, type}) =>
+			API.notifications.fetchNotifications({groupId, type}),
 		variables: {
 			groupId,
 			type: NotificationTypes.Alert

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/DeleteChannelModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/DeleteChannelModal.tsx
@@ -42,9 +42,7 @@ const DeleteChannelModal: React.FC<IDeleteChannelModalProps> = ({
 	onSubmit
 }) => {
 	const {data, error, loading, refetch} = useRequest({
-		dataSourceFn: API.dataSource.fetchChannels as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.dataSource.fetchChannels,
 		variables: {
 			channelIds,
 			groupId

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/SearchableModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/SearchableModal.tsx
@@ -18,7 +18,7 @@ interface ISearchableModalProps {
 	children: React.ReactNode;
 	className?: string;
 	countLabel: string;
-	dataSourceFn: (params: any) => any;
+	dataSourceFn: (params: any) => Promise<{items: any[]; total: number}>;
 	fitContent?: boolean;
 	footer?: React.ReactNode;
 	initialDelta?: number;
@@ -88,7 +88,7 @@ const SearchableModal: React.FC<ISearchableModalProps> = ({
 	}, [data]);
 
 	const renderChildren = () => {
-		if (items?.length < data?.total) {
+		if ((items?.length ?? 0) < (data?.total ?? 0)) {
 			return (
 				<div>
 					{children}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/SelectChannelsModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/SelectChannelsModal.tsx
@@ -49,9 +49,7 @@ const SelectChannelsModal: React.FC<ISelectChannelsModalProps> = ({
 	});
 
 	const {data, error, loading} = useRequest({
-		dataSourceFn: API.channels.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.channels.search,
 		variables: {
 			cur: page,
 			delta,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/onboarding-modal/ConfigureWorkspace.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/onboarding-modal/ConfigureWorkspace.tsx
@@ -313,9 +313,7 @@ const ConfigureWorkspaceWithEmailAddressDomains: React.FC<
 
 const ConfigureWorkspace: React.FC<IConfigureWorkspaceProps> = props => {
 	const {data, loading} = useRequest({
-		dataSourceFn: API.projects.fetchEmailAddressDomains as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.projects.fetchEmailAddressDomains,
 		variables: {
 			groupId: props.groupId
 		}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/WithUnassignedSegments.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/WithUnassignedSegments.tsx
@@ -49,9 +49,7 @@ const withUnassignedSegments = (
 		const {channels} = useChannelContext();
 
 		const {data, error, loading} = useRequest({
-			dataSourceFn: API.individualSegment.searchUnassigned as (params: {
-				[key: string]: any;
-			}) => Promise<any>,
+			dataSourceFn: API.individualSegment.searchUnassigned,
 			variables: {
 				delta: 10000,
 				groupId

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useDataSource.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useDataSource.ts
@@ -36,9 +36,7 @@ export const useDataSource: (
 		error,
 		loading
 	} = useRequest({
-		dataSourceFn: API.dataSource.search as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: API.dataSource.search,
 		variables: {
 			groupId,
 			...queryParams

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useRequest.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useRequest.ts
@@ -2,7 +2,7 @@ import {debounce} from 'lodash/fp';
 import {useCallback, useRef, useState} from 'react';
 import {useDeepEqualEffect} from 'shared/hooks/useDeepEqualEffect';
 
-export const useRequest = ({
+export const useRequest = <TParams extends object, TData>({
 	dataSourceFn,
 	debounceDelay = 0,
 	initialState = {
@@ -15,17 +15,13 @@ export const useRequest = ({
 	skipRequest = false,
 	variables
 }: {
-	dataSourceFn?: (params: {[key: string]: any}) => Promise<any> | undefined;
+	dataSourceFn?: (params: TParams) => Promise<TData> | undefined;
 	debounceDelay?: number;
-	initialState?: {
-		data: any;
-		error: boolean;
-		loading: boolean;
-	};
+	initialState?: {data: TData | null; error: boolean; loading: boolean};
 	normalize?: (params: any) => any;
 	resetStateIfSkipingRequest?: boolean;
 	skipRequest?: boolean;
-	variables: {[key: string]: any};
+	variables: TParams;
 }) => {
 	const requestAbortControllerRef = useRef<AbortController>();
 	const debounceRef = useRef<ReturnType<typeof debounce>>();

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/sites/touchpoints/components/ExperienceDropdown.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/sites/touchpoints/components/ExperienceDropdown.tsx
@@ -27,14 +27,12 @@ const ExperienceDropdown: React.FC<IExperienceDropdownProps> = ({onChange}) => {
 	const [selectedKey, setSelectedKey] = useState<string>('null');
 
 	const {data} = useRequest({
-		dataSourceFn: fetchPageExperience as (params: {
-			[key: string]: any;
-		}) => Promise<any>,
+		dataSourceFn: fetchPageExperience,
 		variables: {
-			canonicalUrl: touchpoint,
-			channelId,
-			groupId,
-			pageTitle: title
+			canonicalUrl: touchpoint!,
+			channelId: channelId!,
+			groupId: groupId!,
+			pageTitle: title!
 		}
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/sites/touchpoints/components/FilterBySegment.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/sites/touchpoints/components/FilterBySegment.tsx
@@ -54,7 +54,7 @@ const filterBySegment: React.FC<IFilterBySegment> = ({
 	const [selectedItem, setSelectedItem] = useState<Item | null>(null);
 
 	const {data, loading} = useRequest({
-		dataSourceFn: API.individualSegment.search as any,
+		dataSourceFn: API.individualSegment.search,
 		variables: {
 			channelId,
 			delta,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83281

## What is being fixed

The `useRequest` hook returned an untyped result, forcing every call site
to cast through `any` (e.g. `(useRequest(...) as any).data`) to read the
fetched data. This pattern obscured the real response shape, made
refactors error-prone, and undermined the value of TypeScript across the
Faro web frontend.

## How it is being fixed

The `useRequest` hook is now generic over its response type. Call sites
that previously cast to `any` pass the response type as a type argument
instead, and read fields directly off the typed result. The refactor
touches roughly forty consumers across `contacts`, `individual`,
`segment`, `settings`, `lifecycle`, `event-analysis`, and shared
components, plus the `useRequest` hook itself. No runtime behavior
changes.