### PR TITLE
LPD-91300 | master - Unable to reconnect a DXP to the AC

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -605,6 +605,11 @@ public interface ContactsEngineClient {
 			Class<T> returnType)
 		throws Exception;
 
+	public DataSource reconnectDataSource(
+		FaroProject faroProject, String id, Credentials credentials,
+		long userId, String name, String url, Provider provider, Event event,
+		String status);
+
 	public List<Map<String, Object>> refreshLiferay(FaroProject faroProject);
 
 	public void setEngineURL(String engineURL);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -587,9 +587,9 @@ public interface ContactsEngineClient {
 		List<Map<String, String>> groups);
 
 	public DataSource patchDataSource(
-		FaroProject faroProject, String id, Credentials credentials,
-		long userId, String name, String url, Provider provider, Event event,
-		String status);
+		Credentials credentials, Event event, FaroProject faroProject,
+		String id, String name, Provider provider, String status, String url,
+		long userId);
 
 	public FieldMapping patchFieldMapping(
 		FaroProject faroProject, String id, String dataSourceId,
@@ -606,9 +606,9 @@ public interface ContactsEngineClient {
 		throws Exception;
 
 	public DataSource reconnectDataSource(
-		FaroProject faroProject, String id, Credentials credentials,
-		long userId, String name, String url, Provider provider, Event event,
-		String status);
+		Credentials credentials, Event event, FaroProject faroProject,
+		String id, String name, Provider provider, String status, String url,
+		long userId);
 
 	public List<Map<String, Object>> refreshLiferay(FaroProject faroProject);
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -3277,6 +3277,17 @@ public class ContactsEngineClientImpl
 	}
 
 	@Override
+	public DataSource reconnectDataSource(
+		FaroProject faroProject, String id, Credentials credentials,
+		long userId, String name, String url, Provider provider, Event event,
+		String status) {
+
+		return _patchDataSource(
+			Rels.DATA_SOURCE_RECONNECT, faroProject, id, credentials, userId,
+			name, url, provider, event, status);
+	}
+
+	@Override
 	public List<Map<String, Object>> refreshLiferay(FaroProject faroProject) {
 		Map<String, Object> uriVariables = getUriVariables(
 			faroProject, 1, 10000, null);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -3212,13 +3212,13 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public DataSource patchDataSource(
-		FaroProject faroProject, String id, Credentials credentials,
-		long userId, String name, String url, Provider provider, Event event,
-		String status) {
+		Credentials credentials, Event event, FaroProject faroProject,
+		String id, String name, Provider provider, String status, String url,
+		long userId) {
 
 		return _patchDataSource(
-			Rels.DATA_SOURCE, faroProject, id, credentials, userId, name, url,
-			provider, event, status);
+			credentials, event, faroProject, id, name, provider, status,
+			Rels.DATA_SOURCE, url, userId);
 	}
 
 	@Override
@@ -3278,13 +3278,13 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public DataSource reconnectDataSource(
-		FaroProject faroProject, String id, Credentials credentials,
-		long userId, String name, String url, Provider provider, Event event,
-		String status) {
+		Credentials credentials, Event event, FaroProject faroProject,
+		String id, String name, Provider provider, String status, String url,
+		long userId) {
 
 		return _patchDataSource(
-			Rels.DATA_SOURCE_RECONNECT, faroProject, id, credentials, userId,
-			name, url, provider, event, status);
+			credentials, event, faroProject, id, name, provider, status,
+			Rels.DATA_SOURCE_RECONNECT, url, userId);
 	}
 
 	@Override
