### PR TITLE
LPD-91079 | LPD-91083 Add activity status column to contacts lists | v4.15.x

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_event_analysis_editor.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_event_analysis_editor.scss
@@ -55,6 +55,10 @@
 
 		.dropdown-item-primary-button {
 			line-height: 32px;
+			min-width: 0;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
 		}
 
 		.options-button {
@@ -261,9 +265,11 @@
 	.description {
 		color: $secondary;
 		padding-bottom: 8px;
+		word-break: break-word;
 	}
 
 	.filter-name {
 		font-weight: $fontWeightSemiBold;
+		word-break: break-word;
 	}
 }

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
@@ -213,7 +213,8 @@ const IndividualsList: React.FC<IIndividualsList> = ({rangeSelectors}) => {
 							IndividualsListCDPColumns.country,
 							IndividualsListCDPColumns.firstSeen,
 							IndividualsListCDPColumns.lastActive,
-							IndividualsListCDPColumns.profileType
+							IndividualsListCDPColumns.profileType,
+							IndividualsListCDPColumns.activityStatus
 						]}
 						dataSourceFn={API.individuals.search}
 						dataSourceParams={{

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
@@ -43,6 +43,7 @@ describe('Individuals List', () => {
 					{
 						accountName: 'Liferay Inc.',
 						activitiesCount: 8,
+						activityStatus: 'ACTIVE',
 						dateCreated: 1769697362927,
 						firstActivityDate: 1769697128235,
 						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c1',
@@ -57,6 +58,7 @@ describe('Individuals List', () => {
 					{
 						accountName: 'Liferay',
 						activitiesCount: 8,
+						activityStatus: 'ACTIVE',
 						dateCreated: 1769697362927,
 						firstActivityDate: 1769697128235,
 						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c3',
@@ -70,6 +72,7 @@ describe('Individuals List', () => {
 					},
 					{
 						activitiesCount: 3,
+						activityStatus: 'INACTIVE',
 						dateCreated: 1769697362927,
 						firstActivityDate: 1769697128235,
 						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c2',
@@ -172,6 +175,74 @@ describe('Individuals List', () => {
 				activityStatus: 'ACTIVE'
 			})
 		);
+	});
+
+	it('renders the activity status column header', async () => {
+		(API.individuals.search as jest.Mock).mockReturnValue(
+			Promise.resolve({items: [], total: 0})
+		);
+
+		const history = createMemoryHistory();
+
+		const {getByText} = render(
+			<Router history={history}>
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		expect(getByText('Activity Status')).toBeInTheDocument();
+	});
+
+	it('renders active and inactive activity status labels', async () => {
+		(API.individuals.search as jest.Mock).mockReturnValue(
+			Promise.resolve({
+				items: [
+					{
+						activitiesCount: 1,
+						activityStatus: 'ACTIVE',
+						dateCreated: 1769697362927,
+						firstActivityDate: 1769697128235,
+						id: 'id-active',
+						lastActivityDate: 1769697160365,
+						name: 'Active User',
+						profileType: 'KNOWN',
+						properties: {}
+					},
+					{
+						activitiesCount: 0,
+						activityStatus: 'INACTIVE',
+						dateCreated: 1769697362927,
+						firstActivityDate: 1769697128235,
+						id: 'id-inactive',
+						lastActivityDate: 1769697160365,
+						name: 'Inactive User',
+						profileType: 'KNOWN',
+						properties: {}
+					}
+				],
+				total: 2
+			})
+		);
+
+		const history = createMemoryHistory();
+
+		render(
+			<Router history={history}>
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		expect(
+			document.querySelector('.label-success .label-item')
+		).toHaveTextContent('Active');
+
+		expect(
+			document.querySelector('.label-secondary .label-item')
+		).toHaveTextContent('Inactive');
 	});
 
 	it('passes undefined activityStatus when both active and inactive are selected', async () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -105,6 +105,16 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 				apiURL={rangeApiURL}
 				configInURLBehavior={EConfigInURLBehavior.OFF}
 				customDataRenderers={{
+					accountActivityStatusRenderer: ({value}: {value: string}) =>
+						value &&
+						columns.cmsLabelRenderer({
+							displayType:
+								value === 'ACTIVE' ? 'success' : 'secondary',
+							label:
+								value === 'ACTIVE'
+									? Liferay.Language.get('active')
+									: Liferay.Language.get('inactive')
+						}),
 					accountLifecycleStageRenderer: ({
 						value
 					}: {
@@ -275,6 +285,15 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 									fieldName: 'lastEnriched',
 									label: Liferay.Language.get(
 										'last-enriched'
+									),
+									sortable: true
+								},
+								{
+									contentRenderer:
+										'accountActivityStatusRenderer',
+									fieldName: 'activityStatus',
+									label: Liferay.Language.get(
+										'activity-status'
 									),
 									sortable: true
 								}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -49,6 +49,9 @@ type FakeFilter = {
 };
 
 type FakeCustomDataRenderers = {
+	accountActivityStatusRenderer: (props: {
+		value: string;
+	}) => React.ReactElement | null | false;
 	accountNameRenderer: (props: {
 		itemData: {id: string | number};
 		value: string;
@@ -327,5 +330,60 @@ describe('AccountsDataSet', () => {
 		expect(lastApiURL).toBe(
 			'fake-url&rangeKey=CUSTOM&rangeEnd=2024-01-31&rangeStart=2024-01-01'
 		);
+	});
+
+	it('should render "Active" label for ACTIVE activity status', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
+			/>
+		);
+
+		const {getByText} = render(
+			lastCustomDataRenderers!.accountActivityStatusRenderer({
+				value: 'ACTIVE'
+			}) as React.ReactElement
+		);
+
+		expect(getByText('Active')).toBeInTheDocument();
+	});
+
+	it('should render "Inactive" label for INACTIVE activity status', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
+			/>
+		);
+
+		const {getByText} = render(
+			lastCustomDataRenderers!.accountActivityStatusRenderer({
+				value: 'INACTIVE'
+			}) as React.ReactElement
+		);
+
+		expect(getByText('Inactive')).toBeInTheDocument();
+	});
+
+	it('should render nothing when activity status value is empty', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
+			/>
+		);
+
+		const result = lastCustomDataRenderers!.accountActivityStatusRenderer({
+			value: ''
+		});
+
+		expect(result).toBeFalsy();
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/DownloadPDFReport.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/DownloadPDFReport.tsx
@@ -226,7 +226,11 @@ export const formattedContainers = (
 
 let _spriteSVG: Element | null = null;
 
-const fetchSprite = async (): Promise<Element | null> => {
+export const resetSpriteCache = () => {
+	_spriteSVG = null;
+};
+
+export const fetchSprite = async (): Promise<Element | null> => {
 	if (_spriteSVG) {
 		return _spriteSVG;
 	}
@@ -255,7 +259,7 @@ const fetchSprite = async (): Promise<Element | null> => {
 	return _spriteSVG;
 };
 
-const inlineSVGIcons = (clonedDoc: Document, sprite: Element) => {
+export const inlineSVGIcons = (clonedDoc: Document, sprite: Element) => {
 	clonedDoc.querySelectorAll('svg use').forEach(useEl => {
 		const href =
 			useEl.getAttribute('href') ||

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/DownloadPDFReport.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/DownloadPDFReport.tsx
@@ -224,11 +224,78 @@ export const formattedContainers = (
 		return acc;
 	}, {} as ContainerList);
 
+let _spriteSVG: Element | null = null;
+
+const fetchSprite = async (): Promise<Element | null> => {
+	if (_spriteSVG) {
+		return _spriteSVG;
+	}
+
+	const useEl = document.querySelector('svg use');
+
+	if (!useEl) {
+		return null;
+	}
+
+	const href =
+		useEl.getAttribute('href') || useEl.getAttribute('xlink:href') || '';
+
+	const spriteUrl = href.split('#')[0];
+
+	if (!spriteUrl) {
+		return null;
+	}
+
+	const res = await fetch(spriteUrl);
+	const text = await res.text();
+	const doc = new DOMParser().parseFromString(text, 'image/svg+xml');
+
+	_spriteSVG = doc.documentElement;
+
+	return _spriteSVG;
+};
+
+const inlineSVGIcons = (clonedDoc: Document, sprite: Element) => {
+	clonedDoc.querySelectorAll('svg use').forEach(useEl => {
+		const href =
+			useEl.getAttribute('href') ||
+			useEl.getAttribute('xlink:href') ||
+			'';
+
+		const symbolId = href.split('#')[1];
+
+		if (!symbolId) {
+			return;
+		}
+
+		const symbol = sprite.querySelector(`#${symbolId}`);
+
+		if (!symbol) {
+			return;
+		}
+
+		const svgEl = useEl.closest('svg');
+
+		if (!svgEl) {
+			return;
+		}
+
+		svgEl.innerHTML = symbol.innerHTML;
+
+		const viewBox = symbol.getAttribute('viewBox');
+
+		if (viewBox) {
+			svgEl.setAttribute('viewBox', viewBox);
+		}
+	});
+};
+
 const getContainers = async (
 	containers: TransformedContainer[]
 ): Promise<JSPDFExtensionContainer[]> => {
 	const containerArr: JSPDFExtensionContainer[] = [];
 	const promises: Promise<void>[] = [];
+	const sprite = await fetchSprite();
 
 	containers.map(({id, layout}) => {
 		const containerElement = document.getElementById(id);
@@ -239,7 +306,10 @@ const getContainers = async (
 
 		const promise = html2canvas(containerElement, {
 			backgroundColor: '#F1F2F5',
-			logging: false
+			logging: false,
+			onclone: sprite
+				? clonedDoc => inlineSVGIcons(clonedDoc, sprite)
+				: undefined
 		}).then(canvas => {
 			const imageData = canvas.toDataURL('image/jpeg', 1.0);
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/__tests__/DownloadPDFReport.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/download-report/__tests__/DownloadPDFReport.tsx
@@ -1,0 +1,196 @@
+import {
+	fetchSprite,
+	inlineSVGIcons,
+	resetSpriteCache
+} from '../DownloadPDFReport';
+
+const SPRITE_SVG =
+	'<svg xmlns="http://www.w3.org/2000/svg">' +
+	'<symbol id="icon-home" viewBox="0 0 16 16">' +
+	'<path d="M8 1l7 7H1z"></path>' +
+	'</symbol>' +
+	'</svg>';
+
+const mockFetch = (text: string) => {
+	global.fetch = jest.fn().mockResolvedValue({
+		text: jest.fn().mockResolvedValue(text)
+	}) as any;
+};
+
+describe('fetchSprite', () => {
+	let querySelectorSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		resetSpriteCache();
+		querySelectorSpy = jest.spyOn(document, 'querySelector');
+	});
+
+	afterEach(() => {
+		querySelectorSpy.mockRestore();
+	});
+
+	it('returns null when no svg use element exists', async () => {
+		querySelectorSpy.mockReturnValue(null);
+
+		expect(await fetchSprite()).toBeNull();
+	});
+
+	it('returns null when href has no sprite URL (fragment only)', async () => {
+		const useEl = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'use'
+		);
+
+		useEl.setAttribute('href', '#icon-home');
+		querySelectorSpy.mockReturnValue(useEl);
+
+		expect(await fetchSprite()).toBeNull();
+	});
+
+	it('fetches the sprite URL and returns the parsed SVG element', async () => {
+		const useEl = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'use'
+		);
+
+		useEl.setAttribute('href', '/o/frontend-icons/icons.svg#icon-home');
+		querySelectorSpy.mockReturnValue(useEl);
+		mockFetch(SPRITE_SVG);
+
+		const result = await fetchSprite();
+
+		expect(result).not.toBeNull();
+		expect(result!.tagName.toLowerCase()).toBe('svg');
+		expect(global.fetch).toHaveBeenCalledWith(
+			'/o/frontend-icons/icons.svg'
+		);
+	});
+
+	it('reads xlink:href as fallback when href is absent', async () => {
+		const useEl = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'use'
+		);
+
+		useEl.setAttribute(
+			'xlink:href',
+			'/o/frontend-icons/icons.svg#icon-home'
+		);
+		querySelectorSpy.mockReturnValue(useEl);
+		mockFetch(SPRITE_SVG);
+
+		const result = await fetchSprite();
+
+		expect(result).not.toBeNull();
+		expect(global.fetch).toHaveBeenCalledWith(
+			'/o/frontend-icons/icons.svg'
+		);
+	});
+
+	it('caches the fetched sprite so fetch is called only once', async () => {
+		const useEl = document.createElementNS(
+			'http://www.w3.org/2000/svg',
+			'use'
+		);
+
+		useEl.setAttribute('href', '/o/frontend-icons/icons.svg#icon-home');
+		querySelectorSpy.mockReturnValue(useEl);
+		mockFetch(SPRITE_SVG);
+
+		await fetchSprite();
+		await fetchSprite();
+
+		expect(global.fetch).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('inlineSVGIcons', () => {
+	let sprite: Element;
+
+	beforeEach(() => {
+		const doc = new DOMParser().parseFromString(
+			SPRITE_SVG,
+			'image/svg+xml'
+		);
+
+		sprite = doc.documentElement;
+	});
+
+	const buildDoc = (svgInner: string): Document => {
+		const clonedDoc = document.implementation.createHTMLDocument();
+
+		clonedDoc.body.innerHTML = `<svg>${svgInner}</svg>`;
+
+		return clonedDoc;
+	};
+
+	it('replaces use element with the matching symbol innerHTML', () => {
+		const clonedDoc = buildDoc('<use href="/icons.svg#icon-home"></use>');
+
+		inlineSVGIcons(clonedDoc, sprite);
+
+		const svg = clonedDoc.querySelector('svg')!;
+
+		expect(svg.querySelector('use')).toBeNull();
+		expect(svg.querySelector('path')).not.toBeNull();
+	});
+
+	it('sets viewBox from the symbol onto the parent svg element', () => {
+		const clonedDoc = buildDoc('<use href="/icons.svg#icon-home"></use>');
+
+		inlineSVGIcons(clonedDoc, sprite);
+
+		expect(clonedDoc.querySelector('svg')!.getAttribute('viewBox')).toBe(
+			'0 0 16 16'
+		);
+	});
+
+	it('leaves use element unchanged when href has no symbol fragment', () => {
+		const clonedDoc = buildDoc('<use href="/icons.svg"></use>');
+
+		inlineSVGIcons(clonedDoc, sprite);
+
+		expect(clonedDoc.querySelector('use')).not.toBeNull();
+	});
+
+	it('leaves use element unchanged when symbol is not found in sprite', () => {
+		const clonedDoc = buildDoc(
+			'<use href="/icons.svg#icon-nonexistent"></use>'
+		);
+
+		inlineSVGIcons(clonedDoc, sprite);
+
+		expect(clonedDoc.querySelector('use')).not.toBeNull();
+	});
+
+	it('does not set viewBox when symbol has no viewBox attribute', () => {
+		const spriteDoc = new DOMParser().parseFromString(
+			'<svg xmlns="http://www.w3.org/2000/svg">' +
+				'<symbol id="icon-plain"><circle cx="8" cy="8" r="4"></circle></symbol>' +
+				'</svg>',
+			'image/svg+xml'
+		);
+		const spriteWithoutViewBox = spriteDoc.documentElement;
+		const clonedDoc = buildDoc('<use href="/icons.svg#icon-plain"></use>');
+
+		inlineSVGIcons(clonedDoc, spriteWithoutViewBox);
+
+		expect(
+			clonedDoc.querySelector('svg')!.getAttribute('viewBox')
+		).toBeNull();
+	});
+
+	it('handles xlink:href when href attribute is absent', () => {
+		const clonedDoc = document.implementation.createHTMLDocument();
+
+		clonedDoc.body.innerHTML =
+			'<svg><use xlink:href="/icons.svg#icon-home"></use></svg>';
+
+		inlineSVGIcons(clonedDoc, sprite);
+
+		const svg = clonedDoc.querySelector('svg')!;
+
+		expect(svg.querySelector('use')).toBeNull();
+		expect(svg.querySelector('path')).not.toBeNull();
+	});
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/table-columns.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/table-columns.tsx
@@ -293,6 +293,36 @@ export const IndividualsListCDPColumns = {
 		label: Liferay.Language.get('account-name'),
 		sortable: true
 	},
+	activityStatus: {
+		accessor: 'activityStatus',
+		cellRenderer: ({
+			className,
+			data: {activityStatus}
+		}: {
+			className?: string;
+			data: {activityStatus: string};
+		}) => (
+			<td className={getCN('name-cell-root', className)}>
+				{activityStatus && (
+					<Label
+						display={
+							activityStatus === 'ACTIVE'
+								? 'success'
+								: 'secondary'
+						}
+						size='lg'
+						uppercase
+					>
+						{activityStatus === 'ACTIVE'
+							? Liferay.Language.get('active')
+							: Liferay.Language.get('inactive')}
+					</Label>
+				)}
+			</td>
+		),
+		label: Liferay.Language.get('activity-status'),
+		sortable: true
+	},
 	country: {
 		accessor: 'countries',
 		cellRenderer: ({


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91079

## What is being fixed

The individuals list and accounts list were missing an Activity Status column, making it impossible to see whether a contact or account is active or inactive at a glance without applying a filter.

## How it is being fixed

A new `activityStatus` column was added to the individuals list by extending `IndividualsListCDPColumns` in `table-columns.tsx` with a cell renderer that displays a success badge for ACTIVE and a secondary badge for INACTIVE. The column was placed after `profileType` in `IndividualsList`.

For the accounts list, a matching `accountActivityStatusRenderer` was registered in `AccountsDataSet`'s `customDataRenderers` using `columns.cmsLabelRenderer`, following the same pattern as the existing lifecycle stage renderer, and the field was added to the FrontendDataSet table schema.

Unit tests were added for both components, covering the column header, correct badge per status value, and the empty-value case for accounts.