### PR TITLE
LPD-92556 Show the metric card trend percentage with one decimal

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
@@ -97,7 +97,7 @@ const MetricCard: React.FC<IMetricCardProps> = ({
 							>
 								{`${toRounded(
 									Math.abs(trend?.percentage ?? 0),
-									2
+									1
 								)}%`}
 							</span>
 						)}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/MetricCard.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/MetricCard.tsx
@@ -133,7 +133,7 @@ describe('MetricCard', () => {
 		expect(getByTestId('custom-value')).toBeTruthy();
 	});
 
-	it('should round the percentage to two decimals', () => {
+	it('should round the percentage to one decimal', () => {
 		const {getByText} = render(
 			<MetricCard
 				{...defaultProps}
@@ -144,6 +144,6 @@ describe('MetricCard', () => {
 			/>
 		);
 
-		expect(getByText('12.35%')).toBeTruthy();
+		expect(getByText('12.3%')).toBeTruthy();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92556

## What Is Being Fixed

The account metrics cards (Total, New, and Active accounts) displayed the trend percentage with more than one decimal place. The expected behavior is a single decimal place.

## How It Is Being Fixed

The shared `MetricCard` component rounded the trend percentage with a precision of two decimals via `toRounded`. The precision is now one decimal, so every card that uses the shared component shows the percentage with a single decimal place. The component test is updated accordingly.