### PR TITLE
LPD-92182 Fix token generation in webhook connector onboarding

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__tests__/connector.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/__tests__/connector.ts
@@ -111,8 +111,18 @@ describe('Connector API', () => {
 
 			expect(sendRequest).toHaveBeenCalledWith({
 				method: 'POST',
-				path: 'main/23/oauth2/tokens/new?type=demandbase&expiresIn='
+				path: 'main/23/oauth2/tokens/new?type=demandbase'
 			});
+		});
+
+		it('omits the expiresIn query param so the backend default applies', () => {
+			generateConnectorToken({groupId: '23', type: 'webhook'});
+
+			expect(sendRequest).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: expect.not.stringContaining('expiresIn')
+				})
+			);
 		});
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/connector.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/connector.ts
@@ -85,6 +85,6 @@ export function generateConnectorToken({
 }: RESTParams & {type: string}) {
 	return sendRequest({
 		method: 'POST',
-		path: `main/${groupId}/oauth2/tokens/new?type=${type}&expiresIn=`
+		path: `main/${groupId}/oauth2/tokens/new?type=${type}`
 	});
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92182

## What is being fixed

The webhook connector onboarding screen in Analytics Cloud could not generate an authentication token, blocking the connector setup flow.

## How it is being fixed

The frontend was sending an empty `expiresIn` query parameter to the OAuth2 token endpoint. The backend declares `expiresIn` as a `Long`, so JAX-RS rejected the request before the null fallback (3153600000 seconds, ~100 years) could apply, and no token was ever returned. Dropping the empty parameter lets the request reach the backend default and a token is now generated as expected.