### PR TITLE
LPD-91690 Stub memberLookup overloads in registry unit test

### DIFF
--- a/modules/apps/segments/segments-service/src/test/java/com/liferay/segments/internal/provider/SegmentsEntryProviderRegistryTest.java
+++ b/modules/apps/segments/segments-service/src/test/java/com/liferay/segments/internal/provider/SegmentsEntryProviderRegistryTest.java
@@ -230,7 +230,7 @@ public class SegmentsEntryProviderRegistryTest {
 		).when(
 			segmentsEntryProvider
 		).getSegmentsEntryClassPKsCount(
-			segmentsEntryId
+			segmentsEntryId, true
 		);
 
 		return segmentsEntryProvider;
@@ -248,7 +248,7 @@ public class SegmentsEntryProviderRegistryTest {
 		).when(
 			segmentsEntryProvider
 		).getSegmentsEntryClassPKs(
-			segmentsEntryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS
+			segmentsEntryId, true, QueryUtil.ALL_POS, QueryUtil.ALL_POS
 		);
 
 		return segmentsEntryProvider;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91690

## What Is Being Fixed

The SegmentsEntryProviderRegistryTest unit tests testGetSegmentsEntryClassPKs and testGetSegmentsEntryClassPKsCount fail on master. Propagating memberLookup through the provider registry (this ticket) changed SegmentsEntryProviderRegistryImpl to delegate to the memberLookup overloads, but the unit test still stubbed the non-memberLookup overloads, so Mockito returned the unstubbed defaults: a null array and a zero count.

## How It Is Being Fixed

Stub the overloads the registry actually calls: getSegmentsEntryClassPKs(segmentsEntryId, true, start, end) and getSegmentsEntryClassPKsCount(segmentsEntryId, true).

## Why Are There No Tests?

This change only fixes the stubs in existing unit tests; there is no production code change to cover.