### PR TITLE
LPD-92195 | master Known Individuals CSV is empty for non-ASCII page URLs

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/sites/touchpoints/pages/TouchpointRoutes.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/sites/touchpoints/pages/TouchpointRoutes.jsx
@@ -14,7 +14,7 @@ import TextTruncate from 'shared/components/TextTruncate';
 import {CSVType} from 'shared/components/download-report/utils';
 import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
 import {getMatchedRoute, Routes} from 'shared/util/router';
-import {getSafeDecodedURIComponent} from 'shared/util/util';
+import {getSafeDecodedURIComponent, getSafeTouchpoint} from 'shared/util/util';
 import {pickBy} from 'lodash';
 import {PropTypes} from 'prop-types';
 import {removeUriQueryParam, setUriQueryValues} from 'shared/util/router';
@@ -171,7 +171,7 @@ function TouchpointRoutes({className, router}) {
 				<BasePage.SubHeader>
 					<div className='d-flex justify-content-end w-100'>
 						<DownloadCSVReport
-							assetId={decodedTouchpoint}
+							assetId={getSafeTouchpoint(touchpoint)}
 							assetType='page'
 							disabled={dataSourceStates.empty}
 							type={CSVType.Individual}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/sites/touchpoints/pages/__tests__/TouchpointRoutes.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/sites/touchpoints/pages/__tests__/TouchpointRoutes.jsx
@@ -1,0 +1,102 @@
+import mockStore from 'test/mock-store';
+import React from 'react';
+import TouchpointRoutes from '../TouchpointRoutes';
+import {MemoryRouter} from 'react-router-dom';
+import {Provider} from 'react-redux';
+import {render, screen} from '@testing-library/react';
+
+jest.unmock('react-dom');
+
+jest.mock('shared/components/download-report/DownloadCSVReport', () => ({
+	__esModule: true,
+	default: ({assetId}) => (
+		<div data-asset-id={assetId} data-testid='download-csv-report' />
+	)
+}));
+
+jest.mock('shared/components/download-report/DownloadPDFReport', () => ({
+	__esModule: true,
+	default: () => null
+}));
+
+jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
+	DropdownRangeKey: () => null
+}));
+
+jest.mock('shared/components/Loading', () => ({
+	__esModule: true,
+	default: () => null
+}));
+
+jest.mock('shared/components/RouteNotFound', () => ({
+	__esModule: true,
+	default: () => null
+}));
+
+jest.mock('route-middleware/BundleRouter', () => ({
+	__esModule: true,
+	default: () => null
+}));
+
+jest.mock('../../components/ExperienceDropdown', () => ({
+	__esModule: true,
+	default: () => null
+}));
+
+jest.mock('../../components/FilterBySegment', () => ({
+	__esModule: true,
+	default: () => null
+}));
+
+jest.mock('shared/context/channel', () => ({
+	useChannelContext: () => ({selectedChannel: {name: 'test channel'}})
+}));
+
+jest.mock('shared/context/dataSources', () => ({
+	useDataSources: () => ({empty: false})
+}));
+
+jest.mock('shared/hooks/useQueryRangeSelectors', () => ({
+	useQueryRangeSelectors: () => ({rangeKey: '30'})
+}));
+
+jest.mock('shared/util/router', () => {
+	const actual = jest.requireActual('shared/util/router');
+
+	return {
+		...actual,
+		getMatchedRoute: jest.fn(
+			() => actual.Routes.SITES_TOUCHPOINTS_KNOWN_INDIVIDUALS
+		)
+	};
+});
+
+describe('TouchpointRoutes', () => {
+	it('forwards a percent-encoded touchpoint as assetId for the Known Individuals CSV download', () => {
+		const router = {
+			params: {
+				channelId: '1',
+				experienceId: '',
+				groupId: '2',
+				title: 'page',
+				touchpoint: 'http://example.com/web/site/人事発告'
+			}
+		};
+
+		render(
+			<Provider store={mockStore()}>
+				<MemoryRouter>
+					<TouchpointRoutes router={router} />
+				</MemoryRouter>
+			</Provider>
+		);
+
+		expect(
+			screen
+				.getByTestId('download-csv-report')
+				.getAttribute('data-asset-id')
+		).toBe(
+			'http://example.com/web/site/%E4%BA%BA%E4%BA%8B%E7%99%BA%E5%91%8A'
+		);
+	});
+});


### PR DESCRIPTION
Motivation
----
Fix When downloading Known Individuals data, only the header is recorded in the CSV file; user information is not included.

https://liferay.atlassian.net/browse/LPD-92195

Proposed Solution
----

Downloading the Known Individuals CSV from a page's dashboard produced a file with only the header row for pages whose canonical URL contains non-ASCII characters (kanji, full-width digits, cyrillic, etc.). The BigQuery `canonicalurl` column stores the URL with those characters percent-encoded, but `TouchpointRoutes` was passing the decoded touchpoint to `DownloadCSVReport`, so the backend `WHERE canonicalurl = ?` filter never matched and no rows were written.

The dashboard view kept working because its GraphQL variables run the touchpoint through `getSafeTouchpoint`, which normalizes the URL back into the percent-encoded form via the standard `URL` constructor. We wire the CSV download to the same helper so both code paths agree on the encoding contract, and add a regression test that exercises `TouchpointRoutes` with a non-ASCII touchpoint to lock the expectation.