### PR TITLE
LPD-90937 Rename breadcrumb to "Individuals" and route by LDP plan

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutes.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutes.tsx
@@ -14,6 +14,7 @@ import {CSVType} from 'shared/components/download-report/utils';
 import {getMatchedRoute, Routes} from 'shared/util/router';
 import {Switch, withRouter} from 'react-router-dom';
 import {useDataSources} from 'shared/context/dataSources';
+import {useLDPEnabled} from 'shared/hooks/useLDPEnabled';
 import {useRequest} from 'shared/hooks/useRequest';
 
 const AssociatedSegments = lazy(
@@ -86,6 +87,8 @@ export const IndividualProfileRoutes = ({
 }: IIndividualProfileRoutesProps) => {
 	const dataSourceStates = useDataSources();
 
+	const LDPEnabled = useLDPEnabled({groupId});
+
 	const {selectedChannel} = useContext(ChannelContext);
 
 	const matchedRoute = getMatchedRoute(NAV_ITEMS);
@@ -120,7 +123,11 @@ export const IndividualProfileRoutes = ({
 						groupId,
 						label: selectedChannel && selectedChannel.name
 					}),
-					breadcrumbs.getKnownIndividuals({channelId, groupId}),
+					breadcrumbs.getIndividuals({
+						channelId,
+						groupId,
+						LDPEnabled
+					}),
 					breadcrumbs.getEntityName({label: entityName})
 				]}
 				groupId={groupId}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutesCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutesCDP.tsx
@@ -14,6 +14,7 @@ import {CSVType} from 'shared/components/download-report/utils';
 import {getMatchedRoute, Routes} from 'shared/util/router';
 import {Switch, withRouter} from 'react-router-dom';
 import {useDataSources} from 'shared/context/dataSources';
+import {useLDPEnabled} from 'shared/hooks/useLDPEnabled';
 import {useRequest} from 'shared/hooks/useRequest';
 
 const AssociatedSegments = lazy(
@@ -92,6 +93,8 @@ export const IndividualProfileRoutesCDP = ({
 }: IIndividualProfileRoutesCDPProps) => {
 	const dataSourceStates = useDataSources();
 
+	const LDPEnabled = useLDPEnabled({groupId});
+
 	const {selectedChannel} = useContext(ChannelContext);
 
 	const matchedRoute = getMatchedRoute(NAV_ITEMS_CDP);
@@ -126,7 +129,11 @@ export const IndividualProfileRoutesCDP = ({
 						groupId,
 						label: selectedChannel && selectedChannel.name
 					}),
-					breadcrumbs.getKnownIndividuals({channelId, groupId}),
+					breadcrumbs.getIndividuals({
+						channelId,
+						groupId,
+						LDPEnabled
+					}),
 					breadcrumbs.getEntityName({label: entityName})
 				]}
 				groupId={groupId}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/__tests__/ProfileRoutesCDP.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/__tests__/ProfileRoutesCDP.jsx
@@ -1,7 +1,7 @@
 import * as data from 'test/data';
 import DataSourcesProvider from 'shared/context/dataSources';
 import IndividualProfileRoutesCDP from '../ProfileRoutesCDP';
-import mockStore from 'test/mock-store';
+import mockStore, {mockStoreDataLDP} from 'test/mock-store';
 import React from 'react';
 import {BrowserRouter} from 'react-router-dom';
 import {ChannelContext} from 'shared/context/channel';
