### PR TITLE
LPD-90928 faro-v4.15.x Fix misaligned loaders on LDP metric cards

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
@@ -1,4 +1,5 @@
 import * as API from 'shared/api';
+import ClayLayout from '@clayui/layout';
 import MetricCard from 'shared/components/MetricCard';
 import React from 'react';
 import {
@@ -37,16 +38,15 @@ const TotalAccounts = ({groupId}: {groupId: string}) => {
 			false
 		);
 
-	const cardContainerClassName = 'col-12 col-lg-4 d-flex';
-
 	return (
-		<div className='row g-4'>
-			<div className={cardContainerClassName}>
+		<ClayLayout.Row>
+			<ClayLayout.Col lg={4} md={12}>
 				<MetricCard
 					description={Liferay.Language.get(
 						'displays-all-accounts-included-in-this-property'
 					)}
 					loading={loading}
+					minHeight={160}
 					renderTrendLabel={renderTrendLabel}
 					title={Liferay.Language.get('total-accounts')}
 					trend={getMetric(AccountMetricType.Total)?.trend}
@@ -54,25 +54,29 @@ const TotalAccounts = ({groupId}: {groupId: string}) => {
 						getMetric(AccountMetricType.Total)
 					)}
 				/>
-			</div>
-			<div className={cardContainerClassName}>
+			</ClayLayout.Col>
+
+			<ClayLayout.Col lg={4} md={12}>
 				<MetricCard
 					description={Liferay.Language.get(
 						'displays-all-new-accounts-included-in-this-property'
 					)}
 					loading={loading}
+					minHeight={160}
 					renderTrendLabel={renderTrendLabel}
 					title={Liferay.Language.get('new-accounts')}
 					trend={getMetric(AccountMetricType.New)?.trend}
 					value={renderAccountValue(getMetric(AccountMetricType.New))}
 				/>
-			</div>
-			<div className={cardContainerClassName}>
+			</ClayLayout.Col>
+
+			<ClayLayout.Col lg={4} md={12}>
 				<MetricCard
 					description={Liferay.Language.get(
 						'displays-all-active-accounts-included-in-this-property'
 					)}
 					loading={loading}
+					minHeight={160}
 					renderTrendLabel={renderTrendLabel}
 					title={Liferay.Language.get('active-accounts')}
 					trend={getMetric(AccountMetricType.Active)?.trend}
@@ -80,8 +84,8 @@ const TotalAccounts = ({groupId}: {groupId: string}) => {
 						getMetric(AccountMetricType.Active)
 					)}
 				/>
-			</div>
-		</div>
+			</ClayLayout.Col>
+		</ClayLayout.Row>
 	);
 };
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/__tests__/__snapshots__/TotalAccounts.tsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/account/__tests__/__snapshots__/TotalAccounts.tsx.snap
@@ -3,13 +3,14 @@
 exports[`TotalAccounts should load with empty values when there's no data 1`] = `
 <div>
   <div
-    class="row g-4"
+    class="row"
   >
     <div
-      class="col-12 col-lg-4 d-flex"
+      class="col-lg-4 col-md-12"
     >
       <div
         class="card card-root flex-fill p-3 w-100"
+        style="min-height: 160px;"
       >
         <div
           class="card-title"
@@ -25,10 +26,10 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
           </div>
         </div>
         <div
-          class="card-body no-padding"
+          class="card-body justify-content-between d-flex no-padding"
         >
           <div
-            class="mt-1"
+            class="mt-2"
           >
             <span
               class="text-3 text-secondary"
@@ -36,34 +37,37 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
               Displays all accounts included in this property.
             </span>
           </div>
-          <span
-            class="mt-3 text-lowercase text-weight-semi-bold"
-          >
-            <span
-              class="text-7"
+          <div>
+            <div
+              class="mt-2 text-lowercase text-weight-semi-bold"
             >
-              0 Accounts
-            </span>
-          </span>
-          <span
-            class="text-secondary"
-          >
-            <span
-              class="mr-1"
-              style="color: rgb(107, 108, 126);"
+              <span
+                class="text-7"
+              >
+                0 Accounts
+              </span>
+            </div>
+            <div
+              class="text-secondary"
             >
-              0%
-            </span>
-             vs. Previous 90 Days
-          </span>
+              <span
+                class="mr-1"
+                style="color: rgb(107, 108, 126);"
+              >
+                0%
+              </span>
+               vs. Previous 90 Days
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      class="col-12 col-lg-4 d-flex"
+      class="col-lg-4 col-md-12"
     >
       <div
         class="card card-root flex-fill p-3 w-100"
+        style="min-height: 160px;"
       >
         <div
           class="card-title"
@@ -79,10 +83,10 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
           </div>
         </div>
         <div
-          class="card-body no-padding"
+          class="card-body justify-content-between d-flex no-padding"
         >
           <div
-            class="mt-1"
+            class="mt-2"
           >
             <span
               class="text-3 text-secondary"
@@ -90,34 +94,37 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
               Displays all new accounts included in this property.
             </span>
           </div>
-          <span
-            class="mt-3 text-lowercase text-weight-semi-bold"
-          >
-            <span
-              class="text-7"
+          <div>
+            <div
+              class="mt-2 text-lowercase text-weight-semi-bold"
             >
-              0 Accounts
-            </span>
-          </span>
-          <span
-            class="text-secondary"
-          >
-            <span
-              class="mr-1"
-              style="color: rgb(107, 108, 126);"
+              <span
+                class="text-7"
+              >
+                0 Accounts
+              </span>
+            </div>
+            <div
+              class="text-secondary"
             >
-              0%
-            </span>
-             vs. Previous 90 Days
-          </span>
+              <span
+                class="mr-1"
+                style="color: rgb(107, 108, 126);"
+              >
+                0%
+              </span>
+               vs. Previous 90 Days
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      class="col-12 col-lg-4 d-flex"
+      class="col-lg-4 col-md-12"
     >
       <div
         class="card card-root flex-fill p-3 w-100"
+        style="min-height: 160px;"
       >
         <div
           class="card-title"
@@ -133,10 +140,10 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
           </div>
         </div>
         <div
-          class="card-body no-padding"
+          class="card-body justify-content-between d-flex no-padding"
         >
           <div
-            class="mt-1"
+            class="mt-2"
           >
             <span
               class="text-3 text-secondary"
@@ -144,26 +151,28 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
               Displays all active accounts included in this property.
             </span>
           </div>
-          <span
-            class="mt-3 text-lowercase text-weight-semi-bold"
-          >
-            <span
-              class="text-7"
+          <div>
+            <div
+              class="mt-2 text-lowercase text-weight-semi-bold"
             >
-              0 Accounts
-            </span>
-          </span>
-          <span
-            class="text-secondary"
-          >
-            <span
-              class="mr-1"
-              style="color: rgb(107, 108, 126);"
+              <span
+                class="text-7"
+              >
+                0 Accounts
+              </span>
+            </div>
+            <div
+              class="text-secondary"
             >
-              0%
-            </span>
-             vs. Previous 90 Days
-          </span>
+              <span
+                class="mr-1"
+                style="color: rgb(107, 108, 126);"
+              >
+                0%
+              </span>
+               vs. Previous 90 Days
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -174,13 +183,14 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
 exports[`TotalAccounts should render 1`] = `
 <div>
   <div
