### PR TITLE
LPD-92065 Remove extra space below last filter dropdown option

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/FilterAndOrder.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/FilterAndOrder.tsx
@@ -209,28 +209,33 @@ const FilterAndOrder: React.FC<IFilterAndOrderProps> = ({
 					</ClayButton>
 				}
 			>
-				<FilterOptionsList
-					filterBy={filterBy}
-					filterByOptions={filterByOptions}
-					flat={flat}
-					onChange={(value, field) => {
-						const option = filterByOptions.find(
-							({key}) => key === field
-						);
+				<ClayDropDown.ItemList>
+					<FilterOptionsList
+						filterBy={filterBy}
+						filterByOptions={filterByOptions}
+						flat={flat}
+						onChange={(value, field) => {
+							const option = filterByOptions.find(
+								({key}) => key === field
+							);
 
-						onFilterByChange(
-							filterBy.update(field, (values: any = Set()) => {
-								if (option?.type === 'radio') {
-									return Set([value]);
-								}
+							onFilterByChange(
+								filterBy.update(
+									field,
+									(values: any = Set()) => {
+										if (option?.type === 'radio') {
+											return Set([value]);
+										}
 
-								return values.has(value)
-									? values.delete(value)
-									: values.add(value);
-							})
-						);
-					}}
-				/>
+										return values.has(value)
+											? values.delete(value)
+											: values.add(value);
+									}
+								)
+							);
+						}}
+					/>
+				</ClayDropDown.ItemList>
 			</ClayDropDown>
 		)}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92065

## What Is Being Fixed

The filter dropdown in the individual list had 16px of extra space below the last option. The browser's default `ul { margin-bottom: 1rem }` rule applied to the `<ul>` rendered by `ClayDropDown.Group` because it was nested inside `div > li`, not inside another `<ul>`, so the overriding rule `ul ul { margin-bottom: 0 }` never fired.

## How It Is Being Fixed

`FilterOptionsList` inside the filter dropdown is now wrapped in `ClayDropDown.ItemList`, which renders an outer `<ul class="list-unstyled">`. This makes the inner `<ul>` from `ClayDropDown.Group` a `ul ul` descendant, so `margin-bottom: 0` applies and the extra space disappears. This mirrors the pattern already used by the order dropdown in the same component.

## Why Are There No Tests?

This is a pure structural fix. The change adds a wrapper element to correct a CSS margin that only manifests visually. The existing FilterAndOrder unit tests still pass and cover the component's functional behavior.