### PR TITLE
LPD-92325 faro-v4.15.x Pass sequential to form-level validateSegmentEditor

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
@@ -254,7 +254,8 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 						onSubmit={this.handleSubmit}
 						validate={(values: FormValues) => {
 							const error = validateSegmentEditor(
-								values.criteria
+								values.criteria,
+								values.sequential
 							);
 
 							return error ? {criteria: error} : {};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92325

Backport-style follow-up to `faro-v4.15.x`: the form-level `validate` was already wired here, but it was calling `validateSegmentEditor(values.criteria)` without forwarding `values.sequential`. With the sequential argument missing the validator never reaches the sequential branch, so the Save Segment button stays enabled even when the criteria exceed the 5/3 limits — e.g. editing the title of a saved segment with > 5 criteria re-enables Save. Passing the second argument restores the limit guard.