### PR TITLE
LPD-92210 Fix accounts page showing wrong empty state when property has no data sources

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -1743,7 +1743,7 @@ public class ContactsEngineClientImpl
 			for (String channelId : channelIds) {
 				channelIdsFilterBuilder.addFilter(
 					"channelId", FilterConstants.COMPARISON_OPERATOR_EQUALS,
-					channelId, false);
+					GetterUtil.getLong(channelId), false);
 			}
 
 			filterBuilder.addFilter(channelIdsFilterBuilder, true);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
@@ -35,9 +35,9 @@ const List: React.FC<IListProps> = ({channelId, groupId}) => {
 	});
 
 	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
-		dataSourceFn: API.dataSource.search,
+		dataSourceFn: API.dataSource.fetchChannels,
 		variables: {
-			delta: 1,
+			channelIds: [channelId],
 			groupId
 		}
 	});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
@@ -58,10 +58,10 @@ const buildHistory = (path = '/workspace/23/123/accounts') => {
 
 const store = mockStore();
 
-// `useRequest` is consumed by both `List` (data source search, expects an
-// object with `total`) and `TotalAccounts` (account metrics, expects an array
-// of `IAccountMetric`). Differentiate by `variables.delta`, which is only
-// present in the data source search call.
+// `useRequest` is consumed by both `List` (fetchChannels, expects an object
+// with `total`) and `TotalAccounts` (account metrics, expects an array of
+// `IAccountMetric`). Differentiate by `variables.channelIds`, which is only
+// present in the fetchChannels call.
 
 const accountMetricsMock = [
 	{
@@ -84,7 +84,7 @@ const accountMetricsMock = [
 const useRequestImpl =
 	({total = 1}: {total?: number} = {}) =>
 	({variables}: {variables: {[key: string]: any}}) =>
-		variables?.delta !== undefined
+		variables?.channelIds !== undefined
 			? {data: {total}}
 			: {data: accountMetricsMock};
 


### PR DESCRIPTION
## Summary

https://liferay.atlassian.net/browse/LPD-92210

- The accounts page was calling `API.dataSource.search` with only `groupId`, which returns all datasources across the entire group regardless of the current channel/property — causing `dataSourceConnected` to be `true` even when the selected property had no datasources, and showing the wrong empty state ("no accounts found" instead of "no data sources connected")
- Fixed by switching to `API.dataSource.fetchChannels` with `channelIds: [channelId]`, which filters datasources by the current channel and correctly returns `total: 0` when none are attached
- Fixed a related backend type mismatch in `ContactsEngineClientImpl.getDataSources(FaroProject, List<String> channelIds)` where channel IDs were passed as strings to `FilterBuilder`, producing an OData filter like `channelId eq '123'` (varchar) instead of `channelId eq 123` (numeric) — causing PostgreSQL to throw `operator does not exist: bigint = character varying`