@@ -31,7 +31,7 @@ describe('IndividualProfileRoutes', () => {
 		window.location = {pathname: '/'};
 
 		const {container} = render(
-			<Provider store={mockStore()}>
+			<Provider store={mockStore(mockStoreDataLDP)}>
 				<ChannelContext.Provider value={mockChannelContext()}>
 					<DataSourcesProvider groupId={defaultProps.groupId}>
 						<BrowserRouter>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutes.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutes.jsx.snap
@@ -37,7 +37,7 @@ exports[`IndividualProfileRoutes should render 1`] = `
                 class="breadcrumb-text-truncate breadcrumb-link"
                 href="/workspace/23/123/contacts/individuals/known-individuals"
               >
-                Known Individuals
+                Individuals
               </a>
             </li>
             <li

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutesCDP.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutesCDP.jsx.snap
@@ -35,9 +35,9 @@ exports[`IndividualProfileRoutes should render 1`] = `
             >
               <a
                 class="breadcrumb-text-truncate breadcrumb-link"
-                href="/workspace/23/123/contacts/individuals/known-individuals"
+                href="/workspace/23/123/contacts/individuals"
               >
-                Known Individuals
+                Individuals
               </a>
             </li>
             <li

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/breadcrumbs.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/breadcrumbs.ts
@@ -54,15 +54,21 @@ export const getAccounts = ({channelId, groupId}: IBasicSidebarRouteArgs) => ({
 	label: Liferay.Language.get('accounts')
 });
 
-export const getKnownIndividuals = ({
+export const getIndividuals = ({
+	LDPEnabled,
 	channelId,
 	groupId
-}: IBasicSidebarRouteArgs) => ({
-	href: toRoute(Routes.CONTACTS_INDIVIDUALS_KNOWN_INDIVIDUALS, {
-		channelId,
-		groupId
-	}),
-	label: Liferay.Language.get('known-individuals')
+}: IBasicSidebarRouteArgs & {LDPEnabled: boolean}) => ({
+	href: toRoute(
+		LDPEnabled
+			? Routes.CONTACTS_INDIVIDUALS
+			: Routes.CONTACTS_INDIVIDUALS_KNOWN_INDIVIDUALS,
+		{
+			channelId,
+			groupId
+		}
+	),
+	label: Liferay.Language.get('individuals')
 });
 
 export const getSegments = ({channelId, groupId}: IBasicSidebarRouteArgs) => ({

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/webpack.dev.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/webpack.dev.js
@@ -1,8 +1,53 @@
 const common = require('./webpack.common');
+const {responseInterceptor} = require('http-proxy-middleware');
 const {merge} = require('webpack-merge');
 const webpack = require('webpack');
 
 require('dotenv').config();
+
+const TARGET = (process.env.FARO_URL || 'http://0.0.0.0:8080').replace(
+	/\/$/,
+	''
+);
+
+// The dev server proxies to a remote Liferay (e.g. analytics-stg) whose
+// `web.server.host` makes it emit absolute URLs back to itself. We buffer
+// each response and rewrite those URLs (in Location, Set-Cookie Domain, and
+// the body) so the browser stays on the dev server instead of leaving for
+// the upstream host.
+
+async function rewriteUpstreamResponse(responseBuffer, proxyRes, req, res) {
+	const proxyOrigin = `http://${req.headers.host}`;
+
+	if (proxyRes.headers['location']) {
+		res.setHeader(
+			'location',
+			proxyRes.headers['location'].split(TARGET).join(proxyOrigin)
+		);
+	}
+
+	if (proxyRes.headers['set-cookie']) {
+		res.setHeader(
+			'set-cookie',
+			proxyRes.headers['set-cookie'].map(cookie =>
+				cookie.replace(/;\s*Domain=[^;]+/gi, '')
+			)
+		);
+	}
+
+	const contentType = proxyRes.headers['content-type'] || '';
+	const isTextual =
+		contentType.includes('text/html') ||
+		contentType.includes('javascript') ||
+		contentType.includes('application/json') ||
+		contentType.includes('text/css');
+
+	if (!isTextual) {
+		return responseBuffer;
+	}
+
+	return responseBuffer.toString('utf8').split(TARGET).join(proxyOrigin);
+}
 
 module.exports = merge(common.config, {
 	devServer: {
@@ -12,7 +57,12 @@ module.exports = merge(common.config, {
 		host: '0.0.0.0',
 		port: 3000,
 		proxy: {
-			'**': process.env.FARO_URL || 'http://0.0.0.0:8080'
+			'**': {
+				changeOrigin: true,
+				onProxyRes: responseInterceptor(rewriteUpstreamResponse),
+				selfHandleResponse: true,
+				target: TARGET
+			}
 		}
 	},
 	devtool: 'eval-source-map',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90937

## What is being fixed

The individual-profile breadcrumb read "Known Individuals" even when the profile being viewed was anonymous, which was misleading. Beyond that, in LDP-enabled plans the linked URL pointed at /individuals/known-individuals, a sub-route that does not exist in the LDP UI — LDP renders the combined Individuals list at /individuals.

## How it is being fixed

breadcrumbs.getKnownIndividuals is replaced by breadcrumbs.getIndividuals, which always renders the label "Individuals" and picks the destination route from the new LDPEnabled flag: LDP plans link to Routes.CONTACTS_INDIVIDUALS (/individuals), non-LDP plans keep the legacy link to Routes.CONTACTS_INDIVIDUALS_KNOWN_INDIVIDUALS. ProfileRoutes.tsx and ProfileRoutesCDP.tsx both consume the new helper via the existing useLDPEnabled hook so the per-plan switch lives at one shared call site. The ProfileRoutesCDP test now runs against mockStoreDataLDP so the LDP branch is actually exercised by snapshot coverage.