### PR TITLE
LPD-92290 faro-v4.15.x Prevent getInitials from crashing when name is null

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/util.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/util.js
@@ -1,6 +1,7 @@
 import {
 	formatStringToLowercase,
 	getAlignPosition,
+	getInitials,
 	getPercentage,
 	getRangeSelectorsFromQuery,
 	getSafeDecodedURIComponent,
@@ -62,6 +63,28 @@ describe('util', () => {
 			expect(getAlignPosition(source, target, 'bottom')).toEqual(
 				'bottom'
 			);
+		});
+	});
+
+	describe('getInitials', () => {
+		it('should return uppercased initials for a full name', () => {
+			expect(getInitials('Adriano Interaminense')).toEqual('AI');
+		});
+
+		it('should cap the result at three initials', () => {
+			expect(getInitials('Foo Bar Baz Qux')).toEqual('FBB');
+		});
+
+		it('should return an empty string when name is undefined', () => {
+			expect(getInitials(undefined)).toEqual('');
+		});
+
+		it('should return an empty string when name is null', () => {
+			expect(getInitials(null)).toEqual('');
+		});
+
+		it('should return an empty string when no argument is provided', () => {
+			expect(getInitials()).toEqual('');
 		});
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/util.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/util.ts
@@ -261,8 +261,8 @@ export const mergeRef =
 			}
 		});
 
-export function getInitials(name = '') {
-	const nameArray = name.split(' ', 3);
+export function getInitials(name: string | null | undefined = '') {
+	const nameArray = (name ?? '').split(' ', 3);
 
 	return nameArray
 		.reduce((acc, val) => acc + val.substring(0, 1), '')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92290

Backport of #3354 to `faro-v4.15.x`.