-    class="row g-4"
+    class="row"
   >
     <div
-      class="col-12 col-lg-4 d-flex"
+      class="col-lg-4 col-md-12"
     >
       <div
         class="card card-root flex-fill p-3 w-100"
+        style="min-height: 160px;"
       >
         <div
           class="card-title"
@@ -196,10 +206,10 @@ exports[`TotalAccounts should render 1`] = `
           </div>
         </div>
         <div
-          class="card-body no-padding"
+          class="card-body justify-content-between d-flex no-padding"
         >
           <div
-            class="mt-1"
+            class="mt-2"
           >
             <span
               class="text-3 text-secondary"
@@ -207,43 +217,46 @@ exports[`TotalAccounts should render 1`] = `
               Displays all accounts included in this property.
             </span>
           </div>
-          <span
-            class="mt-3 text-lowercase text-weight-semi-bold"
-          >
-            <span
-              class="text-7"
+          <div>
+            <div
+              class="mt-2 text-lowercase text-weight-semi-bold"
             >
-              15 Accounts
-            </span>
-          </span>
-          <span
-            class="text-secondary"
-          >
-            <svg
-              class="lexicon-icon lexicon-icon-caret-top-l"
-              role="presentation"
-              style="color: rgb(40, 125, 60);"
+              <span
+                class="text-7"
+              >
+                15 Accounts
+              </span>
+            </div>
+            <div
+              class="text-secondary"
             >
-              <use
-                href="#caret-top-l"
-              />
-            </svg>
-            <span
-              class="mr-1"
-              style="color: rgb(40, 125, 60);"
-            >
-              50%
-            </span>
-             vs. Previous 90 Days
-          </span>
+              <svg
+                class="lexicon-icon lexicon-icon-caret-top-l"
+                role="presentation"
+                style="color: rgb(40, 125, 60);"
+              >
+                <use
+                  href="#caret-top-l"
+                />
+              </svg>
+              <span
+                class="mr-1"
+                style="color: rgb(40, 125, 60);"
+              >
+                50%
+              </span>
+               vs. Previous 90 Days
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      class="col-12 col-lg-4 d-flex"
+      class="col-lg-4 col-md-12"
     >
       <div
         class="card card-root flex-fill p-3 w-100"
+        style="min-height: 160px;"
       >
         <div
           class="card-title"
@@ -259,10 +272,10 @@ exports[`TotalAccounts should render 1`] = `
           </div>
         </div>
         <div
-          class="card-body no-padding"
+          class="card-body justify-content-between d-flex no-padding"
         >
           <div
-            class="mt-1"
+            class="mt-2"
           >
             <span
               class="text-3 text-secondary"
@@ -270,43 +283,46 @@ exports[`TotalAccounts should render 1`] = `
               Displays all new accounts included in this property.
             </span>
           </div>
-          <span
-            class="mt-3 text-lowercase text-weight-semi-bold"
-          >
-            <span
-              class="text-7"
+          <div>
+            <div
+              class="mt-2 text-lowercase text-weight-semi-bold"
             >
-              10 Accounts
-            </span>
-          </span>
-          <span
-            class="text-secondary"
-          >
-            <svg
-              class="lexicon-icon lexicon-icon-caret-bottom-l"
-              role="presentation"
-              style="color: rgb(218, 20, 20);"
+              <span
+                class="text-7"
+              >
+                10 Accounts
+              </span>
+            </div>
+            <div
+              class="text-secondary"
             >
