### PR TITLE
LPD-90903 fix hubspot stream events bugs

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_vertical_timeline.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_vertical_timeline.scss
@@ -76,6 +76,7 @@
 					}
 
 					.timeline-panel-body-content-details {
+						max-width: none;
 						width: auto;
 					}
 
@@ -88,6 +89,7 @@
 						line-height: 1;
 
 						.text-truncate {
+							line-height: normal;
 							margin-bottom: 8px;
 						}
 					}
@@ -142,7 +144,7 @@
 				display: flex;
 				justify-content: space-between;
 				margin-left: auto;
-				width: 30%;
+				max-width: 30%;
 
 				.icon-group {
 					display: flex;
@@ -168,7 +170,7 @@
 			}
 
 			.timeline-panel-body-content-text {
-				overflow-x: hidden;
+				overflow-x: clip;
 
 				.event-icon {
 					margin-left: 40px;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
@@ -241,7 +241,7 @@ const TimelinePanelBodyContentDetails: FC<{
 				<span className='item-count'>{itemCount}</span>
 
 				<span
-					className='device-icon'
+					className='device-icon mr-2'
 					data-tooltip
 					data-tooltip-align='bottom'
 					title={`${deviceIconTitle}\n${browserName}`}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/VerticalTimeline.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/VerticalTimeline.jsx.snap
@@ -125,7 +125,7 @@ exports[`VerticalTimeline should render with a header and initialExpanded 1`] = 
                     2
                   </span>
                   <span
-                    class="device-icon"
+                    class="device-icon mr-2"
                     data-tooltip="true"
                     data-tooltip-align="bottom"
                     title="Unknown Device
@@ -444,7 +444,7 @@ Firefox"
                     2
                   </span>
                   <span
-                    class="device-icon"
+                    class="device-icon mr-2"
                     data-tooltip="true"
                     data-tooltip-align="bottom"
                     title="Mobile
@@ -730,7 +730,7 @@ Firefox"
                     2
                   </span>
                   <span
-                    class="device-icon"
+                    class="device-icon mr-2"
                     data-tooltip="true"
                     data-tooltip-align="bottom"
                     title="Desktop


### PR DESCRIPTION
https://issues.liferay.com/browse/LPD-90903

- Fix event name text being clipped at the bottom in nested timeline items by overriding line-height to normal on text-truncate inside .title, which was constrained by the parent's line-height: 1 combined with Clay's overflow: hidden

- Replace overflow-x: hidden with overflow-x: clip on .timeline-panel-body-content-text to prevent the implicit overflow-y clipping side effect

- Change .timeline-panel-body-content-details width from 30% to max-width: 30%, and add max-width: none to the nested override to prevent unintended cascade