### PR TITLE
LPD-90903 Fix event name bottom clipping and details width in timeline

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_vertical_timeline.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_vertical_timeline.scss
@@ -76,6 +76,7 @@
 					}
 
 					.timeline-panel-body-content-details {
+						max-width: none;
 						width: auto;
 					}
 
@@ -88,6 +89,7 @@
 						line-height: 1;
 
 						.text-truncate {
+							line-height: normal;
 							margin-bottom: 8px;
 						}
 					}
@@ -142,7 +144,7 @@
 				display: flex;
 				justify-content: space-between;
 				margin-left: auto;
-				width: 30%;
+				max-width: 30%;
 
 				.icon-group {
 					display: flex;
@@ -168,7 +170,7 @@
 			}
 
 			.timeline-panel-body-content-text {
-				overflow-x: hidden;
+				overflow-x: clip;
 
 				.event-icon {
 					margin-left: 40px;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_vertical_timeline.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_vertical_timeline.scss
@@ -159,33 +159,16 @@
 				}
 			}
 
+			.attributes-payload {
+				color: $mainLighten28;
+				font-family: monospace;
+				font-size: 12px;
+				white-space: pre-wrap;
+				width: 100%;
+			}
+
 			.timeline-panel-body-content-text {
 				overflow-x: hidden;
-
-				.attributes-title {
-					margin-bottom: 9px;
-				}
-
-				.attributes-item {
-					color: $mainLighten28;
-					font-weight: $fontWeightRegular;
-					margin-bottom: 8px;
-
-					.attribute-key {
-						display: table-cell;
-						min-width: 140px;
-						padding-right: 8px;
-					}
-
-					.attribute-value {
-						display: table-cell;
-						max-width: 550px;
-
-						&.attribute-important {
-							font-weight: $fontWeightSemiBold;
-						}
-					}
-				}
 
 				.event-icon {
 					margin-left: 40px;
@@ -232,7 +215,7 @@
 			background-color: $primaryLighten45;
 
 			.timeline-panel-body-content:not(.selectable) {
-				background-color: $lightBackground;
+				background-color: $white;
 			}
 		}
 
@@ -295,6 +278,18 @@
 			border: 2px solid $white;
 			height: 22px;
 			width: 22px;
+		}
+
+		&.timeline-increment-dxp {
+			> .sticker-point {
+				background-color: $primary;
+			}
+		}
+
+		&.timeline-increment-webhook {
+			> .sticker-point {
+				background-color: $cadmin-teal-l1;
+			}
 		}
 
 		.timeline-time-label {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceController.java
@@ -8,9 +8,6 @@ package com.liferay.osb.faro.web.internal.controller.contacts;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFileVersion;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
-import com.liferay.oauth2.provider.model.OAuth2Application;
-import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
-import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
 import com.liferay.osb.faro.contacts.model.constants.ContactsConstants;
 import com.liferay.osb.faro.engine.client.constants.FieldMappingConstants;
 import com.liferay.osb.faro.engine.client.exception.InvalidFilterException;
@@ -382,19 +379,6 @@ public class DataSourceController extends BaseFaroController {
 				null,
 				_language.get(
 					resourceBundle, "data-source-already-disconnected"));
-		}
-
-		Provider provider = dataSource.getProvider();
-
-		if (StringUtil.equals(provider.getType(), DemandbaseProvider.TYPE)) {
-			OAuth2Application oAuth2Application =
-				_oAuth2ApplicationLocalService.fetchOAuth2Application(
-					getCompanyId(), DemandbaseProvider.TYPE);
-
-			if (oAuth2Application != null) {
-				_oAuth2AuthorizationService.revokeAllOAuth2Authorizations(
-					oAuth2Application.getOAuth2ApplicationId());
-			}
 		}
 
 		contactsEngineClient.disconnectDataSource(faroProject, id);
