### PR TITLE
LPD-88174 faro-v4.15.x Move CrossPageSelect inside modal body

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/SearchableTableModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/SearchableTableModal.tsx
@@ -109,37 +109,37 @@ const SearchableTableModal: React.FC<ISearchableTableModalProps> = ({
 		<Modal className={className} size='lg'>
 			<Modal.Header onClose={onClose} title={title} />
 
-			<Modal.Body>
+			<Modal.Body className='p-0'>
 				<div className='text-secondary'>{instruction}</div>
-			</Modal.Body>
 
-			<CrossPageSelect
-				autoFocusSearch
-				checkDisabled={checkDisabled}
-				columns={columns}
-				dataSourceFn={dataSourceFn}
-				delta={delta}
-				entityLabel={entityLabel}
-				error={error}
-				items={data?.items}
-				loading={loading}
-				noResultsIcon={noResultsIcon}
-				onDeltaChange={onDeltaChange}
-				onFilterByChange={onFilterByChange}
-				onOrderIOMapChange={onOrderIOMapChange}
-				onPageChange={onPageChange}
-				onQueryChange={onQueryChange}
-				orderByOptions={orderByOptions}
-				orderIOMap={orderIOMap}
-				page={page}
-				pageDisplay={false}
-				query={query}
-				rowIdentifier='id'
-				selectedItems={selectedItems.map(({id}) => id)}
-				selectedItemsIOMap={selectedItems}
-				showCheckbox
-				total={data?.total}
-			/>
+				<CrossPageSelect
+					autoFocusSearch
+					checkDisabled={checkDisabled}
+					columns={columns}
+					dataSourceFn={dataSourceFn}
+					delta={delta}
+					entityLabel={entityLabel}
+					error={error}
+					items={data?.items}
+					loading={loading}
+					noResultsIcon={noResultsIcon}
+					onDeltaChange={onDeltaChange}
+					onFilterByChange={onFilterByChange}
+					onOrderIOMapChange={onOrderIOMapChange}
+					onPageChange={onPageChange}
+					onQueryChange={onQueryChange}
+					orderByOptions={orderByOptions}
+					orderIOMap={orderIOMap}
+					page={page}
+					pageDisplay={false}
+					query={query}
+					rowIdentifier='id'
+					selectedItems={selectedItems.map(({id}) => id)}
+					selectedItemsIOMap={selectedItems}
+					showCheckbox
+					total={data?.total}
+				/>
+			</Modal.Body>
 
 			<Modal.Footer>
 				<ClayButton

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/SearchableTableModalGraphql.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/SearchableTableModalGraphql.tsx
@@ -96,28 +96,28 @@ const SearchableTableModalGraphql: React.FC<
 		<Modal className={className} size='lg'>
 			<Modal.Header onClose={onClose} title={title} />
 
-			<Modal.Body>
+			<Modal.Body className='p-0'>
 				<div className='text-secondary'>{instruction}</div>
-			</Modal.Body>
 
-			<CrossPageSelect
-				{...otherProps}
-				autoFocus
-				columns={columns}
-				delta={delta}
-				empty={empty}
-				items={items}
-				loading={loading}
-				onDeltaChange={onDeltaChange}
-				onOrderIOMapChange={onOrderIOMapChange}
-				onPageChange={onPageChange}
-				onQueryChange={onQueryChange}
-				orderIOMap={orderIOMap}
-				page={page}
-				pageDisplay={false}
-				query={query}
-				total={total}
-			/>
+				<CrossPageSelect
+					{...otherProps}
+					autoFocus
+					columns={columns}
+					delta={delta}
+					empty={empty}
+					items={items}
+					loading={loading}
+					onDeltaChange={onDeltaChange}
+					onOrderIOMapChange={onOrderIOMapChange}
+					onPageChange={onPageChange}
+					onQueryChange={onQueryChange}
+					orderIOMap={orderIOMap}
+					page={page}
+					pageDisplay={false}
+					query={query}
+					total={total}
+				/>
+			</Modal.Body>
 
 			<Modal.Footer>
 				<ClayButton

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/__snapshots__/SearchableTableModal.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/__snapshots__/SearchableTableModal.jsx.snap
@@ -34,96 +34,96 @@ exports[`SearchableTableModal should render 1`] = `
         </button>
       </div>
       <div
-        class="modal-body"
+        class="modal-body p-0"
       >
         <div
           class="text-secondary"
         />
-      </div>
-      <div
-        class="toolbar-root"
-      >
-        <nav
-          class="navbar navbar-root management-bar management-bar-light navbar-expand"
+        <div
+          class="toolbar-root"
         >
-          <div
-            class="container-fluid"
+          <nav
+            class="navbar navbar-root management-bar management-bar-light navbar-expand"
           >
-            <ul
-              class="nav-root front-nav navbar-nav"
-              role="tablist"
-            >
-              <li
-                class="nav-item"
-                role="presentation"
-              >
-                <div
-                  class="custom-control custom-checkbox"
-                >
-                  <label>
-                    <input
-                      class="custom-control-input"
-                      data-testid="select-all-checkbox"
-                      disabled=""
-                      type="checkbox"
-                      value="false"
-                    />
-                    <span
-                      class="custom-control-label"
-                    />
-                  </label>
-                </div>
-              </li>
-            </ul>
             <div
-              class="navbar-form navbar-form-autofit mx-2"
+              class="container-fluid"
             >
+              <ul
+                class="nav-root front-nav navbar-nav"
+                role="tablist"
+              >
+                <li
+                  class="nav-item"
+                  role="presentation"
+                >
+                  <div
+                    class="custom-control custom-checkbox"
+                  >
+                    <label>
+                      <input
+                        class="custom-control-input"
+                        data-testid="select-all-checkbox"
+                        disabled=""
+                        type="checkbox"
+                        value="false"
+                      />
+                      <span
+                        class="custom-control-label"
+                      />
+                    </label>
+                  </div>
+                </li>
+              </ul>
               <div
-                class="input-group search"
+                class="navbar-form navbar-form-autofit mx-2"
               >
                 <div
-                  class="input-group-item"
+                  class="input-group search"
                 >
-                  <input
-                    class="input-root form-control input-group-inset input-group-inset-after"
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
                   <div
-                    class="input-group-inset-item input-group-inset-item-after"
+                    class="input-group-item"
                   >
-                    <button
-                      aria-label="Search"
-                      class="button-root btn btn-unstyled"
-                      type="button"
+                    <input
+                      class="input-root form-control input-group-inset input-group-inset-after"
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
+                    <div
+                      class="input-group-inset-item input-group-inset-item-after"
                     >
-                      <svg
-                        class="lexicon-icon lexicon-icon-search icon-root"
-                        role="presentation"
+                      <button
+                        aria-label="Search"
+                        class="button-root btn btn-unstyled"
+                        type="button"
                       >
-                        <use
-                          href="#search"
-                        />
-                      </svg>
-                    </button>
+                        <svg
+                          class="lexicon-icon lexicon-icon-search icon-root"
+                          role="presentation"
+                        >
+                          <use
+                            href="#search"
+                          />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </nav>
-      </div>
-      <div
-        class="no-results-root flex-grow-1"
-      >
+          </nav>
+        </div>
         <div
-          class="no-results-content"
+          class="no-results-root flex-grow-1"
         >
           <div
-            class="h4 no-results-title"
+            class="no-results-content"
           >
-            There are no items found.
+            <div
+              class="h4 no-results-title"
+            >
+              There are no items found.
+            </div>
           </div>
         </div>
       </div>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/__snapshots__/SearchableTableModalGraphql.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/modals/__tests__/__snapshots__/SearchableTableModalGraphql.jsx.snap
@@ -34,337 +34,337 @@ exports[`SearchableTableModalGraphql should render 1`] = `
         </button>
       </div>
       <div
-        class="modal-body"
+        class="modal-body p-0"
       >
         <div
           class="text-secondary"
         />
-      </div>
-      <div
-        class="toolbar-root"
-      >
-        <nav
-          class="navbar navbar-root management-bar management-bar-light navbar-expand"
-        >
-          <div
-            class="container-fluid"
-          >
-            <ul
-              class="nav-root front-nav navbar-nav"
-              role="tablist"
-            >
-              <li
-                class="nav-item"
-                role="presentation"
-              >
-                <div
-                  class="custom-control custom-checkbox"
-                >
-                  <label>
-                    <input
-                      class="custom-control-input"
-                      data-testid="select-all-checkbox"
-                      type="checkbox"
-                      value="false"
-                    />
-                    <span
-                      class="custom-control-label"
-                    />
-                  </label>
-                </div>
-              </li>
-            </ul>
-            <div
-              class="navbar-form navbar-form-autofit mx-2"
-            >
-              <div
-                class="input-group search"
-              >
-                <div
-                  class="input-group-item"
-                >
-                  <input
-                    class="input-root form-control input-group-inset input-group-inset-after"
-                    placeholder="Search"
-                    type="text"
-                    value=""
-                  />
-                  <div
-                    class="input-group-inset-item input-group-inset-item-after"
-                  >
-                    <button
-                      aria-label="Search"
-                      class="button-root btn btn-unstyled"
-                      type="button"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-search icon-root"
-                        role="presentation"
-                      >
-                        <use
-                          href="#search"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </nav>
-      </div>
-      <div
-        class="flex-grow-1 mx-4 table-root"
-      >
         <div
-          class="table-responsive"
+          class="toolbar-root"
         >
-          <table
-            class="table table-autofit table-list table-nowrap table-head-bordered table-hover table-striped"
+          <nav
+            class="navbar navbar-root management-bar management-bar-light navbar-expand"
           >
-            <thead>
-              <tr>
-                <th />
-                <th
-                  class="table-head-title"
+            <div
+              class="container-fluid"
+            >
+              <ul
+                class="nav-root front-nav navbar-nav"
+                role="tablist"
+              >
+                <li
+                  class="nav-item"
+                  role="presentation"
                 >
-                  <button
-                    class="inline-item text-truncate-inline btn btn-unstyled"
-                    type="button"
+                  <div
+                    class="custom-control custom-checkbox"
                   >
+                    <label>
+                      <input
+                        class="custom-control-input"
+                        data-testid="select-all-checkbox"
+                        type="checkbox"
+                        value="false"
+                      />
+                      <span
+                        class="custom-control-label"
+                      />
+                    </label>
+                  </div>
+                </li>
+              </ul>
+              <div
+                class="navbar-form navbar-form-autofit mx-2"
+              >
+                <div
+                  class="input-group search"
+                >
+                  <div
+                    class="input-group-item"
+                  >
+                    <input
+                      class="input-root form-control input-group-inset input-group-inset-after"
+                      placeholder="Search"
+                      type="text"
+                      value=""
+                    />
                     <div
-                      class="align-items-center d-flex justify-content-between"
+                      class="input-group-inset-item input-group-inset-item-after"
                     >
-                      <div
-                        class="text-truncate"
-                      >
-                        name
-                      </div>
                       <button
-                        aria-label="Ascending"
-                        class="component-action ml-2 btn btn-sm btn-primary"
+                        aria-label="Search"
+                        class="button-root btn btn-unstyled"
                         type="button"
                       >
                         <svg
-                          class="lexicon-icon lexicon-icon-order_arrow_ascending icon-root"
+                          class="lexicon-icon lexicon-icon-search icon-root"
                           role="presentation"
                         >
                           <use
-                            href="#order_arrow_ascending"
+                            href="#search"
                           />
                         </svg>
                       </button>
                     </div>
-                  </button>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                class="clickable"
-              >
-                <td>
-                  <div
-                    class="custom-control custom-checkbox"
-                  >
-                    <label>
-                      <input
-                        class="custom-control-input"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <span
-                        class="custom-control-label"
-                      />
-                    </label>
                   </div>
-                </td>
-                <td>
-                  fooOrganization-0
-                </td>
-              </tr>
-              <tr
-                class="clickable"
-              >
-                <td>
-                  <div
-                    class="custom-control custom-checkbox"
-                  >
-                    <label>
-                      <input
-                        class="custom-control-input"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <span
-                        class="custom-control-label"
-                      />
-                    </label>
-                  </div>
-                </td>
-                <td>
-                  fooOrganization-1
-                </td>
-              </tr>
-              <tr
-                class="clickable"
-              >
-                <td>
-                  <div
-                    class="custom-control custom-checkbox"
-                  >
-                    <label>
-                      <input
-                        class="custom-control-input"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <span
-                        class="custom-control-label"
-                      />
-                    </label>
-                  </div>
-                </td>
-                <td>
-                  fooOrganization-2
-                </td>
-              </tr>
-              <tr
-                class="clickable"
-              >
-                <td>
-                  <div
-                    class="custom-control custom-checkbox"
-                  >
-                    <label>
-                      <input
-                        class="custom-control-input"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <span
-                        class="custom-control-label"
-                      />
-                    </label>
-                  </div>
-                </td>
-                <td>
-                  fooOrganization-3
-                </td>
-              </tr>
-              <tr
-                class="clickable"
-              >
-                <td>
-                  <div
-                    class="custom-control custom-checkbox"
-                  >
-                    <label>
-                      <input
-                        class="custom-control-input"
-                        type="checkbox"
-                        value="false"
-                      />
-                      <span
-                        class="custom-control-label"
-                      />
-                    </label>
-                  </div>
-                </td>
-                <td>
-                  fooOrganization-4
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                </div>
+              </div>
+            </div>
+          </nav>
         </div>
-      </div>
-      <nav
-        class="navbar navbar-root pagination-bar-root"
-      >
         <div
-          class="container-fluid"
+          class="flex-grow-1 mx-4 table-root"
         >
           <div
-            class="dropdown dropdown-root pagination-items-per-page"
+            class="table-responsive"
           >
-            <button
-              aria-expanded="false"
-              aria-haspopup="true"
-              class="dropdown-toggle button-root btn btn-sm btn-secondary"
-              type="button"
+            <table
+              class="table table-autofit table-list table-nowrap table-head-bordered table-hover table-striped"
             >
-              5 Items
-              <svg
-                class="lexicon-icon lexicon-icon-caret-bottom ml-2"
-                role="presentation"
-              >
-                <use
-                  href="#caret-bottom"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="pagination-results"
-          >
-            Showing 1 to 5 of 5 entries.
-          </div>
-          <ul
-            class="pagination pagination-root"
-          >
-            <li
-              class="page-item disabled"
-            >
-              <button
-                class="button-root btn btn-unstyled page-link btn btn-primary"
-                disabled=""
-                href=""
-                type="button"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-left-small icon-root"
-                  role="presentation"
+              <thead>
+                <tr>
+                  <th />
+                  <th
+                    class="table-head-title"
+                  >
+                    <button
+                      class="inline-item text-truncate-inline btn btn-unstyled"
+                      type="button"
+                    >
+                      <div
+                        class="align-items-center d-flex justify-content-between"
+                      >
+                        <div
+                          class="text-truncate"
+                        >
+                          name
+                        </div>
+                        <button
+                          aria-label="Ascending"
+                          class="component-action ml-2 btn btn-sm btn-primary"
+                          type="button"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-order_arrow_ascending icon-root"
+                            role="presentation"
+                          >
+                            <use
+                              href="#order_arrow_ascending"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  class="clickable"
                 >
-                  <use
-                    href="#angle-left-small"
-                  />
-                </svg>
-              </button>
-            </li>
-            <li
-              class="page-item active"
-            >
-              <button
-                class="button-root btn btn-unstyled page-link btn btn-primary"
-                href=""
-                type="button"
-              >
-                1
-              </button>
-            </li>
-            <li
-              class="page-item disabled"
-            >
-              <button
-                class="button-root btn btn-unstyled page-link btn btn-primary"
-                disabled=""
-                href=""
-                type="button"
-              >
-                <svg
-                  class="lexicon-icon lexicon-icon-angle-right-small icon-root"
-                  role="presentation"
+                  <td>
+                    <div
+                      class="custom-control custom-checkbox"
+                    >
+                      <label>
+                        <input
+                          class="custom-control-input"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <span
+                          class="custom-control-label"
+                        />
+                      </label>
+                    </div>
+                  </td>
+                  <td>
+                    fooOrganization-0
+                  </td>
+                </tr>
+                <tr
+                  class="clickable"
                 >
-                  <use
-                    href="#angle-right-small"
-                  />
-                </svg>
-              </button>
-            </li>
-          </ul>
+                  <td>
+                    <div
+                      class="custom-control custom-checkbox"
+                    >
+                      <label>
+                        <input
+                          class="custom-control-input"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <span
+                          class="custom-control-label"
+                        />
+                      </label>
+                    </div>
+                  </td>
+                  <td>
+                    fooOrganization-1
+                  </td>
+                </tr>
+                <tr
+                  class="clickable"
+                >
+                  <td>
+                    <div
+                      class="custom-control custom-checkbox"
+                    >
+                      <label>
+                        <input
+                          class="custom-control-input"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <span
+                          class="custom-control-label"
+                        />
+                      </label>
+                    </div>
+                  </td>
+                  <td>
+                    fooOrganization-2
+                  </td>
+                </tr>
+                <tr
+                  class="clickable"
+                >
+                  <td>
+                    <div
+                      class="custom-control custom-checkbox"
+                    >
+                      <label>
+                        <input
+                          class="custom-control-input"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <span
+                          class="custom-control-label"
+                        />
+                      </label>
+                    </div>
+                  </td>
+                  <td>
+                    fooOrganization-3
+                  </td>
+                </tr>
+                <tr
+                  class="clickable"
+                >
+                  <td>
+                    <div
+                      class="custom-control custom-checkbox"
+                    >
+                      <label>
+                        <input
+                          class="custom-control-input"
+                          type="checkbox"
+                          value="false"
+                        />
+                        <span
+                          class="custom-control-label"
+                        />
+                      </label>
+                    </div>
+                  </td>
+                  <td>
+                    fooOrganization-4
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
-      </nav>
+        <nav
+          class="navbar navbar-root pagination-bar-root"
+        >
+          <div
+            class="container-fluid"
+          >
+            <div
+              class="dropdown dropdown-root pagination-items-per-page"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="dropdown-toggle button-root btn btn-sm btn-secondary"
+                type="button"
+              >
+                5 Items
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-bottom ml-2"
+                  role="presentation"
+                >
+                  <use
+                    href="#caret-bottom"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div
+              class="pagination-results"
+            >
+              Showing 1 to 5 of 5 entries.
+            </div>
+            <ul
+              class="pagination pagination-root"
+            >
+              <li
+                class="page-item disabled"
+              >
+                <button
+                  class="button-root btn btn-unstyled page-link btn btn-primary"
+                  disabled=""
+                  href=""
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-left-small icon-root"
+                    role="presentation"
+                  >
+                    <use
+                      href="#angle-left-small"
+                    />
+                  </svg>
+                </button>
+              </li>
+              <li
+                class="page-item active"
+              >
+                <button
+                  class="button-root btn btn-unstyled page-link btn btn-primary"
+                  href=""
+                  type="button"
+                >
+                  1
+                </button>
+              </li>
+              <li
+                class="page-item disabled"
+              >
+                <button
+                  class="button-root btn btn-unstyled page-link btn btn-primary"
+                  disabled=""
+                  href=""
+                  type="button"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right-small icon-root"
+                    role="presentation"
+                  >
+                    <use
+                      href="#angle-right-small"
+                    />
+                  </svg>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </nav>
+      </div>
       <div
         class="modal-footer"
       >


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88174

Backport of `LPD-88174` to `faro-v4.15.x`.

## What is being fixed

The `CrossPageSelect` component in the searchable table modals was rendered as a sibling of `Modal.Body` rather than inside it, which placed the table outside the modal's scrollable body region.

## How it is being fixed

`CrossPageSelect` is now nested inside `Modal.Body` in both `SearchableTableModal` and `SearchableTableModalGraphql`, with the body using `p-0` so the inner content controls its own padding. Snapshot tests are updated to match the new DOM structure.