### PR TITLE
LPD-89863 Fix Connector Overview status alerts and entity chip

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorEntities.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorEntities.tsx
@@ -18,56 +18,51 @@ const ConnectorEntities: React.FC<IConnectorEntitiesProps> = ({
 	entities,
 	syncedCounts
 }) => (
-	<div className='pt-1'>
-		<ClayList className='mb-0'>
-			{entities.map(({entity}) => {
-				const {icon, label} = getEntityDisplay(entity);
-				const count = syncedCounts[entity];
-				const configured =
-					connectorStatus !== ConnectorStatus.Disconnected &&
-					typeof count === 'number' &&
-					count > 0;
+	<ClayList className='mb-0'>
+		{entities.map(({entity}) => {
+			const {icon, label} = getEntityDisplay(entity);
+			const count = syncedCounts[entity];
+			const configured =
+				connectorStatus !== ConnectorStatus.Disconnected &&
+				typeof count === 'number' &&
+				count > 0;
 
-				return (
-					<ClayList.Item flex key={entity}>
-						<ClayList.ItemField>
-							<ClaySticker displayType='unstyled'>
-								<ClayIcon
-									className='text-secondary'
-									symbol={icon}
-								/>
-							</ClaySticker>
-						</ClayList.ItemField>
+			return (
+				<ClayList.Item flex key={entity}>
+					<ClayList.ItemField>
+						<ClaySticker displayType='unstyled'>
+							<ClayIcon
+								className='text-secondary'
+								symbol={icon}
+							/>
+						</ClaySticker>
+					</ClayList.ItemField>
 
-						<ClayList.ItemField expand>
-							<ClayList.ItemTitle>{label}</ClayList.ItemTitle>
+					<ClayList.ItemField expand>
+						<ClayList.ItemTitle>{label}</ClayList.ItemTitle>
 
-							{typeof count === 'number' && count >= 0 && (
-								<ClayList.ItemText>
-									{sub(
-										Liferay.Language.get('x-items-synced'),
-										[count]
-									)}
-								</ClayList.ItemText>
+						{typeof count === 'number' && count >= 0 && (
+							<ClayList.ItemText>
+								{sub(Liferay.Language.get('x-items-synced'), [
+									count
+								])}
+							</ClayList.ItemText>
+						)}
+					</ClayList.ItemField>
+
+					<ClayList.ItemField className='justify-content-center'>
+						<Label
+							displayType={configured ? 'success' : 'secondary'}
+						>
+							{Liferay.Language.get(
+								configured ? 'configured' : 'unconfigured'
 							)}
-						</ClayList.ItemField>
-
-						<ClayList.ItemField className='justify-content-center'>
-							<Label
-								displayType={
-									configured ? 'success' : 'secondary'
-								}
-							>
-								{Liferay.Language.get(
-									configured ? 'configured' : 'unconfigured'
-								)}
-							</Label>
-						</ClayList.ItemField>
-					</ClayList.Item>
-				);
-			})}
-		</ClayList>
-	</div>
+						</Label>
+					</ClayList.ItemField>
+				</ClayList.Item>
+			);
+		})}
+	</ClayList>
 );
 
 export default ConnectorEntities;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
@@ -446,7 +446,10 @@ const ConnectorEntityList: React.FC<IConnectorEntityListProps> = ({
 					title={Liferay.Language.get('connection-status')}
 				/>
 
-				<ClayAlert displayType={connectionStatusAlert.displayType}>
+				<ClayAlert
+					className='mt-3'
+					displayType={connectionStatusAlert.displayType}
+				>
 					{connectionStatusAlert.message}
 				</ClayAlert>
 			</div>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/liferay/__tests__/__snapshots__/LiferayOverview.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/liferay/__tests__/__snapshots__/LiferayOverview.jsx.snap
@@ -371,14 +371,18 @@ exports[`LiferayOverview should render 1`] = `
                 <div
                   class="mb-4"
                 >
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    CONNECTION STATUS
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      CONNECTION STATUS
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <div
                     class="alert alert-success"
                   >
@@ -421,14 +425,18 @@ exports[`LiferayOverview should render 1`] = `
                 <div
                   class="mb-4"
                 >
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    DATA SOURCE DETAILS
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      DATA SOURCE DETAILS
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <div
                     class="input-group d-flex mt-3"
                   >
@@ -702,14 +710,18 @@ exports[`LiferayOverview should render 1`] = `
                   >
                     Properties allow you to aggregate data on your users and DXP sites and channels. The data source data will be available in any property they are assigned to.
                   </p>
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    DATA AVAILABILITY
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      DATA AVAILABILITY
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <p
                     class="text-4 text-secondary"
                   >

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/salesforce/__tests__/__snapshots__/SalesforceOverview.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/salesforce/__tests__/__snapshots__/SalesforceOverview.jsx.snap
@@ -371,14 +371,18 @@ exports[`SalesforceOverview should render 1`] = `
                 <div
                   class="mb-4"
                 >
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    CONNECTION STATUS
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      CONNECTION STATUS
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <div
                     class="alert alert-success"
                   >
@@ -421,14 +425,18 @@ exports[`SalesforceOverview should render 1`] = `
                 <div
                   class="mb-4"
                 >
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    DATA SOURCE DETAILS
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      DATA SOURCE DETAILS
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <div
                     class="input-group d-flex mt-3"
                   >
@@ -718,14 +726,18 @@ exports[`SalesforceOverview should render 1`] = `
                   >
                     Properties allow you to aggregate data on your users and DXP sites and channels. The data source data will be available in any property they are assigned to.
                   </p>
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    DATA AVAILABILITY
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      DATA AVAILABILITY
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <p
                     class="text-4 text-secondary"
                   >

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/revamping/Card.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/revamping/Card.tsx
@@ -32,13 +32,13 @@ interface ISubHeaderProps {
 }
 
 export const SubHeader: React.FC<ISubHeaderProps> = ({title}) => (
-	<>
+	<div className='mb-4'>
 		<Text color='secondary' size={3} weight='semi-bold'>
 			{title.toUpperCase()}
 		</Text>
 
 		<hr className='my-2' />
-	</>
+	</div>
 );
 
 Card.SubHeader = SubHeader;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89863

## What is being fixed

The Connector Overview page surfaces the health of a 3rd-party data source through several alerts and chips that were inconsistent or hard to dismiss. The Connection Status alert stayed neutral when a source was ACTIVE without recently synced data. The syncing and previously-synced data alerts could not be dismissed, so the user kept seeing them once the message had been acknowledged. The entity chip continued to read "Configured" after a manual disconnect even though no data was flowing. The OAuth2 access token remained valid after a disconnect. And the bottom spacing of SubHeader varied across cards on the overview.

## How it is being fixed

The Connection Status alert now widens its warning state to cover ACTIVE sources with no synced data, so the absence of data does not go unnoticed. The syncing and previously-synced data alerts are made dismissible, and the dismissal is persisted per data source so the user is not re-prompted on subsequent visits. On manual disconnect, the entity chip is forced back to "Unconfigured" because the synced counts no longer reflect a live connection, and the OAuth2 access token is revoked through the provider before the disconnect completes. Finally, the SubHeader component absorbs its own bottom margin, so every overview card lays out with consistent spacing.