### PR TITLE
LPD-89216 | master Individuals Profile page breaks with invalid currency code

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/AccountMembership.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/AccountMembership.tsx
@@ -95,12 +95,7 @@ const AccountMembership: React.FC<IAccountMembershipProps> = ({
 		}
 
 		if (key === 'annualRevenue') {
-			return accountData?.get(key)
-				? formatCurrency(
-						accountData?.get('currencyCode'),
-						accountData?.get(key)
-				  )
-				: undefined;
+			return formatCurrency(accountData?.get('currencyCode'), data);
 		}
 
 		return data;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/AccountMembership.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/AccountMembership.tsx
@@ -12,7 +12,14 @@ import {formatUTCDate} from 'shared/util/date';
 import {Map} from 'immutable';
 import {SectionHeader} from 'shared/components/SectionHeader';
 
-function formatCurrency(currencyCode: string, value: string): string {
+function formatCurrency(
+	currencyCode: string | null | undefined,
+	value: string
+): string {
+	if (!currencyCode) {
+		return new Intl.NumberFormat().format(parseFloat(value));
+	}
+
 	return new Intl.NumberFormat(undefined, {
 		currency: currencyCode
 	}).format(parseFloat(value));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/__tests__/AccountMembership.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/__tests__/AccountMembership.tsx
@@ -57,4 +57,17 @@ describe('Account Membership', () => {
 		const dashes = getAllByText('-');
 		expect(dashes.length).toBeGreaterThan(0);
 	});
+
+	it('should render annualRevenue without throwing when currencyCode is null', () => {
+		expect(() =>
+			render(
+				<AccountMembership
+					accountData={fromJS({
+						...mockData,
+						currencyCode: null
+					})}
+				/>
+			)
+		).not.toThrow();
+	});
 });


### PR DESCRIPTION
Motivation
----
Fix for Individuals Profile page breaks with invalid currency code

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-89216)

Proposed Solution
----
This PR improves the handling of `currencyCode` values in the affected flow by properly taking into account cases where the value can be `null` or `undefined`.

Additionally, the implementation was slightly simplified by removing a redundant condition where `accountData?.get(key)` was already validated a few lines earlier, helping keep the logic cleaner and easier to follow.

The PR also adds new test coverage to reproduce and validate the reported issue, ensuring the new behavior is properly covered moving forward.