### PR TITLE
LPD-90929 Add empty state to IndividualsList when no individuals are synced

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
@@ -1,7 +1,10 @@
 import * as API from 'shared/api';
 import Card from 'shared/components/Card';
+import ClayLink from '@clayui/link';
+import NoResultsDisplay from 'shared/components/NoResultsDisplay';
 import React, {useMemo} from 'react';
 import SearchableEntityTable from 'shared/components/SearchableEntityTable';
+import URLConstants from 'shared/util/url-constants';
 import {
 	ACCOUNT_NAME,
 	COUNTRY,
@@ -18,6 +21,7 @@ import {
 } from 'segment/segment-editor/dynamic/utils/constants';
 import {FilterOptionType} from 'shared/types';
 import {IndividualsListCDPColumns} from 'shared/util/table-columns';
+import {Sizes} from 'shared/util/constants';
 import {useParams} from 'react-router-dom';
 import {useRequest} from 'shared/hooks/useRequest';
 import {useStatefulPagination} from 'shared/hooks/useStatefulPagination';
@@ -126,6 +130,38 @@ const IndividualsList = () => {
 			paginationParams.filterBy.get('profileTypes')?.toArray() || []
 	};
 
+	const renderNoResults = () => (
+		<NoResultsDisplay
+			description={
+				<>
+					{Liferay.Language.get(
+						'connect-a-data-source-with-people-data'
+					)}
+
+					<ClayLink
+						className='d-block mb-3'
+						href={URLConstants.DataSourceConnection}
+						key='DOCUMENTATION'
+						target='_blank'
+					>
+						{Liferay.Language.get(
+							'access-our-documentation-to-learn-more'
+						)}
+					</ClayLink>
+				</>
+			}
+			icon={{
+				border: false,
+				size: Sizes.XXXLarge,
+				symbol: 'ac_satellite'
+			}}
+			spacer
+			title={Liferay.Language.get(
+				'no-individuals-synced-from-data-sources'
+			)}
+		/>
+	);
+
 	return (
 		<Card>
 			<Card.Title className='card-header'>
@@ -157,6 +193,7 @@ const IndividualsList = () => {
 						}}
 						filterByOptions={FILTER_BY_OPTIONS}
 						key='individuals-list-table'
+						noResultsRenderer={renderNoResults}
 						orderByOptions={ORDER_BY_OPTIONS}
 						rowIdentifier='id'
 					/>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
@@ -18,59 +18,61 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('Individuals List', () => {
-	// @ts-ignore
-	API.individuals.fetchFieldValues.mockReturnValue(
-		Promise.resolve({items: ['United States', 'Canada']})
-	);
-
-	// @ts-ignore
-	API.individuals.search.mockReturnValue(
-		Promise.resolve({
-			items: [
-				{
-					accountName: 'Liferay Inc.',
-					activitiesCount: 8,
-					dateCreated: 1769697362927,
-					firstActivityDate: 1769697128235,
-					id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c1',
-					lastActivityDate: 1769697160365,
-					name: 'Test Test',
-					profileType: 'KNOWN',
-					properties: {
-						country: 'United States',
-						email: 'test@liferay.com'
-					}
-				},
-				{
-					accountName: 'Liferay',
-					activitiesCount: 8,
-					dateCreated: 1769697362927,
-					firstActivityDate: 1769697128235,
-					id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c3',
-					lastActivityDate: 1769697160365,
-					name: 'John Doe',
-					profileType: 'KNOWN',
-					properties: {
-						country: 'Canada',
-						email: 'john.doe@liferay.com'
-					}
-				},
-				{
-					activitiesCount: 3,
-					dateCreated: 1769697362927,
-					firstActivityDate: 1769697128235,
-					id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c2',
-					lastActivityDate: 1769697160365,
-					name: 'AC-79742349',
-					profileType: 'ANONYMOUS',
-					properties: {}
-				}
-			],
-			total: 3
-		})
-	);
+	beforeEach(() => {
+		// @ts-ignore
+		API.individuals.fetchFieldValues.mockReturnValue(
+			Promise.resolve({items: ['United States', 'Canada']})
+		);
+	});
 
 	it('renders', async () => {
+		// @ts-ignore
+		API.individuals.search.mockReturnValue(
+			Promise.resolve({
+				items: [
+					{
+						accountName: 'Liferay Inc.',
+						activitiesCount: 8,
+						dateCreated: 1769697362927,
+						firstActivityDate: 1769697128235,
+						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c1',
+						lastActivityDate: 1769697160365,
+						name: 'Test Test',
+						profileType: 'KNOWN',
+						properties: {
+							country: 'United States',
+							email: 'test@liferay.com'
+						}
+					},
+					{
+						accountName: 'Liferay',
+						activitiesCount: 8,
+						dateCreated: 1769697362927,
+						firstActivityDate: 1769697128235,
+						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c3',
+						lastActivityDate: 1769697160365,
+						name: 'John Doe',
+						profileType: 'KNOWN',
+						properties: {
+							country: 'Canada',
+							email: 'john.doe@liferay.com'
+						}
+					},
+					{
+						activitiesCount: 3,
+						dateCreated: 1769697362927,
+						firstActivityDate: 1769697128235,
+						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c2',
+						lastActivityDate: 1769697160365,
+						name: 'AC-79742349',
+						profileType: 'ANONYMOUS',
+						properties: {}
+					}
+				],
+				total: 3
+			})
+		);
+
 		const history = createMemoryHistory();
 
 		const {getByText} = render(
@@ -83,5 +85,34 @@ describe('Individuals List', () => {
 
 		expect(getByText('Individual Profiles')).toBeInTheDocument();
 		expect(getByText('Test Test')).toBeInTheDocument();
+	});
+
+	it('renders empty state when no individuals are synced', async () => {
+		// @ts-ignore
+		API.individuals.search.mockReturnValue(
+			Promise.resolve({items: [], total: 0})
+		);
+
+		const history = createMemoryHistory();
+
+		const {getByText} = render(
+			<Router history={history}>
+				<IndividualsList />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		expect(
+			getByText('No Individuals Synced from Data Sources')
+		).toBeInTheDocument();
+
+		expect(
+			getByText('Connect a data source with people data.')
+		).toBeInTheDocument();
+
+		expect(
+			getByText('Access our documentation to learn more.')
+		).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90929

## What is being fixed

The IndividualsList had no empty state when the connected data sources
had not yet synced any individuals. The table simply rendered nothing,
leaving the user with no feedback about why the list was empty.

## How it is being fixed

A `noResultsRenderer` is passed to `SearchableEntityTable` following
the same pattern used in `IndividualAttributes.tsx`. When the API
returns zero individuals and no filters are active, a `NoResultsDisplay`
is shown with the `ac_satellite` icon, the title
"No Individuals Synced from Data Sources", a description prompting the
user to connect a data source with people data, and a link to the
documentation. The connect data source button is intentionally omitted
since the page is already inside a property context where data sources
are present.