### PR TITLE
LPD-89863 faro-v4.15.x Standardize SubHeader spacing on data source overview

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorEntities.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorEntities.tsx
@@ -18,56 +18,51 @@ const ConnectorEntities: React.FC<IConnectorEntitiesProps> = ({
 	entities,
 	syncedCounts
 }) => (
-	<div className='pt-1'>
-		<ClayList className='mb-0'>
-			{entities.map(({entity}) => {
-				const {icon, label} = getEntityDisplay(entity);
-				const count = syncedCounts[entity];
-				const configured =
-					connectorStatus !== ConnectorStatus.Disconnected &&
-					typeof count === 'number' &&
-					count > 0;
+	<ClayList className='mb-0'>
+		{entities.map(({entity}) => {
+			const {icon, label} = getEntityDisplay(entity);
+			const count = syncedCounts[entity];
+			const configured =
+				connectorStatus !== ConnectorStatus.Disconnected &&
+				typeof count === 'number' &&
+				count > 0;
 
-				return (
-					<ClayList.Item flex key={entity}>
-						<ClayList.ItemField>
-							<ClaySticker displayType='unstyled'>
-								<ClayIcon
-									className='text-secondary'
-									symbol={icon}
-								/>
-							</ClaySticker>
-						</ClayList.ItemField>
+			return (
+				<ClayList.Item flex key={entity}>
+					<ClayList.ItemField>
+						<ClaySticker displayType='unstyled'>
+							<ClayIcon
+								className='text-secondary'
+								symbol={icon}
+							/>
+						</ClaySticker>
+					</ClayList.ItemField>
 
-						<ClayList.ItemField expand>
-							<ClayList.ItemTitle>{label}</ClayList.ItemTitle>
+					<ClayList.ItemField expand>
+						<ClayList.ItemTitle>{label}</ClayList.ItemTitle>
 
-							{typeof count === 'number' && count >= 0 && (
-								<ClayList.ItemText>
-									{sub(
-										Liferay.Language.get('x-items-synced'),
-										[count]
-									)}
-								</ClayList.ItemText>
+						{typeof count === 'number' && count >= 0 && (
+							<ClayList.ItemText>
+								{sub(Liferay.Language.get('x-items-synced'), [
+									count
+								])}
+							</ClayList.ItemText>
+						)}
+					</ClayList.ItemField>
+
+					<ClayList.ItemField className='justify-content-center'>
+						<Label
+							displayType={configured ? 'success' : 'secondary'}
+						>
+							{Liferay.Language.get(
+								configured ? 'configured' : 'unconfigured'
 							)}
-						</ClayList.ItemField>
-
-						<ClayList.ItemField className='justify-content-center'>
-							<Label
-								displayType={
-									configured ? 'success' : 'secondary'
-								}
-							>
-								{Liferay.Language.get(
-									configured ? 'configured' : 'unconfigured'
-								)}
-							</Label>
-						</ClayList.ItemField>
-					</ClayList.Item>
-				);
-			})}
-		</ClayList>
-	</div>
+						</Label>
+					</ClayList.ItemField>
+				</ClayList.Item>
+			);
+		})}
+	</ClayList>
 );
 
 export default ConnectorEntities;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
@@ -446,7 +446,10 @@ const ConnectorEntityList: React.FC<IConnectorEntityListProps> = ({
 					title={Liferay.Language.get('connection-status')}
 				/>
 
-				<ClayAlert displayType={connectionStatusAlert.displayType}>
+				<ClayAlert
+					className='mt-3'
+					displayType={connectionStatusAlert.displayType}
+				>
 					{connectionStatusAlert.message}
 				</ClayAlert>
 			</div>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/liferay/__tests__/__snapshots__/LiferayOverview.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/liferay/__tests__/__snapshots__/LiferayOverview.jsx.snap
@@ -371,14 +371,18 @@ exports[`LiferayOverview should render 1`] = `
                 <div
                   class="mb-4"
                 >
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    CONNECTION STATUS
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      CONNECTION STATUS
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <div
                     class="alert alert-success"
                   >
@@ -421,14 +425,18 @@ exports[`LiferayOverview should render 1`] = `
                 <div
                   class="mb-4"
                 >
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    DATA SOURCE DETAILS
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      DATA SOURCE DETAILS
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <div
                     class="input-group d-flex mt-3"
                   >
@@ -702,14 +710,18 @@ exports[`LiferayOverview should render 1`] = `
                   >
                     Properties allow you to aggregate data on your users and DXP sites and channels. The data source data will be available in any property they are assigned to.
                   </p>
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    DATA AVAILABILITY
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      DATA AVAILABILITY
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <p
                     class="text-4 text-secondary"
                   >

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/salesforce/__tests__/__snapshots__/SalesforceOverview.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/salesforce/__tests__/__snapshots__/SalesforceOverview.jsx.snap
@@ -371,14 +371,18 @@ exports[`SalesforceOverview should render 1`] = `
                 <div
                   class="mb-4"
                 >
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    CONNECTION STATUS
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      CONNECTION STATUS
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <div
                     class="alert alert-success"
                   >
@@ -421,14 +425,18 @@ exports[`SalesforceOverview should render 1`] = `
                 <div
                   class="mb-4"
                 >
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    DATA SOURCE DETAILS
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      DATA SOURCE DETAILS
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <div
                     class="input-group d-flex mt-3"
                   >
@@ -718,14 +726,18 @@ exports[`SalesforceOverview should render 1`] = `
                   >
                     Properties allow you to aggregate data on your users and DXP sites and channels. The data source data will be available in any property they are assigned to.
                   </p>
-                  <span
-                    class="text-3 text-secondary font-weight-semi-bold"
+                  <div
+                    class="mb-4"
                   >
-                    DATA AVAILABILITY
-                  </span>
-                  <hr
-                    class="my-2"
-                  />
+                    <span
+                      class="text-3 text-secondary font-weight-semi-bold"
+                    >
+                      DATA AVAILABILITY
+                    </span>
+                    <hr
+                      class="my-2"
+                    />
+                  </div>
                   <p
                     class="text-4 text-secondary"
                   >

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/revamping/Card.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/revamping/Card.tsx
@@ -32,13 +32,13 @@ interface ISubHeaderProps {
 }
 
 export const SubHeader: React.FC<ISubHeaderProps> = ({title}) => (
-	<>
+	<div className='mb-4'>
 		<Text color='secondary' size={3} weight='semi-bold'>
 			{title.toUpperCase()}
 		</Text>
 
 		<hr className='my-2' />
-	</>
+	</div>
 );
 
 Card.SubHeader = SubHeader;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89863

Backport of https://github.com/liferay-ac/liferay-portal/pull/3176 to `faro-v4.15.x`.

## What is being fixed

The SubHeader component on the data source overview did not provide its own bottom margin, so consumers had to pad above and below it on every callsite. The result was inconsistent spacing between the SubHeader and the content beneath it (status alerts, entity lists, properties tables).

## How it is being fixed

`SubHeader` now wraps its content in a `<div className='mb-4'>` instead of a Fragment, so it carries its own bottom margin. The consequential adjustments — removing a redundant `pt-1` wrapper in `ConnectorEntities` and adding `mt-3` to the connection status alert in `ConnectorOverview` — keep the surrounding cards visually aligned. Snapshots for `LiferayOverview` and `SalesforceOverview` are regenerated to reflect the new DOM.