### PR TITLE
LPD-91690 | master - Segments including other segments do not work

### DIFF
--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/criteria/contributor/SegmentsCriteriaContributor.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/criteria/contributor/SegmentsCriteriaContributor.java
@@ -47,6 +47,13 @@ public interface SegmentsCriteriaContributor {
 			criteria, filterString, conjunction, getKey(), getType());
 	}
 
+	public default void contributeForMemberLookup(
+		Criteria criteria, String filterString,
+		Criteria.Conjunction conjunction) {
+
+		contribute(criteria, filterString, conjunction);
+	}
+
 	/**
 	 * Returns a criteria as a JSONObject.
 	 *

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/provider/SegmentsEntryProvider.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/provider/SegmentsEntryProvider.java
@@ -20,6 +20,10 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface SegmentsEntryProvider {
 
+	public long[] getSegmentsEntryClassPKs(
+			long segmentsEntryId, boolean memberLookup, int start, int end)
+		throws PortalException;
+
 	/**
 	 * Returns the primary keys of the entities related to the segment.
 	 *
@@ -41,6 +45,10 @@ public interface SegmentsEntryProvider {
 	 * @throws PortalException if a portal exception occurred
 	 */
 	public int getSegmentsEntryClassPKsCount(long segmentsEntryId)
+		throws PortalException;
+
+	public int getSegmentsEntryClassPKsCount(
+			long segmentsEntryId, boolean memberLookup)
 		throws PortalException;
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/provider/packageinfo
+++ b/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/provider/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/criteria/contributor/SegmentsEntrySegmentsCriteriaContributor.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/criteria/contributor/SegmentsEntrySegmentsCriteriaContributor.java
@@ -41,7 +41,7 @@ public class SegmentsEntrySegmentsCriteriaContributor
 	public static final String KEY = "segments";
 
 	@Override
-	public void contribute(
+	public void contributeForMemberLookup(
 		Criteria criteria, String filterString,
 		Criteria.Conjunction conjunction) {
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/BaseSegmentsEntryProvider.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/BaseSegmentsEntryProvider.java
@@ -66,7 +66,7 @@ public abstract class BaseSegmentsEntryProvider
 
 	@Override
 	public long[] getSegmentsEntryClassPKs(
-			long segmentsEntryId, int start, int end)
+			long segmentsEntryId, boolean memberLookup, int start, int end)
 		throws PortalException {
 
 		SegmentsEntry segmentsEntry =
@@ -77,7 +77,7 @@ public abstract class BaseSegmentsEntryProvider
 		}
 
 		String filterString = getFilterString(
-			segmentsEntry, Criteria.Type.MODEL);
+			memberLookup, segmentsEntry, Criteria.Type.MODEL);
 
 		if (Validator.isNull(filterString)) {
 			return TransformUtil.transformToLongArray(
@@ -94,7 +94,23 @@ public abstract class BaseSegmentsEntryProvider
 	}
 
 	@Override
+	public long[] getSegmentsEntryClassPKs(
+			long segmentsEntryId, int start, int end)
+		throws PortalException {
+
+		return getSegmentsEntryClassPKs(segmentsEntryId, false, start, end);
+	}
+
+	@Override
 	public int getSegmentsEntryClassPKsCount(long segmentsEntryId)
+		throws PortalException {
+
+		return getSegmentsEntryClassPKsCount(segmentsEntryId, false);
+	}
+
+	@Override
+	public int getSegmentsEntryClassPKsCount(
+			long segmentsEntryId, boolean memberLookup)
 		throws PortalException {
 
 		SegmentsEntry segmentsEntry =
@@ -105,7 +121,7 @@ public abstract class BaseSegmentsEntryProvider
 		}
 
 		String filterString = getFilterString(
-			segmentsEntry, Criteria.Type.MODEL);
+			memberLookup, segmentsEntry, Criteria.Type.MODEL);
 
 		if (Validator.isNull(filterString)) {
 			return segmentsEntryRelLocalService.getSegmentsEntryRelsCount(
@@ -198,7 +214,7 @@ public abstract class BaseSegmentsEntryProvider
 	}
 
 	protected String getFilterString(
-		SegmentsEntry segmentsEntry, Criteria.Type type) {
+		boolean memberLookup, SegmentsEntry segmentsEntry, Criteria.Type type) {
 
 		Criteria existingCriteria = segmentsEntry.getCriteriaObj();
 
@@ -219,12 +235,25 @@ public abstract class BaseSegmentsEntryProvider
 				continue;
 			}
 
-			segmentsCriteriaContributor.contribute(
-				criteria, criterion.getFilterString(),
-				Criteria.Conjunction.parse(criterion.getConjunction()));
+			if (memberLookup) {
+				segmentsCriteriaContributor.contributeForMemberLookup(
+					criteria, criterion.getFilterString(),
+					Criteria.Conjunction.parse(criterion.getConjunction()));
+			}
+			else {
+				segmentsCriteriaContributor.contribute(
+					criteria, criterion.getFilterString(),
+					Criteria.Conjunction.parse(criterion.getConjunction()));
+			}
 		}
 
 		return criteria.getFilterString(type);
