### PR TITLE
LPD-52931 LPD-55902 Fix event analysis report download issues

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_event_analysis_editor.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_event_analysis_editor.scss
@@ -55,6 +55,10 @@
 
 		.dropdown-item-primary-button {
 			line-height: 32px;
+			min-width: 0;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
 		}
 
 		.options-button {
@@ -261,9 +265,11 @@
 	.description {
 		color: $secondary;
 		padding-bottom: 8px;
+		word-break: break-word;
 	}
 
 	.filter-name {
 		font-weight: $fontWeightSemiBold;
+		word-break: break-word;
 	}
 }

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/DownloadPDFReport.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/DownloadPDFReport.tsx
@@ -226,7 +226,11 @@ export const formattedContainers = (
 
 let _spriteSVG: Element | null = null;
 
-const fetchSprite = async (): Promise<Element | null> => {
+export const resetSpriteCache = () => {
+	_spriteSVG = null;
+};
+
+export const fetchSprite = async (): Promise<Element | null> => {
 	if (_spriteSVG) {
 		return _spriteSVG;
 	}
@@ -255,7 +259,7 @@ const fetchSprite = async (): Promise<Element | null> => {
 	return _spriteSVG;
 };
 
-const inlineSVGIcons = (clonedDoc: Document, sprite: Element) => {
+export const inlineSVGIcons = (clonedDoc: Document, sprite: Element) => {
 	clonedDoc.querySelectorAll('svg use').forEach(useEl => {
 		const href =
 			useEl.getAttribute('href') ||

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/DownloadPDFReport.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/DownloadPDFReport.tsx
@@ -224,11 +224,78 @@ export const formattedContainers = (
 		return acc;
 	}, {} as ContainerList);
 
+let _spriteSVG: Element | null = null;
+
+const fetchSprite = async (): Promise<Element | null> => {
+	if (_spriteSVG) {
+		return _spriteSVG;
+	}
+
+	const useEl = document.querySelector('svg use');
+
+	if (!useEl) {
+		return null;
+	}
+
+	const href =
+		useEl.getAttribute('href') || useEl.getAttribute('xlink:href') || '';
+
+	const spriteUrl = href.split('#')[0];
+
+	if (!spriteUrl) {
+		return null;
+	}
+
+	const res = await fetch(spriteUrl);
+	const text = await res.text();
+	const doc = new DOMParser().parseFromString(text, 'image/svg+xml');
+
+	_spriteSVG = doc.documentElement;
+
+	return _spriteSVG;
+};
+
+const inlineSVGIcons = (clonedDoc: Document, sprite: Element) => {
+	clonedDoc.querySelectorAll('svg use').forEach(useEl => {
+		const href =
+			useEl.getAttribute('href') ||
+			useEl.getAttribute('xlink:href') ||
+			'';
+
+		const symbolId = href.split('#')[1];
+
+		if (!symbolId) {
+			return;
+		}
+
+		const symbol = sprite.querySelector(`#${symbolId}`);
+
+		if (!symbol) {
+			return;
+		}
+
+		const svgEl = useEl.closest('svg');
+
+		if (!svgEl) {
+			return;
+		}
+
+		svgEl.innerHTML = symbol.innerHTML;
+
+		const viewBox = symbol.getAttribute('viewBox');
+
+		if (viewBox) {
+			svgEl.setAttribute('viewBox', viewBox);
+		}
+	});
+};
+
 const getContainers = async (
 	containers: TransformedContainer[]
 ): Promise<JSPDFExtensionContainer[]> => {
 	const containerArr: JSPDFExtensionContainer[] = [];
 	const promises: Promise<void>[] = [];
+	const sprite = await fetchSprite();
 
 	containers.map(({id, layout}) => {
 		const containerElement = document.getElementById(id);
@@ -239,7 +306,10 @@ const getContainers = async (
 
 		const promise = html2canvas(containerElement, {
 			backgroundColor: '#F1F2F5',
-			logging: false
+			logging: false,
+			onclone: sprite
+				? clonedDoc => inlineSVGIcons(clonedDoc, sprite)
+				: undefined
 		}).then(canvas => {
 			const imageData = canvas.toDataURL('image/jpeg', 1.0);
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/__tests__/DownloadPDFReport.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/__tests__/DownloadPDFReport.tsx
@@ -1,0 +1,196 @@
+import {
+	fetchSprite,
+	inlineSVGIcons,
+	resetSpriteCache
+} from '../DownloadPDFReport';
+
+const SPRITE_SVG =
+	'<svg xmlns="http://www.w3.org/2000/svg">' +
+	'<symbol id="icon-home" viewBox="0 0 16 16">' +
+	'<path d="M8 1l7 7H1z"></path>' +
+	'</symbol>' +
+	'</svg>';
+
+const mockFetch = (text: string) => {
+	global.fetch = jest.fn().mockResolvedValue({
+		text: jest.fn().mockResolvedValue(text)
+	}) as any;
+};
+
+describe('fetchSprite', () => {
+	let querySelectorSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		resetSpriteCache();
+		querySelectorSpy = jest.spyOn(document, 'querySelector');
+	});
+
+	afterEach(() => {
+		querySelectorSpy.mockRestore();
+	});
+
+	it('returns null when no svg use element exists', async () => {
+		querySelectorSpy.mockReturnValue(null);
+
+		expect(await fetchSprite()).toBeNull();
+	});
+
+	it('returns null when href has no sprite URL (fragment only)', async () => {
+		const useEl = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'use'
+		);
+
+		useEl.setAttribute('href', '#icon-home');
+		querySelectorSpy.mockReturnValue(useEl);
+
+		expect(await fetchSprite()).toBeNull();
+	});
+
+	it('fetches the sprite URL and returns the parsed SVG element', async () => {
+		const useEl = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'use'
+		);
+
+		useEl.setAttribute('href', '/o/frontend-icons/icons.svg#icon-home');
+		querySelectorSpy.mockReturnValue(useEl);
+		mockFetch(SPRITE_SVG);
+
+		const result = await fetchSprite();
+
+		expect(result).not.toBeNull();
+		expect(result!.tagName.toLowerCase()).toBe('svg');
+		expect(global.fetch).toHaveBeenCalledWith(
+			'/o/frontend-icons/icons.svg'
+		);
+	});
+
+	it('reads xlink:href as fallback when href is absent', async () => {
+		const useEl = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'use'
+		);
+
+		useEl.setAttribute(
+			'xlink:href',
+			'/o/frontend-icons/icons.svg#icon-home'
+		);
+		querySelectorSpy.mockReturnValue(useEl);
+		mockFetch(SPRITE_SVG);
+
+		const result = await fetchSprite();
+
+		expect(result).not.toBeNull();
+		expect(global.fetch).toHaveBeenCalledWith(
+			'/o/frontend-icons/icons.svg'
+		);
+	});
+
+	it('caches the fetched sprite so fetch is called only once', async () => {
+		const useEl = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'use'
+		);
+
+		useEl.setAttribute('href', '/o/frontend-icons/icons.svg#icon-home');
+		querySelectorSpy.mockReturnValue(useEl);
+		mockFetch(SPRITE_SVG);
+
+		await fetchSprite();
+		await fetchSprite();
+
+		expect(global.fetch).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('inlineSVGIcons', () => {
+	let sprite: Element;
+
+	beforeEach(() => {
+		const doc = new DOMParser().parseFromString(
+			SPRITE_SVG,
+			'image/svg+xml'
+		);
+
+		sprite = doc.documentElement;
+	});
+
+	const buildDoc = (svgInner: string): Document => {
+		const clonedDoc = document.implementation.createHTMLDocument();
+
+		clonedDoc.body.innerHTML = `<svg>${svgInner}</svg>`;
+
+		return clonedDoc;
+	};
+
+	it('replaces use element with the matching symbol innerHTML', () => {
+		const clonedDoc = buildDoc('<use href="/icons.svg#icon-home"></use>');
+
+		inlineSVGIcons(clonedDoc, sprite);
+
+		const svg = clonedDoc.querySelector('svg')!;
+
+		expect(svg.querySelector('use')).toBeNull();
+		expect(svg.querySelector('path')).not.toBeNull();
+	});
+
+	it('sets viewBox from the symbol onto the parent svg element', () => {
+		const clonedDoc = buildDoc('<use href="/icons.svg#icon-home"></use>');
+
+		inlineSVGIcons(clonedDoc, sprite);
+
+		expect(clonedDoc.querySelector('svg')!.getAttribute('viewBox')).toBe(
+			'0 0 16 16'
+		);
+	});
+
+	it('leaves use element unchanged when href has no symbol fragment', () => {
+		const clonedDoc = buildDoc('<use href="/icons.svg"></use>');
+
+		inlineSVGIcons(clonedDoc, sprite);
+
+		expect(clonedDoc.querySelector('use')).not.toBeNull();
+	});
+
+	it('leaves use element unchanged when symbol is not found in sprite', () => {
+		const clonedDoc = buildDoc(
+			'<use href="/icons.svg#icon-nonexistent"></use>'
+		);
+
+		inlineSVGIcons(clonedDoc, sprite);
+
+		expect(clonedDoc.querySelector('use')).not.toBeNull();
+	});
+
+	it('does not set viewBox when symbol has no viewBox attribute', () => {
+		const spriteDoc = new DOMParser().parseFromString(
+			'<svg xmlns="http://www.w3.org/2000/svg">' +
+				'<symbol id="icon-plain"><circle cx="8" cy="8" r="4"></circle></symbol>' +
+				'</svg>',
+			'image/svg+xml'
+		);
+		const spriteWithoutViewBox = spriteDoc.documentElement;
+		const clonedDoc = buildDoc('<use href="/icons.svg#icon-plain"></use>');
+
+		inlineSVGIcons(clonedDoc, spriteWithoutViewBox);
+
+		expect(
+			clonedDoc.querySelector('svg')!.getAttribute('viewBox')
+		).toBeNull();
+	});
+
+	it('handles xlink:href when href attribute is absent', () => {
+		const clonedDoc = document.implementation.createHTMLDocument();
+
+		clonedDoc.body.innerHTML =
+			'<svg><use xlink:href="/icons.svg#icon-home"></use></svg>';
+
+		inlineSVGIcons(clonedDoc, sprite);
+
+		const svg = clonedDoc.querySelector('svg')!;
+
+		expect(svg.querySelector('use')).toBeNull();
+		expect(svg.querySelector('path')).not.toBeNull();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52931

## What is being fixed

Two bugs in the Event Analysis report download feature:

1. **(LPD-52931)** When downloading a PDF report, Clay icons (filter type icons, drag handles) were missing from the output because `html2canvas` cannot render SVG `<use>` elements that reference an external sprite file.

2. **(LPD-55902)** When hovering over a custom event with a long name in the Events modal dropdown, the UI would break due to text overflow — elements would shift or overflow outside the container.

## How it is being fixed

For the missing icons (LPD-52931): a `fetchSprite` helper pre-fetches the Clay icons sprite once and caches it at module level. An `inlineSVGIcons` helper runs inside html2canvas's `onclone` callback to replace each `<use>` element with the actual SVG path data from the sprite, making the icons visible in the captured canvas.

For the text overflow (LPD-55902): the dropdown item button lacked `min-width: 0` (required for flex items to shrink below content size) and text-truncation properties. The info card popover lacked word-break handling for long names and descriptions. Both are fixed with targeted CSS additions.

## Why are there no tests?

Both fixes are visual rendering changes — CSS layout and SVG canvas capture — which cannot be covered by unit or integration tests.