@@ -1855,12 +1839,6 @@ public class DataSourceController extends BaseFaroController {
 
 	@Reference
 	private Language _language;
-
-	@Reference
-	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
-
-	@Reference
-	private OAuth2AuthorizationService _oAuth2AuthorizationService;
 
 	@Reference
 	private PortletFileRepository _portletFileRepository;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/resolvers/EventsByUserSessionsResolver.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/resolvers/EventsByUserSessionsResolver.js
@@ -1,0 +1,269 @@
+export default () => ({
+	__typename: 'EventsByUserSession',
+	totalEvents: 10,
+	userSessions: [
+		{
+			__typename: 'UserSession',
+			browserName: 'Default Browser',
+			completeDate: 'Fri May 08 18:00:15 GMT 2026',
+			contentLanguageId: null,
+			createDate: 'Fri May 08 17:59:59 GMT 2026',
+			devicePixelRatio: '',
+			deviceType: 'Unknown',
+			events: [
+				{
+					__typename: 'Event',
+					applicationId: 'HubSpot',
+					assetTitle: null,
+					canonicalUrl: 'https://hubspot.com',
+					createDate: 'Fri May 08 18:00:15 GMT 2026',
+					eventDate: '2026-05-08T18:00:15.000Z',
+					eventId: 'emailView',
+					name: 'emailView',
+					pageDescription: null,
+					pageKeywords: null,
+					pageTitle: null,
+					properties: [
+						{name: 'email', value: 'john.doe@example.com'},
+						{name: 'subject', value: 'Welcome Newsletter'}
+					],
+					referrer: 'https://hubspot.com',
+					url: 'https://hubspot.com'
+				},
+				{
+					__typename: 'Event',
+					applicationId: 'HubSpot',
+					assetTitle: null,
+					canonicalUrl: 'https://hubspot.com',
+					createDate: 'Fri May 08 17:59:59 GMT 2026',
+					eventDate: '2026-05-08T17:59:59.000Z',
+					eventId: 'formSubmit',
+					name: 'formSubmit',
+					pageDescription: null,
+					pageKeywords: null,
+					pageTitle: null,
+					properties: [
+						{name: 'formId', value: 'abc123'},
+						{
+							name: 'pageUrl',
+							value: 'https://hubspot.com/landing-page'
+						}
+					],
+					referrer: 'https://hubspot.com',
+					url: 'https://hubspot.com'
+				}
+			],
+			languageId: null,
+			screenHeight: '',
+			screenWidth: '',
+			timezoneOffset: null,
+			userAgent: 'HubSpot Webhook'
+		},
+		{
+			__typename: 'UserSession',
+			browserName: 'Chrome',
+			completeDate: 'Thu May 07 19:57:32 GMT 2026',
+			contentLanguageId: 'en-US',
+			createDate: 'Thu May 07 19:37:32 GMT 2026',
+			devicePixelRatio: '1.5',
+			deviceType: 'Desktop',
+			events: [
+				{
+					__typename: 'Event',
+					applicationId: 'Page',
+					assetTitle:
+						'Content Management System - learn-dev.lxc.liferay.com',
+					canonicalUrl:
+						'https://learn-dev.liferay.com/capabilities/content-management-system',
+					createDate: 'Thu May 07 19:57:21 GMT 2026',
+					eventDate: '2026-05-07T19:57:21.000Z',
+					eventId: 'pageViewed',
+					name: 'pageViewed',
+					pageDescription: '',
+					pageKeywords: '',
+					pageTitle:
+						'Content Management System - learn-dev.lxc.liferay.com',
+					properties: [
+						{
+							name: 'externalReferenceCode',
+							value: '2d420977-ed76-97d2-4478-379f03130595'
+						}
+					],
+					referrer: 'https://learn-dev.liferay.com/home',
+					url: 'https://learn-dev.liferay.com/capabilities/content-management-system'
+				},
+				{
+					__typename: 'Event',
+					applicationId: 'Page',
+					assetTitle: 'Home - learn-dev.lxc.liferay.com',
+					canonicalUrl: 'https://learn-dev.liferay.com/home',
+					createDate: 'Thu May 07 19:56:55 GMT 2026',
+					eventDate: '2026-05-07T19:56:55.000Z',
+					eventId: 'pageViewed',
+					name: 'pageViewed',
+					pageDescription: '',
+					pageKeywords: '',
+					pageTitle: 'Home - learn-dev.lxc.liferay.com',
+					properties: [
+						{
+							name: 'externalReferenceCode',
+							value: '2d420977-ed76-97d2-4478-379f03130595'
+						}
+					],
+					referrer: 'https://learn-dev.liferay.com/c/portal/logout',
+					url: 'https://learn-dev.liferay.com/home'
+				},
+				{
+					__typename: 'Event',
+					applicationId: 'Page',
+					assetTitle: 'Home - learn-dev.lxc.liferay.com',
+					canonicalUrl: 'https://learn-dev.liferay.com',
+					createDate: 'Thu May 07 19:56:21 GMT 2026',
+					eventDate: '2026-05-07T19:56:21.000Z',
+					eventId: 'pageViewed',
+					name: 'pageViewed',
+					pageDescription: '',
+					pageKeywords: '',
+					pageTitle: 'Home - learn-dev.lxc.liferay.com',
+					properties: [
+						{
+							name: 'externalReferenceCode',
+							value: '2d420977-ed76-97d2-4478-379f03130595'
+						}
+					],
+					referrer: '',
+					url: 'https://learn-dev.liferay.com/'
+				},
+				{
+					__typename: 'Event',
+					applicationId: 'Page',
+					assetTitle: 'Home - learn-dev.lxc.liferay.com',
+					canonicalUrl: 'https://learn-dev.liferay.com',
+					createDate: 'Thu May 07 19:38:43 GMT 2026',
+					eventDate: '2026-05-07T19:38:43.000Z',
+					eventId: 'pageViewed',
+					name: 'pageViewed',
+					pageDescription: '',
+					pageKeywords: '',
+					pageTitle: 'Home - learn-dev.lxc.liferay.com',
+					properties: [
+						{
+							name: 'externalReferenceCode',
+							value: '2d420977-ed76-97d2-4478-379f03130595'
+						}
+					],
+					referrer:
+						'https://learn-dev.liferay.com/capabilities/security',
+					url: 'https://learn-dev.liferay.com/'
+				},
+				{
+					__typename: 'Event',
+					applicationId: 'Page',
+					assetTitle: 'Security - learn-dev.lxc.liferay.com',
+					canonicalUrl:
+						'https://learn-dev.liferay.com/capabilities/security',
+					createDate: 'Thu May 07 19:38:36 GMT 2026',
+					eventDate: '2026-05-07T19:38:36.000Z',
+					eventId: 'pageViewed',
+					name: 'pageViewed',
+					pageDescription: '',
+					pageKeywords: '',
+					pageTitle: 'Security - learn-dev.lxc.liferay.com',
+					properties: [
+						{
+							name: 'externalReferenceCode',
+							value: '2d420977-ed76-97d2-4478-379f03130595'
+						}
+					],
+					referrer: 'https://learn-dev.liferay.com/',
+					url: 'https://learn-dev.liferay.com/capabilities/security'
+				},
+				{
+					__typename: 'Event',
+					applicationId: 'Page',
+					assetTitle: 'Home - learn-dev.lxc.liferay.com',
+					canonicalUrl: 'https://learn-dev.liferay.com',
+					createDate: 'Thu May 07 19:37:43 GMT 2026',
+					eventDate: '2026-05-07T19:37:43.000Z',
+					eventId: 'pageViewed',
+					name: 'pageViewed',
+					pageDescription: '',
+					pageKeywords: '',
+					pageTitle: 'Home - learn-dev.lxc.liferay.com',
+					properties: [
+						{
+							name: 'externalReferenceCode',
+							value: '2d420977-ed76-97d2-4478-379f03130595'
+						}
+					],
+					referrer:
+						'https://learn-dev.liferay.com/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fview_configuration_screen&_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_configurationScreenKey=analytics-cloud-connection',
+					url: 'https://learn-dev.liferay.com/'
+				}
+			],
+			languageId: 'en-US',
+			screenHeight: '1321',
+			screenWidth: '2560',
+			timezoneOffset: '-03:00',
+			userAgent:
+				'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36'
+		},
+		{
+			__typename: 'UserSession',
+			browserName: 'Default Browser',
+			completeDate: 'Thu May 07 21:15:44 GMT 2026',
+			contentLanguageId: null,
+			createDate: 'Thu May 07 21:15:44 GMT 2026',
+			devicePixelRatio: '',
+			deviceType: 'Unknown',
+			events: [
+				{
+					__typename: 'Event',
+					applicationId: 'HubSpot',
+					assetTitle: null,
+					canonicalUrl: 'https://hubspot.com',
+					createDate: 'Thu May 07 21:15:44 GMT 2026',
+					eventDate: '2026-05-07T21:15:44.000Z',
+					eventId: 'emailOpen',
+					name: 'emailOpen',
+					pageDescription: null,
+					pageKeywords: null,
+					pageTitle: null,
+					properties: [
+						{name: 'email', value: 'john.doe@example.com'},
+						{name: 'subject', value: 'May Product Updates'}
+					],
+					referrer: 'https://hubspot.com',
+					url: 'https://hubspot.com'
+				},
+				{
+					__typename: 'Event',
+					applicationId: 'HubSpot',
+					assetTitle: null,
+					canonicalUrl: 'https://hubspot.com',
+					createDate: 'Thu May 07 21:15:44 GMT 2026',
+					eventDate: '2026-05-07T21:15:44.000Z',
+					eventId: 'linkClick',
+					name: 'linkClick',
+					pageDescription: null,
+					pageKeywords: null,
+					pageTitle: null,
+					properties: [
+						{
+							name: 'linkUrl',
+							value: 'https://liferay.com/products'
+						},
+						{name: 'email', value: 'john.doe@example.com'}
+					],
+					referrer: 'https://hubspot.com',
+					url: 'https://hubspot.com'
+				}
+			],
+			languageId: null,
+			screenHeight: '',
+			screenWidth: '',
+			timezoneOffset: null,
+			userAgent: 'HubSpot Webhook'
+		}
+	]
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/resolvers/resolvers.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/apollo/resolvers/resolvers.ts
@@ -7,6 +7,7 @@ import CustomAssetsListResolver from './CustomAssetsListResolver';
 import DocumentsAndMediaListResolver from './DocumentsAndMediaListResolver';
 import DocumentsAndMediaMetricsResolver from './DocumentsAndMediaMetricsResolver';
 import EventAnalysisListResolver from './EventAnalysisListResolver';
+import EventsByUserSessionsResolver from './EventsByUserSessionsResolver';
 import ExperimentResolver from './ExperimentResolver';
 import IndividualSiteMetricsResolver from './individualSiteMetricsResolver';
 import InterestsResolver from './InterestsResolver';
@@ -31,6 +32,7 @@ export const resolvers = {
 	document: DocumentsAndMediaMetricsResolver,
 	documents: DocumentsAndMediaListResolver,
 	eventAnalysisList: EventAnalysisListResolver,
+	eventsByUserSessions: EventsByUserSessionsResolver,
 	experiment: ExperimentResolver,
 	individualInterests: InterestsResolver,
 	orderAccountAverageCurrencyValues: CommerceAverageRevenuePerAccountResolver,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
@@ -241,7 +241,7 @@ const TimelinePanelBodyContentDetails: FC<{
 				<span className='item-count'>{itemCount}</span>
 
 				<span
-					className='device-icon'
+					className='device-icon mr-2'
 					data-tooltip
 					data-tooltip-align='bottom'
 					title={`${deviceIconTitle}\n${browserName}`}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
@@ -1,4 +1,6 @@
 import ClayIcon from '@clayui/icon';
+import ClayLabel from '@clayui/label';
+import ClayLink from '@clayui/link';
 import getCN from 'classnames';
 import Loading from 'shared/components/Loading';
 import React, {FC, useState} from 'react';
@@ -7,7 +9,6 @@ import TextTruncate from './TextTruncate';
 import {Colors} from 'shared/util/colors-size';
 import {formatDateToTimeZone} from 'shared/util/date';
 import {Link} from 'react-router-dom';
-import {UserSessionAttributes} from 'shared/util/activities';
 
 const DEVICE_ICONS_MAP = {
 	any: {
@@ -28,12 +29,25 @@ const DEVICE_ICONS_MAP = {
 	}
 };
 
-const ATTRIBUTE_CLASSES_MAP = {
-	title: 'attribute-important'
-};
+const LIFERAY_DXP_APPLICATION_IDS = new Set([
+	'Blog',
+	'Comment',
+	'Custom',
+	'Document',
+	'Form',
+	'Layout',
+	'ObjectEntry',
+	'Page',
+	'Ratings',
+	'WebContent'
+]);
+
+const normalizeApplicationId = (applicationId: string): string =>
+	LIFERAY_DXP_APPLICATION_IDS.has(applicationId) ? 'DXP' : applicationId;
 
 type ITEM_SHAPE = {
-	attributes: UserSessionAttributes;
+	applicationId: string;
+	attributes: Record<string, unknown>;
 	browserName: string;
 	description: string;
 	device: string;
@@ -45,6 +59,7 @@ type ITEM_SHAPE = {
 	title: string;
 	totalEvents: number;
 	url: string;
+	userAgent: string;
 };
 
 type ITimelineItemProps = {
@@ -60,6 +75,7 @@ const TimelineItem: FC<ITimelineItemProps> = ({
 	className,
 	initialExpanded = false,
 	item: {
+		applicationId,
 		attributes,
 		browserName,
 		description,
@@ -71,7 +87,8 @@ const TimelineItem: FC<ITimelineItemProps> = ({
 		time,
 		title,
 		totalEvents,
-		url
+		url,
+		userAgent
 	},
 	timeZoneId
 }) => {
@@ -93,6 +110,7 @@ const TimelineItem: FC<ITimelineItemProps> = ({
 							nestedItems={nestedItems}
 							time={time}
 							timeZoneId={timeZoneId}
+							userAgent={userAgent}
 						/>
 					)}
 
@@ -118,9 +136,11 @@ const TimelineItem: FC<ITimelineItemProps> = ({
 
 						{expandable && !!nestedItems && (
 							<TimelinePanelBodyContentDetails
+								applicationId={applicationId}
 								browserName={browserName}
 								device={device}
 								itemCount={nestedItems.length}
+								userAgent={userAgent}
 							/>
 						)}
 
@@ -132,8 +152,8 @@ const TimelineItem: FC<ITimelineItemProps> = ({
 						)}
 					</TimelinePanelBody>
 
-					{expanded && (
-						<TimelineItemAttributes attributes={attributes} />
+					{expanded && !!attributes && (
+						<TimelineItemAttributes payload={attributes} />
 					)}
 				</div>
 
@@ -182,20 +202,41 @@ const TimelinePanelBody: FC<{
 };
 
 const TimelinePanelBodyContentDetails: FC<{
+	applicationId: string;
 	browserName: string;
 	device: string;
 	itemCount: number;
-}> = ({browserName, device, itemCount}) => {
+	userAgent: string;
+}> = ({applicationId, browserName, device, itemCount, userAgent}) => {
 	const {title: deviceIconTitle, ...otherIconAttributes} =
 		(DEVICE_ICONS_MAP as any)[device.toLowerCase()] || DEVICE_ICONS_MAP.any;
 
 	return (
 		<div className='timeline-panel-body-content-details'>
 			<div className='icon-group'>
-				<ClayIcon
-					className='event-icon icon-root'
-					symbol='ac_event_icon'
-				/>
+				{applicationId && (
+					<div className='align-items-center d-flex'>
+						<ClayLabel
+							className='label-lg mr-3'
+							displayType={
+								userAgent?.toLowerCase().includes('webhook')
+									? 'success'
+									: 'info'
+							}
+						>
+							<strong>
+								{normalizeApplicationId(
+									applicationId
+								).toUpperCase()}
+							</strong>
+						</ClayLabel>
+
+						<ClayIcon
+							className='event-icon icon-root'
+							symbol='ac_event_icon'
+						/>
+					</div>
+				)}
 
 				<span className='item-count'>{itemCount}</span>
 
@@ -223,7 +264,7 @@ const TimelinePanelBodyContentText: FC<{
 	title: string;
 	totalEvents: number;
 	url: string;
-}> = ({className, description, header, subtitle, title, totalEvents, url}) => {
+}> = ({className, header, subtitle, title, totalEvents, url}) => {
 	const eventTitle =
 		title && !header ? <TextTruncate title={`${title}`} /> : title;
 
@@ -250,9 +291,16 @@ const TimelinePanelBodyContentText: FC<{
 				</>
 			)}
 
-			{description && <span className='description'>{description}</span>}
-
-			{subtitle && <TextTruncate className='subtitle' title={subtitle} />}
+			{subtitle && (
+				<ClayLink
+					className='d-inline-block subtitle'
+					href={subtitle}
+					rel='noopener noreferrer'
+					target='_blank'
+				>
+					<TextTruncate title={subtitle} />
+				</ClayLink>
+			)}
 		</div>
 	);
 };
@@ -262,7 +310,10 @@ const TimelineElement: FC<{
 	nestedItems: ITEM_SHAPE[];
 	time: string;
 	timeZoneId: string;
-}> = ({endTime, nestedItems, time, timeZoneId}) => {
+	userAgent: string;
+}> = ({endTime, nestedItems, time, timeZoneId, userAgent}) => {
+	const isSession = !!nestedItems;
+
 	const timeRange = !nestedItems ? (
 		formatDateToTimeZone(time, 'h:mma', timeZoneId)
 	) : (
@@ -281,7 +332,16 @@ const TimelineElement: FC<{
 		<>
 			<div className='timeline-line' />
 
-			<div className='timeline-increment'>
+			<div
+				className={getCN('timeline-increment', {
+					'timeline-increment-dxp':
+						isSession &&
+						!userAgent?.toLowerCase().includes('webhook'),
+					'timeline-increment-webhook':
+						isSession &&
+						userAgent?.toLowerCase().includes('webhook')
+				})}
+			>
 				<Sticker circle display='point' size='lg' />
 
 				{time && (
@@ -294,29 +354,13 @@ const TimelineElement: FC<{
 	);
 };
 
-const TimelineItemAttributes: FC<{attributes: UserSessionAttributes}> = ({
-	attributes: {header: attributesTitle, ...otherValues} = {}
+const TimelineItemAttributes: FC<{payload: Record<string, unknown>}> = ({
+	payload
 }) => (
 	<div className='timeline-panel-body-content'>
-		<div className='timeline-panel-body-content-text'>
-			<div className='attributes-title'>
-				<span className='label-root'>{attributesTitle}</span>
-			</div>
-
-			{Object.entries(otherValues).map(([key, value]) => (
-				<div className='attributes-item' key={key}>
-					<span className='attribute-key'>{`${key}`}</span>
-
-					<TextTruncate
-						className={getCN(
-							'attribute-value',
-							(ATTRIBUTE_CLASSES_MAP as any)[key]
-						)}
-						title={value || '""'}
-					/>
-				</div>
-			))}
-		</div>
+		<code className='attributes-payload'>
+			{JSON.stringify(payload, null, 2)}
+		</code>
 	</div>
 );
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
@@ -200,7 +200,7 @@ describe('VerticalTimeline', () => {
 		);
 
 		const sessionAttributes = await waitFor(
-			() => getAllByText('Session Attributes')[0]
+			() => getAllByText(/Session Attributes/)[0]
 		);
 
 		expect(sessionAttributes).toHaveTextContent(SESSION_ATTRIBUTES_TITLE);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/VerticalTimeline.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/VerticalTimeline.jsx.snap
@@ -125,7 +125,7 @@ exports[`VerticalTimeline should render with a header and initialExpanded 1`] = 
                     2
                   </span>
                   <span
-                    class="device-icon"
+                    class="device-icon mr-2"
                     data-tooltip="true"
                     data-tooltip-align="bottom"
                     title="Unknown Device
@@ -444,7 +444,7 @@ Firefox"
                     2
                   </span>
                   <span
-                    class="device-icon"
+                    class="device-icon mr-2"
                     data-tooltip="true"
                     data-tooltip-align="bottom"
                     title="Mobile
@@ -730,7 +730,7 @@ Firefox"
                     2
                   </span>
                   <span
-                    class="device-icon"
+                    class="device-icon mr-2"
                     data-tooltip="true"
                     data-tooltip-align="bottom"
                     title="Desktop

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/VerticalTimeline.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/VerticalTimeline.jsx.snap
@@ -41,21 +41,6 @@ exports[`VerticalTimeline should render with a header and initialExpanded 1`] = 
                 />
               </div>
             </div>
-            <div
-              class="timeline-panel-body-content"
-            >
-              <div
-                class="timeline-panel-body-content-text"
-              >
-                <div
-                  class="attributes-title"
-                >
-                  <span
-                    class="label-root"
-                  />
-                </div>
-              </div>
-            </div>
           </div>
         </div>
       </li>
@@ -72,7 +57,7 @@ exports[`VerticalTimeline should render with a header and initialExpanded 1`] = 
               class="timeline-line"
             />
             <div
-              class="timeline-increment"
+              class="timeline-increment timeline-increment-dxp"
             >
               <div
                 class="sticker sticker-root sticker-static sticker-circle sticker-point sticker-lg"
@@ -108,13 +93,25 @@ exports[`VerticalTimeline should render with a header and initialExpanded 1`] = 
                     Opened Email
                   </span>
                 </span>
-                <span
-                  class="text-truncate subtitle"
-                  data-tooltip="false"
-                  title=""
+                <a
+                  class="d-inline-block subtitle"
+                  href="3 Document Downloads, 2 Form Submissions, 24 Page Visits"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
-                  3 Document Downloads, 2 Form Submissions, 24 Page Visits
-                </span>
+                  <span
+                    class="text-truncate"
+                    data-tooltip="false"
+                    title=""
+                  >
+                    3 Document Downloads, 2 Form Submissions, 24 Page Visits
+                  </span>
+                  <span
+                    class="sr-only"
+                  >
+                    (Opens a new window)
+                  </span>
+                </a>
               </div>
               <div
                 class="timeline-panel-body-content-details"
@@ -122,14 +119,6 @@ exports[`VerticalTimeline should render with a header and initialExpanded 1`] = 
                 <div
                   class="icon-group"
                 >
-                  <svg
-                    class="lexicon-icon lexicon-icon-ac_event_icon event-icon icon-root"
-                    role="presentation"
-                  >
-                    <use
-                      href="#ac_event_icon"
-                    />
-                  </svg>
                   <span
                     class="item-count"
                   >
@@ -167,99 +156,17 @@ Firefox"
             <div
               class="timeline-panel-body-content"
             >
-              <div
-                class="timeline-panel-body-content-text"
+              <code
+                class="attributes-payload"
               >
-                <div
-                  class="attributes-title"
-                >
-                  <span
-                    class="label-root"
-                  >
-                    Session Attributes
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    contentLanguageID
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    ""
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    screenHeight
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    1229
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    screenWidth
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    1541
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    timezoneOffset
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    -07:00
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    userAgent
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36
-                  </span>
-                </div>
-              </div>
+                {
+  "header": "Session Attributes",
+  "screenHeight": "1229",
+  "screenWidth": "1541",
+  "timezoneOffset": "-07:00",
+  "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36"
+}
+              </code>
             </div>
           </div>
           <div
@@ -311,13 +218,25 @@ Firefox"
                             Visited Liferay: Testing
                           </span>
                         </span>
-                        <span
-                          class="text-truncate subtitle"
-                          data-tooltip="false"
-                          title=""
+                        <a
+                          class="d-inline-block subtitle"
+                          href="www.liferay.com/testing"
+                          rel="noopener noreferrer"
+                          target="_blank"
                         >
-                          www.liferay.com/testing
-                        </span>
+                          <span
+                            class="text-truncate"
+                            data-tooltip="false"
+                            title=""
+                          >
+                            www.liferay.com/testing
+                          </span>
+                          <span
+                            class="sr-only"
+                          >
+                            (Opens a new window)
+                          </span>
+                        </a>
                       </div>
                       <svg
                         class="lexicon-icon lexicon-icon-caret-bottom icon-root"
@@ -372,13 +291,25 @@ Firefox"
                             Visited Liferay: Testing 2
                           </span>
                         </span>
-                        <span
-                          class="text-truncate subtitle"
-                          data-tooltip="false"
-                          title=""
+                        <a
+                          class="d-inline-block subtitle"
+                          href="www.liferay.com/testing 2"
+                          rel="noopener noreferrer"
+                          target="_blank"
                         >
-                          www.liferay.com/testing 2
-                        </span>
+                          <span
+                            class="text-truncate"
+                            data-tooltip="false"
+                            title=""
+                          >
+                            www.liferay.com/testing 2
+                          </span>
+                          <span
+                            class="sr-only"
+                          >
+                            (Opens a new window)
+                          </span>
+                        </a>
                       </div>
                       <svg
                         class="lexicon-icon lexicon-icon-caret-bottom icon-root"
@@ -429,21 +360,6 @@ Firefox"
                 />
               </div>
             </div>
-            <div
-              class="timeline-panel-body-content"
-            >
-              <div
-                class="timeline-panel-body-content-text"
-              >
-                <div
-                  class="attributes-title"
-                >
-                  <span
-                    class="label-root"
-                  />
-                </div>
-              </div>
-            </div>
           </div>
         </div>
       </li>
@@ -460,7 +376,7 @@ Firefox"
               class="timeline-line"
             />
             <div
-              class="timeline-increment"
+              class="timeline-increment timeline-increment-dxp"
             >
               <div
                 class="sticker sticker-root sticker-static sticker-circle sticker-point sticker-lg"
@@ -496,13 +412,25 @@ Firefox"
                     Opened Email
                   </span>
                 </span>
-                <span
-                  class="text-truncate subtitle"
-                  data-tooltip="false"
-                  title=""
+                <a
+                  class="d-inline-block subtitle"
+                  href="3 Document Downloads, 2 Form Submissions, 24 Page Visits"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
-                  3 Document Downloads, 2 Form Submissions, 24 Page Visits
-                </span>
+                  <span
+                    class="text-truncate"
+                    data-tooltip="false"
+                    title=""
+                  >
+                    3 Document Downloads, 2 Form Submissions, 24 Page Visits
+                  </span>
+                  <span
+                    class="sr-only"
+                  >
+                    (Opens a new window)
+                  </span>
+                </a>
               </div>
               <div
                 class="timeline-panel-body-content-details"
@@ -510,14 +438,6 @@ Firefox"
                 <div
                   class="icon-group"
                 >
-                  <svg
-                    class="lexicon-icon lexicon-icon-ac_event_icon event-icon icon-root"
-                    role="presentation"
-                  >
-                    <use
-                      href="#ac_event_icon"
-                    />
-                  </svg>
                   <span
                     class="item-count"
                   >
@@ -553,83 +473,17 @@ Firefox"
             <div
               class="timeline-panel-body-content"
             >
-              <div
-                class="timeline-panel-body-content-text"
+              <code
+                class="attributes-payload"
               >
-                <div
-                  class="attributes-title"
-                >
-                  <span
-                    class="label-root"
-                  >
-                    Session Attributes
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    screenHeight
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    1229
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    screenWidth
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    1541
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    timezoneOffset
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    -07:00
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    userAgent
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36
-                  </span>
-                </div>
-              </div>
+                {
+  "header": "Session Attributes",
+  "screenHeight": "1229",
+  "screenWidth": "1541",
+  "timezoneOffset": "-07:00",
+  "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36"
+}
+              </code>
             </div>
           </div>
           <div
@@ -681,13 +535,25 @@ Firefox"
                             Visited Liferay: Testing
                           </span>
                         </span>
-                        <span
-                          class="text-truncate subtitle"
-                          data-tooltip="false"
-                          title=""
+                        <a
+                          class="d-inline-block subtitle"
+                          href="www.liferay.com/testing"
+                          rel="noopener noreferrer"
+                          target="_blank"
                         >
-                          www.liferay.com/testing
-                        </span>
+                          <span
+                            class="text-truncate"
+                            data-tooltip="false"
+                            title=""
+                          >
+                            www.liferay.com/testing
+                          </span>
+                          <span
+                            class="sr-only"
+                          >
+                            (Opens a new window)
+                          </span>
+                        </a>
                       </div>
                       <svg
                         class="lexicon-icon lexicon-icon-caret-bottom icon-root"
@@ -742,13 +608,25 @@ Firefox"
                             Visited Liferay: Testing 2
                           </span>
                         </span>
-                        <span
-                          class="text-truncate subtitle"
-                          data-tooltip="false"
-                          title=""
+                        <a
+                          class="d-inline-block subtitle"
+                          href="www.liferay.com/testing 2"
+                          rel="noopener noreferrer"
+                          target="_blank"
                         >
-                          www.liferay.com/testing 2
-                        </span>
+                          <span
+                            class="text-truncate"
+                            data-tooltip="false"
+                            title=""
+                          >
+                            www.liferay.com/testing 2
+                          </span>
+                          <span
+                            class="sr-only"
+                          >
+                            (Opens a new window)
+                          </span>
+                        </a>
                       </div>
                       <svg
                         class="lexicon-icon lexicon-icon-caret-bottom icon-root"
@@ -779,7 +657,7 @@ Firefox"
               class="timeline-line"
             />
             <div
-              class="timeline-increment"
+              class="timeline-increment timeline-increment-dxp"
             >
               <div
                 class="sticker sticker-root sticker-static sticker-circle sticker-point sticker-lg"
@@ -820,13 +698,25 @@ Firefox"
                     </span>
                   </a>
                 </span>
-                <span
-                  class="text-truncate subtitle"
-                  data-tooltip="false"
-                  title=""
+                <a
+                  class="d-inline-block subtitle"
+                  href="3 Document Downloads, 2 Form Submissions, 24 Page Visits"
+                  rel="noopener noreferrer"
+                  target="_blank"
                 >
-                  3 Document Downloads, 2 Form Submissions, 24 Page Visits
-                </span>
+                  <span
+                    class="text-truncate"
+                    data-tooltip="false"
+                    title=""
+                  >
+                    3 Document Downloads, 2 Form Submissions, 24 Page Visits
+                  </span>
+                  <span
+                    class="sr-only"
+                  >
+                    (Opens a new window)
+                  </span>
+                </a>
               </div>
               <div
                 class="timeline-panel-body-content-details"
@@ -834,14 +724,6 @@ Firefox"
                 <div
                   class="icon-group"
                 >
-                  <svg
-                    class="lexicon-icon lexicon-icon-ac_event_icon event-icon icon-root"
-                    role="presentation"
-                  >
-                    <use
-                      href="#ac_event_icon"
-                    />
-                  </svg>
                   <span
                     class="item-count"
                   >
@@ -877,83 +759,17 @@ Firefox"
             <div
               class="timeline-panel-body-content"
             >
-              <div
-                class="timeline-panel-body-content-text"
+              <code
+                class="attributes-payload"
               >
-                <div
-                  class="attributes-title"
-                >
-                  <span
-                    class="label-root"
-                  >
-                    Session Attributes
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    screenHeight
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    1229
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    screenWidth
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    1541
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    timezoneOffset
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    -07:00
-                  </span>
-                </div>
-                <div
-                  class="attributes-item"
-                >
-                  <span
-                    class="attribute-key"
-                  >
-                    userAgent
-                  </span>
-                  <span
-                    class="text-truncate attribute-value"
-                    data-tooltip="false"
-                    title=""
-                  >
-                    Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36
-                  </span>
-                </div>
-              </div>
+                {
+  "header": "Session Attributes",
+  "screenHeight": "1229",
+  "screenWidth": "1541",
+  "timezoneOffset": "-07:00",
+  "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36"
+}
+              </code>
             </div>
           </div>
           <div
@@ -1005,18 +821,25 @@ Firefox"
                             Visited Liferay: Testing
                           </span>
                         </span>
-                        <span
-                          class="description"
+                        <a
+                          class="d-inline-block subtitle"
+                          href="www.liferay.com/testing"
+                          rel="noopener noreferrer"
+                          target="_blank"
                         >
-                          Liferay: Digital experience software tailored to your needs
-                        </span>
-                        <span
-                          class="text-truncate subtitle"
-                          data-tooltip="false"
-                          title=""
-                        >
-                          www.liferay.com/testing
-                        </span>
+                          <span
+                            class="text-truncate"
+                            data-tooltip="false"
+                            title=""
+                          >
+                            www.liferay.com/testing
+                          </span>
+                          <span
+                            class="sr-only"
+                          >
+                            (Opens a new window)
+                          </span>
+                        </a>
                       </div>
                       <svg
                         class="lexicon-icon lexicon-icon-caret-bottom icon-root"
@@ -1073,13 +896,25 @@ Firefox"
                             Visited Liferay: Testing 2
                           </span>
                         </span>
-                        <span
-                          class="text-truncate subtitle"
-                          data-tooltip="false"
-                          title=""
+                        <a
+                          class="d-inline-block subtitle"
+                          href="www.liferay.com/testing 2"
+                          rel="noopener noreferrer"
+                          target="_blank"
                         >
-                          www.liferay.com/testing 2
-                        </span>
+                          <span
+                            class="text-truncate"
+                            data-tooltip="false"
+                            title=""
+                          >
+                            www.liferay.com/testing 2
+                          </span>
+                          <span
+                            class="sr-only"
+                          >
+                            (Opens a new window)
+                          </span>
+                        </a>
                       </div>
                       <svg
                         class="lexicon-icon lexicon-icon-caret-bottom icon-root"

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/UserSessionQuery.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/UserSessionQuery.ts
@@ -68,6 +68,7 @@ export default gql`
 			channelId: $channelId
 			entityId: $entityId
 			entityType: $entityType
+			includeWebhookEvents: true
 			keywords: $keywords
 			page: $page
 			rangeEnd: $rangeEnd

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/UserSessionQuery.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/UserSessionQuery.ts
@@ -6,9 +6,12 @@ export interface UserSessionEvent {
 	assetTitle: string;
 	canonicalUrl: string;
 	createDate: string;
+	eventDate: string;
+	eventId: string;
 	name: string;
 	pageDescription: string;
 	pageTitle: string;
+	properties: Array<{name: string; value: string}>;
 	referrer: string;
 	url: string;
 }
@@ -17,6 +20,7 @@ export interface UserSession {
 	browserName: string;
 	completeDate: Date;
 	contentLanguageID: string;
+	createDate: string;
 	description: string;
 	devicePixelRatioz: number;
 	deviceType: string;
@@ -84,10 +88,16 @@ export default gql`
 						assetTitle
 						canonicalUrl
 						createDate
+						eventDate
+						eventId
 						name
 						pageDescription
 						pageKeywords
 						pageTitle
+						properties {
+							name
+							value
+						}
 						referrer
 						url
 					}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/activities.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/activities.jsx
@@ -37,13 +37,14 @@ describe('activities', () => {
 	});
 
 	describe('formatEvents', () => {
-		it('should decode canonicalUrl, referrer and url params', () => {
+		it('should decode canonicalUrl into subtitle for DXP events', () => {
 			const result = formatEvents([
 				{
 					applicationId: 'Page',
 					assetTitle: 'this is a page title',
 					canonicalUrl:
 						'http://localhost:7400/%e6%96%b0%e3%81%97%e3%81%84%e3%82%b5%e3%82%a4%e3%83%88',
+					eventId: 'pageViewed',
 					name: 'eventName',
 					pageDescription: 'this is a page description',
 					pageTitle: 'this is a page title',
@@ -56,17 +57,71 @@ describe('activities', () => {
 			expect(result).toMatchObject([
 				{
 					attributes: {
-						canonicalUrl: 'http://localhost:7400/新しいサイト',
-						header: 'Event Attributes',
-						pageTitle: 'this is a page title',
-						referrer: 'http://localhost:7400/新しいサイト',
-						url: 'http://localhost:7400/新しいサイト'
+						applicationId: 'Page',
+						eventId: 'pageViewed'
 					},
 					description: 'this is a page title',
 					subtitle: 'http://localhost:7400/新しいサイト',
 					title: 'eventName'
 				}
 			]);
+		});
+
+		it('should not set subtitle for HubSpot events', () => {
+			const result = formatEvents([
+				{
+					applicationId: 'HubSpot',
+					assetTitle: null,
+					canonicalUrl: 'https://hubspot.com',
+					eventId: 'emailView',
+					name: 'emailView'
+				}
+			]);
+
+			expect(result[0].subtitle).toBeUndefined();
+		});
+
+		it('should transform properties array into an object in attributes', () => {
+			const result = formatEvents([
+				{
+					applicationId: 'HubSpot',
+					eventId: 'formSubmit',
+					name: 'formSubmit',
+					properties: [
+						{name: 'formId', value: 'abc123'},
+						{name: 'pageUrl', value: 'https://hubspot.com/landing'}
+					]
+				}
+			]);
+
+			expect(result[0].attributes.properties).toEqual({
+				formId: 'abc123',
+				pageUrl: 'https://hubspot.com/landing'
+			});
+		});
+
+		it('should include eventDate in attributes only when present', () => {
+			const withDate = formatEvents([
+				{
+					applicationId: 'Page',
+					eventDate: '2026-05-07T19:57:21.000Z',
+					eventId: 'pageViewed',
+					name: 'pageViewed'
+				}
+			]);
+
+			const withoutDate = formatEvents([
+				{
+					applicationId: 'Page',
+					eventId: 'pageViewed',
+					name: 'pageViewed'
+				}
+			]);
+
+			expect(withDate[0].attributes.eventDate).toBe(
+				'2026-05-07T19:57:21.000Z'
+			);
+			expect(withoutDate[0].attributes).not.toHaveProperty('eventDate');
 		});
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/activities.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/activities.tsx
@@ -26,20 +26,11 @@ export const INTERVAL_MAP = {
 };
 
 type SessionEvent = {
-	attributes: SessionEventAttribute;
+	attributes: Record<string, unknown>;
 	description: string;
-	subtitle: string;
+	subtitle: string | undefined;
 	time: moment.Moment;
 	title: string;
-};
-
-type SessionEventAttribute = {
-	assetTitle?: string;
-	canonicalUrl: string;
-	header: string;
-	referrer: string;
-	pageTitle: string;
-	url: string;
 };
 
 export type UserSessionAttributes = {
@@ -62,11 +53,13 @@ export type VerticalTimelineHeader = {
 };
 
 export type VerticalTimelineSession = {
+	applicationId: string;
 	attributes: UserSessionAttributes;
 	device: string;
 	endTime: Date;
 	nestedItems: SessionEvent[];
 	time: moment.Moment;
+	userAgent: string;
 };
 
 /**
@@ -108,30 +101,32 @@ export const formatEvents = (events: UserSessionEvent[]): Array<SessionEvent> =>
 			assetTitle,
 			canonicalUrl,
 			createDate,
+			eventDate,
+			eventId,
 			name,
-			pageTitle,
-			referrer,
-			url
-		}) => {
-			const isAsset = ['Blog', 'Document', 'Form', 'WebContent'].includes(
-				applicationId
-			);
-
-			return {
-				attributes: {
-					...(isAsset && {assetTitle}),
-					canonicalUrl: getSafeDecodedURIComponent(canonicalUrl),
-					header: Liferay.Language.get('event-attributes'),
-					pageTitle,
-					referrer: getSafeDecodedURIComponent(referrer),
-					url: getSafeDecodedURIComponent(url)
-				},
-				description: assetTitle,
-				subtitle: getSafeDecodedURIComponent(canonicalUrl),
-				time: moment(createDate),
-				title: name
-			};
-		}
+			properties
+		}) => ({
+			attributes: {
+				applicationId,
+				...(eventDate && {eventDate}),
+				eventId,
+				...(properties?.length && {
+					properties: Object.fromEntries(
+						properties.map(({name: propName, value}) => [
+							propName,
+							value
+						])
+					)
+				})
+			},
+			description: assetTitle,
+			subtitle:
+				applicationId !== 'HubSpot'
+					? getSafeDecodedURIComponent(canonicalUrl)
+					: undefined,
+			time: moment(createDate),
+			title: name
+		})
 	);
 
 /**
@@ -158,7 +153,7 @@ export const formatSessions = (
 	sessions: UserSession[]
 ): (VerticalTimelineHeader | VerticalTimelineSession)[] =>
 	flow(
-		groupBy(({createDate}) =>
+		groupBy(({createDate}: UserSession) =>
 			moment.utc(createDate).startOf('day').format()
 		),
 		mapValues((items: unknown) =>
@@ -177,6 +172,9 @@ export const formatSessions = (
 					timezoneOffset,
 					userAgent
 				}) => ({
+					applicationId:
+						(events as unknown as UserSessionEvent[])[0]
+							?.applicationId ?? '',
 					attributes: {
 						contentLanguageID,
 						devicePixelRatioz,
@@ -193,7 +191,8 @@ export const formatSessions = (
 					nestedItems: formatEvents(
 						events as unknown as UserSessionEvent[]
 					),
-					time: createDate
+					time: createDate,
+					userAgent
 				})
 			)
 		),


### PR DESCRIPTION
## Summary

https://liferay.atlassian.net/browse/LPD-90903

- Fix event name text being clipped at the bottom in nested timeline items by overriding `line-height` to `normal` on `.text-truncate` inside `.title`, which was constrained by the parent's `line-height: 1` combined with Clay's `overflow: hidden`
- Replace `overflow-x: hidden` with `overflow-x: clip` on `.timeline-panel-body-content-text` to prevent the implicit `overflow-y` clipping side effect
- Change `.timeline-panel-body-content-details` width from `30%` to `max-width: 30%`, and add `max-width: none` to the nested override to prevent unintended cascade