+	}
+
+	protected String getFilterString(
+		SegmentsEntry segmentsEntry, Criteria.Type type) {
+
+		return getFilterString(false, segmentsEntry, type);
 	}
 
 	protected abstract String getSource();

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/SegmentsEntryProviderRegistryImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/SegmentsEntryProviderRegistryImpl.java
@@ -74,7 +74,7 @@ public class SegmentsEntryProviderRegistryImpl
 		}
 
 		return segmentsEntryProvider.getSegmentsEntryClassPKs(
-			segmentsEntryId, start, end);
+			segmentsEntryId, true, start, end);
 	}
 
 	@Override
@@ -108,7 +108,7 @@ public class SegmentsEntryProviderRegistryImpl
 		}
 
 		return segmentsEntryProvider.getSegmentsEntryClassPKsCount(
-			segmentsEntryId);
+			segmentsEntryId, true);
 	}
 
 	@Override

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/ReferredSegmentsEntryProviderTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/ReferredSegmentsEntryProviderTest.java
@@ -10,12 +10,14 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -32,6 +34,7 @@ import com.liferay.segments.service.SegmentsEntryRelLocalService;
 import com.liferay.segments.test.util.SegmentsTestUtil;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
@@ -248,6 +251,71 @@ public class ReferredSegmentsEntryProviderTest {
 	}
 
 	@Test
+	public void testGetSegmentsEntryIdsWithAllCriterionTypesMatchedDynamically()
+		throws Exception {
+
+		Organization organization = OrganizationTestUtil.addOrganization();
+
+		_organizations.add(organization);
+
+		_user1 = UserTestUtil.addOrganizationUser(
+			organization, RoleConstants.ORGANIZATION_USER);
+
+		Criteria referencedCriteria = new Criteria();
+
+		_contextSegmentsCriteriaContributor.contribute(
+			referencedCriteria, "(signedIn eq true)", Criteria.Conjunction.AND);
+
+		SegmentsEntry referencedSegmentsEntry =
+			SegmentsTestUtil.addSegmentsEntry(
+				_group.getGroupId(),
+				CriteriaSerializer.serialize(referencedCriteria));
+
+		Criteria criteria = new Criteria();
+
+		_contextSegmentsCriteriaContributor.contribute(
+			criteria, "(languageId eq 'en_US')", Criteria.Conjunction.AND);
+		_userSegmentsCriteriaContributor.contribute(
+			criteria,
+			String.format(
+				"(firstName eq '%s' and lastName eq '%s')",
+				_user1.getFirstName(), _user1.getLastName()),
+			Criteria.Conjunction.AND);
+		_userOrganizationSegmentsCriteriaContributor.contribute(
+			criteria, String.format("(name eq '%s')", organization.getName()),
+			Criteria.Conjunction.AND);
+		_segmentsEntrySegmentsCriteriaContributor.contribute(
+			criteria,
+			String.format(
+				"(segmentsEntryIds eq '%s')",
+				referencedSegmentsEntry.getSegmentsEntryId()),
+			Criteria.Conjunction.AND);
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId(), CriteriaSerializer.serialize(criteria));
+
+		Context context = new Context();
+
+		context.put(Context.LANGUAGE_ID, "en_US");
+		context.put(Context.SIGNED_IN, true);
+
+		long[] segmentsEntryIds =
+			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
+				_group.getGroupId(), User.class.getName(), _user1.getUserId(),
+				context);
+
+		Assert.assertEquals(
+			Arrays.toString(segmentsEntryIds), 2, segmentsEntryIds.length);
+		Assert.assertTrue(
+			ArrayUtil.containsAll(
+				segmentsEntryIds,
+				new long[] {
+					referencedSegmentsEntry.getSegmentsEntryId(),
+					segmentsEntry.getSegmentsEntryId()
+				}));
+	}
+
+	@Test
 	public void testGetSegmentsEntryIdsWithAllReferredSegments()
 		throws Exception {
 
@@ -437,6 +505,141 @@ public class ReferredSegmentsEntryProviderTest {
 				segmentsEntryIds));
 	}
 