-              <use
-                href="#caret-bottom-l"
-              />
-            </svg>
-            <span
-              class="mr-1"
-              style="color: rgb(218, 20, 20);"
-            >
-              30%
-            </span>
-             vs. Previous 90 Days
-          </span>
+              <svg
+                class="lexicon-icon lexicon-icon-caret-bottom-l"
+                role="presentation"
+                style="color: rgb(218, 20, 20);"
+              >
+                <use
+                  href="#caret-bottom-l"
+                />
+              </svg>
+              <span
+                class="mr-1"
+                style="color: rgb(218, 20, 20);"
+              >
+                30%
+              </span>
+               vs. Previous 90 Days
+            </div>
+          </div>
         </div>
       </div>
     </div>
     <div
-      class="col-12 col-lg-4 d-flex"
+      class="col-lg-4 col-md-12"
     >
       <div
         class="card card-root flex-fill p-3 w-100"
+        style="min-height: 160px;"
       >
         <div
           class="card-title"
@@ -322,10 +338,10 @@ exports[`TotalAccounts should render 1`] = `
           </div>
         </div>
         <div
-          class="card-body no-padding"
+          class="card-body justify-content-between d-flex no-padding"
         >
           <div
-            class="mt-1"
+            class="mt-2"
           >
             <span
               class="text-3 text-secondary"
@@ -333,26 +349,28 @@ exports[`TotalAccounts should render 1`] = `
               Displays all active accounts included in this property.
             </span>
           </div>
-          <span
-            class="mt-3 text-lowercase text-weight-semi-bold"
-          >
-            <span
-              class="text-7"
+          <div>
+            <div
+              class="mt-2 text-lowercase text-weight-semi-bold"
             >
-              1 Account
-            </span>
-          </span>
-          <span
-            class="text-secondary"
-          >
-            <span
-              class="mr-1"
-              style="color: rgb(107, 108, 126);"
+              <span
+                class="text-7"
+              >
+                1 Account
+              </span>
+            </div>
+            <div
+              class="text-secondary"
             >
