### PR TITLE
LPD-92554 | master The tooltip for the lifecycle stages filter fails to appear on hover

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/LifecycleChart.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/LifecycleChart.tsx
@@ -77,10 +77,16 @@ const StageMetrics = ({
 					aria-labelledby={titleId}
 					borderless
 					className='ml-auto'
+					data-tooltip-align='top'
 					displayType='secondary'
 					onClick={() => onFilterClick(stageType)}
 					size='sm'
 					symbol='filter'
+					title={
+						sub(Liferay.Language.get('filter-by-x'), [
+							lifecycleStagesLabelMap[stageType].label
+						]) as string
+					}
 				/>
 			</div>
 			<Text as='p' color='secondary'>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/__tests__/LifecycleChart.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/__tests__/LifecycleChart.tsx
@@ -172,4 +172,22 @@ describe('LifecycleChart', () => {
 			LifecycleStages.PIPELINE
 		);
 	});
+
+	it('should render a "filter by stage" tooltip on each stage filter button', () => {
+		const {getAllByRole} = renderChart({stages: sampleStages});
+
+		const filterButtons = getAllByRole('button');
+
+		expect(filterButtons[0]).toHaveAttribute('title', 'Filter By Aware');
+		expect(filterButtons[1]).toHaveAttribute('title', 'Filter By Engaged');
+		expect(filterButtons[2]).toHaveAttribute('title', 'Filter By Pipeline');
+		expect(filterButtons[3]).toHaveAttribute(
+			'title',
+			'Filter By Onboarding'
+		);
+		expect(filterButtons[4]).toHaveAttribute(
+			'title',
+			'Filter By Established'
+		);
+	});
 });


### PR DESCRIPTION
Motivation
----

https://liferay.atlassian.net/browse/LPD-92554

Proposed Solution
----

On the Lifecycle page, the stage filter buttons gave no hint about what they do when hovered. We add a tooltip to each stage filter button that reads "Filter By <stage>", reusing the existing `filter-by-x` language key and the global Clay tooltip provider already wired into the app. This makes the buttons' purpose discoverable on hover, matching the expected behavior. We also add a test that verifies the tooltip text rendered for every stage.