### PR TITLE
LPD-92358 Round avg. day in Lifecycle stages to two decimals

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/LifecycleChart.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/LifecycleChart.tsx
@@ -107,7 +107,9 @@ const StageMetrics = ({
 				<div className='mt-3 text-secondary'>
 					{averageDaysInStage != 0 ? (
 						<>
-							<span className='mr-4'>{`${averageDaysInStage}`}</span>
+							<span className='mr-4'>{`${averageDaysInStage.toFixed(
+								2
+							)}`}</span>
 							<span>
 								{Liferay.Language.get('avg.-day').toLowerCase()}
 							</span>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/__tests__/LifecycleChart.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/__tests__/LifecycleChart.tsx
@@ -135,6 +135,63 @@ describe('LifecycleChart', () => {
 		expect(getByText('no activity')).toBeInTheDocument();
 	});
 
+	it('should render avg. day values rounded to two decimals', () => {
+		const stagesWithLongDecimals: ILifecycleStage[] = [
+			{
+				accountCount: 1,
+				averageStageDuration: 9.8333333,
+				conversionRateToNextStage: 10,
+				description: '',
+				percentage: 10,
+				stageType: LifecycleStages.AWARE
+			},
+			{
+				accountCount: 1,
+				averageStageDuration: 4.6789,
+				conversionRateToNextStage: 10,
+				description: '',
+				percentage: 10,
+				stageType: LifecycleStages.ENGAGED
+			},
+			{
+				accountCount: 1,
+				averageStageDuration: 12,
+				conversionRateToNextStage: 10,
+				description: '',
+				percentage: 10,
+				stageType: LifecycleStages.PIPELINE
+			},
+			{
+				accountCount: 1,
+				averageStageDuration: 4.5,
+				conversionRateToNextStage: 10,
+				description: '',
+				percentage: 10,
+				stageType: LifecycleStages.ONBOARDING
+			},
+			{
+				accountCount: 0,
+				averageStageDuration: 0,
+				conversionRateToNextStage: null,
+				description: '',
+				percentage: 0,
+				stageType: LifecycleStages.ESTABLISHED
+			}
+		];
+
+		const {getByText, queryByText} = renderChart({
+			stages: stagesWithLongDecimals
+		});
+
+		expect(getByText('9.83')).toBeInTheDocument();
+		expect(getByText('4.68')).toBeInTheDocument();
+		expect(getByText('12.00')).toBeInTheDocument();
+		expect(getByText('4.50')).toBeInTheDocument();
+
+		expect(queryByText('9.8333333')).toBeNull();
+		expect(queryByText('4.6789')).toBeNull();
+	});
+
 	it('should render progression labels from conversionRateToNextStage', () => {
 		const {container} = renderChart({stages: sampleStages});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92358

## What is being fixed

On the Lifecycle Dashboard, the "avg. day" value for each stage was rendered as the raw `averageStageDuration` double, so values such as `9.8333333` appeared unrounded in the UI.

## How it is being fixed

Apply `.toFixed(2)` at the render site in `LifecycleChart.tsx`, matching the rounding pattern already used across `osb-faro-web` for percentages and ratings. The backend keeps returning the raw double; the formatting decision stays at the presentation layer. A new Jest test in `LifecycleChart.tsx` locks the behavior across truncation, rounding up, and zero-decimal padding.