-              0%
-            </span>
-             vs. Previous 90 Days
-          </span>
+              <span
+                class="mr-1"
+                style="color: rgb(107, 108, 126);"
+              >
+                0%
+              </span>
+               vs. Previous 90 Days
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/Activities.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/Activities.tsx
@@ -33,6 +33,7 @@ const Activities = () => {
 				headerProps={{showRangeKey: true}}
 				label={Liferay.Language.get('activity-stream').toUpperCase()}
 				legacyDropdownRangeKey={false}
+				minHeight={500}
 				showInterval
 			>
 				{({

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/Profile.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/Profile.tsx
@@ -15,8 +15,10 @@ const Profile: React.FC<IProfileProps> = ({account, loading}) => (
 			icon='plus-squares'
 			title={Liferay.Language.get('account-details')}
 		/>
+
 		<div className='account-profile-cards mb-3'>
 			<LifecycleStatus className='h-100' />
+
 			<AccountInfo
 				account={account}
 				className='h-100'

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
@@ -67,13 +67,14 @@ exports[`List rendering should match the snapshot 1`] = `
         class="children-wrapper"
       >
         <div
-          class="row g-4"
+          class="row"
         >
           <div
-            class="col-12 col-lg-4 d-flex"
+            class="col-lg-4 col-md-12"
           >
             <div
               class="card card-root flex-fill p-3 w-100"
+              style="min-height: 160px;"
             >
               <div
                 class="card-title"
@@ -89,10 +90,10 @@ exports[`List rendering should match the snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="card-body no-padding"
+                class="card-body justify-content-between d-flex no-padding"
               >
                 <div
-                  class="mt-1"
+                  class="mt-2"
                 >
                   <span
                     class="text-3 text-secondary"
@@ -100,34 +101,37 @@ exports[`List rendering should match the snapshot 1`] = `
                     Displays all accounts included in this property.
                   </span>
                 </div>
-                <span
-                  class="mt-3 text-lowercase text-weight-semi-bold"
-                >
-                  <span
-                    class="text-7"
+                <div>
+                  <div
+                    class="mt-2 text-lowercase text-weight-semi-bold"
                   >
-                    0 Accounts
-                  </span>
-                </span>
-                <span
-                  class="text-secondary"
-                >
-                  <span
-                    class="mr-1"
-                    style="color: rgb(107, 108, 126);"
+                    <span
+                      class="text-7"
+                    >
+                      0 Accounts
+                    </span>
+                  </div>
+                  <div
+                    class="text-secondary"
                   >
-                    0%
-                  </span>
-                   vs. Previous 90 Days
-                </span>
+                    <span
+                      class="mr-1"
+                      style="color: rgb(107, 108, 126);"
+                    >
+                      0%
+                    </span>
+                     vs. Previous 90 Days
+                  </div>
+                </div>
               </div>
             </div>
           </div>
           <div
-            class="col-12 col-lg-4 d-flex"
+            class="col-lg-4 col-md-12"
           >
             <div
               class="card card-root flex-fill p-3 w-100"
+              style="min-height: 160px;"
             >
               <div
                 class="card-title"
@@ -143,10 +147,10 @@ exports[`List rendering should match the snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="card-body no-padding"
+                class="card-body justify-content-between d-flex no-padding"
               >
                 <div
-                  class="mt-1"
+                  class="mt-2"
                 >
                   <span
                     class="text-3 text-secondary"
@@ -154,34 +158,37 @@ exports[`List rendering should match the snapshot 1`] = `
                     Displays all new accounts included in this property.
                   </span>
                 </div>
-                <span
-                  class="mt-3 text-lowercase text-weight-semi-bold"
-                >
-                  <span
-                    class="text-7"
+                <div>
+                  <div
+                    class="mt-2 text-lowercase text-weight-semi-bold"
                   >
-                    0 Accounts
-                  </span>
-                </span>
-                <span
-                  class="text-secondary"
-                >
-                  <span
-                    class="mr-1"
-                    style="color: rgb(107, 108, 126);"
+                    <span
+                      class="text-7"
+                    >
+                      0 Accounts
+                    </span>
+                  </div>
+                  <div
+                    class="text-secondary"
                   >
-                    0%
-                  </span>
-                   vs. Previous 90 Days
-                </span>
+                    <span
+                      class="mr-1"
+                      style="color: rgb(107, 108, 126);"
+                    >
+                      0%
+                    </span>
+                     vs. Previous 90 Days
+                  </div>
+                </div>
               </div>
             </div>
           </div>
           <div
-            class="col-12 col-lg-4 d-flex"
+            class="col-lg-4 col-md-12"
           >
             <div
               class="card card-root flex-fill p-3 w-100"
+              style="min-height: 160px;"
             >
               <div
                 class="card-title"
@@ -197,10 +204,10 @@ exports[`List rendering should match the snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="card-body no-padding"
+                class="card-body justify-content-between d-flex no-padding"
               >
                 <div
-                  class="mt-1"
+                  class="mt-2"
                 >
                   <span
                     class="text-3 text-secondary"
@@ -208,26 +215,28 @@ exports[`List rendering should match the snapshot 1`] = `
                     Displays all active accounts included in this property.
                   </span>
                 </div>
-                <span
-                  class="mt-3 text-lowercase text-weight-semi-bold"
-                >
-                  <span
-                    class="text-7"
+                <div>
+                  <div
+                    class="mt-2 text-lowercase text-weight-semi-bold"
                   >
-                    0 Accounts
-                  </span>
-                </span>
-                <span
-                  class="text-secondary"
-                >
-                  <span
-                    class="mr-1"
-                    style="color: rgb(107, 108, 126);"
+                    <span
+                      class="text-7"
+                    >
+                      0 Accounts
+                    </span>
+                  </div>
+                  <div
+                    class="text-secondary"
                   >
-                    0%
-                  </span>
-                   vs. Previous 90 Days
-                </span>
+                    <span
+                      class="mr-1"
+                      style="color: rgb(107, 108, 126);"
+                    >
+                      0%
+                    </span>
+                     vs. Previous 90 Days
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountInfo.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountInfo.tsx
@@ -68,7 +68,7 @@ const AccountInfo: React.FC<IAccountInfoProps> = ({
 
 	if (loading) {
 		return (
-			<Card className={classNames(className, 'p-3')}>
+			<Card className={classNames(className, 'p-3')} minHeight={284}>
 				<Card.Body>
 					<Loading />
 				</Card.Body>
@@ -95,7 +95,7 @@ const AccountInfo: React.FC<IAccountInfoProps> = ({
 
 	return (
 		<>
-			<Card className={classNames(className, 'p-3')}>
+			<Card className={classNames(className, 'p-3')} minHeight={284}>
 				<Card.Title>
 					<Text size={4} weight='semi-bold'>
 						<span className='text-uppercase'>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/LifecycleStatus.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/LifecycleStatus.tsx
@@ -58,7 +58,7 @@ const LifecycleStatus: React.FC<LifecycleStatusProps> = ({className}) => {
 
 	if (isLoading) {
 		return (
-			<Card className={classNames(className, 'p-3')}>
+			<Card className={classNames(className, 'p-3')} minHeight={284}>
 				<Card.Body>
 					<Loading />
 				</Card.Body>
@@ -87,7 +87,7 @@ const LifecycleStatus: React.FC<LifecycleStatusProps> = ({className}) => {
 	const isAtRisk = Boolean(atRiskStage?.startDate && !atRiskStage.endDate);
 
 	return (
-		<Card className={classNames(className, 'p-3')}>
+		<Card className={classNames(className, 'p-3')} minHeight={284}>
 			<Card.Title>
 				<Text weight='semi-bold'>
 					{Liferay.Language.get('lifecycle-status').toUpperCase()}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
@@ -2,143 +2,59 @@ import * as API from 'shared/api';
 import BasePage from 'shared/components/base-page';
 import Card from 'shared/components/Card';
 import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import IndividualMetricsQuery from 'shared/queries/IndividualMetricsQuery';
 import IndividualsList from './IndividualsList';
 import Loading from 'shared/components/Loading';
+import MetricCard from 'shared/components/MetricCard';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
 import React from 'react';
 import URLConstants from 'shared/util/url-constants';
 import {Text as ClayText} from '@clayui/core';
 import {CSVType} from 'shared/components/download-report/utils';
 import {DownloadStaticCSVReport} from 'shared/components/download-report/DownloadStaticCSVReport';
-import {getIcon, getStatsColor} from 'shared/util/metrics';
 import {INTERVAL_KEY_MAP} from 'shared/util/time';
 import {isNil} from 'lodash';
 import {RangeKeyTimeRanges, Sizes} from 'shared/util/constants';
 import {Routes, toRoute} from 'shared/util/router';
 import {sub} from 'shared/util/lang';
-import {toRounded, toThousands} from 'shared/util/numbers';
-import {TrendClassification} from 'segment/types';
+import {toThousands} from 'shared/util/numbers';
 import {useCurrentUser} from 'shared/hooks/useCurrentUser';
 import {useDataSources} from 'shared/context/dataSources';
 import {useParams} from 'react-router-dom';
 import {useQuery} from '@apollo/client';
 import {useRequest} from 'shared/hooks/useRequest';
 
-type IndividualsMetricCard = {
-	trend: {
-		percentage: number | null;
-		trendClassification: TrendClassification;
-	};
-	value: number;
-};
-
-interface IIndividualsMetricsCardProps {
-	data: IndividualsMetricCard;
-	description: string;
-	title: string;
-}
-
 interface IIndividualsOverviewEmptyStateProps {
 	authorized: boolean;
-	dataSourceData: {total?: number} | null;
-	dataSourceLoading: boolean;
+	data: {total?: number} | null;
 	groupId: string;
+	loading: boolean;
 }
 
-const IndividualsMetricsCard: React.FC<IIndividualsMetricsCardProps> = ({
-	data,
-	description,
-	title
-}) => {
-	const rawValue = data?.value || 0;
+const renderIndividualsValue = (value?: number) => {
+	const rawValue = value || 0;
 
-	const individuals = toThousands(rawValue);
-
-	return (
-		<>
-			<Card.Header>
-				<ClayText weight='semi-bold'>{title.toUpperCase()}</ClayText>
-			</Card.Header>
-
-			<Card.Body className='d-flex flex-column'>
-				<div className='flex-grow-1'>
-					<span className='text-secondary'>{description}</span>
-				</div>
-
-				<h2 className='mt-2'>
-					{
-						sub(
-							rawValue === 1
-								? Liferay.Language.get('x-individual')
-								: Liferay.Language.get('x-individuals'),
-							[individuals]
-						) as string
-					}
-				</h2>
-
-				<div>
-					{!!data?.trend.trendClassification &&
-						data?.trend.trendClassification !==
-							TrendClassification.Neutral && (
-							<span
-								style={{
-									color: getStatsColor(
-										data?.trend?.trendClassification
-									)
-								}}
-							>
-								<ClayIcon
-									symbol={
-										getIcon(data?.trend?.percentage ?? 0) ??
-										''
-									}
-								/>
-							</span>
-						)}
-
-					<span className='text-secondary'>
-						{sub(
-							Liferay.Language.get('x-vs-previous-30-days'),
-							[
-								<span
-									className='mr-1'
-									key='percentage'
-									style={{
-										color:
-											getStatsColor(
-												data?.trend?.trendClassification
-											) || TrendClassification.Neutral
-									}}
-								>
-									{`${toRounded(
-										data?.trend?.percentage ?? 0,
-										2
-									)}%`}
-								</span>
-							],
-							false
-						)}
-					</span>
-				</div>
-			</Card.Body>
-		</>
-	);
+	return sub(
+		rawValue === 1
+			? Liferay.Language.get('x-individual')
+			: Liferay.Language.get('x-individuals'),
+		[toThousands(rawValue)]
+	) as string;
 };
+
+const renderTrendLabel = (percentageNode: React.ReactNode) =>
+	sub(Liferay.Language.get('x-vs-previous-30-days'), [percentageNode], false);
 
 const IndividualsOverviewEmptyState: React.FC<
 	IIndividualsOverviewEmptyStateProps
-> = ({authorized, dataSourceData, dataSourceLoading, groupId}) => {
-	if (dataSourceLoading) {
-		return (
-			<NoResultsDisplay>
-				<Loading key='LOADING' />
-			</NoResultsDisplay>
-		);
+> = ({authorized, data, groupId, loading}) => {
+	if (loading) {
+		return <Loading key='LOADING' />;
 	}
 
-	if (isNil(dataSourceData?.total) || dataSourceData?.total === 0) {
+	if (isNil(data?.total) || data?.total === 0) {
 		return (
 			<Card pageDisplay>
 				<NoResultsDisplay
@@ -246,61 +162,80 @@ const IndividualsOverviewCDP = () => {
 			<BasePage.Body pageContainer>
 				<IndividualsOverviewEmptyState
 					authorized={authorized}
-					dataSourceData={dataSourceData}
-					dataSourceLoading={dataSourceLoading}
+					data={dataSourceData}
 					groupId={groupId}
+					loading={dataSourceLoading}
 				/>
 
 				{dataSourceData?.total > 0 && (
 					<>
-						<div className='d-flex flex-row justify-content-between'>
-							{loading && <Loading key='LOADING' />}
-
-							<Card className='w-100'>
-								<IndividualsMetricsCard
-									data={
-										data?.individualMetric
-											?.totalIndividualsMetric
-									}
+						<ClayLayout.Row>
+							<ClayLayout.Col lg={4} md={12}>
+								<MetricCard
 									description={Liferay.Language.get(
 										'this-is-the-total-number-of-individuals,-including-both-known-individuals-and-anonymous-individuals'
 									)}
+									loading={loading}
+									minHeight={198}
+									renderTrendLabel={renderTrendLabel}
 									title={Liferay.Language.get(
 										'total-individuals'
 									)}
-								/>
-							</Card>
-
-							<Card className='mx-3 w-100'>
-								<IndividualsMetricsCard
-									data={
+									trend={
 										data?.individualMetric
-											?.knownIndividualsMetric
+											?.totalIndividualsMetric?.trend
 									}
+									value={renderIndividualsValue(
+										data?.individualMetric
+											?.totalIndividualsMetric?.value
+									)}
+								/>
+							</ClayLayout.Col>
+
+							<ClayLayout.Col lg={4} sm={12}>
+								<MetricCard
 									description={Liferay.Language.get(
 										'this-is-the-total-number-of-known-individuals.-an-individual-is-considered-known-if-we-have-any-identifiable-information-about-the-individual'
 									)}
+									loading={loading}
+									minHeight={198}
+									renderTrendLabel={renderTrendLabel}
 									title={Liferay.Language.get(
 										'known-individuals'
 									)}
-								/>
-							</Card>
-
-							<Card className='w-100'>
-								<IndividualsMetricsCard
-									data={
+									trend={
 										data?.individualMetric
-											?.anonymousIndividualsMetric
+											?.knownIndividualsMetric?.trend
 									}
+									value={renderIndividualsValue(
+										data?.individualMetric
+											?.knownIndividualsMetric?.value
+									)}
+								/>
+							</ClayLayout.Col>
+
+							<ClayLayout.Col lg={4} sm={12}>
+								<MetricCard
 									description={Liferay.Language.get(
 										'this-is-the-total-number-of-anonymous-individuals.-anonymous-individuals-are-removed-after-30-days-of-inactivity'
 									)}
+									loading={loading}
+									minHeight={198}
+									renderTrendLabel={renderTrendLabel}
 									title={Liferay.Language.get(
 										'anonymous-individuals'
 									)}
+									trend={
+										data?.individualMetric
+											?.anonymousIndividualsMetric?.trend
+									}
+									value={renderIndividualsValue(
+										data?.individualMetric
+											?.anonymousIndividualsMetric?.value
+									)}
 								/>
-							</Card>
-						</div>
+							</ClayLayout.Col>
+						</ClayLayout.Row>
 
 						<IndividualsList />
 					</>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
@@ -1,10 +1,45 @@
+import IndividualsOverviewCDP from '../IndividualsOverviewCDP';
 import mockStore from 'test/mock-store';
 import React from 'react';
 import {BrowserRouter} from 'react-router-dom';
 import {Provider} from 'react-redux';
 import {render} from '@testing-library/react';
+import {useCurrentUser} from 'shared/hooks/useCurrentUser';
+import {useDataSources} from 'shared/context/dataSources';
+import {useQuery} from '@apollo/client';
+import {useRequest} from 'shared/hooks/useRequest';
 
 jest.unmock('react-dom');
+
+jest.mock('@apollo/client', () => ({
+	...jest.requireActual('@apollo/client'),
+	useQuery: jest.fn()
+}));
+
+jest.mock('shared/hooks/useRequest', () => ({
+	useRequest: jest.fn()
+}));
+
+jest.mock('shared/hooks/useCurrentUser', () => ({
+	useCurrentUser: jest.fn()
+}));
+
+jest.mock('shared/context/dataSources', () => ({
+	useDataSources: jest.fn()
+}));
+
+jest.mock('react-router-dom', () => ({
+	...jest.requireActual('react-router-dom'),
+	useParams: () => ({
+		channelId: '123',
+		groupId: '456'
+	})
+}));
+
+jest.mock('../IndividualsList', () => ({
+	__esModule: true,
+	default: () => null
+}));
 
 const mockedIndividualMetrics = {
 	data: {
@@ -42,58 +77,52 @@ const mockedIndividualMetrics = {
 	}
 };
 
+const renderIndividualsOverviewCDP = () =>
+	render(
+		<Provider store={mockStore()}>
+			<BrowserRouter>
+				<IndividualsOverviewCDP />
+			</BrowserRouter>
+		</Provider>
+	);
+
 describe('IndividualsOverviewCDP', () => {
-	afterEach(() => {
-		jest.resetAllMocks();
-		jest.resetModules();
+	beforeEach(() => {
+		(useRequest as jest.Mock).mockReturnValue({
+			data: {total: 1},
+			loading: false
+		});
+		(useCurrentUser as jest.Mock).mockReturnValue({isAdmin: () => true});
+		(useDataSources as jest.Mock).mockReturnValue({empty: false});
 	});
 
-	it('should render Individuals Metrics Cards', async () => {
-		jest.doMock('@apollo/client', () => ({
-			...jest.requireActual('@apollo/client'),
-			useQuery: jest.fn(() => ({
-				data: mockedIndividualMetrics.data,
-				loading: false
-			}))
-		}));
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
 
-		jest.doMock('shared/hooks/useRequest', () => ({
-			useRequest: jest.fn(() => ({
-				data: {total: 1},
-				loading: false
-			}))
-		}));
+	it('should render Individuals Metrics Cards', () => {
+		(useQuery as jest.Mock).mockReturnValue({
+			data: mockedIndividualMetrics.data,
+			loading: false
+		});
 
-		jest.doMock('shared/hooks/useCurrentUser', () => ({
-			useCurrentUser: jest.fn(() => ({isAdmin: () => true}))
-		}));
+		const {getByText} = renderIndividualsOverviewCDP();
 
-		jest.doMock('shared/context/dataSources', () => ({
-			useDataSources: jest.fn(() => ({empty: false}))
-		}));
+		expect(getByText('Total Individuals')).toBeInTheDocument();
+		expect(getByText('Known Individuals')).toBeInTheDocument();
+		expect(getByText('Anonymous Individuals')).toBeInTheDocument();
+	});
 
-		jest.doMock('react-router-dom', () => ({
-			...jest.requireActual('react-router-dom'),
-			useParams: () => ({
-				channelId: '123',
-				groupId: '456'
-			})
-		}));
+	it('should render a centered loader inside each metric card while metrics are loading', () => {
+		(useQuery as jest.Mock).mockReturnValue({
+			data: undefined,
+			loading: true
+		});
 
-		const {default: IndividualsOverviewCDP} = await import(
-			'../IndividualsOverviewCDP'
-		);
+		const {container, queryByText} = renderIndividualsOverviewCDP();
 
-		const {getByText} = render(
-			<Provider store={mockStore()}>
-				<BrowserRouter>
-					<IndividualsOverviewCDP />
-				</BrowserRouter>
-			</Provider>
-		);
+		expect(queryByText(/Individuals$/)).not.toBeInTheDocument();
 
-		expect(getByText('TOTAL INDIVIDUALS')).toBeInTheDocument();
-		expect(getByText('KNOWN INDIVIDUALS')).toBeInTheDocument();
-		expect(getByText('ANONYMOUS INDIVIDUALS')).toBeInTheDocument();
+		expect(container.querySelectorAll('.loading-root')).toHaveLength(3);
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/OverviewSection.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/OverviewSection.tsx
@@ -1,3 +1,4 @@
+import ClayLayout from '@clayui/layout';
 import MetricCard from 'shared/components/MetricCard';
 import React from 'react';
 import {IOverviewMetric, OverviewMetricType} from '../utils/types';
@@ -22,9 +23,6 @@ const OverviewSection: React.FC<IOverviewSectionProps> = ({
 	const atRiskAccounts = getMetric(OverviewMetricType.AtRisk);
 	const netNewPipelineGenerated = getMetric(OverviewMetricType.NewPipeline);
 	const stalledAccounts = getMetric(OverviewMetricType.Stalled);
-
-	const cardContainerClassName = 'col-12 col-lg-4 d-flex';
-	const bodyClassName = 'd-flex flex-column justify-content-around';
 
 	const cards = [
 		{
@@ -56,22 +54,23 @@ const OverviewSection: React.FC<IOverviewSectionProps> = ({
 				icon='box-container'
 				title={Liferay.Language.get('overview')}
 			/>
-			<div className='row g-4'>
+
+			<ClayLayout.Row className='row g-4'>
 				{cards.map(({description, metric, title}) => (
-					<div className={cardContainerClassName} key={title}>
+					<ClayLayout.Col key={title} lg={4} md={12}>
 						<MetricCard
-							bodyClassName={bodyClassName}
 							description={description}
 							loading={loading}
+							minHeight={200}
 							renderTrendLabel={renderTrendLabel}
 							title={title}
 							trend={metric?.trend}
 							trendClassName='text-lowercase'
 							value={metric?.value ?? 0}
 						/>
-					</div>
+					</ClayLayout.Col>
 				))}
-			</div>
+			</ClayLayout.Row>
 		</>
 	);
 };

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
@@ -15,10 +15,10 @@ interface IMetricCardTrend {
 }
 
 interface IMetricCardProps {
-	bodyClassName?: string;
 	className?: string;
 	description: string;
 	loading?: boolean;
+	minHeight?: number;
 	renderTrendLabel: (percentageNode: ReactNode) => ReactNode;
 	title: string;
 	trend?: IMetricCardTrend;
@@ -27,10 +27,10 @@ interface IMetricCardProps {
 }
 
 const MetricCard: React.FC<IMetricCardProps> = ({
-	bodyClassName,
 	className,
 	description,
 	loading = false,
+	minHeight,
 	renderTrendLabel,
 	title,
 	trend,
@@ -39,7 +39,10 @@ const MetricCard: React.FC<IMetricCardProps> = ({
 }) => {
 	if (loading) {
 		return (
-			<Card className={classNames(className, 'flex-fill p-3 w-100')}>
+			<Card
+				className={classNames(className, 'flex-fill p-3 w-100')}
+				minHeight={minHeight}
+			>
 				<Card.Body>
 					<Loading />
 				</Card.Body>
@@ -50,45 +53,56 @@ const MetricCard: React.FC<IMetricCardProps> = ({
 	const percentageColor = getStatsColor(trend?.trendClassification || '');
 
 	return (
-		<Card className={classNames(className, 'flex-fill p-3 w-100')}>
+		<Card
+			className={classNames(className, 'flex-fill p-3 w-100')}
+			minHeight={minHeight}
+		>
 			<Card.Title>
 				<div className='text-uppercase text-weight-semi-bold'>
 					<Text>{title}</Text>
 				</div>
 			</Card.Title>
-			<Card.Body className={bodyClassName} noPadding>
-				<div className='mt-1'>
+
+			<Card.Body className='justify-content-between d-flex' noPadding>
+				<div className='mt-2'>
 					<Text color='secondary' size={3}>
 						{description}
 					</Text>
 				</div>
 
-				<span className='mt-3 text-lowercase text-weight-semi-bold'>
-					<Text size={7}>{value}</Text>
-				</span>
+				<div>
+					<div className='mt-2 text-lowercase text-weight-semi-bold'>
+						<Text size={7}>{value}</Text>
+					</div>
 
-				<span className={classNames('text-secondary', trendClassName)}>
-					{!isNil(trend?.trendClassification) &&
-						trend?.trendClassification !==
-							TrendClassification.Neutral && (
-							<ClayIcon
+					<div
+						className={classNames('text-secondary', trendClassName)}
+					>
+						{!isNil(trend?.trendClassification) &&
+							trend?.trendClassification !==
+								TrendClassification.Neutral && (
+								<ClayIcon
+									style={{color: percentageColor}}
+									symbol={
+										getIcon(trend?.percentage ?? 0) ?? ''
+									}
+								/>
+							)}
+
+						{renderTrendLabel(
+							<span
+								className='mr-1'
+								key='percentage'
 								style={{color: percentageColor}}
-								symbol={getIcon(trend?.percentage ?? 0) ?? ''}
-							/>
+							>
+								{`${toRounded(
+									Math.abs(trend?.percentage ?? 0),
+									2
+								)}%`}
+							</span>
 						)}
-					{renderTrendLabel(
-						<span
-							className='mr-1'
-							key='percentage'
-							style={{color: percentageColor}}
-						>
-							{`${toRounded(
-								Math.abs(trend?.percentage ?? 0),
-								2
-							)}%`}
-						</span>
-					)}
-				</span>
+					</div>
+				</div>
 			</Card.Body>
 		</Card>
 	);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/MetricCard.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/MetricCard.tsx
@@ -105,11 +105,10 @@ describe('MetricCard', () => {
 		).toBeNull();
 	});
 
-	it('should apply className, bodyClassName, and trendClassName', () => {
+	it('should apply className and trendClassName', () => {
 		const {container} = render(
 			<MetricCard
 				{...defaultProps}
-				bodyClassName='custom-body'
 				className='custom-card'
 				trend={{
 					percentage: 10,
@@ -120,7 +119,6 @@ describe('MetricCard', () => {
 		);
 
 		expect(container.querySelector('.custom-card')).toBeTruthy();
-		expect(container.querySelector('.custom-body')).toBeTruthy();
 		expect(container.querySelector('.custom-trend')).toBeTruthy();
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/MetricCard.tsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/MetricCard.tsx.snap
@@ -19,10 +19,10 @@ exports[`MetricCard should render 1`] = `
       </div>
     </div>
     <div
-      class="card-body no-padding"
+      class="card-body justify-content-between d-flex no-padding"
     >
       <div
-        class="mt-1"
+        class="mt-2"
       >
         <span
           class="text-3 text-secondary"
@@ -30,27 +30,29 @@ exports[`MetricCard should render 1`] = `
           Test description
         </span>
       </div>
-      <span
-        class="mt-3 text-lowercase text-weight-semi-bold"
-      >
-        <span
-          class="text-7"
+      <div>
+        <div
+          class="mt-2 text-lowercase text-weight-semi-bold"
         >
-          42
-        </span>
-      </span>
-      <span
-        class="text-secondary"
-      >
-        <span
-          class="mr-1"
-          style="color: rgb(107, 108, 126);"
+          <span
+            class="text-7"
+          >
+            42
+          </span>
+        </div>
+        <div
+          class="text-secondary"
         >
-          0%
-        </span>
-         
-        vs last period
-      </span>
+          <span
+            class="mr-1"
+            style="color: rgb(107, 108, 126);"
+          >
+            0%
+          </span>
+           
+          vs last period
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90928

Backport of https://github.com/liferay-ac/liferay-portal/pull/3249 to `faro-v4.15.x`.

## What is being fixed

The loaders inside the Individuals LDP metric cards (Total, Known, and Anonymous Individuals) rendered with inconsistent heights compared to their loaded states. As metrics finished loading, each card resized, causing layout jumps and visual misalignment between sibling cards.

## How it is being fixed

`MetricCard` now accepts a `minHeight` prop and forwards it to the underlying `Card`, so the loading and loaded states share the same height. The body is also reorganized to split description from the value/trend block using a `justify-content-between d-flex` layout, keeping the value and percentage anchored to the bottom regardless of state. The obsolete `bodyClassName` prop is removed since the body now owns its layout, and every caller (`IndividualsOverviewCDP`, `TotalAccounts`, `AccountInfo`, `LifecycleStatus`, `Activities`, `Profile`, `OverviewSection`) is updated to the new prop shape. The `IndividualsOverviewCDP` test is refactored from per-test `jest.doMock` to top-level `jest.mock`, and a new test asserts that three centered loaders render while metrics are loading.