### PR TITLE
LPD-92392 Add asset performance overview metric REST endpoint

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/dto/v1_0/PerformanceOverviewMetric.java
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/dto/v1_0/PerformanceOverviewMetric.java
@@ -1,0 +1,398 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+@GraphQLName("PerformanceOverviewMetric")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "PerformanceOverviewMetric")
+public class PerformanceOverviewMetric implements Serializable {
+
+	public static PerformanceOverviewMetric toDTO(String json) {
+		return ObjectMapperUtil.readValue(
+			PerformanceOverviewMetric.class, json);
+	}
+
+	public static PerformanceOverviewMetric unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			PerformanceOverviewMetric.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Metric getDownloadsMetric() {
+		if (_downloadsMetricSupplier != null) {
+			downloadsMetric = _downloadsMetricSupplier.get();
+
+			_downloadsMetricSupplier = null;
+		}
+
+		return downloadsMetric;
+	}
+
+	public void setDownloadsMetric(Metric downloadsMetric) {
+		this.downloadsMetric = downloadsMetric;
+
+		_downloadsMetricSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDownloadsMetric(
+		UnsafeSupplier<Metric, Exception> downloadsMetricUnsafeSupplier) {
+
+		_downloadsMetricSupplier = () -> {
+			try {
+				return downloadsMetricUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Metric downloadsMetric;
+
+	@JsonIgnore
+	private Supplier<Metric> _downloadsMetricSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Metric getImpressionsMetric() {
+		if (_impressionsMetricSupplier != null) {
+			impressionsMetric = _impressionsMetricSupplier.get();
+
+			_impressionsMetricSupplier = null;
+		}
+
+		return impressionsMetric;
+	}
+
+	public void setImpressionsMetric(Metric impressionsMetric) {
+		this.impressionsMetric = impressionsMetric;
+
+		_impressionsMetricSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setImpressionsMetric(
+		UnsafeSupplier<Metric, Exception> impressionsMetricUnsafeSupplier) {
+
+		_impressionsMetricSupplier = () -> {
+			try {
+				return impressionsMetricUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Metric impressionsMetric;
+
+	@JsonIgnore
+	private Supplier<Metric> _impressionsMetricSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Metric getReadsMetric() {
+		if (_readsMetricSupplier != null) {
+			readsMetric = _readsMetricSupplier.get();
+
+			_readsMetricSupplier = null;
+		}
+
+		return readsMetric;
+	}
+
+	public void setReadsMetric(Metric readsMetric) {
+		this.readsMetric = readsMetric;
+
+		_readsMetricSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setReadsMetric(
+		UnsafeSupplier<Metric, Exception> readsMetricUnsafeSupplier) {
+
+		_readsMetricSupplier = () -> {
+			try {
+				return readsMetricUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Metric readsMetric;
+
+	@JsonIgnore
+	private Supplier<Metric> _readsMetricSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Metric getViewsMetric() {
+		if (_viewsMetricSupplier != null) {
+			viewsMetric = _viewsMetricSupplier.get();
+
+			_viewsMetricSupplier = null;
+		}
+
+		return viewsMetric;
+	}
+
+	public void setViewsMetric(Metric viewsMetric) {
+		this.viewsMetric = viewsMetric;
+
+		_viewsMetricSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setViewsMetric(
+		UnsafeSupplier<Metric, Exception> viewsMetricUnsafeSupplier) {
+
+		_viewsMetricSupplier = () -> {
+			try {
+				return viewsMetricUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Metric viewsMetric;
+
+	@JsonIgnore
+	private Supplier<Metric> _viewsMetricSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PerformanceOverviewMetric)) {
+			return false;
+		}
+
+		PerformanceOverviewMetric performanceOverviewMetric =
+			(PerformanceOverviewMetric)object;
+
+		return Objects.equals(toString(), performanceOverviewMetric.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		Metric downloadsMetric = getDownloadsMetric();
+
+		if (downloadsMetric != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"downloadsMetric\": ");
+
+			sb.append(String.valueOf(downloadsMetric));
+		}
+
+		Metric impressionsMetric = getImpressionsMetric();
+
+		if (impressionsMetric != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"impressionsMetric\": ");
+
+			sb.append(String.valueOf(impressionsMetric));
+		}
+
+		Metric readsMetric = getReadsMetric();
+
+		if (readsMetric != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"readsMetric\": ");
+
+			sb.append(String.valueOf(readsMetric));
+		}
+
+		Metric viewsMetric = getViewsMetric();
+
+		if (viewsMetric != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"viewsMetric\": ");
+
+			sb.append(String.valueOf(viewsMetric));
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.analytics.cms.rest.dto.v1_0.PerformanceOverviewMetric",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:457759237

--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/resource/v1_0/PerformanceOverviewMetricResource.java
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/resource/v1_0/PerformanceOverviewMetricResource.java
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceOverviewMetric;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/analytics-cms-rest/v1.0
+ *
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface PerformanceOverviewMetricResource {
+
+	public PerformanceOverviewMetric getPerformanceOverviewMetric(
+			Long[] groupIds, Integer rangeKey)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public PerformanceOverviewMetricResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1986272890

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/dto/v1_0/PerformanceOverviewMetric.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/dto/v1_0/PerformanceOverviewMetric.java
@@ -1,0 +1,145 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.dto.v1_0;
+
+import com.liferay.analytics.cms.rest.client.function.UnsafeSupplier;
+import com.liferay.analytics.cms.rest.client.serdes.v1_0.PerformanceOverviewMetricSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public class PerformanceOverviewMetric implements Cloneable, Serializable {
+
+	public static PerformanceOverviewMetric toDTO(String json) {
+		return PerformanceOverviewMetricSerDes.toDTO(json);
+	}
+
+	public Metric getDownloadsMetric() {
+		return downloadsMetric;
+	}
+
+	public void setDownloadsMetric(Metric downloadsMetric) {
+		this.downloadsMetric = downloadsMetric;
+	}
+
+	public void setDownloadsMetric(
+		UnsafeSupplier<Metric, Exception> downloadsMetricUnsafeSupplier) {
+
+		try {
+			downloadsMetric = downloadsMetricUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Metric downloadsMetric;
+
+	public Metric getImpressionsMetric() {
+		return impressionsMetric;
+	}
+
+	public void setImpressionsMetric(Metric impressionsMetric) {
+		this.impressionsMetric = impressionsMetric;
+	}
+
+	public void setImpressionsMetric(
+		UnsafeSupplier<Metric, Exception> impressionsMetricUnsafeSupplier) {
+
+		try {
+			impressionsMetric = impressionsMetricUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Metric impressionsMetric;
+
+	public Metric getReadsMetric() {
+		return readsMetric;
+	}
+
+	public void setReadsMetric(Metric readsMetric) {
+		this.readsMetric = readsMetric;
+	}
+
+	public void setReadsMetric(
+		UnsafeSupplier<Metric, Exception> readsMetricUnsafeSupplier) {
+
+		try {
+			readsMetric = readsMetricUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Metric readsMetric;
+
+	public Metric getViewsMetric() {
+		return viewsMetric;
+	}
+
+	public void setViewsMetric(Metric viewsMetric) {
+		this.viewsMetric = viewsMetric;
+	}
+
+	public void setViewsMetric(
+		UnsafeSupplier<Metric, Exception> viewsMetricUnsafeSupplier) {
+
+		try {
+			viewsMetric = viewsMetricUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Metric viewsMetric;
+
+	@Override
+	public PerformanceOverviewMetric clone() throws CloneNotSupportedException {
+		return (PerformanceOverviewMetric)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PerformanceOverviewMetric)) {
+			return false;
+		}
+
+		PerformanceOverviewMetric performanceOverviewMetric =
+			(PerformanceOverviewMetric)object;
+
+		return Objects.equals(toString(), performanceOverviewMetric.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return PerformanceOverviewMetricSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1656600776

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/resource/v1_0/PerformanceOverviewMetricResource.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/resource/v1_0/PerformanceOverviewMetricResource.java
@@ -1,0 +1,280 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceOverviewMetric;
+import com.liferay.analytics.cms.rest.client.http.HttpInvoker;
+import com.liferay.analytics.cms.rest.client.problem.Problem;
+import com.liferay.analytics.cms.rest.client.serdes.v1_0.PerformanceOverviewMetricSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public interface PerformanceOverviewMetricResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public PerformanceOverviewMetric getPerformanceOverviewMetric(
+			Long[] groupIds, Integer rangeKey)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getPerformanceOverviewMetricHttpResponse(
+			Long[] groupIds, Integer rangeKey)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public PerformanceOverviewMetricResource build() {
+			return new PerformanceOverviewMetricResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class PerformanceOverviewMetricResourceImpl
+		implements PerformanceOverviewMetricResource {
+
+		public PerformanceOverviewMetric getPerformanceOverviewMetric(
+				Long[] groupIds, Integer rangeKey)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getPerformanceOverviewMetricHttpResponse(groupIds, rangeKey);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return PerformanceOverviewMetricSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getPerformanceOverviewMetricHttpResponse(
+					Long[] groupIds, Integer rangeKey)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (groupIds != null) {
+				for (int i = 0; i < groupIds.length; i++) {
+					httpInvoker.parameter(
+						"groupIds", String.valueOf(groupIds[i]));
+				}
+			}
+
+			if (rangeKey != null) {
+				httpInvoker.parameter("rangeKey", String.valueOf(rangeKey));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/analytics-cms-rest/v1.0/performance-overview-metric");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private PerformanceOverviewMetricResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			PerformanceOverviewMetricResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1244806822

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/serdes/v1_0/PerformanceOverviewMetricSerDes.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/serdes/v1_0/PerformanceOverviewMetricSerDes.java
@@ -1,0 +1,301 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.serdes.v1_0;
+
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceOverviewMetric;
+import com.liferay.analytics.cms.rest.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public class PerformanceOverviewMetricSerDes {
+
+	public static PerformanceOverviewMetric toDTO(String json) {
+		PerformanceOverviewMetricJSONParser
+			performanceOverviewMetricJSONParser =
+				new PerformanceOverviewMetricJSONParser();
+
+		return performanceOverviewMetricJSONParser.parseToDTO(json);
+	}
+
+	public static PerformanceOverviewMetric[] toDTOs(String json) {
+		PerformanceOverviewMetricJSONParser
+			performanceOverviewMetricJSONParser =
+				new PerformanceOverviewMetricJSONParser();
+
+		return performanceOverviewMetricJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(
+		PerformanceOverviewMetric performanceOverviewMetric) {
+
+		if (performanceOverviewMetric == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (performanceOverviewMetric.getDownloadsMetric() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"downloadsMetric\": ");
+
+			sb.append(
+				String.valueOf(performanceOverviewMetric.getDownloadsMetric()));
+		}
+
+		if (performanceOverviewMetric.getImpressionsMetric() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"impressionsMetric\": ");
+
+			sb.append(
+				String.valueOf(
+					performanceOverviewMetric.getImpressionsMetric()));
+		}
+
+		if (performanceOverviewMetric.getReadsMetric() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"readsMetric\": ");
+
+			sb.append(
+				String.valueOf(performanceOverviewMetric.getReadsMetric()));
+		}
+
+		if (performanceOverviewMetric.getViewsMetric() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"viewsMetric\": ");
+
+			sb.append(
+				String.valueOf(performanceOverviewMetric.getViewsMetric()));
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		PerformanceOverviewMetricJSONParser
+			performanceOverviewMetricJSONParser =
+				new PerformanceOverviewMetricJSONParser();
+
+		return performanceOverviewMetricJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		PerformanceOverviewMetric performanceOverviewMetric) {
+
+		if (performanceOverviewMetric == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (performanceOverviewMetric.getDownloadsMetric() == null) {
+			map.put("downloadsMetric", null);
+		}
+		else {
+			map.put(
+				"downloadsMetric",
+				String.valueOf(performanceOverviewMetric.getDownloadsMetric()));
+		}
+
+		if (performanceOverviewMetric.getImpressionsMetric() == null) {
+			map.put("impressionsMetric", null);
+		}
+		else {
+			map.put(
+				"impressionsMetric",
+				String.valueOf(
+					performanceOverviewMetric.getImpressionsMetric()));
+		}
+
+		if (performanceOverviewMetric.getReadsMetric() == null) {
+			map.put("readsMetric", null);
+		}
+		else {
+			map.put(
+				"readsMetric",
+				String.valueOf(performanceOverviewMetric.getReadsMetric()));
+		}
+
+		if (performanceOverviewMetric.getViewsMetric() == null) {
+			map.put("viewsMetric", null);
+		}
+		else {
+			map.put(
+				"viewsMetric",
+				String.valueOf(performanceOverviewMetric.getViewsMetric()));
+		}
+
+		return map;
+	}
+
+	public static class PerformanceOverviewMetricJSONParser
+		extends BaseJSONParser<PerformanceOverviewMetric> {
+
+		@Override
+		protected PerformanceOverviewMetric createDTO() {
+			return new PerformanceOverviewMetric();
+		}
+
+		@Override
+		protected PerformanceOverviewMetric[] createDTOArray(int size) {
+			return new PerformanceOverviewMetric[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "downloadsMetric")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "impressionsMetric")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "readsMetric")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "viewsMetric")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			PerformanceOverviewMetric performanceOverviewMetric,
+			String jsonParserFieldName, Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "downloadsMetric")) {
+				if (jsonParserFieldValue != null) {
+					performanceOverviewMetric.setDownloadsMetric(
+						MetricSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "impressionsMetric")) {
+				if (jsonParserFieldValue != null) {
+					performanceOverviewMetric.setImpressionsMetric(
+						MetricSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "readsMetric")) {
+				if (jsonParserFieldValue != null) {
+					performanceOverviewMetric.setReadsMetric(
+						MetricSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "viewsMetric")) {
+				if (jsonParserFieldValue != null) {
+					performanceOverviewMetric.setViewsMetric(
+						MetricSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1061989289

--- a/modules/apps/analytics/analytics-cms-rest-impl/rest-openapi.yaml
+++ b/modules/apps/analytics/analytics-cms-rest-impl/rest-openapi.yaml
@@ -129,6 +129,16 @@ components:
                 vocabulariesCount:
                     format: int64
                     type: integer
+        PerformanceOverviewMetric:
+            properties:
+                downloadsMetric:
+                    $ref: "#/components/schemas/Metric"
+                impressionsMetric:
+                    $ref: "#/components/schemas/Metric"
+                readsMetric:
+                    $ref: "#/components/schemas/Metric"
+                viewsMetric:
+                    $ref: "#/components/schemas/Metric"
         TopPage:
             properties:
                 canonicalUrl:
@@ -497,3 +507,28 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntryTopPages"
             tags: ["ObjectEntryTopPages"]
+    "/performance-overview-metric":
+        get:
+            operationId: getPerformanceOverviewMetric
+            parameters:
+                -   in: query
+                    name: groupIds
+                    schema:
+                        items:
+                            format: int64
+                            type: integer
+                        type: array
+                -   in: query
+                    name: rangeKey
+                    schema:
+                        type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PerformanceOverviewMetric"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/PerformanceOverviewMetric"
+            tags: ["PerformanceOverviewMetric"]

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -14,10 +14,12 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
+import com.liferay.analytics.cms.rest.dto.v1_0.Metric;
 import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryAcquisitionChannel;
 import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryHistogramMetric;
 import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryMetric;
 import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryTopPages;
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceOverviewMetric;
 import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -27,6 +29,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.net.HttpURLConnection;
 
@@ -296,6 +299,63 @@ public class AnalyticsCloudClient {
 		}
 	}
 
+	public PerformanceOverviewMetric getPerformanceOverviewMetric(
+			AnalyticsConfiguration analyticsConfiguration, List<Long> groupIds,
+			Integer rangeKey)
+		throws Exception {
+
+		try {
+			Http.Options options = _getOptions(analyticsConfiguration);
+
+			options.setLocation(
+				_getUrl(
+					analyticsConfiguration.liferayAnalyticsDataSourceId(), null,
+					groupIds,
+					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
+					"/performance-overview-metric", rangeKey, null));
+
+			String content = _http.URLtoString(options);
+
+			Http.Response response = options.getResponse();
+
+			if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
+				PerformanceOverviewMetric performanceOverviewMetric = null;
+
+				JsonNode jsonNode = ObjectMapperHolder._objectMapper.readTree(
+					content);
+
+				if (jsonNode != null) {
+					TypeFactory typeFactory = TypeFactory.defaultInstance();
+
+					ObjectReader objectReader =
+						ObjectMapperHolder._objectMapper.readerFor(
+							typeFactory.constructCollectionType(
+								List.class, Metric.class));
+
+					performanceOverviewMetric = _getPerformanceOverviewMetric(
+						objectReader.readValue(jsonNode));
+				}
+
+				return performanceOverviewMetric;
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug("Response code " + response.getResponseCode());
+			}
+
+			throw new PortalException(
+				"Unable to get performance overview metric");
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			throw new PortalException(
+				"Unable to get performance overview metric", exception);
+		}
+	}
+
 	private Http.Options _getOptions(
 			AnalyticsConfiguration analyticsConfiguration)
 		throws Exception {
@@ -313,6 +373,32 @@ public class AnalyticsCloudClient {
 		return options;
 	}
 
+	private PerformanceOverviewMetric _getPerformanceOverviewMetric(
+		List<Metric> metrics) {
+
+		PerformanceOverviewMetric performanceOverviewMetric =
+			new PerformanceOverviewMetric();
+
+		for (Metric metric : metrics) {
+			String metricType = metric.getMetricType();
+
+			if (StringUtil.equals(metricType, "downloadsMetric")) {
+				performanceOverviewMetric.setDownloadsMetric(() -> metric);
+			}
+			else if (StringUtil.equals(metricType, "impressionsMetric")) {
+				performanceOverviewMetric.setImpressionsMetric(() -> metric);
+			}
+			else if (StringUtil.equals(metricType, "readsMetric")) {
+				performanceOverviewMetric.setReadsMetric(() -> metric);
+			}
+			else if (StringUtil.equals(metricType, "viewsMetric")) {
+				performanceOverviewMetric.setViewsMetric(() -> metric);
+			}
+		}
+
+		return performanceOverviewMetric;
+	}
+
 	private String _getUrl(
 		String dataSourceId, String externalReferenceCode, List<Long> groupIds,
 		String liferayAnalyticsFaroBackendURL, String path, Integer rangeKey,
@@ -324,8 +410,11 @@ public class AnalyticsCloudClient {
 
 		url = HttpComponentsUtil.addParameter(
 			url, "dataSourceId", dataSourceId);
-		url = HttpComponentsUtil.addParameter(
-			url, "externalReferenceCode", externalReferenceCode);
+
+		if (Validator.isNotNull(externalReferenceCode)) {
+			url = HttpComponentsUtil.addParameter(
+				url, "externalReferenceCode", externalReferenceCode);
+		}
 
 		if (!groupIds.isEmpty()) {
 			url = HttpComponentsUtil.addParameter(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/BasePerformanceOverviewMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/BasePerformanceOverviewMetricResourceImpl.java
@@ -1,0 +1,530 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.internal.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceOverviewMetric;
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceOverviewMetricResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BasePerformanceOverviewMetricResourceImpl
+	implements PerformanceOverviewMetricResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/analytics-cms-rest/v1.0/performance-overview-metric'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "groupIds"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "rangeKey"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "PerformanceOverviewMetric"
+			)
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/performance-overview-metric")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public PerformanceOverviewMetric getPerformanceOverviewMetric(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("groupIds")
+			Long[] groupIds,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("rangeKey")
+			Integer rangeKey)
+		throws Exception {
+
+		return new PerformanceOverviewMetric();
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "analytics-cms-rest";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BasePerformanceOverviewMetricResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:1690499834

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -103,9 +103,11 @@ public class OpenAPIResourceImpl {
 
 			add(OverviewResourceImpl.class);
 
+			add(PerformanceOverviewMetricResourceImpl.class);
+
 			add(OpenAPIResourceImpl.class);
 		}
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:1723994668
+// LIFERAY-REST-BUILDER-HASH:1295959257

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.internal.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceOverviewMetricResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Rachael Koestartyo
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/performance-overview-metric.properties",
+	scope = ServiceScope.PROTOTYPE,
+	service = PerformanceOverviewMetricResource.class
+)
+public class PerformanceOverviewMetricResourceImpl
+	extends BasePerformanceOverviewMetricResourceImpl {
+}

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
@@ -5,9 +5,17 @@
 
 package com.liferay.analytics.cms.rest.internal.resource.v1_0;
 
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceOverviewMetric;
+import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceOverviewMetricResource;
+import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.util.Http;
+
+import java.util.Arrays;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -20,4 +28,27 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 public class PerformanceOverviewMetricResourceImpl
 	extends BasePerformanceOverviewMetricResourceImpl {
+
+	@Override
+	public PerformanceOverviewMetric getPerformanceOverviewMetric(
+			Long[] groupIds, Integer rangeKey)
+		throws Exception {
+
+		LicenseManagerUtil.checkFreeTier();
+
+		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
+			_http);
+
+		return analyticsCloudClient.getPerformanceOverviewMetric(
+			_analyticsSettingsManager.getAnalyticsConfiguration(
+				contextCompany.getCompanyId()),
+			Arrays.asList(groupIds), rangeKey);
+	}
+
+	@Reference
+	private AnalyticsSettingsManager _analyticsSettingsManager;
+
+	@Reference
+	private Http _http;
+
 }

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/factory/PerformanceOverviewMetricResourceFactoryImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/factory/PerformanceOverviewMetricResourceFactoryImpl.java
@@ -1,0 +1,345 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.internal.resource.v1_0.factory;
+
+import com.liferay.analytics.cms.rest.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceOverviewMetricResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/analytics-cms-rest/v1.0/PerformanceOverviewMetric",
+	service = PerformanceOverviewMetricResource.Factory.class
+)
+@Generated("")
+public class PerformanceOverviewMetricResourceFactoryImpl
+	implements PerformanceOverviewMetricResource.Factory {
+
+	@Override
+	public PerformanceOverviewMetricResource.Builder create() {
+		return new PerformanceOverviewMetricResource.Builder() {
+
+			@Override
+			public PerformanceOverviewMetricResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, PerformanceOverviewMetricResource>
+					performanceOverviewMetricResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_performanceOverviewMetricResourceProxyProviderFunction;
+
+				return performanceOverviewMetricResourceProxyProviderFunction.
+					apply(
+						(proxy, method, arguments) -> _invoke(
+							method, arguments, _checkPermissions,
+							_httpServletRequest, _httpServletResponse,
+							_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public PerformanceOverviewMetricResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceOverviewMetricResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceOverviewMetricResource.Builder
+				httpServletResponse(HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceOverviewMetricResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceOverviewMetricResource.Builder uriInfo(
+				UriInfo uriInfo) {
+
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceOverviewMetricResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function
+		<InvocationHandler, PerformanceOverviewMetricResource>
+			_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			PerformanceOverviewMetricResource.class.getClassLoader(),
+			PerformanceOverviewMetricResource.class);
+
+		try {
+			Constructor<PerformanceOverviewMetricResource> constructor =
+				(Constructor<PerformanceOverviewMetricResource>)
+					proxyClass.getConstructor(InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		PerformanceOverviewMetricResource performanceOverviewMetricResource =
+			_componentServiceObjects.getService();
+
+		performanceOverviewMetricResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		performanceOverviewMetricResource.setContextCompany(company);
+
+		performanceOverviewMetricResource.setContextHttpServletRequest(
+			httpServletRequest);
+		performanceOverviewMetricResource.setContextHttpServletResponse(
+			httpServletResponse);
+		performanceOverviewMetricResource.setContextUriInfo(uriInfo);
+		performanceOverviewMetricResource.setContextUser(user);
+		performanceOverviewMetricResource.setExpressionConvert(
+			_expressionConvert);
+		performanceOverviewMetricResource.setFilterParserProvider(
+			_filterParserProvider);
+		performanceOverviewMetricResource.setGroupLocalService(
+			_groupLocalService);
+		performanceOverviewMetricResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		performanceOverviewMetricResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		performanceOverviewMetricResource.setRoleLocalService(
+			_roleLocalService);
+		performanceOverviewMetricResource.setSortParserProvider(
+			_sortParserProvider);
+
+		try {
+			return method.invoke(performanceOverviewMetricResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(
+				performanceOverviewMetricResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<PerformanceOverviewMetricResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function
+			<InvocationHandler, PerformanceOverviewMetricResource>
+				_performanceOverviewMetricResourceProxyProviderFunction =
+					_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1115120489

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/performance-overview-metric.properties
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/performance-overview-metric.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.analytics.cms.rest.dto.v1_0.PerformanceOverviewMetric
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Analytics.CMS.REST)
+osgi.jaxrs.resource=true

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceOverviewMetricResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceOverviewMetricResourceTestCase.java
@@ -1,0 +1,902 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceOverviewMetric;
+import com.liferay.analytics.cms.rest.client.http.HttpInvoker;
+import com.liferay.analytics.cms.rest.client.pagination.Page;
+import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceOverviewMetricResource;
+import com.liferay.analytics.cms.rest.client.serdes.v1_0.PerformanceOverviewMetricSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public abstract class BasePerformanceOverviewMetricResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_performanceOverviewMetricResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		performanceOverviewMetricResource =
+			PerformanceOverviewMetricResource.builder(
+			).authentication(
+				_testCompanyAdminUser.getEmailAddress(),
+				PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		PerformanceOverviewMetric performanceOverviewMetric1 =
+			randomPerformanceOverviewMetric();
+
+		String json = objectMapper.writeValueAsString(
+			performanceOverviewMetric1);
+
+		PerformanceOverviewMetric performanceOverviewMetric2 =
+			PerformanceOverviewMetricSerDes.toDTO(json);
+
+		Assert.assertTrue(
+			equals(performanceOverviewMetric1, performanceOverviewMetric2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		PerformanceOverviewMetric performanceOverviewMetric =
+			randomPerformanceOverviewMetric();
+
+		String json1 = objectMapper.writeValueAsString(
+			performanceOverviewMetric);
+		String json2 = PerformanceOverviewMetricSerDes.toJSON(
+			performanceOverviewMetric);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		PerformanceOverviewMetric performanceOverviewMetric =
+			randomPerformanceOverviewMetric();
+
+		String json = PerformanceOverviewMetricSerDes.toJSON(
+			performanceOverviewMetric);
+
+		Assert.assertFalse(json.contains(regex));
+
+		performanceOverviewMetric = PerformanceOverviewMetricSerDes.toDTO(json);
+	}
+
+	@Test
+	public void testGetPerformanceOverviewMetric() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	protected void assertContains(
+		PerformanceOverviewMetric performanceOverviewMetric,
+		List<PerformanceOverviewMetric> performanceOverviewMetrics) {
+
+		boolean contains = false;
+
+		for (PerformanceOverviewMetric item : performanceOverviewMetrics) {
+			if (equals(performanceOverviewMetric, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			performanceOverviewMetrics + " does not contain " +
+				performanceOverviewMetric,
+			contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		PerformanceOverviewMetric performanceOverviewMetric1,
+		PerformanceOverviewMetric performanceOverviewMetric2) {
+
+		Assert.assertTrue(
+			performanceOverviewMetric1 + " does not equal " +
+				performanceOverviewMetric2,
+			equals(performanceOverviewMetric1, performanceOverviewMetric2));
+	}
+
+	protected void assertEquals(
+		List<PerformanceOverviewMetric> performanceOverviewMetrics1,
+		List<PerformanceOverviewMetric> performanceOverviewMetrics2) {
+
+		Assert.assertEquals(
+			performanceOverviewMetrics1.size(),
+			performanceOverviewMetrics2.size());
+
+		for (int i = 0; i < performanceOverviewMetrics1.size(); i++) {
+			PerformanceOverviewMetric performanceOverviewMetric1 =
+				performanceOverviewMetrics1.get(i);
+			PerformanceOverviewMetric performanceOverviewMetric2 =
+				performanceOverviewMetrics2.get(i);
+
+			assertEquals(
+				performanceOverviewMetric1, performanceOverviewMetric2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<PerformanceOverviewMetric> performanceOverviewMetrics1,
+		List<PerformanceOverviewMetric> performanceOverviewMetrics2) {
+
+		Assert.assertEquals(
+			performanceOverviewMetrics1.size(),
+			performanceOverviewMetrics2.size());
+
+		for (PerformanceOverviewMetric performanceOverviewMetric1 :
+				performanceOverviewMetrics1) {
+
+			boolean contains = false;
+
+			for (PerformanceOverviewMetric performanceOverviewMetric2 :
+					performanceOverviewMetrics2) {
+
+				if (equals(
+						performanceOverviewMetric1,
+						performanceOverviewMetric2)) {
+
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				performanceOverviewMetrics2 + " does not contain " +
+					performanceOverviewMetric1,
+				contains);
+		}
+	}
+
+	protected void assertValid(
+			PerformanceOverviewMetric performanceOverviewMetric)
+		throws Exception {
+
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("downloadsMetric", additionalAssertFieldName)) {
+				if (performanceOverviewMetric.getDownloadsMetric() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"impressionsMetric", additionalAssertFieldName)) {
+
+				if (performanceOverviewMetric.getImpressionsMetric() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("readsMetric", additionalAssertFieldName)) {
+				if (performanceOverviewMetric.getReadsMetric() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("viewsMetric", additionalAssertFieldName)) {
+				if (performanceOverviewMetric.getViewsMetric() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<PerformanceOverviewMetric> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<PerformanceOverviewMetric> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<PerformanceOverviewMetric>
+			performanceOverviewMetrics = page.getItems();
+
+		int size = performanceOverviewMetrics.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.analytics.cms.rest.dto.v1_0.
+						PerformanceOverviewMetric.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		PerformanceOverviewMetric performanceOverviewMetric1,
+		PerformanceOverviewMetric performanceOverviewMetric2) {
+
+		if (performanceOverviewMetric1 == performanceOverviewMetric2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("downloadsMetric", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						performanceOverviewMetric1.getDownloadsMetric(),
+						performanceOverviewMetric2.getDownloadsMetric())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"impressionsMetric", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						performanceOverviewMetric1.getImpressionsMetric(),
+						performanceOverviewMetric2.getImpressionsMetric())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("readsMetric", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						performanceOverviewMetric1.getReadsMetric(),
+						performanceOverviewMetric2.getReadsMetric())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("viewsMetric", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						performanceOverviewMetric1.getViewsMetric(),
+						performanceOverviewMetric2.getViewsMetric())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_performanceOverviewMetricResource instanceof
+				EntityModelResource)) {
+
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_performanceOverviewMetricResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		PerformanceOverviewMetric performanceOverviewMetric) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("downloadsMetric")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("impressionsMetric")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("readsMetric")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("viewsMetric")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected PerformanceOverviewMetric randomPerformanceOverviewMetric()
+		throws Exception {
+
+		return new PerformanceOverviewMetric() {
+			{
+			}
+		};
+	}
+
+	protected PerformanceOverviewMetric
+			randomIrrelevantPerformanceOverviewMetric()
+		throws Exception {
+
+		PerformanceOverviewMetric randomIrrelevantPerformanceOverviewMetric =
+			randomPerformanceOverviewMetric();
+
+		return randomIrrelevantPerformanceOverviewMetric;
+	}
+
+	protected PerformanceOverviewMetric randomPatchPerformanceOverviewMetric()
+		throws Exception {
+
+		return randomPerformanceOverviewMetric();
+	}
+
+	protected PerformanceOverviewMetricResource
+		performanceOverviewMetricResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(
+			BasePerformanceOverviewMetricResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.analytics.cms.rest.resource.v1_0.
+		PerformanceOverviewMetricResource _performanceOverviewMetricResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1928614357

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rachael Koestartyo
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class PerformanceOverviewMetricResourceTest
+	extends BasePerformanceOverviewMetricResourceTestCase {
+}

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
@@ -5,16 +5,176 @@
 
 package com.liferay.analytics.cms.rest.resource.v1_0.test;
 
+import com.liferay.analytics.cms.rest.dto.v1_0.Metric;
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceOverviewMetric;
+import com.liferay.analytics.cms.rest.dto.v1_0.Trend;
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceOverviewMetricResource;
+import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.MockHttp;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import org.junit.Ignore;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Rachael Koestartyo
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class PerformanceOverviewMetricResourceTest
 	extends BasePerformanceOverviewMetricResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	@Test
+	public void testGetPerformanceOverviewMetric() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						AnalyticsConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsDataSourceId",
+							RandomTestUtil.nextLong()
+						).put(
+							"liferayAnalyticsEnableAllGroupIds", true
+						).put(
+							"liferayAnalyticsFaroBackendSecuritySignature",
+							RandomTestUtil.randomString()
+						).put(
+							"liferayAnalyticsFaroBackendURL",
+							"http://" + RandomTestUtil.randomString()
+						).build())) {
+
+			ReflectionTestUtil.setFieldValue(
+				_performanceOverviewMetricResource, "_http",
+				new MockHttp(
+					Collections.singletonMap(
+						"/api/1.0/asset-metric/objectEntry" +
+							"/performance-overview-metric",
+						() -> JSONUtil.putAll(
+							JSONUtil.put(
+								"metricType", "downloadsMetric"
+							).put(
+								"previousValue", 4
+							).put(
+								"trend",
+								JSONUtil.put(
+									"classification", "POSITIVE"
+								).put(
+									"percentage", 50
+								)
+							).put(
+								"value", 6
+							),
+							JSONUtil.put(
+								"metricType", "impressionsMetric"
+							).put(
+								"previousValue", 4
+							).put(
+								"trend",
+								JSONUtil.put(
+									"classification", "NEGATIVE"
+								).put(
+									"percentage", 25
+								)
+							).put(
+								"value", 3
+							),
+							JSONUtil.put(
+								"metricType", "readsMetric"
+							).put(
+								"previousValue", 5
+							).put(
+								"trend",
+								JSONUtil.put(
+									"classification", "NEUTRAL"
+								).put(
+									"percentage", 0
+								)
+							).put(
+								"value", 5
+							),
+							JSONUtil.put(
+								"metricType", "viewsMetric"
+							).put(
+								"previousValue", 1
+							).put(
+								"trend",
+								JSONUtil.put(
+									"classification", "POSITIVE"
+								).put(
+									"percentage", 100
+								)
+							).put(
+								"value", 2
+							)
+						).toString())));
+
+			PerformanceOverviewMetric performanceOverviewMetric =
+				_performanceOverviewMetricResource.getPerformanceOverviewMetric(
+					new Long[] {testGroup.getGroupId()}, 30);
+
+			_assertMetric(
+				performanceOverviewMetric.getDownloadsMetric(),
+				"downloadsMetric", 4, 6, Trend.Classification.POSITIVE, 50);
+			_assertMetric(
+				performanceOverviewMetric.getImpressionsMetric(),
+				"impressionsMetric", 4, 3, Trend.Classification.NEGATIVE, 25);
+			_assertMetric(
+				performanceOverviewMetric.getReadsMetric(), "readsMetric", 5, 5,
+				Trend.Classification.NEUTRAL, 0);
+			_assertMetric(
+				performanceOverviewMetric.getViewsMetric(), "viewsMetric", 1, 2,
+				Trend.Classification.POSITIVE, 100);
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				_performanceOverviewMetricResource, "_http", _http);
+		}
+	}
+
+	private void _assertMetric(
+		Metric metric, String metricType, double previousValue, double value,
+		Trend.Classification classification, double percentage) {
+
+		Assert.assertEquals(metricType, metric.getMetricType());
+		Assert.assertEquals(previousValue, metric.getPreviousValue(), 0);
+		Assert.assertEquals(value, metric.getValue(), 0);
+
+		Trend trend = metric.getTrend();
+
+		Assert.assertEquals(
+			classification.toString(),
+			String.valueOf(trend.getClassification()));
+		Assert.assertEquals(percentage, trend.getPercentage(), 0);
+	}
+
+	@Inject
+	private Http _http;
+
+	@Inject
+	private PerformanceOverviewMetricResource
+		_performanceOverviewMetricResource;
+
 }

--- a/modules/apps/analytics/source-formatter-suppressions.xml
+++ b/modules/apps/analytics/source-formatter-suppressions.xml
@@ -7,5 +7,6 @@
 		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ObjectEntryHistogramMetricResourceTest\.java" />
 		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ObjectEntryMetricResourceTest\.java" />
 		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ObjectEntryTopPagesResourceTest\.java" />
+		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest\.java" />
 	</checkstyle>
 </suppressions>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92392

## What Is Being Fixed

The analytics CMS REST API had no endpoint for retrieving an aggregated performance overview of an asset. Consumers could read individual metrics but had no single combined view of downloads, impressions, reads, and views across a set of sites for a given time range.

## How It Is Being Fixed

This adds a new `/performance-overview-metric` GET endpoint to the analytics CMS REST API, declared in `rest-openapi.yaml` and regenerated through REST Builder. The endpoint accepts a list of `groupIds` and a `rangeKey` and returns a `PerformanceOverviewMetric` DTO that bundles the downloads, impressions, reads, and views metrics. The implementation runs a free-tier license check and then delegates to `AnalyticsCloudClient`, which was extended to call Analytics Cloud and deserialize the combined response. Integration test coverage was added for the new resource.