### PR TITLE
LPD-92650 Display canonicalUrl instead of url in activity stream

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamTimeline.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamTimeline.tsx
@@ -411,9 +411,9 @@ const EventRow: React.FC<IEventRowProps> = ({event, timeZoneId}) => {
 								{event.pageTitle || event.assetTitle}
 							</div>
 
-							{event.url && (
+							{event.canonicalUrl && (
 								<div className='text-secondary text-truncate'>
-									{event.url}
+									{event.canonicalUrl}
 								</div>
 							)}
 						</div>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamTimeline.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamTimeline.tsx
@@ -257,6 +257,69 @@ describe('ActivityStreamTimeline rendering', () => {
 		).toBeInTheDocument();
 	});
 
+	it('renders an event canonicalUrl and not its raw url', () => {
+		const {getByText, queryByText} = render(
+			<ActivityStreamTimeline
+				{...baseProps}
+				sessions={[
+					buildSession({
+						events: [
+							{
+								applicationId: 'app',
+								assetTitle: 'Asset',
+								canonicalUrl: 'https://example.com/canonical',
+								createDate: '2024-04-03T08:05:00.000Z',
+								name: 'View Page',
+								pageDescription: '',
+								pageKeywords: '',
+								pageTitle: 'Home',
+								referrer: '',
+								url: 'https://example.com/raw?utm=1'
+							}
+						]
+					})
+				]}
+				totalItems={1}
+			/>
+		);
+
+		expect(getByText('https://example.com/canonical')).toBeInTheDocument();
+		expect(
+			queryByText('https://example.com/raw?utm=1')
+		).not.toBeInTheDocument();
+	});
+
+	it('omits the event url line when canonicalUrl is empty', () => {
+		const {queryByText} = render(
+			<ActivityStreamTimeline
+				{...baseProps}
+				sessions={[
+					buildSession({
+						events: [
+							{
+								applicationId: 'app',
+								assetTitle: 'Asset',
+								canonicalUrl: '',
+								createDate: '2024-04-03T08:05:00.000Z',
+								name: 'View Page',
+								pageDescription: '',
+								pageKeywords: '',
+								pageTitle: 'Home',
+								referrer: '',
+								url: 'https://example.com/raw?utm=1'
+							}
+						]
+					})
+				]}
+				totalItems={1}
+			/>
+		);
+
+		expect(
+			queryByText('https://example.com/raw?utm=1')
+		).not.toBeInTheDocument();
+	});
+
 	it('renders an anonymous session with the anonymize icon', () => {
 		const {container, getByText} = render(
 			<ActivityStreamTimeline


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92650

## What Is Being Fixed

The account activity stream timeline displayed each event's raw `url` field, which carries query parameters and tracking noise. The canonical URL is the normalized address that more cleanly identifies the page the visitor viewed.

## How It Is Being Fixed

The event row in `ActivityStreamTimeline` now reads `event.canonicalUrl` instead of `event.url`, both in the guard that decides whether to render the URL line and in the displayed text. A unit test was added covering that the row shows `canonicalUrl`, suppresses the raw `url`, and omits the line entirely when `canonicalUrl` is empty.