### PR TITLE
LPD-92577 | master | Fix Top Assets and Top Categories account profile cards

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_account_profile.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_account_profile.scss
@@ -13,3 +13,22 @@
 		margin-bottom: 0;
 	}
 }
+
+.top-assets,
+.top-categories-and-tags {
+	.tab-content,
+	.tab-pane.active {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+	}
+
+	.c-empty-state {
+		margin-bottom: auto;
+		margin-top: auto;
+	}
+
+	.c-empty-state-title {
+		margin-top: 0;
+	}
+}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopAssets.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopAssets.tsx
@@ -43,6 +43,15 @@ const TAB_OBJECT_TYPES: Record<(typeof TABS)[number], TopAssetObjectType> = {
 	files: 'file'
 };
 
+const TAB_GROUP_BY_METRICS: Record<(typeof TABS)[number], GroupByMetric[]> = {
+	content: [GroupByMetric.IMPRESSIONS, GroupByMetric.VIEWS],
+	files: [
+		GroupByMetric.DOWNLOADS,
+		GroupByMetric.IMPRESSIONS,
+		GroupByMetric.VIEWS
+	]
+};
+
 const ASSET_ROUTE_MAP = {
 	blog: Routes.ASSETS_BLOGS_OVERVIEW,
 	document: Routes.ASSETS_DOCUMENTS_AND_MEDIA_OVERVIEW,
@@ -59,6 +68,7 @@ interface ITopAssetsTabContentProps {
 	groupBy: GroupByMetric;
 	isFiles: boolean;
 	loading: boolean;
+	metrics: GroupByMetric[];
 	setGroupBy: (metric: GroupByMetric) => void;
 }
 
@@ -67,6 +77,7 @@ const TopAssetsTabContent: React.FC<ITopAssetsTabContentProps> = ({
 	groupBy,
 	isFiles,
 	loading,
+	metrics,
 	setGroupBy
 }) => {
 	const {channelId, groupId} = useParams<{
@@ -138,19 +149,17 @@ const TopAssetsTabContent: React.FC<ITopAssetsTabContentProps> = ({
 					}
 				>
 					<ClayDropDown.ItemList>
-						{(Object.keys(groupByLabels) as GroupByMetric[]).map(
-							key => (
-								<ClayDropDown.Item
-									key={key}
-									onClick={() => setGroupBy(key)}
-									symbolRight={
-										groupBy === key ? 'check' : undefined
-									}
-								>
-									{groupByLabels[key]}
-								</ClayDropDown.Item>
-							)
-						)}
+						{metrics.map(key => (
+							<ClayDropDown.Item
+								key={key}
+								onClick={() => setGroupBy(key)}
+								symbolRight={
+									groupBy === key ? 'check' : undefined
+								}
+							>
+								{groupByLabels[key]}
+							</ClayDropDown.Item>
+						))}
 					</ClayDropDown.ItemList>
 				</ClayDropDown>
 
@@ -250,6 +259,16 @@ const TopAssets: React.FC<ITopAssetsProps> = ({className}) => {
 
 	const selectedMetric = GROUP_BY_TO_METRIC[groupBy];
 
+	const metrics = TAB_GROUP_BY_METRICS[TABS[activeTab]];
+
+	const handleActiveTabChange = (index: number) => {
+		setActiveTab(index);
+
+		if (!TAB_GROUP_BY_METRICS[TABS[index]].includes(groupBy)) {
+			setGroupBy(GroupByMetric.IMPRESSIONS);
+		}
+	};
+
 	const {data, loading} = useRequest<
 		Parameters<typeof API.assets.fetchAccountTopAssets>[0],
 		{items: ITopAsset[]}
@@ -272,6 +291,7 @@ const TopAssets: React.FC<ITopAssetsProps> = ({className}) => {
 			groupBy={groupBy}
 			isFiles={TABS[activeTab] === 'files'}
 			loading={loading}
+			metrics={metrics}
 			setGroupBy={setGroupBy}
 		/>
 	);
@@ -284,7 +304,10 @@ const TopAssets: React.FC<ITopAssetsProps> = ({className}) => {
 				</Text>
 			</Card.Title>
 			<Card.Body className='p-0'>
-				<ClayTabs active={activeTab} onActiveChange={setActiveTab}>
+				<ClayTabs
+					active={activeTab}
+					onActiveChange={handleActiveTabChange}
+				>
 					<ClayTabs.Item>
 						{Liferay.Language.get('content')}
 					</ClayTabs.Item>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopAssets.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopAssets.tsx
@@ -325,20 +325,22 @@ const TopAssets: React.FC<ITopAssetsProps> = ({className}) => {
 					</ClayTabs.TabPane>
 				</ClayTabs.Content>
 
-				<div className='d-flex p-3'>
-					<ClayButton
-						borderless
-						className='ml-auto rounded-lg'
-						onClick={() =>
-							history.push(
-								toRoute(Routes.ASSETS, {channelId, groupId})
-							)
-						}
-						size='sm'
-					>
-						{Liferay.Language.get('view-all')}
-					</ClayButton>
-				</div>
+				{assets.length > 0 && (
+					<div className='d-flex p-3'>
+						<ClayButton
+							borderless
+							className='ml-auto rounded-lg'
+							onClick={() =>
+								history.push(
+									toRoute(Routes.ASSETS, {channelId, groupId})
+								)
+							}
+							size='sm'
+						>
+							{Liferay.Language.get('view-all')}
+						</ClayButton>
+					</div>
+				)}
 			</Card.Body>
 		</Card>
 	);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopCategoriesAndTags.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopCategoriesAndTags.tsx
@@ -268,7 +268,10 @@ const TopCategoriesAndTags: React.FC<ITopCategoriesAndTagsProps> = ({
 	);
 
 	return (
-		<Card className={classNames(className)} minHeight={260}>
+		<Card
+			className={classNames('top-categories-and-tags', className)}
+			minHeight={260}
+		>
 			<Card.Title className='p-3'>
 				<Text weight='semi-bold'>
 					{Liferay.Language.get(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopCategoriesAndTags.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopCategoriesAndTags.tsx
@@ -7,7 +7,7 @@ import ClayEmptyState from '@clayui/empty-state';
 import ClayIcon from '@clayui/icon';
 import ClayTable from '@clayui/table';
 import ClayTabs from '@clayui/tabs';
-import React, {useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import StatesRenderer from 'shared/components/states-renderer/StatesRenderer';
 import {Text} from '@clayui/core';
 import {toThousands} from 'shared/util/numbers';
@@ -223,19 +223,35 @@ const TopCategoriesAndTags: React.FC<ITopCategoriesAndTagsProps> = ({
 
 	const isCategory = TABS[activeTab] === 'category';
 
+	const dataSourceFn = useCallback(
+		({
+			isCategory,
+			...vars
+		}: {
+			accountId: string;
+			channelId: string;
+			groupId: string;
+			isCategory: boolean;
+			selectedMetric: TaxonomyMetric;
+		}) =>
+			isCategory
+				? API.categories.fetchAccountTopCategories(vars)
+				: API.tags.fetchAccountTopTags(vars),
+		[]
+	);
+
 	const {data, loading} = useRequest<
 		{
 			accountId: string;
 			channelId: string;
 			groupId: string;
+			isCategory: boolean;
 			selectedMetric: TaxonomyMetric;
 		},
 		{items: TaxonomyItem[]}
 	>({
-		dataSourceFn: isCategory
-			? API.categories.fetchAccountTopCategories
-			: API.tags.fetchAccountTopTags,
-		variables: {accountId, channelId, groupId, selectedMetric}
+		dataSourceFn,
+		variables: {accountId, channelId, groupId, isCategory, selectedMetric}
 	});
 
 	const items = data?.items ?? [];

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopAssets.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopAssets.tsx
@@ -394,6 +394,32 @@ describe('TopAssets', () => {
 				screen.queryByRole('link', {name: 'Web Content One'})
 			).toBeNull();
 		});
+
+		it('should not render the View All button while loading', () => {
+			mockUseRequestWith({loading: true});
+
+			render(<TopAssets />);
+
+			expect(screen.queryByRole('button', {name: 'View All'})).toBeNull();
+		});
+	});
+
+	describe('view all visibility', () => {
+		it('should not render the View All button when there are no assets', () => {
+			mockUseRequestWith({data: {items: []}});
+
+			render(<TopAssets />);
+
+			expect(screen.queryByRole('button', {name: 'View All'})).toBeNull();
+		});
+
+		it('should render the View All button when assets are returned', () => {
+			render(<TopAssets />);
+
+			expect(
+				screen.getByRole('button', {name: 'View All'})
+			).toBeInTheDocument();
+		});
 	});
 
 	describe('empty state', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopAssets.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopAssets.tsx
@@ -250,8 +250,10 @@ describe('TopAssets', () => {
 			expect(lastCall.variables.selectedMetric).toBe('viewsMetric');
 		});
 
-		it('should refetch with downloadsMetric when the user picks Downloads', () => {
+		it('should refetch with downloadsMetric when the user picks Downloads on the Files tab', () => {
 			render(<TopAssets />);
+
+			fireEvent.click(screen.getByRole('tab', {name: 'Files'}));
 
 			fireEvent.click(
 				screen.getAllByRole('button', {name: /Group By/})[0]
@@ -267,6 +269,62 @@ describe('TopAssets', () => {
 				][0];
 
 			expect(lastCall.variables.selectedMetric).toBe('downloadsMetric');
+		});
+
+		it('should not offer the Downloads metric on the Content tab', () => {
+			render(<TopAssets />);
+
+			fireEvent.click(
+				screen.getAllByRole('button', {name: /Group By/})[0]
+			);
+
+			expect(
+				screen.queryByRole('menuitem', {name: 'Downloads'})
+			).toBeNull();
+			expect(
+				screen.getAllByRole('menuitem', {name: 'Impressions'}).length
+			).toBeGreaterThan(0);
+			expect(
+				screen.getAllByRole('menuitem', {name: 'Views'}).length
+			).toBeGreaterThan(0);
+		});
+
+		it('should offer the Downloads metric on the Files tab', () => {
+			render(<TopAssets />);
+
+			fireEvent.click(screen.getByRole('tab', {name: 'Files'}));
+
+			fireEvent.click(
+				screen.getAllByRole('button', {name: /Group By/})[0]
+			);
+
+			expect(
+				screen.getAllByRole('menuitem', {name: 'Downloads'}).length
+			).toBeGreaterThan(0);
+		});
+
+		it('should reset to impressionsMetric when switching to Content while Downloads is selected', () => {
+			render(<TopAssets />);
+
+			fireEvent.click(screen.getByRole('tab', {name: 'Files'}));
+
+			fireEvent.click(
+				screen.getAllByRole('button', {name: /Group By/})[0]
+			);
+
+			fireEvent.click(
+				screen.getAllByRole('menuitem', {name: 'Downloads'})[0]
+			);
+
+			fireEvent.click(screen.getByRole('tab', {name: 'Content'}));
+
+			const lastCall =
+				mockedUseRequest.mock.calls[
+					mockedUseRequest.mock.calls.length - 1
+				][0];
+
+			expect(lastCall.variables.objectType).toBe('content');
+			expect(lastCall.variables.selectedMetric).toBe('impressionsMetric');
 		});
 	});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopCategoriesAndTags.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopCategoriesAndTags.tsx
@@ -274,19 +274,22 @@ describe('TopCategoriesAndTags', () => {
 	});
 
 	describe('tab switching', () => {
-		it('should use the categories data source on initial render', () => {
+		it('should query the categories data source on initial render', () => {
 			const API = jest.requireMock('shared/api');
 
 			render(<TopCategoriesAndTags />);
 
 			const firstCall = mockedUseRequest.mock.calls[0][0];
 
-			expect(firstCall.dataSourceFn).toBe(
-				API.categories.fetchAccountTopCategories
-			);
+			expect(firstCall.variables.isCategory).toBe(true);
+
+			firstCall.dataSourceFn(firstCall.variables);
+
+			expect(API.categories.fetchAccountTopCategories).toHaveBeenCalled();
+			expect(API.tags.fetchAccountTopTags).not.toHaveBeenCalled();
 		});
 
-		it('should switch to the tags data source when the Tag tab is clicked', () => {
+		it('should query the tags data source when the Tag tab is clicked', () => {
 			const API = jest.requireMock('shared/api');
 
 			render(<TopCategoriesAndTags />);
@@ -298,7 +301,32 @@ describe('TopCategoriesAndTags', () => {
 					mockedUseRequest.mock.calls.length - 1
 				][0];
 
-			expect(lastCall.dataSourceFn).toBe(API.tags.fetchAccountTopTags);
+			expect(lastCall.variables.isCategory).toBe(false);
+
+			lastCall.dataSourceFn(lastCall.variables);
+
+			expect(API.tags.fetchAccountTopTags).toHaveBeenCalled();
+			expect(
+				API.categories.fetchAccountTopCategories
+			).not.toHaveBeenCalled();
+		});
+
+		it('should change the request variables when switching tabs so the request refetches', () => {
+			render(<TopCategoriesAndTags />);
+
+			const categoryVariables =
+				mockedUseRequest.mock.calls[0][0].variables;
+
+			fireEvent.click(screen.getByRole('tab', {name: 'Tag'}));
+
+			const tagVariables =
+				mockedUseRequest.mock.calls[
+					mockedUseRequest.mock.calls.length - 1
+				][0].variables;
+
+			expect(tagVariables).not.toEqual(categoryVariables);
+			expect(categoryVariables.isCategory).toBe(true);
+			expect(tagVariables.isCategory).toBe(false);
 		});
 
 		it('should render tag items after switching to the Tag tab', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92577

## What Is Being Fixed

Three issues on the account profile's Top Assets and Top Asset Vocabularies and Categories cards:

- Switching to the Tag tab did not trigger a request, so the tab kept showing the previous tab's data (LPD-92577).
- The Content tab offered a Downloads metric even though content assets are not downloadable (LPD-91217).
- The empty states were misaligned — the message jammed against the bottom edge when a card collapsed to its minimum height and was stranded at the top when a sibling card grew tall (LPD-91217).

## How It Is Being Fixed

The Tag tab now refetches by carrying the active tab in the request variables and branching inside a stable data source function, so the shared useRequest hook re-runs when the tab changes. The Group By dropdown offers Downloads only on the Files tab and resets to Impressions when switching to a tab where the current metric no longer applies. The empty states are centered within the tab content area regardless of card height, and the Top Assets View All button renders only when there are assets so the empty card has no footer and lines up with the Top Categories card.
