### PR TITLE
LPD-92381 Prevent ghost table from appearing during loading

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/table/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/table/index.tsx
@@ -145,6 +145,14 @@ const Table: React.FC<ITableProps> = ({
 
 	const itemsSorted = internalSort ? sortItems(items) : items;
 
+	if (loading && !itemsSorted.length) {
+		return (
+			<div className={getCN('flex-grow-1 mx-4 table-root', className)}>
+				<Loading spacer />
+			</div>
+		);
+	}
+
 	return (
 		<div className={getCN('flex-grow-1 mx-4 table-root', className)}>
 			<div className='table-responsive'>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92381

## What is being fixed

When opening the Interests or Search Terms tabs under Sites, the table briefly renders its header row with a loading overlay before showing either the actual data or the empty state. This ghost appears because Apollo's safeResultToProps drops items during loading, causing withEmpty to pass through to Table with no rows and loading=true — rendering an empty table shell.

## How it is being fixed

An early return is added to the Table component: when loading is true and there are no items to display, a standalone Loading spinner is rendered in place of the table structure. This replaces the ghost (header row + overlay on an empty table) with a clean loading indicator, and the transition goes directly from spinner to content — either data or the empty state — with no flash.

## Why are there no tests?

The change is purely visual/UI — it prevents a momentary ghost render that is better verified manually than covered by unit tests. The Table component has no existing test suite for its rendering behavior.