+	@Test
+	public void testGetSegmentsEntryIdsWithOnlyContextCriterion()
+		throws Exception {
+
+		_user1 = UserTestUtil.addUser(_group.getGroupId());
+
+		Criteria criteria = new Criteria();
+
+		_contextSegmentsCriteriaContributor.contribute(
+			criteria, "(signedIn eq true)", Criteria.Conjunction.AND);
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId(), CriteriaSerializer.serialize(criteria));
+
+		Context context = new Context();
+
+		context.put(Context.SIGNED_IN, true);
+
+		long[] segmentsEntryIds =
+			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
+				_group.getGroupId(), User.class.getName(), _user1.getUserId(),
+				context);
+
+		Assert.assertEquals(
+			Arrays.toString(segmentsEntryIds), 1, segmentsEntryIds.length);
+		Assert.assertEquals(
+			segmentsEntry.getSegmentsEntryId(), segmentsEntryIds[0]);
+	}
+
+	@Test
+	public void testGetSegmentsEntryIdsWithOnlyReferredCriterionMatchedDynamically()
+		throws Exception {
+
+		_user1 = UserTestUtil.addUser(_group.getGroupId());
+
+		Criteria referencedCriteria = new Criteria();
+
+		_contextSegmentsCriteriaContributor.contribute(
+			referencedCriteria, "(signedIn eq true)", Criteria.Conjunction.AND);
+
+		SegmentsEntry referencedSegmentsEntry =
+			SegmentsTestUtil.addSegmentsEntry(
+				_group.getGroupId(),
+				CriteriaSerializer.serialize(referencedCriteria));
+
+		Criteria criteria = new Criteria();
+
+		_segmentsEntrySegmentsCriteriaContributor.contribute(
+			criteria,
+			String.format(
+				"(segmentsEntryIds eq '%s')",
+				referencedSegmentsEntry.getSegmentsEntryId()),
+			Criteria.Conjunction.AND);
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId(), CriteriaSerializer.serialize(criteria));
+
+		Context context = new Context();
+
+		context.put(Context.SIGNED_IN, true);
+
+		long[] segmentsEntryIds =
+			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
+				_group.getGroupId(), User.class.getName(), _user1.getUserId(),
+				context);
+
+		Assert.assertEquals(
+			Arrays.toString(segmentsEntryIds), 2, segmentsEntryIds.length);
+		Assert.assertTrue(
+			ArrayUtil.containsAll(
+				segmentsEntryIds,
+				new long[] {
+					referencedSegmentsEntry.getSegmentsEntryId(),
+					segmentsEntry.getSegmentsEntryId()
+				}));
+	}
+
+	@Test
+	public void testGetSegmentsEntryIdsWithOnlyUserCriterion()
+		throws Exception {
+
+		_user1 = UserTestUtil.addUser(_group.getGroupId());
+
+		Criteria criteria = new Criteria();
+
+		_userSegmentsCriteriaContributor.contribute(
+			criteria,
+			String.format("(firstName eq '%s')", _user1.getFirstName()),
+			Criteria.Conjunction.AND);
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId(), CriteriaSerializer.serialize(criteria));
+
+		long[] segmentsEntryIds =
+			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
+				_group.getGroupId(), User.class.getName(), _user1.getUserId(),
+				new Context());
+
+		Assert.assertEquals(
+			Arrays.toString(segmentsEntryIds), 1, segmentsEntryIds.length);
+		Assert.assertEquals(
+			segmentsEntry.getSegmentsEntryId(), segmentsEntryIds[0]);
+	}
+
+	@Test
+	public void testGetSegmentsEntryIdsWithOnlyUserOrganizationCriterion()
+		throws Exception {
+
+		Organization organization = OrganizationTestUtil.addOrganization();
+
+		_organizations.add(organization);
+
+		_user1 = UserTestUtil.addOrganizationUser(
+			organization, RoleConstants.ORGANIZATION_USER);
+
+		Criteria criteria = new Criteria();
+
+		_userOrganizationSegmentsCriteriaContributor.contribute(
+			criteria, String.format("(name eq '%s')", organization.getName()),
+			Criteria.Conjunction.AND);
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId(), CriteriaSerializer.serialize(criteria));
+
+		long[] segmentsEntryIds =
+			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
+				_group.getGroupId(), User.class.getName(), _user1.getUserId(),
+				new Context());
+
+		Assert.assertEquals(
+			Arrays.toString(segmentsEntryIds), 1, segmentsEntryIds.length);
+		Assert.assertEquals(
+			segmentsEntry.getSegmentsEntryId(), segmentsEntryIds[0]);
+	}
+
 	@Inject(
 		filter = "segments.criteria.contributor.key=context",
 		type = SegmentsCriteriaContributor.class
@@ -473,6 +676,13 @@ public class ReferredSegmentsEntryProviderTest {
 
 	@DeleteAfterTestRun
 	private User _user2;
+
+	@Inject(
+		filter = "segments.criteria.contributor.key=user-organization",
+		type = SegmentsCriteriaContributor.class
+	)
+	private SegmentsCriteriaContributor
+		_userOrganizationSegmentsCriteriaContributor;
 
 	@Inject(
 		filter = "segments.criteria.contributor.key=user",

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/provider/AsahSegmentsEntryProvider.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/provider/AsahSegmentsEntryProvider.java
@@ -46,6 +46,14 @@ public class AsahSegmentsEntryProvider implements SegmentsEntryProvider {
 
 	@Override
 	public long[] getSegmentsEntryClassPKs(
+			long segmentsEntryId, boolean memberLookup, int start, int end)
+		throws PortalException {
+
+		return getSegmentsEntryClassPKs(segmentsEntryId, start, end);
+	}
+
+	@Override
+	public long[] getSegmentsEntryClassPKs(
 			long segmentsEntryId, int start, int end)
 		throws PortalException {
 
@@ -61,6 +69,14 @@ public class AsahSegmentsEntryProvider implements SegmentsEntryProvider {
 
 		return _segmentsEntryRelLocalService.getSegmentsEntryRelsCount(
 			segmentsEntryId);
+	}
+
+	@Override
+	public int getSegmentsEntryClassPKsCount(
+			long segmentsEntryId, boolean memberLookup)
+		throws PortalException {
+
+		return getSegmentsEntryClassPKsCount(segmentsEntryId);
 	}
 
 	@Override


### PR DESCRIPTION
Motivation
-----
Fix for Segments including other segments do not work

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-91690)

Proposed Solution
-----
This PR introduces support for differentiating member lookup behavior when building segment criteria, ensuring that referred-to-model filters are only applied when validating segment membership.

### Changes included

- Added a new `contributeForMemberLookup` method to allow providers to contribute criteria specifically for member lookup scenarios.
- Extended `SegmentsEntryProvider` with new `memberLookup` overloads to support the new behavior across implementations.
- Propagated the `memberLookup` flag through the provider registry so the context is preserved during provider resolution.
- Updated `BaseSegmentsEntryProvider` to honor the `memberLookup` parameter when generating criteria.
- Implemented the new `memberLookup` overloads in `AsahSegmentsEntryProvider`.
- Restricted referred-to-model filtering logic so it is only applied during member lookup operations.
- Added tests to validate the expected segment membership behavior and ensure the new flow works correctly end to end.