### PR TITLE
LPD-91079 Fix activity status column order and badge size

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
@@ -213,8 +213,8 @@ const IndividualsList: React.FC<IIndividualsList> = ({rangeSelectors}) => {
 							IndividualsListCDPColumns.country,
 							IndividualsListCDPColumns.firstSeen,
 							IndividualsListCDPColumns.lastActive,
-							IndividualsListCDPColumns.profileType,
-							IndividualsListCDPColumns.activityStatus
+							IndividualsListCDPColumns.activityStatus,
+							IndividualsListCDPColumns.profileType
 						]}
 						dataSourceFn={API.individuals.search}
 						dataSourceParams={{

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/table-columns.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/table-columns.tsx
@@ -312,7 +312,7 @@ export const IndividualsListCDPColumns = {
 								? 'success'
 								: 'secondary'
 						}
-						size='lg'
+						size='sm'
 						uppercase
 					>
 						{activityStatus === 'ACTIVE'


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91079

## What Is Being Fixed

The activity status column in the Individuals List was appearing after the profile type column instead of before it. Additionally, the activity status badge was using the wrong size (`lg` instead of `sm`).

## How It Is Being Fixed

Swaps the order of `activityStatus` and `profileType` columns in `IndividualsList.tsx` so activity status appears in the correct position. In `table-columns.tsx`, corrects the badge size from `lg` to `sm` to match the design specification.

## Why Are There No Tests?

These are visual-only changes — a column order swap and a badge size adjustment. The existing `IndividualsList` test suite covers the surrounding logic (7 tests passing).