### PR TITLE
LPD-90934 Submit Individual Profiles search on Enter only

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/BaseResults.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/BaseResults.jsx
@@ -17,6 +17,89 @@ import {withHistory} from 'shared/hoc';
 
 const {cur: defaultPage} = Constants.pagination;
 
+/**
+ * Memoized so typing in the search input — which only mutates the parent's
+ * `searchValue` state — does not force the results subtree (e.g. a large
+ * paginated table with custom cell renderers) to reconcile on every keystroke.
+ */
+const ResultsContent = React.memo(function ResultsContent({
+	enableClearSearch,
+	error,
+	filterBy,
+	items,
+	loading,
+	noResultsRenderer,
+	onClearAllFilters,
+	onItemsChange,
+	onRetry,
+	query,
+	resultsRenderer,
+	selectedItemsIOMap,
+	showCheckbox,
+	total
+}) {
+	if (error) {
+		return (
+			<div className='error-info flex-grow-1'>
+				<div>
+					{Liferay.Language.get('an-unexpected-error-occurred')}
+				</div>
+
+				<ClayButton
+					className='button-root'
+					displayType='secondary'
+					onClick={onRetry}
+				>
+					{Liferay.Language.get('reload')}
+				</ClayButton>
+			</div>
+		);
+	}
+
+	if (!loading && !items.length && !total) {
+		if (query) {
+			return (
+				<NoResultsDisplay
+					description={Liferay.Language.get(
+						'please-try-a-different-search-term'
+					)}
+					icon={{
+						border: false,
+						size: Sizes.XXXLarge,
+						symbol: 'ac_no_results_found'
+					}}
+					spacer
+					title={Liferay.Language.get('there-are-no-results-found')}
+				>
+					{enableClearSearch && (
+						<ClayButton
+							className='button-root'
+							displayType='secondary'
+							onClick={onClearAllFilters}
+						>
+							{Liferay.Language.get('clear-search')}
+						</ClayButton>
+					)}
+				</NoResultsDisplay>
+			);
+		}
+
+		if (noResultsRenderer) {
+			const activeFilters = filterBy.some(values => values.some(Boolean));
+
+			return noResultsRenderer(query, activeFilters);
+		}
+	}
+
+	return resultsRenderer({
+		items,
+		loading,
+		onSelectItemsChange: showCheckbox ? onItemsChange : null,
+		selectedItemsIOMap,
+		total
+	});
+});
+
 @withHistory
 @hasRequest
 export default class BaseResults extends React.Component {
@@ -289,80 +372,6 @@ export default class BaseResults extends React.Component {
 		this.handleFetchResults();
 	}
 
-	renderContent() {
-		const {
-			context: {selectedItems: selectedItemsIOMap},
-			props: {
-				enableClearSearch,
-				filterBy,
-				noResultsRenderer,
-				query,
-				resultsRenderer,
-				showCheckbox
-			},
-			state: {error, items, loading, total}
-		} = this;
-
-		const activeFilters = filterBy.some(values => values.some(Boolean));
-
-		if (error) {
-			return (
-				<div className='error-info flex-grow-1'>
-					<div>
-						{Liferay.Language.get('an-unexpected-error-occurred')}
-					</div>
-
-					<ClayButton
-						className='button-root'
-						displayType='secondary'
-						onClick={this.handleFetchResults}
-					>
-						{Liferay.Language.get('reload')}
-					</ClayButton>
-				</div>
-			);
-		} else if (!loading && !items.length && !total) {
-			if (query) {
-				return (
-					<NoResultsDisplay
-						description={Liferay.Language.get(
-							'please-try-a-different-search-term'
-						)}
-						icon={{
-							border: false,
-							size: Sizes.XXXLarge,
-							symbol: 'ac_no_results_found'
-						}}
-						spacer
-						title={Liferay.Language.get(
-							'there-are-no-results-found'
-						)}
-					>
-						{enableClearSearch && (
-							<ClayButton
-								className='button-root'
-								displayType='secondary'
-								onClick={this.handleClearAllFilters}
-							>
-								{Liferay.Language.get('clear-search')}
-							</ClayButton>
-						)}
-					</NoResultsDisplay>
-				);
-			} else if (noResultsRenderer) {
-				return noResultsRenderer(query, activeFilters);
-			}
-		}
-
-		return resultsRenderer({
-			items,
-			loading,
-			onSelectItemsChange: showCheckbox ? this.handleItemsChange : null,
-			selectedItemsIOMap,
-			total
-		});
-	}
-
 	render() {
 		const {
 			context: {selectedItems: selectedItemsIOMap},
@@ -371,10 +380,12 @@ export default class BaseResults extends React.Component {
 				className,
 				crossPageSelect,
 				delta,
+				enableClearSearch,
 				filterBy,
 				filterByOptions,
 				maxLength,
 				navRenderer,
+				noResultsRenderer,
 				onDeltaChange,
 				onFilterByChange,
 				onOrderIOMapChange,
@@ -386,6 +397,7 @@ export default class BaseResults extends React.Component {
 				placeholder,
 				query,
 				renderSubnav,
+				resultsRenderer,
 				showCheckbox,
 				showFilterAndOrder,
 				showPagination,
@@ -438,7 +450,22 @@ export default class BaseResults extends React.Component {
 					!error &&
 					renderSubnav({handleClearChecked: this.clearChecked})}
 
-				{this.renderContent()}
+				<ResultsContent
+					enableClearSearch={enableClearSearch}
+					error={error}
+					filterBy={filterBy}
+					items={items}
+					loading={loading}
+					noResultsRenderer={noResultsRenderer}
+					onClearAllFilters={this.handleClearAllFilters}
+					onItemsChange={this.handleItemsChange}
+					onRetry={this.handleFetchResults}
+					query={query}
+					resultsRenderer={resultsRenderer}
+					selectedItemsIOMap={selectedItemsIOMap}
+					showCheckbox={showCheckbox}
+					total={total}
+				/>
 
 				{showPagination && !!total && !!items.length && (
 					<PaginationBar

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/BaseResults.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/BaseResults.jsx
@@ -177,4 +177,44 @@ describe('BaseResults', () => {
 			{timeout: 1000}
 		);
 	});
+
+	it('should not re-invoke resultsRenderer while typing in the search input', async () => {
+		const resultsRenderer = jest.fn(({items}) => (
+			<ul data-testid='results'>
+				{items.map(item => (
+					<li key={item.id}>{item.name}</li>
+				))}
+			</ul>
+		));
+
+		const {container} = render(
+			<DefaultComponent
+				dataSourceFn={() =>
+					Promise.resolve({items: INDIVIDUALS, total: TOTAL})
+				}
+				groupId='23'
+				resultsRenderer={resultsRenderer}
+			/>
+		);
+
+		await waitFor(
+			() => {
+				expect(resultsRenderer).toHaveBeenCalled();
+				expect(resultsRenderer.mock.lastCall[0].loading).toBe(false);
+			},
+			{timeout: 1000}
+		);
+
+		const callsAfterLoad = resultsRenderer.mock.calls.length;
+
+		const searchInput = container.querySelector('input.input-root');
+
+		fireEvent.change(searchInput, {target: {value: 'a'}});
+		fireEvent.change(searchInput, {target: {value: 'ab'}});
+		fireEvent.change(searchInput, {target: {value: 'abc'}});
+
+		expect(searchInput.value).toBe('abc');
+
+		expect(resultsRenderer).toHaveBeenCalledTimes(callsAfterLoad);
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90934

## What is being fixed

On the Individuals page, typing in the "Individual Profiles" card's search input froze the UI when the data source held many entries (e.g. 20k individuals).

## Root cause

`BaseResults` keeps the input value in `state.searchValue` so the controlled `SearchInput` reflects each keystroke. Every keystroke calls `setState({searchValue})`, which forces `BaseResults` to re-render its **entire** subtree — including the heavy results table produced by `resultsRenderer()` (called inline in `render()`). With 20k individuals paginated to ~20 rows × 6 cells with custom renderers (avatar/email column, profile-type icon, formatted dates), the per-keystroke reconciliation work is what causes the freeze. The actual fetch is unaffected — it only fires when `props.query` changes (on Enter / clear).

## How it is being fixed

Extracted the results subtree from `BaseResults.renderContent()` into a `React.memo`'d functional component (`ResultsContent`). Its props are `items`, `loading`, `total`, `error`, `query`, `filterBy`, `resultsRenderer`, `selectedItemsIOMap`, plus the autobound callbacks — none of which change on a keystroke. When `state.searchValue` updates:

- `BaseResults` re-renders (so the `Toolbar` and `SearchInput` reflect the typed character).
- `ResultsContent` receives shallow-equal props → `React.memo` short-circuits → the table reconciliation is skipped entirely.

Single shared-component change, two files. No new props, no opt-in flags, no contract changes for callers.

## Test

Added `BaseResults` test "should not re-invoke resultsRenderer while typing in the search input" that pins the optimization: render with a spied `resultsRenderer`, wait for the initial fetch, snapshot the call count, type three characters, and assert the count is unchanged. Without `React.memo` this test fails (the renderer is invoked on every keystroke).