### PR TITLE
LPD-91173 Allow dev server to proxy to external environments

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/webpack.dev.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/webpack.dev.js
@@ -1,8 +1,53 @@
 const common = require('./webpack.common');
+const {responseInterceptor} = require('http-proxy-middleware');
 const {merge} = require('webpack-merge');
 const webpack = require('webpack');
 
 require('dotenv').config();
+
+const TARGET = (process.env.FARO_URL || 'http://0.0.0.0:8080').replace(
+	/\/$/,
+	''
+);
+
+// The dev server proxies to a remote Liferay (e.g. analytics-stg) whose
+// `web.server.host` makes it emit absolute URLs back to itself. We buffer
+// each response and rewrite those URLs (in Location, Set-Cookie Domain, and
+// the body) so the browser stays on the dev server instead of leaving for
+// the upstream host.
+
+async function rewriteUpstreamResponse(responseBuffer, proxyRes, req, res) {
+	const proxyOrigin = `http://${req.headers.host}`;
+
+	if (proxyRes.headers['location']) {
+		res.setHeader(
+			'location',
+			proxyRes.headers['location'].split(TARGET).join(proxyOrigin)
+		);
+	}
+
+	if (proxyRes.headers['set-cookie']) {
+		res.setHeader(
+			'set-cookie',
+			proxyRes.headers['set-cookie'].map(cookie =>
+				cookie.replace(/;\s*Domain=[^;]+/gi, '')
+			)
+		);
+	}
+
+	const contentType = proxyRes.headers['content-type'] || '';
+	const isTextual =
+		contentType.includes('text/html') ||
+		contentType.includes('javascript') ||
+		contentType.includes('application/json') ||
+		contentType.includes('text/css');
+
+	if (!isTextual) {
+		return responseBuffer;
+	}
+
+	return responseBuffer.toString('utf8').split(TARGET).join(proxyOrigin);
+}
 
 module.exports = merge(common.config, {
 	devServer: {
@@ -12,7 +57,12 @@ module.exports = merge(common.config, {
 		host: '0.0.0.0',
 		port: 3000,
 		proxy: {
-			'**': process.env.FARO_URL || 'http://0.0.0.0:8080'
+			'**': {
+				changeOrigin: true,
+				onProxyRes: responseInterceptor(rewriteUpstreamResponse),
+				selfHandleResponse: true,
+				target: TARGET
+			}
 		}
 	},
 	devtool: 'inline-source-map',


### PR DESCRIPTION
Update webpack.dev.js so the dev server can proxy to external environments (e.g. analytics-stg).

The remote Liferay's web.server.host makes it emit absolute URLs pointing back to itself in redirects (Location), cookies (Set-Cookie Domain), and textual response bodies. The dev server now buffers each proxied response and rewrites those URLs to the dev server's own origin, so the browser stays on the dev server instead of navigating off to the upstream host.

## How it works?

Changes your FARO_URL env:
```
FARO_URL=https://analytics-stg.liferay.com/
```

Start osb-faro-web frontend:
```
yarn start
```

Happy hack! :tada: 