### PR TITLE
LPD-92679 faro-v4.15.x Copy the metrics array before sorting in the audience report

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/audience-report/__tests__/util.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/audience-report/__tests__/util.ts
@@ -1,0 +1,30 @@
+import {formatData} from '../util';
+
+describe('formatData', () => {
+	/**
+	 * Apollo Client 3 deep-freezes query results in development to surface
+	 * accidental mutations. formatData must therefore not sort the metrics
+	 * array in place, otherwise Array.prototype.sort throws "Cannot assign to
+	 * read only property '0'" as soon as the channel has two or more segments.
+	 */
+	it('does not mutate the frozen metrics array returned by the Apollo cache', () => {
+		const metrics = Object.freeze([
+			{value: 434, valueKey: '804330050123744518'},
+			{value: 214, valueKey: '804357143036930828'},
+			{value: 141, valueKey: 'Liferayers'}
+		]);
+
+		expect(() =>
+			formatData({
+				audienceReport: {
+					anonymousUsersCount: 100,
+					knownUsersCount: 100,
+					nonsegmentedKnownUsersCount: 40,
+					segmentedAnonymousUsersCount: 30,
+					segmentedKnownUsersCount: 30
+				},
+				segment: {metrics, total: 789}
+			})
+		).not.toThrow();
+	});
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/audience-report/util.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/audience-report/util.ts
@@ -212,6 +212,7 @@ export const formatData = ({
 		{
 			segments: [
 				...metrics
+					.slice()
 					.sort((a: any, b: any) => b.value - a.value)
 					.filter(({valueKey}: any) => valueKey !== 'others'),
 				...metrics.filter(({valueKey}: any) => valueKey === 'others')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92679

Backport of #3419 to `faro-v4.15.x`.