### PR TITLE
LPD-92566 | master Saved View disappears on refresh

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/pages/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/assets/pages/List.tsx
@@ -5,6 +5,7 @@ import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import ClaySticker from '@clayui/sticker';
 import FaroConstants from 'shared/util/constants';
+import Loading from 'shared/components/Loading';
 import React, {useMemo, useState} from 'react';
 import URLConstants from 'shared/util/url-constants';
 import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
@@ -258,119 +259,126 @@ const List = () => {
 
 			<BasePage.Body fluid sidebarOpened={!!infoPanelData}>
 				<Card>
-					<FrontendDataSet
-						apiURL={`/o/faro/contacts/${groupId}/asset-summary?channelId=${channelId}&${rangeSelectorParams}`}
-						// Trick to turn off dirty the URL with paramas.
+					{snapshots === null ? (
+						<Loading />
+					) : (
+						<FrontendDataSet
+							apiURL={`/o/faro/contacts/${groupId}/asset-summary?channelId=${channelId}&${rangeSelectorParams}`}
+							// Trick to turn off dirty the URL with paramas.
 
-						configInURLBehavior={EConfigInURLBehavior.OFF}
-						customDataRenderers={{
-							assetMetricRenderer: columns.assetMetricRenderer,
-							assetTitleRenderer: columns.assetTitleRenderer({
-								channelId: channelId!,
-								groupId: groupId!,
-								rangeSelectorParams
-							})
-						}}
-						emptyState={{
-							description:
-								assetsEmptyStateDescription as unknown as string,
-							image: '/states/satellite.svg',
-							title: Liferay.Language.get(
-								'there-are-no-assets-found'
-							)
-						}}
-						filters={filters}
-						id='assetTable'
-						itemsActions={[
-							{
-								data: {
-									id: 'infoPanel'
+							configInURLBehavior={EConfigInURLBehavior.OFF}
+							customDataRenderers={{
+								assetMetricRenderer:
+									columns.assetMetricRenderer,
+								assetTitleRenderer: columns.assetTitleRenderer({
+									channelId: channelId!,
+									groupId: groupId!,
+									rangeSelectorParams
+								})
+							}}
+							emptyState={{
+								description:
+									assetsEmptyStateDescription as unknown as string,
+								image: '/states/satellite.svg',
+								title: Liferay.Language.get(
+									'there-are-no-assets-found'
+								)
+							}}
+							filters={filters}
+							id='assetTable'
+							itemsActions={[
+								{
+									data: {
+										id: 'infoPanel'
+									},
+									icon: 'info-circle-open',
+									label: Liferay.Language.get('show-details'),
+									onClick: setInfoPanelData
 								},
-								icon: 'info-circle-open',
-								label: Liferay.Language.get('show-details'),
-								onClick: setInfoPanelData
-							},
-							{
-								data: {
-									id: 'viewAsset'
-								},
-								icon: 'view',
-								label: Liferay.Language.get('view'),
-								onClick: ({itemData}: {itemData: any}) => {
-									history.push(
-										getAssetURL({
-											channelId: channelId!,
-											groupId: groupId!,
-											itemData,
-											rangeSelectorParams
-										})
-									);
+								{
+									data: {
+										id: 'viewAsset'
+									},
+									icon: 'view',
+									label: Liferay.Language.get('view'),
+									onClick: ({itemData}: {itemData: any}) => {
+										history.push(
+											getAssetURL({
+												channelId: channelId!,
+												groupId: groupId!,
+												itemData,
+												rangeSelectorParams
+											})
+										);
+									}
 								}
-							}
-						]}
-						// Trick to restart FDS every time the rangeSelectors changes.
+							]}
+							// Trick to restart FDS every time the rangeSelectors changes.
 
-						key={Object.values(rangeSelectors).join()}
-						pagination={pagination}
-						showPagination
-						snapshots={snapshots}
-						snapshotsEnabled
-						views={[
-							{
-								contentRenderer: 'table',
-								default: true,
-								label: Liferay.Language.get('default-view'),
-								name: 'table',
-								schema: {
-									fields: [
-										{
-											contentRenderer:
-												'assetTitleRenderer',
-											fieldName: 'assetTitle',
-											label: Liferay.Language.get(
-												'title'
-											),
-											sortable: true,
-											truncate: true
-										},
-										{
-											fieldName: 'assetType',
-											label: Liferay.Language.get('type'),
-											sortable: true
-										},
-										{
-											contentRenderer:
-												'assetMetricRenderer',
-											fieldName: 'viewsMetric',
-											label: Liferay.Language.get(
-												'views'
-											),
-											sortable: true
-										},
-										{
-											contentRenderer:
-												'assetMetricRenderer',
-											fieldName: 'impressionsMetric',
-											label: Liferay.Language.get(
-												'impressions'
-											),
-											sortable: true
-										},
-										{
-											contentRenderer:
-												'assetMetricRenderer',
-											fieldName: 'downloadsMetric',
-											label: Liferay.Language.get(
-												'downloads'
-											),
-											sortable: true
-										}
-									]
-								},
-								thumbnail: 'table'
-							}
-						]}
-					/>
+							key={Object.values(rangeSelectors).join()}
+							pagination={pagination}
+							showPagination
+							snapshots={snapshots}
+							snapshotsEnabled
+							views={[
+								{
+									contentRenderer: 'table',
+									default: true,
+									label: Liferay.Language.get('default-view'),
+									name: 'table',
+									schema: {
+										fields: [
+											{
+												contentRenderer:
+													'assetTitleRenderer',
+												fieldName: 'assetTitle',
+												label: Liferay.Language.get(
+													'title'
+												),
+												sortable: true,
+												truncate: true
+											},
+											{
+												fieldName: 'assetType',
+												label: Liferay.Language.get(
+													'type'
+												),
+												sortable: true
+											},
+											{
+												contentRenderer:
+													'assetMetricRenderer',
+												fieldName: 'viewsMetric',
+												label: Liferay.Language.get(
+													'views'
+												),
+												sortable: true
+											},
+											{
+												contentRenderer:
+													'assetMetricRenderer',
+												fieldName: 'impressionsMetric',
+												label: Liferay.Language.get(
+													'impressions'
+												),
+												sortable: true
+											},
+											{
+												contentRenderer:
+													'assetMetricRenderer',
+												fieldName: 'downloadsMetric',
+												label: Liferay.Language.get(
+													'downloads'
+												),
+												sortable: true
+											}
+										]
+									},
+									thumbnail: 'table'
+								}
+							]}
+						/>
+					)}
 				</Card>
 
 				<InfoPanel

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -1,5 +1,6 @@
 import * as API from 'shared/api';
 import Card from 'shared/components/Card';
+import Loading from 'shared/components/Loading';
 import React from 'react';
 import {columns, pagination, useSnapshots} from 'shared/util/frontend-data-set';
 import {
@@ -101,208 +102,222 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 
 	return (
 		<Card>
-			<FrontendDataSet
-				apiURL={rangeApiURL}
-				configInURLBehavior={EConfigInURLBehavior.OFF}
-				customDataRenderers={{
-					accountActivityStatusRenderer: ({value}: {value: string}) =>
-						value &&
-						columns.cmsLabelRenderer({
-							displayType:
-								value === 'ACTIVE' ? 'success' : 'secondary',
-							label:
-								value === 'ACTIVE'
-									? Liferay.Language.get('active')
-									: Liferay.Language.get('inactive')
-						}),
-					accountLifecycleStageRenderer: ({
-						value
-					}: {
-						value: LifecycleStages;
-					}) =>
-						value &&
-						columns.cmsLabelRenderer({
-							displayType:
-								lifecycleStagesLabelMap[value].displayType,
-							label: lifecycleStagesLabelMap[value].label
-						}),
-					accountNameRenderer: ({
-						itemData,
-						value
-					}: {
-						itemData: {id: string | number};
-						value: string;
-					}) =>
-						columns.nameAndLinkRenderer({
-							channelId,
-							groupId,
-							itemData,
-							route: Routes.CONTACTS_ACCOUNT,
+			{snapshots === null ? (
+				<Loading />
+			) : (
+				<FrontendDataSet
+					apiURL={rangeApiURL}
+					configInURLBehavior={EConfigInURLBehavior.OFF}
+					customDataRenderers={{
+						accountActivityStatusRenderer: ({
 							value
-						}),
-					annualRevenueRenderer: ({value}: {value: number}) => (
-						<div>{toThousands(value)}</div>
-					),
-					dateRenderer: ({value}: {value: string}) =>
-						columns.dateRenderer({itemData: {}, value})
-				}}
-				emptyState={{
-					description: Liferay.Language.get(
-						'no-accounts-were-synced-from-the-connected-data-sources'
-					),
-					image: '/states/satellite.svg',
-					title: Liferay.Language.get('no-accounts-found')
-				}}
-				filters={[
-					{
-						id: 'activityStatus',
-						items: activityStatusItems,
-						label: Liferay.Language.get('activity-status'),
-						name: 'activityStatus',
-						preloadedData: buildSelectionPreloadedData(
-							activityStatusFilter,
-							activityStatusItems.find(
-								({value}) => value === activityStatusFilter
-							)?.label
+						}: {
+							value: string;
+						}) =>
+							value &&
+							columns.cmsLabelRenderer({
+								displayType:
+									value === 'ACTIVE'
+										? 'success'
+										: 'secondary',
+								label:
+									value === 'ACTIVE'
+										? Liferay.Language.get('active')
+										: Liferay.Language.get('inactive')
+							}),
+						accountLifecycleStageRenderer: ({
+							value
+						}: {
+							value: LifecycleStages;
+						}) =>
+							value &&
+							columns.cmsLabelRenderer({
+								displayType:
+									lifecycleStagesLabelMap[value].displayType,
+								label: lifecycleStagesLabelMap[value].label
+							}),
+						accountNameRenderer: ({
+							itemData,
+							value
+						}: {
+							itemData: {id: string | number};
+							value: string;
+						}) =>
+							columns.nameAndLinkRenderer({
+								channelId,
+								groupId,
+								itemData,
+								route: Routes.CONTACTS_ACCOUNT,
+								value
+							}),
+						annualRevenueRenderer: ({value}: {value: number}) => (
+							<div>{toThousands(value)}</div>
 						),
-						type: 'selection'
-					},
-					...(accountLifecycleId
-						? [
-								{
-									id: 'lifecycleStatus',
-									items: lifecycleStageItems,
-									label: Liferay.Language.get('status'),
-									name: 'status',
-									preloadedData: buildSelectionPreloadedData(
-										preloadedLifecycleStage?.id,
-										lifecycleStageFilter
-											? lifecycleStagesLabelMap[
-													lifecycleStageFilter
-											  ].label
-											: undefined
-									),
-									type: 'selection' as const
-								}
-						  ]
-						: []),
-					{
-						apiURL: `/o/faro/contacts/${groupId}/account/fds_field_values?channelId=${channelId}&fieldMappingFieldName=industry`,
-						entityFieldType: 'string',
-						id: 'industry',
-						itemKey: 'name',
-						itemLabel: 'name',
-						label: Liferay.Language.get('industry'),
-						multiple: true,
-						preloadedData:
-							buildSelectionPreloadedData(industryFilter),
-						type: 'selection'
-					},
-					{
-						apiURL: `/o/faro/contacts/${groupId}/account/fds_field_values?channelId=${channelId}&fieldMappingFieldName=country`,
-						entityFieldType: 'string',
-						id: 'country',
-						itemKey: 'name',
-						itemLabel: 'name',
-						label: Liferay.Language.get('country'),
-						multiple: true,
-						preloadedData:
-							buildSelectionPreloadedData(countryFilter),
-						type: 'selection'
-					}
-				]}
-				id='accounts-list-dataset'
-				key={[
-					activityStatusFilter,
-					countryFilter,
-					industryFilter,
-					lifecycleStageFilter,
-					lifecycleStages.length,
-					...Object.values(rangeSelectors)
-				].join()}
-				pagination={pagination}
-				showPagination
-				snapshots={snapshots}
-				snapshotsEnabled
-				sorts={[
-					{
-						active: true,
-						direction: 'asc',
-						key: 'accountName',
-						label: Liferay.Language.get('account')
-					}
-				]}
-				views={[
-					{
-						contentRenderer: 'table',
-						default: true,
-						label: Liferay.Language.get('default-view'),
-						name: 'table',
-						schema: {
-							fields: [
-								{
-									contentRenderer: 'accountNameRenderer',
-									fieldName: 'accountName',
-									label: Liferay.Language.get('account'),
-									sortable: true,
-									truncate: true
-								},
-								{
-									fieldName: 'industry',
-									label: Liferay.Language.get('industry'),
-									sortable: true
-								},
-								{
-									contentRenderer:
-										'accountLifecycleStageRenderer',
-									fieldName: 'lifecycleStage',
-									label: Liferay.Language.get(
-										'lifecycle-stage'
-									),
-									sortable: true
-								},
-								{
-									contentRenderer: 'annualRevenueRenderer',
-									fieldName: 'annualRevenue',
-									label: Liferay.Language.get(
-										'annual-revenue'
-									),
-									sortable: true
-								},
-								{
-									fieldName: 'country',
-									label: Liferay.Language.get('country'),
-									sortable: true
-								},
-								{
-									contentRenderer: 'dateRenderer',
-									fieldName: 'lastActive',
-									label: Liferay.Language.get('last-active'),
-									sortable: true
-								},
-								{
-									contentRenderer: 'dateRenderer',
-									fieldName: 'lastEnriched',
-									label: Liferay.Language.get(
-										'last-enriched'
-									),
-									sortable: true
-								},
-								{
-									contentRenderer:
-										'accountActivityStatusRenderer',
-									fieldName: 'activityStatus',
-									label: Liferay.Language.get(
-										'activity-status'
-									),
-									sortable: true
-								}
-							]
+						dateRenderer: ({value}: {value: string}) =>
+							columns.dateRenderer({itemData: {}, value})
+					}}
+					emptyState={{
+						description: Liferay.Language.get(
+							'no-accounts-were-synced-from-the-connected-data-sources'
+						),
+						image: '/states/satellite.svg',
+						title: Liferay.Language.get('no-accounts-found')
+					}}
+					filters={[
+						{
+							id: 'activityStatus',
+							items: activityStatusItems,
+							label: Liferay.Language.get('activity-status'),
+							name: 'activityStatus',
+							preloadedData: buildSelectionPreloadedData(
+								activityStatusFilter,
+								activityStatusItems.find(
+									({value}) => value === activityStatusFilter
+								)?.label
+							),
+							type: 'selection'
 						},
-						thumbnail: 'table'
-					}
-				]}
-			/>
+						...(accountLifecycleId
+							? [
+									{
+										id: 'lifecycleStatus',
+										items: lifecycleStageItems,
+										label: Liferay.Language.get('status'),
+										name: 'status',
+										preloadedData:
+											buildSelectionPreloadedData(
+												preloadedLifecycleStage?.id,
+												lifecycleStageFilter
+													? lifecycleStagesLabelMap[
+															lifecycleStageFilter
+													  ].label
+													: undefined
+											),
+										type: 'selection' as const
+									}
+							  ]
+							: []),
+						{
+							apiURL: `/o/faro/contacts/${groupId}/account/fds_field_values?channelId=${channelId}&fieldMappingFieldName=industry`,
+							entityFieldType: 'string',
+							id: 'industry',
+							itemKey: 'name',
+							itemLabel: 'name',
+							label: Liferay.Language.get('industry'),
+							multiple: true,
+							preloadedData:
+								buildSelectionPreloadedData(industryFilter),
+							type: 'selection'
+						},
+						{
+							apiURL: `/o/faro/contacts/${groupId}/account/fds_field_values?channelId=${channelId}&fieldMappingFieldName=country`,
+							entityFieldType: 'string',
+							id: 'country',
+							itemKey: 'name',
+							itemLabel: 'name',
+							label: Liferay.Language.get('country'),
+							multiple: true,
+							preloadedData:
+								buildSelectionPreloadedData(countryFilter),
+							type: 'selection'
+						}
+					]}
+					id='accounts-list-dataset'
+					key={[
+						activityStatusFilter,
+						countryFilter,
+						industryFilter,
+						lifecycleStageFilter,
+						lifecycleStages.length,
+						...Object.values(rangeSelectors)
+					].join()}
+					pagination={pagination}
+					showPagination
+					snapshots={snapshots}
+					snapshotsEnabled
+					sorts={[
+						{
+							active: true,
+							direction: 'asc',
+							key: 'accountName',
+							label: Liferay.Language.get('account')
+						}
+					]}
+					views={[
+						{
+							contentRenderer: 'table',
+							default: true,
+							label: Liferay.Language.get('default-view'),
+							name: 'table',
+							schema: {
+								fields: [
+									{
+										contentRenderer: 'accountNameRenderer',
+										fieldName: 'accountName',
+										label: Liferay.Language.get('account'),
+										sortable: true,
+										truncate: true
+									},
+									{
+										fieldName: 'industry',
+										label: Liferay.Language.get('industry'),
+										sortable: true
+									},
+									{
+										contentRenderer:
+											'accountLifecycleStageRenderer',
+										fieldName: 'lifecycleStage',
+										label: Liferay.Language.get(
+											'lifecycle-stage'
+										),
+										sortable: true
+									},
+									{
+										contentRenderer:
+											'annualRevenueRenderer',
+										fieldName: 'annualRevenue',
+										label: Liferay.Language.get(
+											'annual-revenue'
+										),
+										sortable: true
+									},
+									{
+										fieldName: 'country',
+										label: Liferay.Language.get('country'),
+										sortable: true
+									},
+									{
+										contentRenderer: 'dateRenderer',
+										fieldName: 'lastActive',
+										label: Liferay.Language.get(
+											'last-active'
+										),
+										sortable: true
+									},
+									{
+										contentRenderer: 'dateRenderer',
+										fieldName: 'lastEnriched',
+										label: Liferay.Language.get(
+											'last-enriched'
+										),
+										sortable: true
+									},
+									{
+										contentRenderer:
+											'accountActivityStatusRenderer',
+										fieldName: 'activityStatus',
+										label: Liferay.Language.get(
+											'activity-status'
+										),
+										sortable: true
+									}
+								]
+							},
+							thumbnail: 'table'
+						}
+					]}
+				/>
+			)}
 		</Card>
 	);
 };

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/frontend-data-set.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/frontend-data-set.tsx
@@ -72,6 +72,16 @@ describe('useSnapshots', () => {
 		delete Liferay.FeatureFlags['LPS-164563'];
 	});
 
+	it('should return null while the snapshots are still loading', () => {
+		mockFetch([]);
+
+		const {result} = renderHook(() =>
+			useSnapshots('accounts-list-dataset')
+		);
+
+		expect(result.current).toBeNull();
+	});
+
 	it('should wrap saved views in a single headerless group', async () => {
 		mockFetch([
 			{
@@ -102,15 +112,13 @@ describe('useSnapshots', () => {
 	});
 
 	it('should return an empty array when there are no saved views', async () => {
-		const fetch = mockFetch([]);
+		mockFetch([]);
 
 		const {result} = renderHook(() =>
 			useSnapshots('accounts-list-dataset')
 		);
 
-		await waitFor(() => expect(fetch).toHaveBeenCalled());
-
-		expect(result.current).toEqual([]);
+		await waitFor(() => expect(result.current).toEqual([]));
 	});
 
 	it('should not fetch when the feature flags are disabled', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/frontend-data-set.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/frontend-data-set.tsx
@@ -1,5 +1,5 @@
-import {columns} from '../frontend-data-set';
-import {render, screen} from '@testing-library/react';
+import {columns, useSnapshots} from '../frontend-data-set';
+import {render, renderHook, screen, waitFor} from '@testing-library/react';
 import {Routes} from '../router';
 
 jest.unmock('react-dom');
@@ -48,5 +48,81 @@ describe('columns.nameAndLinkRenderer', () => {
 		);
 
 		expect(screen.getByRole('link')).toHaveTextContent('abc');
+	});
+});
+
+describe('useSnapshots', () => {
+	const mockFetch = (items: unknown[]) => {
+		const fetch = jest.fn(() =>
+			Promise.resolve({json: () => Promise.resolve({items})})
+		);
+
+		Liferay.Util = {fetch} as unknown as typeof Liferay.Util;
+
+		return fetch;
+	};
+
+	beforeEach(() => {
+		Liferay.FeatureFlags['LPD-34594'] = true;
+		Liferay.FeatureFlags['LPS-164563'] = true;
+	});
+
+	afterEach(() => {
+		delete Liferay.FeatureFlags['LPD-34594'];
+		delete Liferay.FeatureFlags['LPS-164563'];
+	});
+
+	it('should wrap saved views in a single headerless group', async () => {
+		mockFetch([
+			{
+				externalReferenceCode: 'erc-1',
+				label: 'My View',
+				viewConfig: '{"filters":[]}'
+			}
+		]);
+
+		const {result} = renderHook(() =>
+			useSnapshots('accounts-list-dataset')
+		);
+
+		await waitFor(() =>
+			expect(result.current).toEqual([
+				{
+					headerVisible: false,
+					items: [
+						{
+							configuration: '{"filters":[]}',
+							erc: 'erc-1',
+							label: 'My View'
+						}
+					]
+				}
+			])
+		);
+	});
+
+	it('should return an empty array when there are no saved views', async () => {
+		const fetch = mockFetch([]);
+
+		const {result} = renderHook(() =>
+			useSnapshots('accounts-list-dataset')
+		);
+
+		await waitFor(() => expect(fetch).toHaveBeenCalled());
+
+		expect(result.current).toEqual([]);
+	});
+
+	it('should not fetch when the feature flags are disabled', () => {
+		Liferay.FeatureFlags['LPD-34594'] = false;
+
+		const fetch = mockFetch([]);
+
+		const {result} = renderHook(() =>
+			useSnapshots('accounts-list-dataset')
+		);
+
+		expect(fetch).not.toHaveBeenCalled();
+		expect(result.current).toEqual([]);
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/frontend-data-set.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/frontend-data-set.tsx
@@ -82,18 +82,19 @@ export const columns = {
 };
 
 export function useSnapshots(fdsName: string) {
-	if (
-		!Liferay.FeatureFlags['LPD-34594'] ||
-		!Liferay.FeatureFlags['LPS-164563']
-	) {
-		return [];
-	}
+	const enabled =
+		Liferay.FeatureFlags['LPD-34594'] && Liferay.FeatureFlags['LPS-164563'];
 
-	const [snapshots, setSnapshots] = useState<
-		Array<{headerVisible: boolean; items: any[]}>
-	>([]);
+	const [snapshots, setSnapshots] = useState<Array<{
+		headerVisible: boolean;
+		items: any[];
+	}> | null>(enabled ? null : []);
 
 	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
+
 		Liferay.Util.fetch(
 			`/o/data-set-admin/snapshots?filter=fdsName eq '${fdsName}'`,
 			{headers: {'Content-Type': 'application/json'}, method: 'GET'}
@@ -121,8 +122,10 @@ export function useSnapshots(fdsName: string) {
 			.catch(error => {
 				// eslint-disable-next-line no-console
 				console.error('Failed to fetch snapshots:', error);
+
+				setSnapshots([]);
 			});
-	}, [fdsName]);
+	}, [enabled, fdsName]);
 
 	return snapshots;
 }

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/frontend-data-set.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/frontend-data-set.tsx
@@ -89,7 +89,9 @@ export function useSnapshots(fdsName: string) {
 		return [];
 	}
 
-	const [snapshots, setSnapshots] = useState([]);
+	const [snapshots, setSnapshots] = useState<
+		Array<{headerVisible: boolean; items: any[]}>
+	>([]);
 
 	useEffect(() => {
 		Liferay.Util.fetch(
@@ -110,7 +112,11 @@ export function useSnapshots(fdsName: string) {
 					})
 				);
 
-				setSnapshots(formattedSnapshots);
+				setSnapshots(
+					formattedSnapshots.length
+						? [{headerVisible: false, items: formattedSnapshots}]
+						: []
+				);
 			})
 			.catch(error => {
 				// eslint-disable-next-line no-console


### PR DESCRIPTION
Motivation
----

https://liferay.atlassian.net/browse/LPD-92566

Proposed Solution
----

The accounts and assets data sets let users save views, but saved views disappeared from the views dropdown after a page reload. FrontendDataSet reads its snapshots prop only once, when it mounts, while osb-faro loads the snapshots asynchronously, so the data set mounted before they arrived and ignored them.

We now have useSnapshots return null while the request is in flight and group the response into the shape FrontendDataSet expects, and the accounts and assets data sets show a loading indicator until the snapshots resolve before mounting the data set, so it always mounts with the saved views present. This also resolves a crash that happened when a saved view existed on reload.

The branch also carries the related accounts list changes (activity status column and filter, lifecycle status filter options loaded from the engine, and a query string separator fix) so they ship together without conflicts.

**NOTE:** This pr also includes commits from other tickets to prevent rebase errors