### PR TITLE
LPD-92075 Fix segment criteria dropdown section name for page-topics

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/index.tsx
@@ -38,7 +38,7 @@ const GROUP_LABELS: Record<string, string> = {
 	'asset-categorization': Liferay.Language.get('asset-categorization'),
 	attributes: Liferay.Language.get('attributes'),
 	behavioral: Liferay.Language.get('behavioral'),
-	'page-topics': Liferay.Language.get('interests')
+	'page-topics': Liferay.Language.get('page-topics')
 };
 
 interface IPickerGroup {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92075

## What is being fixed

The segment criteria sidebar was displaying "Interests" as the label
for the page-topics group instead of "Page Topics". The GROUP_LABELS
map in criteria-sidebar/index.tsx had the wrong language key
('interests') assigned to the 'page-topics' key.

## How it is being fixed

Changed the language key for the 'page-topics' entry in GROUP_LABELS
from Liferay.Language.get('interests') to
Liferay.Language.get('page-topics').

## Why are there no tests?

This is a single-line text label fix with no logic — the correct label
value is enforced by the language key system and has no testable
branching behavior.