### PR TITLE
LPD-92555 | master Lifecycle metrics cards percentage shows date range as months instead of days

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/OverviewSection.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/OverviewSection.tsx
@@ -11,7 +11,7 @@ interface IOverviewSectionProps {
 }
 
 const renderTrendLabel = (percentageNode: React.ReactNode) =>
-	sub(Liferay.Language.get('x-vs-last-x-months'), [percentageNode, 3], false);
+	sub(Liferay.Language.get('x-vs-last-x-days'), [percentageNode, 90], false);
 
 const OverviewSection: React.FC<IOverviewSectionProps> = ({
 	loading = false,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/__tests__/OverviewSection.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/__tests__/OverviewSection.tsx
@@ -65,6 +65,13 @@ describe('OverviewSection', () => {
 		expect(getAllByText('0')).toHaveLength(2);
 	});
 
+	it('should render the trend label comparing against the last 90 days', () => {
+		const {container} = render(<OverviewSection />);
+
+		expect(container.textContent).toContain('vs. Last 90 Days');
+		expect(container.textContent).not.toContain('Months');
+	});
+
 	it('should render a loading spinner in each card when loading is true', () => {
 		const {container, queryByText} = render(<OverviewSection loading />);
 


### PR DESCRIPTION
Motivation
----

https://liferay.atlassian.net/browse/LPD-92555

Proposed Solution
----

The Lifecycle dashboard Overview cards display a percentage trend compared against a previous period. The comparison label was rendered as "vs. Last 3 Months", while the data and the stage thresholds on the page (for example, the 90-day stalled-accounts threshold) are expressed in days.

We updated the trend label to read "vs. Last 90 Days" so the comparison window matches the day-based semantics of the page, and added a test covering the label.