### PR TITLE
LPD-91083 | Add activity status filter to accounts list | Master

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_global.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_global.scss
@@ -3,7 +3,6 @@
 }
 
 body {
-	background-color: $lightBackground;
 	font-family: $font-family;
 	font-size: 0.875rem;
 }

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
@@ -139,6 +139,7 @@ const List: React.FC<IListProps> = ({channelId, groupId}) => {
 						</div>
 
 						<AccountsDataSet
+							activityStatusFilter='ACTIVE'
 							apiURL={`/o/faro/contacts/${groupId}/account/search?channelId=${channelId}`}
 							channelId={channelId}
 							groupId={groupId}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
@@ -5,11 +5,15 @@ import BasePage from 'shared/components/base-page';
 import Link from '@clayui/link';
 import Loading from 'shared/components/Loading';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
-import React from 'react';
+import React, {useState} from 'react';
 import TotalAccounts from 'contacts/components/account/TotalAccounts';
 import URLConstants from 'shared/util/url-constants';
+import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
 import {isNil} from 'lodash/fp';
+import {RangeKeyTimeRanges} from 'shared/util/constants';
+import {RangeSelectors} from 'shared/types';
 import {Routes, toRoute} from 'shared/util/router';
+import {SectionHeader} from 'shared/components/SectionHeader';
 import {Sizes} from 'shared/util/constants';
 import {useChannelContext} from 'shared/context/channel';
 import {useCurrentUser} from 'shared/hooks/useCurrentUser';
@@ -23,6 +27,12 @@ interface IListProps {
 const List: React.FC<IListProps> = ({channelId, groupId}) => {
 	const currentUser = useCurrentUser();
 	const {selectedChannel} = useChannelContext();
+
+	const [rangeSelectors, setRangeSelectors] = useState<RangeSelectors>({
+		rangeEnd: null,
+		rangeKey: RangeKeyTimeRanges.Last30Days,
+		rangeStart: null
+	});
 
 	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
 		dataSourceFn: API.dataSource.search,
@@ -114,10 +124,25 @@ const List: React.FC<IListProps> = ({channelId, groupId}) => {
 					<>
 						<TotalAccounts groupId={groupId} />
 
+						<div className='align-items-center d-flex justify-content-between mb-3'>
+							<SectionHeader
+								className='mb-0'
+								icon='box-container'
+								title={Liferay.Language.get('accounts')}
+							/>
+
+							<DropdownRangeKey
+								legacy={false}
+								onRangeSelectorChange={setRangeSelectors}
+								rangeSelectors={rangeSelectors}
+							/>
+						</div>
+
 						<AccountsDataSet
 							apiURL={`/o/faro/contacts/${groupId}/account/search?channelId=${channelId}`}
 							channelId={channelId}
 							groupId={groupId}
+							rangeSelectors={rangeSelectors}
 						/>
 					</>
 				) : (

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
@@ -12,11 +12,23 @@ import {waitForLoadingToBeRemoved} from 'test/helpers';
 
 jest.unmock('react-dom');
 
+type FakeFilter = {
+	id: string;
+	preloadedData?: {
+		exclude: boolean;
+		selectedItems: Array<{label?: string; value: string}>;
+	};
+};
+
+let lastFilters: FakeFilter[] | undefined;
+
 jest.mock('@liferay/frontend-data-set-web', () => ({
 	...jest.requireActual('@liferay/frontend-data-set-web'),
-	FrontendDataSet: ({id}: {id: string}) => (
-		<div data-testid='fds-component' id={id} />
-	)
+	FrontendDataSet: ({filters, id}: {filters: FakeFilter[]; id: string}) => {
+		lastFilters = filters;
+
+		return <div data-testid='fds-component' id={id} />;
+	}
 }));
 
 jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
@@ -105,6 +117,7 @@ const renderList = (
 describe('List', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		lastFilters = undefined;
 
 		mockedUseHistory.mockReturnValue({push: mockHistoryPush});
 		mockedUseRequest.mockImplementation(useRequestImpl());
@@ -141,6 +154,19 @@ describe('List', () => {
 			renderList();
 
 			expect(screen.getByTestId('fds-component')).toHaveAttribute('id');
+		});
+
+		it('should pass activityStatusFilter "ACTIVE" to AccountsDataSet by default', () => {
+			renderList();
+
+			const activityStatusFilter = lastFilters?.find(
+				f => f.id === 'activityStatus'
+			);
+
+			expect(activityStatusFilter?.preloadedData).toEqual({
+				exclude: false,
+				selectedItems: [{label: 'Active', value: 'ACTIVE'}]
+			});
 		});
 
 		it('should match the snapshot', async () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
@@ -19,6 +19,10 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 	)
 }));
 
+jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
+	DropdownRangeKey: () => null
+}));
+
 jest.mock('shared/hooks/useRequest', () => ({
 	useRequest: jest.fn()
 }));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
