### PR TITLE
LPD-92430 Fix 404

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -64,7 +64,7 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 		rangeSelectorParams += `&rangeStart=${rangeSelectors.rangeStart}`;
 	}
 
-	const rangeApiURL = `${apiURL}&${rangeSelectorParams}`;
+	const rangeApiURL = `${apiURL}?${rangeSelectorParams}`;
 
 	return (
 		<Card>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -195,7 +195,7 @@ describe('AccountsDataSet', () => {
 			/>
 		);
 
-		expect(lastApiURL).toBe('fake-url&rangeKey=30');
+		expect(lastApiURL).toBe('fake-url?rangeKey=30');
 	});
 
 	it('should append rangeStart and rangeEnd as query params when a custom range is provided', () => {
@@ -213,7 +213,7 @@ describe('AccountsDataSet', () => {
 		);
 
 		expect(lastApiURL).toBe(
-			'fake-url&rangeKey=CUSTOM&rangeEnd=2024-01-31&rangeStart=2024-01-01'
+			'fake-url?rangeKey=CUSTOM&rangeEnd=2024-01-31&rangeStart=2024-01-01'
 		);
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92430

## What is being fixed

The accounts table requested a malformed URL such as `/o/faro/contacts/{groupId}/account-lifecycle/{id}/accounts&rangeKey=30?filter=...`, where the range parameters were appended to the base URL with `&` instead of `?`. The resulting URL was missing the leading query separator, so the request 404'd. 

## How it is being fixed

`AccountsDataSet` now uses `?` as the first separator when appending the range parameters to the base URL, so subsequent FDS-managed query params chain correctly with `&`.