### PR TITLE
LPD-85736 backport | faro-v4.15.x

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -186,8 +186,8 @@ public interface ContactsEngineClient {
 		String query, int cur, int delta);
 
 	public Results<Individual> getAccountIndividuals(
-		FaroProject faroProject, String accountId, int cur, int delta,
-		String sortString);
+		FaroProject faroProject, String accountId, String query, int cur,
+		int delta, String sortString);
 
 	public Results<IndividualSegment> getAccountIndividualSegments(
 		FaroProject faroProject, String accountId, String channelId,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -656,13 +656,17 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public Results<Individual> getAccountIndividuals(
-		FaroProject faroProject, String accountId, int cur, int delta,
-		String sortString) {
+		FaroProject faroProject, String accountId, String query, int cur,
+		int delta, String sortString) {
 
 		Map<String, Object> uriVariables = getUriVariables(
 			faroProject, cur, delta, null);
 
 		uriVariables.put("id", accountId);
+
+		if (Validator.isNotNull(query)) {
+			uriVariables.put("query", query);
+		}
 
 		if (Validator.isNotNull(sortString)) {
 			uriVariables.put(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/MockContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/MockContactsEngineClientImpl.java
@@ -36,11 +36,11 @@ public class MockContactsEngineClientImpl
 
 	@Override
 	public Results<Individual> getAccountIndividuals(
-		FaroProject faroProject, String accountId, int cur, int delta,
-		String sortString) {
+		FaroProject faroProject, String accountId, String query, int cur,
+		int delta, String sortString) {
 
 		return contactsEngineClient.getAccountIndividuals(
-			faroProject, accountId, cur, delta, sortString);
+			faroProject, accountId, query, cur, delta, sortString);
 	}
 
 	@Override

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountController.java
@@ -138,6 +138,7 @@ public class AccountController extends BaseFaroController {
 				@PathParam("groupId") long groupId, @PathParam("id") String id,
 				@QueryParam("page") int page,
 				@QueryParam("pageSize") int pageSize,
+				@QueryParam("search") String search,
 				@DefaultValue(StringPool.BLANK) @QueryParam("sort") String
 					sortString)
 		throws Exception {
@@ -145,7 +146,7 @@ public class AccountController extends BaseFaroController {
 		return new FaroFDSResultsDisplay<>(
 			contactsEngineClient.getAccountIndividuals(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId), id,
-				page, pageSize, sortString),
+				search, page, pageSize, sortString),
 			IndividualDisplay::new, page, pageSize);
 	}
 


### PR DESCRIPTION
Backport of LPD-85736 to faro-v4.15.x.

Cherry-picks:
- ead970ee — Add search param to getIndividualsFaroFDSResultsDisplay endpoint
- 88cc576 — Fix compile error (MockContactsEngineClientImpl missing query param)