### PR TITLE
LPD-90933 Fix ActivityStreamTimeline test to match renamed language key

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamTimeline.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamTimeline.tsx
@@ -224,7 +224,7 @@ describe('ActivityStreamTimeline rendering', () => {
 	it('renders the empty data state when hasQuery=false and no sessions', () => {
 		const {getByText} = render(<ActivityStreamTimeline {...baseProps} />);
 
-		expect(getByText('There is no data found.')).toBeInTheDocument();
+		expect(getByText('No data was found.')).toBeInTheDocument();
 	});
 
 	it('renders a known user with the user icon', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90933

## What is being fixed

A prior commit (`de9043c LPD-90933 Add language key for assets empty state title`) renamed the language key `there-is-no-data-found` (value: `There is no data found.`) to `no-data-was-found` (value: `No data was found.`) and updated three component files accordingly, but did not update the `ActivityStreamTimeline` test. As a result, the test was asserting the old string and failing in CI once the webpack break introduced by LPD-91377 was resolved.

## How it is being fixed

The test assertion in `ActivityStreamTimeline.tsx` is updated from `'There is no data found.'` to `'No data was found.'` to match the current language key value.

## Test results

### yarn test

```
PASS src/main/js/contacts/pages/account/components/__tests__/ActivityStreamTimeline.tsx
  ActivityStreamTimeline helpers
    groupByDate
      ✓ collapses sessions on the same UTC day into one bucket (6 ms)
      ✓ separates different days and sorts descending (2 ms)
      ✓ marks userName=null group as anonymous with localized fallback (5 ms)
      ✓ groups multiple sessions by same userName into one user group (1 ms)
      ✓ sums totalEvents across all sessions for the day (1 ms)
    formatSessionTimeRange
      ✓ renders a range when completeDate is set
      ✓ renders an in-progress label when completeDate is null (7 ms)
      ✓ renders a single time when start equals end (1 ms)
    formatAttributeValue
      ✓ leaves bare-word strings unquoted
      ✓ quotes strings with non-word characters
      ✓ coerces numbers and booleans via String() (1 ms)
      ✓ returns "null" for null
    isEmptyValue
      ✓ returns true for null, undefined, and empty string
      ✓ returns false for non-empty values (1 ms)
  ActivityStreamTimeline rendering
    ✓ renders the loading state (19 ms)
    ✓ renders the no-results state with a clear button when hasQuery=true (27 ms)
    ✓ renders the empty data state when hasQuery=false and no sessions (9 ms)
    ✓ renders a known user with the user icon (76 ms)
    ✓ renders an anonymous session with the anonymize icon (36 ms)

Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        5.297 s
```

### gradlew formatSource

```
> Task :dxp:apps:osb:osb-faro:osb-faro-web:packageRunFormat
yarn run v1.22.19
$ eslint --fix "src/main/js/**/*.+(js|ts)?(x)"
Done in 27.33s.

BUILD SUCCESSFUL in 58s
5 actionable tasks: 5 executed
```