### PR TITLE
LPD-93482 Exclude users in no segments from referred segments

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/ReferredSegmentsEntryProvider.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/provider/ReferredSegmentsEntryProvider.java
@@ -64,12 +64,15 @@ public class ReferredSegmentsEntryProvider
 			className, classPK, context, segmentsEntry, segmentsEntryIds,
 			userAttributes);
 
-		if (ArrayUtil.isEmpty(segmentsEntryIds) ||
-			Validator.isNull(referredFilterString) ||
+		if (Validator.isNull(referredFilterString) ||
 			(member && referredConjunction.equals(Criteria.Conjunction.OR)) ||
 			(!member && referredConjunction.equals(Criteria.Conjunction.AND))) {
 
 			return member;
+		}
+
+		if (ArrayUtil.isEmpty(segmentsEntryIds)) {
+			return false;
 		}
 
 		Map<String, String> segmentsEntryMap = HashMapBuilder.put(

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/ReferredSegmentsEntryProviderTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/provider/test/ReferredSegmentsEntryProviderTest.java
@@ -583,6 +583,47 @@ public class ReferredSegmentsEntryProviderTest {
 	}
 
 	@Test
+	public void testGetSegmentsEntryIdsWithOnlyReferredCriterionNotMatchedDynamically()
+		throws Exception {
+
+		_user1 = UserTestUtil.addUser(_group.getGroupId());
+
+		Criteria referencedCriteria = new Criteria();
+
+		_contextSegmentsCriteriaContributor.contribute(
+			referencedCriteria, "(signedIn eq true)", Criteria.Conjunction.AND);
+
+		SegmentsEntry referencedSegmentsEntry =
+			SegmentsTestUtil.addSegmentsEntry(
+				_group.getGroupId(),
+				CriteriaSerializer.serialize(referencedCriteria));
+
+		Criteria criteria = new Criteria();
+
+		_segmentsEntrySegmentsCriteriaContributor.contribute(
+			criteria,
+			String.format(
+				"(segmentsEntryIds eq '%s')",
+				referencedSegmentsEntry.getSegmentsEntryId()),
+			Criteria.Conjunction.AND);
+
+		SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId(), CriteriaSerializer.serialize(criteria));
+
+		Context context = new Context();
+
+		context.put(Context.SIGNED_IN, false);
+
+		long[] segmentsEntryIds =
+			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
+				_group.getGroupId(), User.class.getName(), _user1.getUserId(),
+				context);
+
+		Assert.assertEquals(
+			Arrays.toString(segmentsEntryIds), 0, segmentsEntryIds.length);
+	}
+
+	@Test
 	public void testGetSegmentsEntryIdsWithOnlyUserCriterion()
 		throws Exception {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93482

## What Is Being Fixed

A segment whose condition is "URL contains <text>" (a context criterion) stops working when it is referenced by another segment. For users who belong to no segments — typically guests — the referencing segment incorrectly reports them as members even when the URL condition does not match.

## How It Is Being Fixed

When a segment references another segment, its membership is resolved by ReferredSegmentsEntryProvider, whose only criterion is of type REFERRED. BaseSegmentsEntryProvider.isMember does not evaluate REFERRED criteria, so for a purely referred segment both the context and model filter strings are null and it falls through to its trailing "return true". The referred provider then short-circuited with "return member" whenever segmentsEntryIds was empty, propagating that spurious true.

A user who belongs to no segments cannot satisfy a referred filter such as "segmentsEntryIds eq X", so an empty segmentsEntryIds is now treated as an unmatched referred filter instead of falling back to the base member result. The empty check is placed after the conjunction guards so that a segment combining other criteria with the referred filter through OR still resolves through member.

The integration test adds a negative counterpart to the existing dynamic referred-segment test: a guest whose context does not match the referenced context segment must not be reported as a member.