@@ -3585,9 +3585,9 @@ public class ContactsEngineClientImpl
 	}
 
 	private DataSource _patchDataSource(
-		String rel, FaroProject faroProject, String id, Credentials credentials,
-		long userId, String name, String url, Provider provider, Event event,
-		String status) {
+		Credentials credentials, Event event, FaroProject faroProject,
+		String id, String name, Provider provider, String status, String rel,
+		String url, long userId) {
 
 		Map<String, Object> dataSourcePatch = new HashMap<>();
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -3216,41 +3216,9 @@ public class ContactsEngineClientImpl
 		long userId, String name, String url, Provider provider, Event event,
 		String status) {
 
-		Map<String, Object> dataSourcePatch = new HashMap<>();
-
-		Author author = getAuthor(userId);
-
-		if (author != null) {
-			dataSourcePatch.put("author", author);
-		}
-
-		if (credentials != null) {
-			dataSourcePatch.put("credentials", credentials);
-		}
-
-		if (event != null) {
-			dataSourcePatch.put("event", event);
-		}
-
-		if (Validator.isNotNull(name)) {
-			dataSourcePatch.put("name", name);
-		}
-
-		if (provider != null) {
-			dataSourcePatch.put("provider", provider);
-		}
-
-		if (Validator.isNotNull(status)) {
-			dataSourcePatch.put("status", status);
-		}
-
-		if (Validator.isNotNull(url)) {
-			dataSourcePatch.put("url", url);
-		}
-
-		return patch(
-			faroProject, Rels.DATA_SOURCE, id, dataSourcePatch,
-			DataSource.class);
+		return _patchDataSource(
+			Rels.DATA_SOURCE, faroProject, id, credentials, userId, name, url,
+			provider, event, status);
 	}
 
 	@Override
@@ -3603,6 +3571,46 @@ public class ContactsEngineClientImpl
 
 	protected String getWorkspaceURL(long groupId) {
 		return FaroPropsValues.FARO_URL + "/workspace/" + groupId;
+	}
+
+	private DataSource _patchDataSource(
+		String rel, FaroProject faroProject, String id, Credentials credentials,
+		long userId, String name, String url, Provider provider, Event event,
+		String status) {
+
+		Map<String, Object> dataSourcePatch = new HashMap<>();
+
+		Author author = getAuthor(userId);
+
+		if (author != null) {
+			dataSourcePatch.put("author", author);
+		}
+
+		if (credentials != null) {
+			dataSourcePatch.put("credentials", credentials);
+		}
+
+		if (event != null) {
+			dataSourcePatch.put("event", event);
+		}
+
+		if (Validator.isNotNull(name)) {
+			dataSourcePatch.put("name", name);
+		}
+
+		if (provider != null) {
+			dataSourcePatch.put("provider", provider);
+		}
+
+		if (Validator.isNotNull(status)) {
+			dataSourcePatch.put("status", status);
+		}
+
+		if (Validator.isNotNull(url)) {
+			dataSourcePatch.put("url", url);
+		}
+
+		return patch(faroProject, rel, id, dataSourcePatch, DataSource.class);
 	}
 
 	private static final String _FARO_TEMP_FIELD = "faro_temp_field";

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
@@ -126,6 +126,8 @@ public interface Rels {
 
 	public static final String DATA_SOURCE_PROGRESS = "data-source-progress";
 
+	public static final String DATA_SOURCE_RECONNECT = "data-source-reconnect";
+
 	public static final String DATA_SOURCE_REFRESH_LIFERAY =
 		"data-source-refresh-liferay";
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -1235,6 +1235,17 @@ public abstract class BaseMockContactsEngineClientImpl
 	}
 
 	@Override
+	public DataSource reconnectDataSource(
+		FaroProject faroProject, String id, Credentials credentials,
+		long userId, String name, String url, Provider provider, Event event,
+		String status) {
+
+		return contactsEngineClient.reconnectDataSource(
+			faroProject, id, credentials, userId, name, url, provider, event,
+			status);
+	}
+
+	@Override
 	public List<Map<String, Object>> refreshLiferay(FaroProject faroProject) {
 		return contactsEngineClient.refreshLiferay(faroProject);
 	}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -1195,13 +1195,13 @@ public abstract class BaseMockContactsEngineClientImpl
 
 	@Override
 	public DataSource patchDataSource(
-		FaroProject faroProject, String id, Credentials credentials,
-		long userId, String name, String url, Provider provider, Event event,
-		String status) {
+		Credentials credentials, Event event, FaroProject faroProject,
+		String id, String name, Provider provider, String status, String url,
+		long userId) {
 
 		return contactsEngineClient.patchDataSource(
-			faroProject, id, credentials, userId, name, url, provider, event,
-			status);
+			credentials, event, faroProject, id, name, provider, status, url,
+			userId);
 	}
 
 	@Override