@@ -242,6 +242,35 @@ exports[`List rendering should match the snapshot 1`] = `
           </div>
         </div>
         <div
+          class="align-items-center d-flex justify-content-between mb-3"
+        >
+          <div
+            class="mb-0"
+          >
+            <span
+              class="mr-2"
+            >
+              <span
+                class="text-4 text-secondary"
+              >
+                <svg
+                  class="lexicon-icon lexicon-icon-box-container"
+                  role="presentation"
+                >
+                  <use
+                    href="#box-container"
+                  />
+                </svg>
+              </span>
+            </span>
+            <span
+              class="text-4 text-secondary font-weight-semi-bold"
+            >
+              ACCOUNTS
+            </span>
+          </div>
+        </div>
+        <div
           class="card card-root"
         >
           <div

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
@@ -19,9 +19,10 @@ import {
 	ProfileTypes,
 	RelationalOperators
 } from 'segment/segment-editor/dynamic/utils/constants';
-import {FilterOptionType, RangeSelectors} from 'shared/types';
+import {FilterByType, FilterOptionType, RangeSelectors} from 'shared/types';
 import {getSafeRangeSelectors} from 'shared/util/util';
 import {IndividualsListCDPColumns} from 'shared/util/table-columns';
+import {Map, Set} from 'immutable';
 import {Sizes} from 'shared/util/constants';
 import {useParams} from 'react-router-dom';
 import {useRequest} from 'shared/hooks/useRequest';
@@ -68,6 +69,20 @@ const DEFAULT_FILTER_BY_OPTIONS: FilterOptionType[] = [
 				value: ProfileTypes.ANONYMOUS
 			}
 		]
+	},
+	{
+		key: 'activityStatus',
+		label: Liferay.Language.get('activity-status'),
+		values: [
+			{
+				label: Liferay.Language.get('active'),
+				value: 'ACTIVE'
+			},
+			{
+				label: Liferay.Language.get('inactive'),
+				value: 'INACTIVE'
+			}
+		]
 	}
 ];
 
@@ -98,6 +113,9 @@ const IndividualsList: React.FC<IIndividualsList> = ({rangeSelectors}) => {
 		getSafeRangeSelectors(rangeSelectors);
 
 	const paginationParams = useStatefulPagination(undefined, {
+		initialFilterBy: Map({
+			activityStatus: Set(['ACTIVE'])
+		}) as FilterByType,
 		initialOrderIOMap: createOrderIOMap(NAME)
 	});
 
@@ -131,6 +149,9 @@ const IndividualsList: React.FC<IIndividualsList> = ({rangeSelectors}) => {
 	}, [countriesData, countriesLoading]);
 
 	const selectedFilters = {
+		activityStatus: paginationParams.filterBy
+			.get('activityStatus')
+			?.first(),
 		filter: transformCountriesInQueryString(
 			paginationParams.filterBy.get('countries')?.toArray()
 		),
@@ -192,6 +213,7 @@ const IndividualsList: React.FC<IIndividualsList> = ({rangeSelectors}) => {
 						]}
 						dataSourceFn={API.individuals.search}
 						dataSourceParams={{
+							activityStatus: selectedFilters.activityStatus,
 							channelId,
 							filter: selectedFilters.filter,
 							groupId,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
@@ -19,7 +19,8 @@ import {
 	ProfileTypes,
 	RelationalOperators
 } from 'segment/segment-editor/dynamic/utils/constants';
-import {FilterOptionType} from 'shared/types';
+import {FilterOptionType, RangeSelectors} from 'shared/types';
+import {getSafeRangeSelectors} from 'shared/util/util';
 import {IndividualsListCDPColumns} from 'shared/util/table-columns';
 import {Sizes} from 'shared/util/constants';
 import {useParams} from 'react-router-dom';
@@ -83,11 +84,18 @@ function transformCountriesInQueryString(countries: string[]) {
 		.join(Conjunctions.Or);
 }
 
-const IndividualsList = () => {
+interface IIndividualsList {
+	rangeSelectors: RangeSelectors;
+}
+
+const IndividualsList = ({rangeSelectors}: IIndividualsList) => {
 	const {channelId = '', groupId = ''} = useParams<{
 		channelId: string;
 		groupId: string;
 	}>();
+
+	const {rangeEnd, rangeKey, rangeStart} =
+		getSafeRangeSelectors(rangeSelectors);
 
 	const paginationParams = useStatefulPagination(undefined, {
 		initialOrderIOMap: createOrderIOMap(NAME)
@@ -189,7 +197,10 @@ const IndividualsList = () => {
 							groupId,
 							profileTypes: selectedFilters.profileTypes.length
 								? selectedFilters.profileTypes
-								: undefined
+								: undefined,
+							rangeEnd,
+							rangeKey,
+							rangeStart
 						}}
 						filterByOptions={FILTER_BY_OPTIONS}
 						key='individuals-list-table'

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
@@ -88,7 +88,7 @@ interface IIndividualsList {
 	rangeSelectors: RangeSelectors;
 }
 
-const IndividualsList = ({rangeSelectors}: IIndividualsList) => {
+const IndividualsList: React.FC<IIndividualsList> = ({rangeSelectors}) => {
 	const {channelId = '', groupId = ''} = useParams<{
 		channelId: string;
 		groupId: string;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
@@ -9,15 +9,18 @@ import IndividualsList from './IndividualsList';
 import Loading from 'shared/components/Loading';
 import MetricCard from 'shared/components/MetricCard';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
-import React from 'react';
+import React, {useState} from 'react';
 import URLConstants from 'shared/util/url-constants';
 import {Text as ClayText} from '@clayui/core';
 import {CSVType} from 'shared/components/download-report/utils';
 import {DownloadStaticCSVReport} from 'shared/components/download-report/DownloadStaticCSVReport';
+import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
 import {INTERVAL_KEY_MAP} from 'shared/util/time';
 import {isNil} from 'lodash';
 import {RangeKeyTimeRanges, Sizes} from 'shared/util/constants';
+import {RangeSelectors} from 'shared/types';
 import {Routes, toRoute} from 'shared/util/router';
+import {SectionHeader} from 'shared/components/SectionHeader';
 import {sub} from 'shared/util/lang';
 import {toThousands} from 'shared/util/numbers';
 import {useCurrentUser} from 'shared/hooks/useCurrentUser';
@@ -131,6 +134,12 @@ const IndividualsOverviewCDP = () => {
 
 	const authorized = currentUser.isAdmin();
 
+	const [rangeSelectors, setRangeSelectors] = useState<RangeSelectors>({
+		rangeEnd: null,
+		rangeKey: RangeKeyTimeRanges.Last30Days,
+		rangeStart: null
+	});
+
 	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
 		dataSourceFn: API.dataSource.search,
 		variables: {
@@ -237,7 +246,21 @@ const IndividualsOverviewCDP = () => {
 							</ClayLayout.Col>
 						</ClayLayout.Row>
 
-						<IndividualsList />
+						<div className='align-items-center d-flex justify-content-between mb-3'>
+							<SectionHeader
+								className='mb-0'
+								icon='box-container'
+								title={Liferay.Language.get('individuals')}
+							/>
+
+							<DropdownRangeKey
+								legacy={false}
+								onRangeSelectorChange={setRangeSelectors}
+								rangeSelectors={rangeSelectors}
+							/>
+						</div>
+
+						<IndividualsList rangeSelectors={rangeSelectors} />
 					</>
 				)}
 			</BasePage.Body>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
@@ -3,9 +3,16 @@ import * as API from 'shared/api';
 import IndividualsList from '../IndividualsList';
 import React from 'react';
 import {createMemoryHistory} from 'history';
+import {RangeKeyTimeRanges} from 'shared/util/constants';
 import {render} from '@testing-library/react';
 import {Router} from 'react-router';
 import {waitForLoadingToBeRemoved} from 'test/helpers';
+
+const defaultRangeSelectors = {
+	rangeEnd: null,
+	rangeKey: RangeKeyTimeRanges.Last30Days,
+	rangeStart: null
+};
 
 jest.unmock('react-dom');
 
@@ -77,7 +84,7 @@ describe('Individuals List', () => {
 
 		const {getByText} = render(
 			<Router history={history}>
-				<IndividualsList />
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
 			</Router>
 		);
 
@@ -97,7 +104,7 @@ describe('Individuals List', () => {
 
 		const {getByText} = render(
 			<Router history={history}>
-				<IndividualsList />
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
 			</Router>
 		);
 
@@ -114,5 +121,31 @@ describe('Individuals List', () => {
 		expect(
 			getByText('Access our documentation to learn more.')
 		).toBeInTheDocument();
+	});
+
+	it('passes range params to the search API', async () => {
+		// @ts-ignore
+		API.individuals.search.mockReturnValue(
+			Promise.resolve({items: [], total: 0})
+		);
+
+		const history = createMemoryHistory();
+
+		render(
+			<Router history={history}>
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		// @ts-ignore
+		expect(API.individuals.search).toHaveBeenCalledWith(
+			expect.objectContaining({
+				rangeEnd: null,
+				rangeKey: 30,
+				rangeStart: null
+			})
+		);
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
@@ -148,4 +148,26 @@ describe('Individuals List', () => {
 			})
 		);
 	});
+
+	it('passes activityStatus ACTIVE to the search API by default', async () => {
+		(API.individuals.search as jest.Mock).mockReturnValue(
+			Promise.resolve({items: [], total: 0})
+		);
+
+		const history = createMemoryHistory();
+
+		render(
+			<Router history={history}>
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		expect(API.individuals.search as jest.Mock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				activityStatus: 'ACTIVE'
+			})
+		);
+	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
@@ -36,6 +36,10 @@ jest.mock('react-router-dom', () => ({
 	})
 }));
 
+jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
+	DropdownRangeKey: () => null
+}));
+
 jest.mock('../IndividualsList', () => ({
 	__esModule: true,
 	default: () => null

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/individuals.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/individuals.js
@@ -89,6 +89,9 @@ export function search(params) {
 		orderIOMap = createOrderIOMap(NAME),
 		page = DEFAULT_PAGE,
 		query = '',
+		rangeEnd = null,
+		rangeKey = null,
+		rangeStart = null,
 		...otherParams
 	} = params;
 
@@ -106,7 +109,10 @@ export function search(params) {
 			individualSegmentId,
 			notIndividualSegmentId,
 			orderByFields,
-			query
+			query,
+			rangeEnd,
+			rangeKey,
+			rangeStart
 		},
 		method: 'POST',
 		path: `contacts/${groupId}/individual/search`

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -9,6 +9,8 @@ import {
 	LifecycleStages,
 	lifecycleStagesLabelMap
 } from 'contacts/pages/account/utils/constants';
+import {RangeKeyTimeRanges} from 'shared/util/constants';
+import {RangeSelectors} from 'shared/types';
 import {Routes} from 'shared/util/router';
 import {toThousands} from 'shared/util/numbers';
 
@@ -26,6 +28,7 @@ interface IAccountsDataSetProps {
 	groupId: string;
 	industryFilter?: string;
 	lifecycleStageFilter?: LifecycleStages;
+	rangeSelectors?: RangeSelectors;
 }
 
 const buildSelectionPreloadedData = (value?: string, label?: string) =>
@@ -42,14 +45,31 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 	countryFilter,
 	groupId,
 	industryFilter,
-	lifecycleStageFilter
+	lifecycleStageFilter,
+	rangeSelectors = {
+		rangeEnd: null,
+		rangeKey: RangeKeyTimeRanges.Last30Days,
+		rangeStart: null
+	}
 }) => {
 	const snapshots = useSnapshots('accounts-list-dataset');
+
+	let rangeSelectorParams = `rangeKey=${rangeSelectors.rangeKey}`;
+
+	if (rangeSelectors.rangeEnd) {
+		rangeSelectorParams += `&rangeEnd=${rangeSelectors.rangeEnd}`;
+	}
+
+	if (rangeSelectors.rangeStart) {
+		rangeSelectorParams += `&rangeStart=${rangeSelectors.rangeStart}`;
+	}
+
+	const rangeApiURL = `${apiURL}&${rangeSelectorParams}`;
 
 	return (
 		<Card>
 			<FrontendDataSet
-				apiURL={apiURL}
+				apiURL={rangeApiURL}
 				configInURLBehavior={EConfigInURLBehavior.OFF}
 				customDataRenderers={{
 					accountLifecycleStageRenderer: ({
@@ -131,9 +151,12 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 					}
 				]}
 				id='accounts-list-dataset'
-				key={`${countryFilter ?? ''}|${industryFilter ?? ''}|${
-					lifecycleStageFilter ?? ''
-				}`}
+				key={[
+					countryFilter,
+					industryFilter,
+					lifecycleStageFilter,
+					...Object.values(rangeSelectors)
+				].join()}
 				pagination={pagination}
 				showPagination
 				snapshots={snapshots}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -14,6 +14,11 @@ import {RangeSelectors} from 'shared/types';
 import {Routes} from 'shared/util/router';
 import {toThousands} from 'shared/util/numbers';
 
+const activityStatusItems = [
+	{label: Liferay.Language.get('active'), value: 'ACTIVE'},
+	{label: Liferay.Language.get('inactive'), value: 'INACTIVE'}
+];
+
 const lifecycleStageItems = Object.entries(lifecycleStagesLabelMap).map(
 	([stage]) => ({
 		label: lifecycleStagesLabelMap[stage as LifecycleStages].label,
@@ -22,6 +27,7 @@ const lifecycleStageItems = Object.entries(lifecycleStagesLabelMap).map(
 );
 
 interface IAccountsDataSetProps {
+	activityStatusFilter?: string;
 	apiURL: string;
 	channelId: string;
 	countryFilter?: string;
@@ -40,6 +46,7 @@ const buildSelectionPreloadedData = (value?: string, label?: string) =>
 		: undefined;
 
 const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
+	activityStatusFilter,
 	apiURL,
 	channelId,
 	countryFilter,
@@ -112,6 +119,19 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 				}}
 				filters={[
 					{
+						id: 'activityStatus',
+						items: activityStatusItems,
+						label: Liferay.Language.get('activity-status'),
+						name: 'activityStatus',
+						preloadedData: buildSelectionPreloadedData(
+							activityStatusFilter,
+							activityStatusItems.find(
+								({value}) => value === activityStatusFilter
+							)?.label
+						),
+						type: 'selection'
+					},
+					{
 						id: 'lifecycleStatus',
 						items: lifecycleStageItems,
 						label: Liferay.Language.get('status'),
@@ -151,7 +171,8 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 					}
 				]}
 				id='accounts-list-dataset'
-				key={[
+			key={[
+					activityStatusFilter,
 					countryFilter,
 					industryFilter,
 					lifecycleStageFilter,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/SectionHeader.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/SectionHeader.tsx
@@ -3,12 +3,17 @@ import React from 'react';
 import {Text} from '@clayui/core';
 
 interface ISectionHeader {
+	className?: string;
 	icon: string;
 	title: string;
 }
 
-const SectionHeader: React.FC<ISectionHeader> = ({icon, title}) => (
-	<div className='mb-3'>
+const SectionHeader: React.FC<ISectionHeader> = ({
+	className = 'mb-3',
+	icon,
+	title
+}) => (
+	<div className={className}>
 		<span className='mr-2'>
 			<Text color='secondary' size={4}>
 				<ClayIcon symbol={icon} />

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -78,7 +78,7 @@ describe('AccountsDataSet', () => {
 		);
 	});
 
-	it('should leave country/industry/lifecycleStatus filters without preloadedData when no props are passed', () => {
+	it('should leave activityStatus/country/industry/lifecycleStatus filters without preloadedData when no props are passed', () => {
 		render(
 			<AccountsDataSet
 				apiURL='fake-url'
@@ -88,15 +88,40 @@ describe('AccountsDataSet', () => {
 			/>
 		);
 
+		const activityStatusFilter = lastFilters?.find(
+			f => f.id === 'activityStatus'
+		);
 		const countryFilter = lastFilters?.find(f => f.id === 'country');
 		const industryFilter = lastFilters?.find(f => f.id === 'industry');
 		const lifecycleStatusFilter = lastFilters?.find(
 			f => f.id === 'lifecycleStatus'
 		);
 
+		expect(activityStatusFilter?.preloadedData).toBeUndefined();
 		expect(countryFilter?.preloadedData).toBeUndefined();
 		expect(industryFilter?.preloadedData).toBeUndefined();
 		expect(lifecycleStatusFilter?.preloadedData).toBeUndefined();
+	});
+
+	it('should preload the activityStatus filter when activityStatusFilter prop is provided', () => {
+		render(
+			<AccountsDataSet
+				activityStatusFilter='ACTIVE'
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
+			/>
+		);
+
+		const activityStatusFilter = lastFilters?.find(
+			f => f.id === 'activityStatus'
+		);
+
+		expect(activityStatusFilter?.preloadedData).toEqual({
+			exclude: false,
+			selectedItems: [{label: 'Active', value: 'ACTIVE'}]
+		});
 	});
 
 	it('should preload the country filter when countryFilter prop is provided', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -2,6 +2,13 @@ import AccountsDataSet from '../AccountsDataSet';
 import React from 'react';
 import {cleanup, render, screen} from '@testing-library/react';
 import {LifecycleStages} from 'contacts/pages/account/utils/constants';
+import {RangeKeyTimeRanges} from 'shared/util/constants';
+
+const defaultRangeSelectors = {
+	rangeEnd: null,
+	rangeKey: RangeKeyTimeRanges.Last30Days,
+	rangeStart: null
+};
 
 jest.unmock('react-dom');
 
@@ -20,20 +27,24 @@ type FakeCustomDataRenderers = {
 	}) => React.ReactElement;
 };
 
+let lastApiURL: string | undefined;
 let lastCustomDataRenderers: FakeCustomDataRenderers | undefined;
 let lastFilters: FakeFilter[] | undefined;
 
 jest.mock('@liferay/frontend-data-set-web', () => ({
 	...jest.requireActual('@liferay/frontend-data-set-web'),
 	FrontendDataSet: ({
+		apiURL,
 		customDataRenderers,
 		filters,
 		id
 	}: {
+		apiURL: string;
 		customDataRenderers: FakeCustomDataRenderers;
 		filters: FakeFilter[];
 		id: string;
 	}) => {
+		lastApiURL = apiURL;
 		lastCustomDataRenderers = customDataRenderers;
 		lastFilters = filters;
 
@@ -44,6 +55,7 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 describe('AccountsDataSet', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		lastApiURL = undefined;
 		lastCustomDataRenderers = undefined;
 		lastFilters = undefined;
 	});
@@ -52,7 +64,12 @@ describe('AccountsDataSet', () => {
 
 	it('should render the FrontendDataSet with id "accounts-list-dataset"', () => {
 		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
+			/>
 		);
 
 		expect(screen.getByTestId('fds-component')).toHaveAttribute(
@@ -63,7 +80,12 @@ describe('AccountsDataSet', () => {
 
 	it('should leave country/industry/lifecycleStatus filters without preloadedData when no props are passed', () => {
 		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
+			/>
 		);
 
 		const countryFilter = lastFilters?.find(f => f.id === 'country');
@@ -84,6 +106,7 @@ describe('AccountsDataSet', () => {
 				channelId='123'
 				countryFilter='US'
 				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -102,6 +125,7 @@ describe('AccountsDataSet', () => {
 				channelId='123'
 				groupId='23'
 				industryFilter='Tech'
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -120,6 +144,7 @@ describe('AccountsDataSet', () => {
 				channelId='123'
 				groupId='23'
 				lifecycleStageFilter={LifecycleStages.AT_RISK}
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -135,7 +160,12 @@ describe('AccountsDataSet', () => {
 
 	it('should render the account name link with channelId in the href', () => {
 		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
+			/>
 		);
 
 		const {container} = render(
@@ -148,6 +178,42 @@ describe('AccountsDataSet', () => {
 		expect(container.querySelector('a')).toHaveAttribute(
 			'href',
 			'/workspace/23/123/contacts/accounts/abc'
+		);
+	});
+
+	it('should append rangeKey as query param when a preset range is provided', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={{
+					rangeEnd: null,
+					rangeKey: RangeKeyTimeRanges.Last30Days,
+					rangeStart: null
+				}}
+			/>
+		);
+
+		expect(lastApiURL).toBe('fake-url&rangeKey=30');
+	});
+
+	it('should append rangeStart and rangeEnd as query params when a custom range is provided', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={{
+					rangeEnd: '2024-01-31',
+					rangeKey: RangeKeyTimeRanges.CustomRange,
+					rangeStart: '2024-01-01'
+				}}
+			/>
+		);
+
+		expect(lastApiURL).toBe(
+			'fake-url&rangeKey=CUSTOM&rangeEnd=2024-01-31&rangeStart=2024-01-01'
 		);
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language.properties
@@ -72,6 +72,7 @@ activities=Activities
 activities-x=Activities {0}
 activity=Activity
 activity-count=Activity Count
+activity-status=Activity Status
 activity-stream=Activity Stream
 activity-x=Activity {0}
 add=Add

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -12,6 +12,7 @@ import {addCMSAdministrator} from '../../../utils/addCMSAdministrator';
 import {checkAccessibility} from '../../../utils/checkAccessibility';
 import getRandomString from '../../../utils/getRandomString';
 import performLoginViaApi, {
+	performUserSwitch,
 	performUserSwitchViaApi,
 	userData,
 } from '../../../utils/performLogin';


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91083

## What is being fixed

The accounts list had no activity status filter and no default filtering, so inactive accounts appeared mixed in with active ones on first load.

## How it is being fixed

An activity status filter is added to `AccountsDataSet` following the same pattern as the existing `lifecycleStageFilter`. The filter offers Active and Inactive options, and the label lookup from `activityStatusItems` ensures the pre-selected value displays as "Active" rather than the raw API value "ACTIVE". `List.tsx` passes `activityStatusFilter='ACTIVE'` as the default so active accounts are shown on first load, consistent with the individuals list behavior. Tests were added to `AccountsDataSet` verifying the filter has no preloaded data when the prop is omitted and that it preloads correctly when provided, and to `List.tsx` verifying that the accounts page passes the active filter by default.