### PR TITLE
LPD-90931 faro-v4.15.x Filter Add Data Source dropdown by plan

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/registry.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/registry.ts
@@ -4,6 +4,7 @@ import {
 	listAvailableConnectors,
 	listConnectors
 } from '../registry';
+import {SubscriptionNames} from 'shared/util/subscriptions';
 
 describe('connector registry', () => {
 	describe('getConnectorConfig', () => {
@@ -60,18 +61,58 @@ describe('connector registry', () => {
 		it('hides singleton connectors that already exist on the data source list', () => {
 			const existing = new Set([DataSourceTypes.Demandbase]);
 
-			const slugs = listAvailableConnectors(existing).map(c => c.slug);
+			const slugs = listAvailableConnectors(
+				existing,
+				SubscriptionNames.LiferayDataPlatform
+			).map(c => c.slug);
 
 			expect(slugs).not.toContain('demandbase');
 			expect(slugs).toContain('hubspot');
 		});
 
 		it('returns all connectors when none are present yet', () => {
-			const slugs = listAvailableConnectors(new Set())
+			const slugs = listAvailableConnectors(
+				new Set(),
+				SubscriptionNames.LiferayDataPlatform
+			)
 				.map(c => c.slug)
 				.sort();
 
 			expect(slugs).toEqual(['demandbase', 'hubspot', 'marketo']);
+		});
+
+		it('hides every connector that requires LDP when the plan is non-LDP', () => {
+			const slugs = listAvailableConnectors(
+				new Set(),
+				SubscriptionNames.LiferayAnalyticsCloudEnterprise
+			).map(c => c.slug);
+
+			const ldpRequired = listConnectors()
+				.filter(config => config.requiresLDP)
+				.map(c => c.slug);
+
+			ldpRequired.forEach(slug => {
+				expect(slugs).not.toContain(slug);
+			});
+		});
+
+		it('shows LDP-only connectors on an LDP plan', () => {
+			const slugs = listAvailableConnectors(
+				new Set(),
+				SubscriptionNames.LiferayDataPlatform
+			)
+				.map(c => c.slug)
+				.sort();
+
+			expect(slugs).toEqual(['demandbase', 'hubspot', 'marketo']);
+		});
+
+		it('hides LDP-only connectors while the subscription is still loading', () => {
+			const slugs = listAvailableConnectors(new Set(), null).map(
+				c => c.slug
+			);
+
+			expect(slugs).toEqual([]);
 		});
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/configs/demandbase.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/configs/demandbase.ts
@@ -18,6 +18,7 @@ const demandbaseConfig: ConnectorConfig = {
 		}
 	],
 	languages: buildLanguages(displayName),
+	requiresLDP: true,
 	singleton: true,
 	slug: SLUG,
 	type: DataSourceTypes.Demandbase

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/configs/hubspot.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/configs/hubspot.ts
@@ -18,6 +18,7 @@ const hubspotConfig: ConnectorConfig = {
 		}
 	],
 	languages: buildLanguages(displayName),
+	requiresLDP: true,
 	singleton: true,
 	slug: SLUG,
 	type: DataSourceTypes.Hubspot

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/configs/marketo.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/configs/marketo.ts
@@ -18,6 +18,7 @@ const marketoConfig: ConnectorConfig = {
 		}
 	],
 	languages: buildLanguages(displayName),
+	requiresLDP: true,
 	singleton: true,
 	slug: SLUG,
 	type: DataSourceTypes.Marketo

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/registry.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/registry.ts
@@ -6,6 +6,7 @@ import hubspotConfig from './configs/hubspot';
 import marketoConfig from './configs/marketo';
 import {ConnectorConfig} from './types';
 import {DataSourceTypes} from 'shared/util/constants';
+import {isLDPPlan} from 'shared/util/subscriptions';
 
 const connectorRegistry: Record<string, ConnectorConfig> = {
 	[DataSourceTypes.Demandbase]: demandbaseConfig,
@@ -28,11 +29,22 @@ export function listConnectors(): ConnectorConfig[] {
 }
 
 export function listAvailableConnectors(
-	existingTypes: ReadonlySet<string>
+	existingTypes: ReadonlySet<string>,
+	subscriptionName: string | null = null
 ): ConnectorConfig[] {
-	return listConnectors().filter(
-		config => !(config.singleton && existingTypes.has(config.type))
-	);
+	const ldpAllowed = isLDPPlan(subscriptionName);
+
+	return listConnectors().filter(config => {
+		if (config.singleton && existingTypes.has(config.type)) {
+			return false;
+		}
+
+		if (config.requiresLDP && !ldpAllowed) {
+			return false;
+		}
+
+		return true;
+	});
 }
 
 export {connectorRegistry};

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/types.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/types.ts
@@ -52,6 +52,7 @@ export interface ConnectorConfig {
 
 	helpUrl?: string;
 	languages: Languages;
+	requiresLDP?: boolean;
 	singleton?: boolean;
 	slug: string;
 	type: string;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
@@ -31,59 +31,33 @@ import {
 } from 'settings/components/3rd-party-connector/registry';
 import {getConnectorStatusDisplay} from 'settings/components/3rd-party-connector/getConnectorStatusDisplay';
 import {getDataSourceDisplayObject} from 'shared/util/data-sources';
+import {isLDPPlan} from 'shared/util/subscriptions';
 import {Link, useHistory, useParams} from 'react-router-dom';
 import {Routes, toRoute} from 'shared/util/router';
 import {sub} from 'shared/util/lang';
-import {SubscriptionNames} from 'shared/util/subscriptions';
 import {useCurrentUser} from 'shared/hooks/useCurrentUser';
 import {useQueryPagination} from 'shared/hooks/useQueryPagination';
 import {useRequest} from 'shared/hooks/useRequest';
 import {useSubscriptionName} from 'shared/hooks/useSubscriptionName';
 import {useTimeZone} from 'shared/hooks/useTimeZone';
 
-const DATA_SOURCE_SUBSCRIPTION_RULES: {
-	[type: string]: {excluded?: string[]; included?: string[]};
-} = {
-	[DataSourceTypes.Demandbase]: {
-		included: [
-			SubscriptionNames.LiferayDataPlatform,
-			SubscriptionNames.LiferayDataPlatformEnterprise
-		]
+interface StandaloneDataSourceDescriptor {
+	label: string;
+	requiresLDP?: boolean;
+	type: DataSourceTypes;
+}
+
+const STANDALONE_DATA_SOURCES: StandaloneDataSourceDescriptor[] = [
+	{
+		label: Liferay.Language.get('liferay-dxp'),
+		type: DataSourceTypes.Liferay
 	},
-	[DataSourceTypes.Hubspot]: {
-		included: [
-			SubscriptionNames.LiferayDataPlatform,
-			SubscriptionNames.LiferayDataPlatformEnterprise
-		]
-	},
-	[DataSourceTypes.Salesforce]: {
-		included: [
-			SubscriptionNames.LiferayDataPlatform,
-			SubscriptionNames.LiferayDataPlatformEnterprise
-		]
+	{
+		label: Liferay.Language.get('salesforce'),
+		requiresLDP: true,
+		type: DataSourceTypes.Salesforce
 	}
-};
-
-export const isDataSourceVisible = (
-	type: string,
-	subscriptionName: string | null
-): boolean => {
-	const rule = DATA_SOURCE_SUBSCRIPTION_RULES[type];
-
-	if (!rule || !subscriptionName) {
-		return true;
-	}
-
-	if (rule.excluded?.includes(subscriptionName)) {
-		return false;
-	}
-
-	if (rule.included && !rule.included.includes(subscriptionName)) {
-		return false;
-	}
-
-	return true;
-};
+];
 
 interface ICellProps {
 	data: {[key: string]: any};
@@ -268,49 +242,36 @@ const DataSourceList: React.FC<IDataSourceListProps> = ({className}) => {
 		)
 	);
 
-	const connectorItems = listAvailableConnectors(existingConnectorTypes)
-		.filter(config => isDataSourceVisible(config.type, subscriptionName))
-		.map(config => ({
-			label: config.displayName,
-			onClick: () => {
-				history.push(
-					toRoute(Routes.SETTINGS_DATA_SOURCE_ONBOARDING, {
-						groupId,
-						id: config.type
-					})
-				);
-			}
-		}));
+	const ldpAllowed = isLDPPlan(subscriptionName);
 
-	const dataSourceItems = [
-		{
-			label: Liferay.Language.get('liferay-dxp'),
-			onClick: () => {
-				history.push(
-					toRoute(Routes.SETTINGS_DATA_SOURCE_ONBOARDING, {
-						groupId,
-						id: DataSourceTypes.Liferay
-					})
-				);
-			},
-			type: DataSourceTypes.Liferay
-		},
-		{
-			label: Liferay.Language.get('salesforce'),
-			onClick: () => {
-				history.push(
-					toRoute(Routes.SETTINGS_DATA_SOURCE_ONBOARDING, {
-						groupId,
-						id: DataSourceTypes.Salesforce
-					})
-				);
-			},
-			type: DataSourceTypes.Salesforce
+	const connectorItems = listAvailableConnectors(
+		existingConnectorTypes,
+		subscriptionName
+	).map(config => ({
+		label: config.displayName,
+		onClick: () => {
+			history.push(
+				toRoute(Routes.SETTINGS_DATA_SOURCE_ONBOARDING, {
+					groupId,
+					id: config.type
+				})
+			);
 		}
-	]
-		.filter(({type}) => isDataSourceVisible(type, subscriptionName))
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		.map(({type, ...item}) => item);
+	}));
+
+	const dataSourceItems = STANDALONE_DATA_SOURCES.filter(
+		({requiresLDP}) => !requiresLDP || ldpAllowed
+	).map(({label, type}) => ({
+		label,
+		onClick: () => {
+			history.push(
+				toRoute(Routes.SETTINGS_DATA_SOURCE_ONBOARDING, {
+					groupId,
+					id: type
+				})
+			);
+		}
+	}));
 
 	const renderDataSourcesDropdown = () => (
 		<ClayDropDownWithItems

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/__tests__/DataSourceList.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/pages/__tests__/DataSourceList.jsx
@@ -1,14 +1,8 @@
 import React from 'react';
-import {
-	DataSourceName,
-	disableRow,
-	isDataSourceVisible,
-	StatusRenderer
-} from '../DataSourceList';
+import {DataSourceName, disableRow, StatusRenderer} from '../DataSourceList';
 import {DataSourceStates, DataSourceTypes} from 'shared/util/constants';
 import {MemoryRouter} from 'react-router-dom';
 import {render} from '@testing-library/react';
-import {SubscriptionNames} from 'shared/util/subscriptions';
 
 jest.unmock('react-dom');
 
@@ -28,76 +22,6 @@ describe('DataSourceList exports', () => {
 			expect(disableRow({state: DataSourceStates.Disconnected})).toBe(
 				false
 			);
-		});
-	});
-
-	describe('isDataSourceVisible', () => {
-		it('always shows data source types with no subscription rule', () => {
-			expect(
-				isDataSourceVisible(
-					DataSourceTypes.Liferay,
-					SubscriptionNames.LiferayDataPlatform
-				)
-			).toBe(true);
-			expect(
-				isDataSourceVisible(
-					DataSourceTypes.Csv,
-					SubscriptionNames.LiferayAnalyticsCloudEnterprise
-				)
-			).toBe(true);
-		});
-
-		it('returns true when the subscription name is null', () => {
-			expect(isDataSourceVisible(DataSourceTypes.Demandbase, null)).toBe(
-				true
-			);
-		});
-
-		it.each([
-			DataSourceTypes.Demandbase,
-			DataSourceTypes.Hubspot,
-			DataSourceTypes.Salesforce
-		])('shows %s when the subscription is Liferay Data Platform', type => {
-			expect(
-				isDataSourceVisible(type, SubscriptionNames.LiferayDataPlatform)
-			).toBe(true);
-		});
-
-		it.each([
-			[
-				DataSourceTypes.Demandbase,
-				SubscriptionNames.LiferayAnalyticsCloudBasic
-			],
-			[
-				DataSourceTypes.Hubspot,
-				SubscriptionNames.LiferayAnalyticsCloudBusiness
-			],
-			[
-				DataSourceTypes.Salesforce,
-				SubscriptionNames.LiferayAnalyticsCloudEnterprise
-			],
-			[
-				DataSourceTypes.Demandbase,
-				SubscriptionNames.LiferaySaasEnterprisePlan
-			],
-			[DataSourceTypes.Hubspot, SubscriptionNames.LxcBusinessPlan]
-		])('hides %s for non-LDP subscription %s', (type, subscription) => {
-			expect(isDataSourceVisible(type, subscription)).toBe(false);
-		});
-
-		it('should show Demandbase, Hubspot and Salesforce only when the subscription is Liferay Data Platform Enterprise', () => {
-			[
-				DataSourceTypes.Demandbase,
-				DataSourceTypes.Hubspot,
-				DataSourceTypes.Salesforce
-			].forEach(type => {
-				expect(
-					isDataSourceVisible(
-						type,
-						SubscriptionNames.LiferayDataPlatformEnterprise
-					)
-				).toBe(true);
-			});
 		});
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/NotificationAlertList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/NotificationAlertList.tsx
@@ -118,7 +118,7 @@ const NotificationAlertList: React.FC<INotificationAlertListProps> = ({
 	stripe = false,
 	subtypes = [NotificationSubtypes.TimeZoneChanged]
 }) => {
-	if (loading || !data.length) return null;
+	if (loading || !data?.length) return null;
 
 	const removeNotification = (notificationId: string) => {
 		API.notifications

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useLDPEnabled.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useLDPEnabled.ts
@@ -1,14 +1,5 @@
-import {Map} from 'immutable';
-import {useSelector} from 'react-redux';
+import {isLDPPlan} from 'shared/util/subscriptions';
+import {useSubscriptionName} from 'shared/hooks/useSubscriptionName';
 
-type RootState = Map<string, any>;
-
-export const useLDPEnabled = ({groupId}: {groupId: string}) => {
-	const project = useSelector((state: RootState) =>
-		state.getIn(['projects', groupId, 'data'], null)
-	);
-
-	const planName: string = project?.getIn(['faroSubscription', 'name'], null);
-
-	return planName?.includes('Data Platform') ?? false;
-};
+export const useLDPEnabled = ({groupId}: {groupId: string}): boolean =>
+	isLDPPlan(useSubscriptionName({groupId}));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/subscriptions.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/subscriptions.js
@@ -5,6 +5,7 @@ import {
 	getPropIcon,
 	getPropLabel,
 	INDIVIDUALS,
+	isLDPPlan,
 	PAGEVIEWS,
 	SubscriptionNames
 } from '../subscriptions';
@@ -133,6 +134,30 @@ describe('subscriptions', () => {
 			const plan = formatPlanData(null);
 
 			expect(plan).toMatchSnapshot();
+		});
+	});
+
+	describe('isLDPPlan', () => {
+		it.each([
+			SubscriptionNames.LiferayDataPlatform,
+			SubscriptionNames.LiferayDataPlatformEnterprise
+		])('returns true for %s', name => {
+			expect(isLDPPlan(name)).toBe(true);
+		});
+
+		it.each([
+			SubscriptionNames.LiferayAnalyticsCloudBasic,
+			SubscriptionNames.LiferayAnalyticsCloudBusiness,
+			SubscriptionNames.LiferayAnalyticsCloudEnterprise,
+			SubscriptionNames.LiferaySaasEnterprisePlan,
+			SubscriptionNames.LxcBusinessPlan
+		])('returns false for non-LDP plan %s', name => {
+			expect(isLDPPlan(name)).toBe(false);
+		});
+
+		it('returns false when the subscription is missing (null/undefined)', () => {
+			expect(isLDPPlan(null)).toBe(false);
+			expect(isLDPPlan(undefined)).toBe(false);
 		});
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/subscriptions.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/subscriptions.js
@@ -437,3 +437,7 @@ export function isBasicPlan(currentPlan) {
 		PLAN_TYPES[currentPlan.name] === 'lxcPro'
 	);
 }
+
+export function isLDPPlan(subscriptionName) {
+	return subscriptionName?.includes('Data Platform') ?? false;
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90931

Backport of https://github.com/liferay-ac/liferay-portal/pull/3252 to `faro-v4.15.x`.

## What is being fixed

DataSourceList decided which data sources to show in the Add Data
Source dropdown using a DATA_SOURCE_SUBSCRIPTION_RULES map that listed
every LDP plan name three times — once per data source. Adding a new
LDP-only connector required editing that map even though the
third-party connector framework's own registry should be the source
of truth. The rule also lived in the wrong place: a page-level
component held knowledge about every data source type.

## How it is being fixed

A small isLDPPlan helper centralizes the "is the current plan LDP?"
check, replacing the bespoke rule map. Each ConnectorConfig now
declares its own requiresLDP flag, so adding a new LDP-only connector
means setting requiresLDP: true in its config — no edits to
DataSourceList.tsx. The same flag gates the two standalone data
sources (Salesforce, Liferay DXP) that do not use the connector
framework, via a STANDALONE_DATA_SOURCES array. The new
listAvailableConnectors(existing, subscriptionName) runs both checks
(singleton dedup and plan gate) in one pass. useLDPEnabled becomes a
one-liner around the same helper.