### PR TITLE
LPD-92543 Show ERC label in segment dashboard header

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/ProfileRoutes.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/ProfileRoutes.jsx
@@ -195,7 +195,9 @@ export const SegmentProfileRoutes = () => {
 				<BasePage.Row>
 					<BasePage.Header.TitleSection
 						className='mb-3'
-						subtitle={segment.externalReferenceCode}
+						subtitle={`${Liferay.Language.get('erc')}: ${
+							segment.externalReferenceCode
+						}`}
 						title={title}
 					>
 						<Label display='secondary' size='lg' uppercase>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/__tests__/ProfileRoutes.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/__tests__/ProfileRoutes.jsx
@@ -1,3 +1,4 @@
+import * as API from 'shared/api';
 import DataSourcesProvider from 'shared/context/dataSources';
 import mockStore from 'test/mock-store';
 import React from 'react';
@@ -5,6 +6,7 @@ import {BrowserRouter} from 'react-router-dom';
 import {ChannelContext} from 'shared/context/channel';
 import {cleanup, render, screen} from '@testing-library/react';
 import {mockChannelContext} from 'test/mock-channel-context';
+import {mockSegment} from 'test/data';
 import {Provider} from 'react-redux';
 import {SegmentProfileRoutes} from '../ProfileRoutes';
 import {waitForLoadingToBeRemoved} from 'test/helpers';
@@ -45,5 +47,29 @@ describe('SegmentProfileRoutes', () => {
 		await waitForLoadingToBeRemoved(container);
 
 		expect(screen.getAllByText('Seattle0').length).toBeGreaterThan(0);
+	});
+
+	it('should render the external reference code with its label', async () => {
+		window.location = {pathname: '/'};
+
+		API.individualSegment.fetch.mockReturnValueOnce(
+			Promise.resolve(mockSegment(0, {externalReferenceCode: 'my-erc'}))
+		);
+
+		const {container} = render(
+			<Provider store={mockStore()}>
+				<BrowserRouter>
+					<ChannelContext.Provider value={mockChannelContext()}>
+						<DataSourcesProvider groupId='23'>
+							<SegmentProfileRoutes />
+						</DataSourcesProvider>
+					</ChannelContext.Provider>
+				</BrowserRouter>
+			</Provider>
+		);
+
+		await waitForLoadingToBeRemoved(container);
+
+		expect(screen.getByText('ERC: my-erc')).toBeTruthy();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92543

## What is being fixed

On a real-time/batch segment dashboard, the header showed the segment's external reference code (ERC) as a bare value with no label, so users could not tell what the number represented.

## How it is being fixed

The segment dashboard header subtitle now prefixes the external reference code with the `erc` language key, rendering it as "ERC: <value>" to match how the ERC is labeled elsewhere (e.g. the asset info panel).