@@ -1236,13 +1236,13 @@ public abstract class BaseMockContactsEngineClientImpl
 
 	@Override
 	public DataSource reconnectDataSource(
-		FaroProject faroProject, String id, Credentials credentials,
-		long userId, String name, String url, Provider provider, Event event,
-		String status) {
+		Credentials credentials, Event event, FaroProject faroProject,
+		String id, String name, Provider provider, String status, String url,
+		long userId) {
 
 		return contactsEngineClient.reconnectDataSource(
-			faroProject, id, credentials, userId, name, url, provider, event,
-			status);
+			credentials, event, faroProject, id, name, provider, status, url,
+			userId);
 	}
 
 	@Override

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
@@ -175,7 +175,7 @@ public class DataSourceFaroController extends BaseFaroController {
 			_tokenManager.setDataSourceId(dataSource.getId(), token);
 		}
 		else {
-			dataSource = contactsEngineClient.patchDataSource(
+			dataSource = contactsEngineClient.reconnectDataSource(
 				faroProject, dataSourceId,
 				OAuthUtil.getOAuth20Credentials(
 					"CLIENT_CREDENTIALS", portalURL, "",

--- a/modules/test/playwright/tests/osb-faro-web/main/reconnection.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/reconnection.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {isolatedChannelTest} from '../../../fixtures/isolatedChannelTest';
+import {loginAnalyticsCloudTest} from '../../../fixtures/loginAnalyticsCloudTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {
+	connectToAnalyticsCloud,
+	disconnectFromAnalyticsCloud,
+	goPreviousStep,
+	goToAnalyticsCloudInstanceSettings,
+} from '../../analytics-settings-web/main/utils/analytics-settings';
+import {
+	createDataSource,
+	gotoLatestLiferayDXPDataSource,
+} from './utils/data-source';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	isolatedChannelTest,
+	loginAnalyticsCloudTest(),
+	loginTest()
+);
+
+test(
+	'Reconnect DXP to an existing Analytics Cloud data source',
+	{
+		tag: '@LPD-91300',
+	},
+	async ({page, project}) => {
+
+		// Create a data source in Analytics Cloud and connect the DXP for the first time
+
+		const {token: initialToken} = await createDataSource(page);
+
+		await goToAnalyticsCloudInstanceSettings(page);
+
+		const disconnectButton = page.getByRole('button', {name: 'Disconnect'});
+
+		if (await disconnectButton.isVisible()) {
+			await disconnectFromAnalyticsCloud(page);
+		}
+
+		await connectToAnalyticsCloud(page, {token: initialToken});
+
+		await expect(
+			page.getByRole('heading', {name: 'Property Assignment'})
+		).toBeVisible();
+
+		await goPreviousStep(page);
+
+		// Disconnect the DXP
+
+		await disconnectFromAnalyticsCloud(page);
+
+		// Grab the regenerated token from the disconnected data source
+
+		await gotoLatestLiferayDXPDataSource(page, project);
+
+		const tokenInput = page.locator('#value');
+
+		await expect(tokenInput).toHaveValue(/.{20,}/);
+
+		const reconnectToken = await tokenInput.inputValue();
+
+		// Reconnect the DXP using the regenerated token
+
+		await goToAnalyticsCloudInstanceSettings(page);
+
+		await connectToAnalyticsCloud(page, {token: reconnectToken});
+
+		await expect(
+			page.getByRole('heading', {name: 'Property Assignment'})
+		).toBeVisible();
+	}
+);


### PR DESCRIPTION
Motivation
----
Fix Unable to reconnect a DXP to the AC

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-91300)

Proposed Solution
----
This PR introduces a new method to handle data source reconnection logic in a more reusable and maintainable way.

The existing reconnection flow has been refactored by extracting the shared logic into a dedicated method, allowing it to be reused across different scenarios and reducing code duplication.

Additionally, the data source reconnection process has been updated to leverage the new method, ensuring the behavior is centralized and consistent.

To help prevent regressions, a new test has also been added to reproduce and validate the reported issue.

**NOTE:** this pr depends on https://github.com/liferay/com-liferay-osb-asah-private/pull/6933