### PR TITLE
LPD-92430

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
@@ -139,9 +139,10 @@ const List: React.FC<IListProps> = ({channelId, groupId}) => {
 						</div>
 
 						<AccountsDataSet
-							apiURL={`/o/faro/contacts/${groupId}/account/search?channelId=${channelId}`}
+							apiURL={`/o/faro/contacts/${groupId}/account/search`}
 							channelId={channelId}
 							groupId={groupId}
+							queryParams={{channelId}}
 							rangeSelectors={rangeSelectors}
 						/>
 					</>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -64,7 +64,7 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 		rangeSelectorParams += `&rangeStart=${rangeSelectors.rangeStart}`;
 	}
 
-	const rangeApiURL = `${apiURL}&${rangeSelectorParams}`;
+	const rangeApiURL = `${apiURL}?${rangeSelectorParams}`;
 
 	return (
 		<Card>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -28,6 +28,7 @@ interface IAccountsDataSetProps {
 	groupId: string;
 	industryFilter?: string;
 	lifecycleStageFilter?: LifecycleStages;
+	queryParams?: Record<string, string>;
 	rangeSelectors?: RangeSelectors;
 }
 
@@ -46,6 +47,7 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 	groupId,
 	industryFilter,
 	lifecycleStageFilter,
+	queryParams,
 	rangeSelectors = {
 		rangeEnd: null,
 		rangeKey: RangeKeyTimeRanges.Last30Days,
@@ -64,7 +66,11 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 		rangeSelectorParams += `&rangeStart=${rangeSelectors.rangeStart}`;
 	}
 
-	const rangeApiURL = `${apiURL}?${rangeSelectorParams}`;
+	const queryParamsString = queryParams
+		? `&${new URLSearchParams(queryParams)}`
+		: '';
+
+	const rangeApiURL = `${apiURL}?${rangeSelectorParams}${queryParamsString}`;
 
 	return (
 		<Card>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -195,7 +195,7 @@ describe('AccountsDataSet', () => {
 			/>
 		);
 
-		expect(lastApiURL).toBe('fake-url&rangeKey=30');
+		expect(lastApiURL).toBe('fake-url?rangeKey=30');
 	});
 
 	it('should append rangeStart and rangeEnd as query params when a custom range is provided', () => {
@@ -213,7 +213,7 @@ describe('AccountsDataSet', () => {
 		);
 
 		expect(lastApiURL).toBe(
-			'fake-url&rangeKey=CUSTOM&rangeEnd=2024-01-31&rangeStart=2024-01-01'
+			'fake-url?rangeKey=CUSTOM&rangeEnd=2024-01-31&rangeStart=2024-01-01'
 		);
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -216,4 +216,18 @@ describe('AccountsDataSet', () => {
 			'fake-url?rangeKey=CUSTOM&rangeEnd=2024-01-31&rangeStart=2024-01-01'
 		);
 	});
+
+	it('should append queryParams entries to the apiURL query string', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				queryParams={{channelId: '123'}}
+				rangeSelectors={defaultRangeSelectors}
+			/>
+		);
+
+		expect(lastApiURL).toBe('fake-url?rangeKey=30&channelId=123');
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92430

## What is being fixed

The previous fix on this ticket (#3370) made AccountsDataSet detect the right separator depending on whether the caller's apiURL already carried a query string. The contract was implicit and easy to misuse: List.tsx inlined `?channelId=` in the apiURL, while BaseLifecycle.tsx passed a clean path.

## How it is being fixed

AccountsDataSet now takes an extra queryParams map that it appends to the existing rangeSelectors query string. List.tsx passes the channelId through it on a clean path, so the rangeKey can always be appended with a known separator.