### PR TITLE
LPD-91239 It is not possible to remove the selected event in Event Analysis view

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/event-analysis-builder/EventChip.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/event-analysis-builder/EventChip.tsx
@@ -6,7 +6,7 @@ import {Event} from 'event-analysis/utils/types';
 
 interface IEventChipProps {
 	event: Event;
-	onEventChange: (event?: Event) => void;
+	onEventChange: (event: Event | null) => void;
 }
 
 const EventChip: React.FC<IEventChipProps> = React.forwardRef<
@@ -15,7 +15,7 @@ const EventChip: React.FC<IEventChipProps> = React.forwardRef<
 >(({event: {displayName, name}, onClick, onEventChange}, ref) => (
 	<Chip
 		className='event-chip-root'
-		onCloseClick={() => onEventChange()}
+		onCloseClick={() => onEventChange(null)}
 		ref={ref}
 	>
 		<ClayButton

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/event-analysis-builder/EventSection.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/event-analysis-builder/EventSection.tsx
@@ -13,7 +13,7 @@ import {Event} from 'event-analysis/utils/types';
 interface IEventSectionProps {
 	deleteAllAttributes: DeleteAllAttributes;
 	event: Event;
-	onEventChange: (event: Event) => void;
+	onEventChange: (event: Event | null) => void;
 }
 
 const EventSection: React.FC<IEventSectionProps> = ({
@@ -21,10 +21,8 @@ const EventSection: React.FC<IEventSectionProps> = ({
 	event,
 	onEventChange
 }) => {
-	const handleEventChange = (event?: Event): void => {
-		if (event) {
-			onEventChange(event);
-		}
+	const handleEventChange = (event: Event | null): void => {
+		onEventChange(event);
 
 		deleteAllAttributes();
 	};

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/event-analysis-builder/__tests__/EventChip.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/event-analysis-builder/__tests__/EventChip.jsx
@@ -3,8 +3,8 @@ import EventChip from '../EventChip';
 import mockStore from 'test/mock-store';
 import React from 'react';
 import {ApolloProvider} from '@apollo/client';
+import {fireEvent, render} from '@testing-library/react';
 import {Provider} from 'react-redux';
-import {render} from '@testing-library/react';
 
 jest.unmock('react-dom');
 
@@ -19,5 +19,25 @@ describe('EventChip', () => {
 		);
 
 		expect(container).toMatchSnapshot();
+	});
+
+	it('calls onEventChange with null when the remove button is clicked', () => {
+		const onEventChange = jest.fn();
+
+		const {container} = render(
+			<ApolloProvider client={client}>
+				<Provider store={mockStore()}>
+					<EventChip
+						event={{id: '1', name: 'View Article'}}
+						onEventChange={onEventChange}
+					/>
+				</Provider>
+			</ApolloProvider>
+		);
+
+		fireEvent.click(container.querySelector('.remove-button'));
+
+		expect(onEventChange).toHaveBeenCalledTimes(1);
+		expect(onEventChange).toHaveBeenCalledWith(null);
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/event-analysis-builder/__tests__/EventSection.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/event-analysis-builder/__tests__/EventSection.jsx
@@ -1,16 +1,17 @@
 import EventSection from '../EventSection';
 import mockStore from 'test/mock-store';
 import React from 'react';
+import {AttributesContext} from '../../context/attributes';
+import {fireEvent, render} from '@testing-library/react';
 import {InMemoryCache} from '@apollo/client';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MockedProvider} from '@apollo/client/testing';
 import {Provider} from 'react-redux';
-import {render} from '@testing-library/react';
 import {Routes} from 'shared/util/router';
 
 jest.unmock('react-dom');
 
-const DefaultComponent = props => (
+const DefaultComponent = ({attributesValue, ...props}) => (
 	<Provider store={mockStore()}>
 		<MemoryRouter initialEntries={['/workspace/23/event-analysis']}>
 			<Route path={Routes.EVENT_ANALYSIS}>
@@ -22,7 +23,13 @@ const DefaultComponent = props => (
 						})
 					}
 				>
-					<EventSection {...props} />
+					{attributesValue ? (
+						<AttributesContext.Provider value={attributesValue}>
+							<EventSection {...props} />
+						</AttributesContext.Provider>
+					) : (
+						<EventSection {...props} />
+					)}
 				</MockedProvider>
 			</Route>
 		</MemoryRouter>
@@ -42,5 +49,32 @@ describe('EventSection', () => {
 		);
 
 		expect(container).toMatchSnapshot();
+	});
+
+	it('clears the event and the attributes when the remove button is clicked', () => {
+		const deleteAllAttributes = jest.fn();
+		const onEventChange = jest.fn();
+
+		const {container} = render(
+			<DefaultComponent
+				attributesValue={{
+					attributes: {},
+					breakdownOrder: [],
+					breakdowns: {},
+					changed: false,
+					deleteAllAttributes,
+					filterOrder: [],
+					filters: {}
+				}}
+				event={{id: '1', name: 'View Article'}}
+				onEventChange={onEventChange}
+			/>
+		);
+
+		fireEvent.click(container.querySelector('.remove-button'));
+
+		expect(onEventChange).toHaveBeenCalledTimes(1);
+		expect(onEventChange).toHaveBeenCalledWith(null);
+		expect(deleteAllAttributes).toHaveBeenCalledTimes(1);
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/event-analysis-builder/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/event-analysis-builder/index.tsx
@@ -6,7 +6,7 @@ import {Event} from 'event-analysis/utils/types';
 
 interface IEventAnalysisBuilderProps {
 	event?: Event;
-	onEventChange: (event: Event) => void;
+	onEventChange: (event: Event | null) => void;
 }
 
 const EventAnalysisBuilder: React.FC<IEventAnalysisBuilderProps> = ({

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/event-analysis/components/event-analysis-editor/index.tsx
@@ -14,7 +14,7 @@ interface IEventAnalysisEditorProps extends React.HTMLAttributes<HTMLElement> {
 	compareToPrevious: boolean;
 	event: Event;
 	onCompareToPreviousChange: (compareToPrevious: boolean) => void;
-	onEventChange: (event: Event) => void;
+	onEventChange: (event: Event | null) => void;
 	onRangeSelectorsChange: (rangeSelectors: RangeSelectors) => void;
 	onTypeChange: (type: CalculationTypes) => void;
 	type: CalculationTypes;


### PR DESCRIPTION
Motivation
----
Fix It is not possible to remove the selected event in Event Analysis view

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-91239)

Proposed Solution
-----
EventSection.handleEventChange dropped the parent onEventChange call when the chip emitted no event, so clicking the close button cleared the local attributes but left the selected event in  BaseEventAnalysisPage state and the chip stayed on screen. Widen onEventChange down the chain to accept Event | null, have the chip emit null on close, and always propagate the value to the  parent.