### PR TITLE
LPD-92385 Add per-card loading states to the individual profile overview

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/AccountMembership.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/AccountMembership.tsx
@@ -67,6 +67,7 @@ const dateKeys = ['createdDate', 'lastActivityDate'];
 interface IAccountMembershipProps {
 	accountData?: Map<string, any>;
 	children?: React.ReactNode;
+	loading?: boolean;
 	showEmptyState?: boolean;
 }
 
@@ -88,6 +89,7 @@ const ACCOUNT_MEMBERSHIP_LABEL_MAP: Record<string, string> = {
 const AccountMembership: React.FC<IAccountMembershipProps> = ({
 	accountData,
 	children: emptyState,
+	loading = false,
 	showEmptyState = false
 }) => {
 	const getValue = (key: string): string | undefined => {
@@ -113,6 +115,7 @@ const AccountMembership: React.FC<IAccountMembershipProps> = ({
 			config={accountMembershipConfig}
 			getValue={getValue}
 			languageMap={ACCOUNT_MEMBERSHIP_LABEL_MAP}
+			loading={loading}
 		/>
 	) : (
 		<Card className='p-5'>
@@ -154,7 +157,7 @@ const AccountMembership: React.FC<IAccountMembershipProps> = ({
 				title={Liferay.Language.get('account-membership')}
 			/>
 
-			{showEmptyState ? emptyState : sectionContent}
+			{showEmptyState && !loading ? emptyState : sectionContent}
 		</>
 	);
 };

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/ContextualInformation.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/ContextualInformation.tsx
@@ -53,6 +53,7 @@ interface IContextualInfoProps {
 	contactId?: string;
 	contextData: Map<string, any>;
 	email?: string;
+	loading?: boolean;
 	showEmptyState?: boolean;
 	userId?: string;
 	uuid?: string;
@@ -80,6 +81,7 @@ const ContextualInformation: React.FC<IContextualInfoProps> = ({
 	contactId,
 	contextData,
 	email,
+	loading = false,
 	showEmptyState = false,
 	userId,
 	uuid
@@ -110,13 +112,14 @@ const ContextualInformation: React.FC<IContextualInfoProps> = ({
 				title={Liferay.Language.get('contextual-information')}
 			/>
 
-			{showEmptyState ? (
+			{showEmptyState && !loading ? (
 				emptyState
 			) : (
 				<GeneralInfoSection
 					config={contextualInfoConfig}
 					getValue={getValue}
 					languageMap={CONTEXTUAL_INFO_LABEL_MAP}
+					loading={loading}
 				/>
 			)}
 		</>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/IndividualAttributesCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/IndividualAttributesCDP.tsx
@@ -9,6 +9,7 @@ import {SectionHeader} from 'shared/components/SectionHeader';
 interface IIndividualAttributesProps {
 	children?: React.ReactNode;
 	contactId?: string;
+	loading?: boolean;
 	propertiesData: Map<string, any>;
 	showEmptyState?: boolean;
 }
@@ -60,6 +61,7 @@ const contextualInfoConfig: DataDrivenConfig = [
 const IndividualAttributesCDP: React.FC<IIndividualAttributesProps> = ({
 	children: emptyState,
 	contactId,
+	loading = false,
 	propertiesData,
 	showEmptyState
 }) => {
@@ -84,13 +86,14 @@ const IndividualAttributesCDP: React.FC<IIndividualAttributesProps> = ({
 				title={Liferay.Language.get('individual-attributes')}
 			/>
 
-			{showEmptyState ? (
+			{showEmptyState && !loading ? (
 				emptyState
 			) : (
 				<GeneralInfoSection
 					config={contextualInfoConfig}
 					getValue={getValue}
 					languageMap={INFO_LANGUAGE_MAP}
+					loading={loading}
 				/>
 			)}
 		</>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/IndividualProfileCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/IndividualProfileCDP.tsx
@@ -5,7 +5,6 @@ import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import IndividualAttributesCDP from '../components/IndividualAttributesCDP';
 import IndividualDetailsCDP from '../components/IndividualAllAttributesCDP';
-import Loading from 'shared/components/Loading';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
 import React from 'react';
 import URLConstants from 'shared/util/url-constants';
@@ -28,7 +27,6 @@ interface IIndividualProfileCDPProps {
 interface IProfileCDPEmptyStateProps {
 	authorized: boolean;
 	dataSourceData?: any;
-	dataSourceLoading: boolean;
 	groupId: string;
 	pageDisplay?: boolean;
 	type?: IndividualProfileCDPCards;
@@ -37,19 +35,10 @@ interface IProfileCDPEmptyStateProps {
 const ProfileCDPEmptyState: React.FC<IProfileCDPEmptyStateProps> = ({
 	authorized,
 	dataSourceData,
-	dataSourceLoading,
 	groupId,
 	pageDisplay = true,
 	type = IndividualProfileCDPCards.IndividualsAttributes
 }) => {
-	if (dataSourceLoading) {
-		return (
-			<NoResultsDisplay>
-				<Loading key='LOADING' />
-			</NoResultsDisplay>
-		);
-	}
-
 	if (isNil(dataSourceData?.total) || dataSourceData?.total === 0) {
 		const isAccount = type === IndividualProfileCDPCards.AccountMembership;
 
@@ -148,19 +137,20 @@ const IndividualProfileCDP: React.FC<IIndividualProfileCDPProps> = ({
 	const authorized = currentUser.isAdmin();
 
 	const showEmptyState =
-		isNil(dataSourceData?.total) || dataSourceData?.total === 0;
+		!dataSourceLoading &&
+		(isNil(dataSourceData?.total) || dataSourceData?.total === 0);
 
 	return (
 		<>
 			<IndividualAttributesCDP
 				contactId={individual.get('id')}
+				loading={dataSourceLoading}
 				propertiesData={individual.get('properties')}
 				showEmptyState={showEmptyState}
 			>
 				<ProfileCDPEmptyState
 					authorized={authorized}
 					dataSourceData={dataSourceData}
-					dataSourceLoading={dataSourceLoading}
 					groupId={groupId}
 					pageDisplay={false}
 				/>
@@ -168,12 +158,12 @@ const IndividualProfileCDP: React.FC<IIndividualProfileCDPProps> = ({
 
 			<AccountMembership
 				accountData={individual.getIn(['accounts', 0])}
+				loading={dataSourceLoading}
 				showEmptyState={showEmptyState}
 			>
 				<ProfileCDPEmptyState
 					authorized={authorized}
 					dataSourceData={dataSourceData}
-					dataSourceLoading={dataSourceLoading}
 					groupId={groupId}
 					pageDisplay={false}
 				/>
@@ -187,7 +177,6 @@ const IndividualProfileCDP: React.FC<IIndividualProfileCDPProps> = ({
 				<ProfileCDPEmptyState
 					authorized={authorized}
 					dataSourceData={dataSourceData}
-					dataSourceLoading={dataSourceLoading}
 					groupId={groupId}
 					pageDisplay={false}
 				/>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/OverviewCDP.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/OverviewCDP.jsx
@@ -3,7 +3,6 @@ import Card from 'shared/components/Card';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import ContextualInformation from '../components/ContextualInformation';
-import Loading from 'shared/components/Loading';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
 import ProfileCardCDP from '../hoc/ProfileCardCDP';
 import React from 'react';
@@ -17,19 +16,10 @@ import {useRequest} from 'shared/hooks/useRequest';
 const OverviewCDPEmptyState = ({
 	authorized,
 	dataSourceData,
-	dataSourceLoading,
 	groupId,
 	hasConnectedDataSources,
 	pageDisplay = true
 }) => {
-	if (dataSourceLoading) {
-		return (
-			<NoResultsDisplay>
-				<Loading key='LOADING' />
-			</NoResultsDisplay>
-		);
-	}
-
 	const noSitesSelected = !dataSourceData?.items?.some(
 		dataSource => dataSource.sitesSelected
 	);
@@ -115,20 +105,22 @@ const Overview = ({channelId, groupId, individual, tabId, timeZoneId}) => {
 		dataSource => dataSource.sitesSelected
 	);
 
+	const showEmptyState = !dataSourceLoading && !sitesSelected;
+
 	return (
 		<div className='overview-column-main'>
 			<ContextualInformation
 				contactId={individual.get('id')}
 				contextData={individual.get('context')}
 				email={individual.getIn(['properties', 'email'])}
-				showEmptyState={!sitesSelected}
+				loading={dataSourceLoading}
+				showEmptyState={showEmptyState}
 				userId={individual.getIn(['properties', 'userId'])}
 				uuid={individual.getIn(['properties', 'uuid'])}
 			>
 				<OverviewCDPEmptyState
 					authorized={authorized}
 					dataSourceData={dataSourceData}
-					dataSourceLoading={dataSourceLoading}
 					groupId={groupId}
 					hasConnectedDataSources={!dataSourceStates.empty}
 					pageDisplay={false}
@@ -139,14 +131,13 @@ const Overview = ({channelId, groupId, individual, tabId, timeZoneId}) => {
 				channelId={channelId}
 				entity={individual}
 				groupId={groupId}
-				showEmptyState={!sitesSelected}
+				showEmptyState={showEmptyState}
 				tabId={tabId}
 				timeZoneId={timeZoneId}
 			>
 				<OverviewCDPEmptyState
 					authorized={authorized}
 					dataSourceData={dataSourceData}
-					dataSourceLoading={dataSourceLoading}
 					groupId={groupId}
 					hasConnectedDataSources={!dataSourceStates.empty}
 				/>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/GeneralInfoSection.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/GeneralInfoSection.tsx
@@ -1,6 +1,7 @@
 import Card from './Card';
 import classNames from 'classnames';
 import Icon from '@clayui/icon';
+import Loading from './Loading';
 import React from 'react';
 import Sticker from '@clayui/sticker';
 import {Text} from '@clayui/core';
@@ -53,12 +54,14 @@ interface IGeneralInfoSectionProps {
 	config: DataDrivenConfig;
 	getValue: (key: string) => string | undefined;
 	languageMap: Record<string, string>;
+	loading?: boolean;
 }
 
 export const GeneralInfoSection: React.FC<IGeneralInfoSectionProps> = ({
 	config,
 	getValue,
-	languageMap
+	languageMap,
+	loading
 }) => (
 	<div className='general-info mb-4'>
 		<div className='row g-3'>
@@ -69,23 +72,27 @@ export const GeneralInfoSection: React.FC<IGeneralInfoSectionProps> = ({
 							<Text size={4}>{section.title}</Text>
 						</Card.Title>
 						<Card.Body className='pb-0 px-2'>
-							<div className='g-2 row'>
-								{section.items.map(item => {
-									const rawValue = getValue(item.key);
+							{loading ? (
+								<Loading />
+							) : (
+								<div className='g-2 row'>
+									{section.items.map(item => {
+										const rawValue = getValue(item.key);
 
-									const displayValue = rawValue || '-';
+										const displayValue = rawValue || '-';
 
-									return (
-										<InfoItem
-											className={item.className}
-											icon={item.icon}
-											key={item.key}
-											label={languageMap[item.key]}
-											value={displayValue}
-										/>
-									);
-								})}
-							</div>
+										return (
+											<InfoItem
+												className={item.className}
+												icon={item.icon}
+												key={item.key}
+												label={languageMap[item.key]}
+												value={displayValue}
+											/>
+										);
+									})}
+								</div>
+							)}
 						</Card.Body>
 					</Card>
 				</div>


### PR DESCRIPTION
## Summary

https://liferay.atlassian.net/browse/LPD-92385

- While the data sources request was in flight, \`showEmptyState\` evaluated to \`true\` (since \`sitesSelected\`/\`dataSourceData\` was not yet resolved), causing a single \`<NoResultsDisplay><Loading /></NoResultsDisplay>\` to replace all cards at once — which also showed the default "There are no items found" title alongside the spinner
- Each card on the overview page (Last Session Device, Last Session Location, Individual Unique Identifiers, Individual Events) and on the details page (Individual Attributes, Account Membership, All Attributes) now shows its own loading indicator while data sources load
- \`showEmptyState\` is now gated on \`!dataSourceLoading\` in both \`OverviewCDP\` and \`IndividualProfileCDP\`, so the empty state is only shown after the request completes with no data sources connected