### PR TITLE
LPD-92538 Add FF Hiding Real Time Segments in LDP

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/List.tsx
@@ -46,6 +46,12 @@ import {
 	USER_NAME
 } from 'shared/util/router';
 import {DateCell} from 'shared/components/table/cell-components';
+import {
+	ENABLE_REAL_TIME_SEGMENTS,
+	SegmentStates,
+	SegmentTypes,
+	Sizes
+} from 'shared/util/constants';
 import {FeatureName, useLimitReached} from 'shared/hooks/useLimitReached';
 import {formatDateToTimeZone} from 'shared/util/date';
 import {
@@ -56,7 +62,6 @@ import {
 import {Link} from 'react-router-dom';
 import {OrderedMap} from 'immutable';
 import {OrderParams} from 'shared/util/records';
-import {SegmentStates, SegmentTypes, Sizes} from 'shared/util/constants';
 import {setUriQueryValues} from 'shared/util/router';
 import {sub} from 'shared/util/lang';
 import {useChannelContext} from 'shared/context/channel';
@@ -486,93 +491,128 @@ export const List: React.FC<IListProps> = ({
 				<Nav>
 					<Nav.Item>
 						<div className='d-flex align-items-center'>
-							<ClayDropDown
-								alignmentPosition={Align.BottomRight}
-								trigger={
-									<ClayButton
-										aria-label={
-											pageActionsLabel &&
-											Liferay.Language.get('menu')
-										}
-										className='button-root p-2 rounded-lg'
-										disabled={
-											error ||
-											loading ||
-											allActionsDisabled
-										}
-										displayType='primary'
-										size='sm'
-									>
-										<>
-											<span>{pageActionsLabel}</span>
-											<ClayIcon
-												className='icon-root ml-2'
-												symbol='caret-bottom'
-											/>
-										</>
-									</ClayButton>
-								}
-							>
-								{usageDropDownMessage && (
-									<div
-										className='alert alert-fluid alert-info'
-										role='alert'
-									>
-										{usageDropDownMessage}
-									</div>
-								)}
-
-								<ClayDropDown.Item
-									data-testid='batch-segment-dropdown-item'
-									disabled={usageLoading || isBatchDisabled}
-									href={setUriQueryValues(
-										{type: SegmentTypes.Batch},
-										toRoute(
-											Routes.CONTACTS_SEGMENT_CREATE,
-											{channelId, groupId}
-										)
-									)}
-								>
-									<ClayIcon
-										className='mr-2'
-										symbol='diagram'
-									/>
-									{Liferay.Language.get('batch')}
-								</ClayDropDown.Item>
-
-								<ClayDropDown.Item
-									data-testid='real-time-segment-dropdown-item'
-									disabled={
-										usageLoading || isRealTimeDisabled
+							{ENABLE_REAL_TIME_SEGMENTS ? (
+								<ClayDropDown
+									alignmentPosition={Align.BottomRight}
+									trigger={
+										<ClayButton
+											aria-label={
+												pageActionsLabel &&
+												Liferay.Language.get('menu')
+											}
+											className='button-root p-2 rounded-lg'
+											disabled={
+												error ||
+												loading ||
+												allActionsDisabled
+											}
+											displayType='primary'
+											size='sm'
+										>
+											<>
+												<span>{pageActionsLabel}</span>
+												<ClayIcon
+													className='icon-root ml-2'
+													symbol='caret-bottom'
+												/>
+											</>
+										</ClayButton>
 									}
-									href={setUriQueryValues(
-										{type: SegmentTypes.RealTime},
-										toRoute(
-											Routes.CONTACTS_SEGMENT_CREATE,
-											{channelId, groupId}
-										)
+								>
+									{usageDropDownMessage && (
+										<div
+											className='alert alert-fluid alert-info'
+											role='alert'
+										>
+											{usageDropDownMessage}
+										</div>
 									)}
-								>
-									<ClayIcon className='mr-2' symbol='bolt' />
-									{Liferay.Language.get('real-time')}
-								</ClayDropDown.Item>
-							</ClayDropDown>
 
-							{usageMessage && (
+									<ClayDropDown.Item
+										data-testid='batch-segment-dropdown-item'
+										disabled={
+											usageLoading || isBatchDisabled
+										}
+										href={setUriQueryValues(
+											{type: SegmentTypes.Batch},
+											toRoute(
+												Routes.CONTACTS_SEGMENT_CREATE,
+												{channelId, groupId}
+											)
+										)}
+									>
+										<ClayIcon
+											className='mr-2'
+											symbol='diagram'
+										/>
+										{Liferay.Language.get('batch')}
+									</ClayDropDown.Item>
+
+									<ClayDropDown.Item
+										data-testid='real-time-segment-dropdown-item'
+										disabled={
+											usageLoading || isRealTimeDisabled
+										}
+										href={setUriQueryValues(
+											{type: SegmentTypes.RealTime},
+											toRoute(
+												Routes.CONTACTS_SEGMENT_CREATE,
+												{channelId, groupId}
+											)
+										)}
+									>
+										<ClayIcon
+											className='mr-2'
+											symbol='bolt'
+										/>
+										{Liferay.Language.get('real-time')}
+									</ClayDropDown.Item>
+								</ClayDropDown>
+							) : (
 								<ClayButton
-									borderless
-									className='ml-2'
-									data-tooltip-align='right'
-									displayType='unstyled'
+									aria-label={pageActionsLabel}
+									className='button-root p-2 rounded-lg'
+									data-testid='new-segment-button'
+									disabled={
+										error ||
+										loading ||
+										usageLoading ||
+										isBatchDisabled
+									}
+									displayType='primary'
+									onClick={() =>
+										history.push(
+											setUriQueryValues(
+												{type: SegmentTypes.Batch},
+												toRoute(
+													Routes.CONTACTS_SEGMENT_CREATE,
+													{channelId, groupId}
+												)
+											)
+										)
+									}
 									size='sm'
-									title={usageMessage}
 								>
-									<ClayIcon
-										className='text-secondary'
-										symbol='exclamation-full'
-									/>
+									{pageActionsLabel}
 								</ClayButton>
 							)}
+
+							{(ENABLE_REAL_TIME_SEGMENTS || isBatchDisabled) &&
+								usageMessage && (
+									<ClayButton
+										borderless
+										className='ml-2'
+										data-tooltip-align='right'
+										displayType='unstyled'
+										size='sm'
+										title={usageMessage}
+									>
+										<ClayIcon
+											className='text-secondary'
+											symbol='exclamation-full'
+										/>
+									</ClayButton>
+								)}
 						</div>
 					</Nav.Item>
 				</Nav>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/__tests__/List.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/__tests__/List.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {act} from '@testing-library/react';
 import {ChannelContext} from 'shared/context/channel';
 import {cleanup, render, screen} from '@testing-library/react';
+import {fireEvent} from '@testing-library/react';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {mockChannelContext} from 'test/mock-channel-context';
 import {Provider} from 'react-redux';
@@ -16,6 +17,22 @@ import {User} from 'shared/util/records';
 import {waitForLoadingToBeRemoved} from 'test/helpers';
 
 jest.unmock('react-dom');
+
+jest.mock('shared/util/constants', () => {
+	const actualConstants = jest.requireActual('shared/util/constants');
+
+	return new Proxy(actualConstants, {
+		get(target, property) {
+			if (property === 'ENABLE_REAL_TIME_SEGMENTS') {
+				return mockEnableRealTimeSegments;
+			}
+
+			return target[property];
+		}
+	});
+});
+
+let mockEnableRealTimeSegments = false;
 
 const MOCK_UNASSIGNED_SEGMENTS_CONTEXT = {
 	showUnassignedAlert: false,
@@ -58,6 +75,8 @@ describe('List', () => {
 		jest.clearAllMocks();
 
 		jest.useFakeTimers();
+
+		mockEnableRealTimeSegments = false;
 	});
 
 	afterEach(() => {
@@ -67,6 +86,8 @@ describe('List', () => {
 	});
 
 	it('should disable batch segment when limit is reached', async () => {
+		mockEnableRealTimeSegments = true;
+
 		API.projects.fetchFeatureUsages.mockReturnValueOnce(
 			Promise.resolve([
 				{
@@ -100,6 +121,8 @@ describe('List', () => {
 	});
 
 	it('should disable real time segment when limit is reached', async () => {
+		mockEnableRealTimeSegments = true;
+
 		API.projects.fetchFeatureUsages.mockReturnValueOnce(
 			Promise.resolve([
 				{
@@ -133,6 +156,8 @@ describe('List', () => {
 	});
 
 	it('should enable segments when usage is under the limit', async () => {
+		mockEnableRealTimeSegments = true;
+
 		API.projects.fetchFeatureUsages.mockReturnValueOnce(
 			Promise.resolve([
 				{
@@ -166,6 +191,8 @@ describe('List', () => {
 	});
 
 	it('should enable segment options when the limit is set to -1 (unlimited)', async () => {
+		mockEnableRealTimeSegments = true;
+
 		API.projects.fetchFeatureUsages.mockReturnValueOnce(
 			Promise.resolve([
 				{
@@ -276,6 +303,62 @@ describe('List', () => {
 
 		expect(
 			container.querySelector('.sticker-info')
+		).not.toBeInTheDocument();
+	});
+
+	it('should hide the new segment dropdown and create a batch segment by default', async () => {
+		mockEnableRealTimeSegments = false;
+
+		const push = jest.fn();
+
+		API.projects.fetchFeatureUsages.mockResolvedValueOnce([
+			{
+				currentUsage: 0,
+				limit: -1,
+				name: 'Segment',
+				type: 'Batch'
+			}
+		]);
+
+		render(<DefaultComponent history={{push}} />);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		expect(
+			screen.queryByTestId('batch-segment-dropdown-item')
+		).not.toBeInTheDocument();
+
+		expect(
+			screen.queryByTestId('real-time-segment-dropdown-item')
+		).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByTestId('new-segment-button'));
+
+		expect(push).toHaveBeenCalledTimes(1);
+		expect(push).toHaveBeenCalledWith(
+			expect.stringContaining(`type=${SegmentTypes.Batch}`)
+		);
+	});
+
+	it('should show the new segment dropdown when real time segments are enabled', async () => {
+		mockEnableRealTimeSegments = true;
+
+		API.projects.fetchFeatureUsages.mockResolvedValueOnce([]);
+
+		render(<DefaultComponent />);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		expect(
+			screen.getByTestId('batch-segment-dropdown-item')
+		).toBeInTheDocument();
+
+		expect(
+			screen.getByTestId('real-time-segment-dropdown-item')
+		).toBeInTheDocument();
+
+		expect(
+			screen.queryByTestId('new-segment-button')
 		).not.toBeInTheDocument();
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/constants.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/constants.ts
@@ -445,6 +445,10 @@ export const ENABLE_GLOBAL_FILTER = false;
 
 export const ENABLE_LAST_ACCESS_DATE = false;
 
+// LPD-92538 Hide the creation of real time segments until the CAP initiative is delivered
+
+export const ENABLE_REAL_TIME_SEGMENTS = false;
+
 // LRAC-11571 Disable temporarily Salesforce
 
 export const ENABLE_SALESFORCE = false;


### PR DESCRIPTION
## What

Adds the `ENABLE_REAL_TIME_SEGMENTS` feature flag (default `false`) to hide Real Time segment creation in the UI until the CAP initiative is delivered.

## Changes

- When the flag is `false` (default), the **New Segment** button no longer opens a dropdown — clicking it now creates a **Batch** segment directly.
- When the flag is `true`, the existing dropdown (Batch / Real Time) behavior is preserved.
- The batch-limit usage tooltip is shown next to the single button when the batch segment limit is reached.

## Scope

Only the segment **creation** entry point is changed. Existing Real Time segments, filters, and displays are untouched.

## Tests

`segment/pages/__tests__/List.jsx`: added coverage for both flag states (single Batch button by default; dropdown when enabled); existing dropdown tests now run with the flag enabled. All 10 tests pass.

Jira: https://liferay.atlassian.net/browse/LPD-92538
