### PR TITLE
LPD-91079 LPD-91083 Filter by active users in individuals and accounts

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
@@ -5,13 +5,10 @@ import BasePage from 'shared/components/base-page';
 import Link from '@clayui/link';
 import Loading from 'shared/components/Loading';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
-import React, {useState} from 'react';
+import React from 'react';
 import TotalAccounts from 'contacts/components/account/TotalAccounts';
 import URLConstants from 'shared/util/url-constants';
-import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
 import {isNil} from 'lodash/fp';
-import {RangeKeyTimeRanges} from 'shared/util/constants';
-import {RangeSelectors} from 'shared/types';
 import {Routes, toRoute} from 'shared/util/router';
 import {SectionHeader} from 'shared/components/SectionHeader';
 import {Sizes} from 'shared/util/constants';
@@ -27,12 +24,6 @@ interface IListProps {
 const List: React.FC<IListProps> = ({channelId, groupId}) => {
 	const currentUser = useCurrentUser();
 	const {selectedChannel} = useChannelContext();
-
-	const [rangeSelectors, setRangeSelectors] = useState<RangeSelectors>({
-		rangeEnd: null,
-		rangeKey: RangeKeyTimeRanges.Last30Days,
-		rangeStart: null
-	});
 
 	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
 		dataSourceFn: API.dataSource.fetchChannels,
@@ -124,26 +115,15 @@ const List: React.FC<IListProps> = ({channelId, groupId}) => {
 					<>
 						<TotalAccounts groupId={groupId} />
 
-						<div className='align-items-center d-flex justify-content-between mb-3'>
-							<SectionHeader
-								className='mb-0'
-								icon='box-container'
-								title={Liferay.Language.get('accounts')}
-							/>
-
-							<DropdownRangeKey
-								legacy={false}
-								onRangeSelectorChange={setRangeSelectors}
-								rangeSelectors={rangeSelectors}
-							/>
-						</div>
+						<SectionHeader
+							icon='box-container'
+							title={Liferay.Language.get('accounts')}
+						/>
 
 						<AccountsDataSet
-							activityStatusFilter='ACTIVE'
 							apiURL={`/o/faro/contacts/${groupId}/account/search?channelId=${channelId}`}
 							channelId={channelId}
 							groupId={groupId}
-							rangeSelectors={rangeSelectors}
 						/>
 					</>
 				) : (

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
@@ -31,10 +31,6 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 	}
 }));
 
-jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
-	DropdownRangeKey: () => null
-}));
-
 jest.mock('shared/hooks/useRequest', () => ({
 	useRequest: jest.fn()
 }));
@@ -156,16 +152,14 @@ describe('List', () => {
 			expect(screen.getByTestId('fds-component')).toHaveAttribute('id');
 		});
 
-		it('should pass activityStatusFilter "ACTIVE" to AccountsDataSet by default', () => {
+		it('should preload the rangeKey filter with Last 30 Days by default', () => {
 			renderList();
 
-			const activityStatusFilter = lastFilters?.find(
-				f => f.id === 'activityStatus'
-			);
+			const rangeKeyFilter = lastFilters?.find(f => f.id === 'rangeKey');
 
-			expect(activityStatusFilter?.preloadedData).toEqual({
+			expect(rangeKeyFilter?.preloadedData).toEqual({
 				exclude: false,
-				selectedItems: [{label: 'Active', value: 'ACTIVE'}]
+				selectedItems: [{label: 'Last 30 days', value: '30'}]
 			});
 		});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
@@ -242,33 +242,29 @@ exports[`List rendering should match the snapshot 1`] = `
           </div>
         </div>
         <div
-          class="align-items-center d-flex justify-content-between mb-3"
+          class="mb-3"
         >
-          <div
-            class="mb-0"
+          <span
+            class="mr-2"
           >
             <span
-              class="mr-2"
+              class="text-4 text-secondary"
             >
-              <span
-                class="text-4 text-secondary"
+              <svg
+                class="lexicon-icon lexicon-icon-box-container"
+                role="presentation"
               >
-                <svg
-                  class="lexicon-icon lexicon-icon-box-container"
-                  role="presentation"
-                >
-                  <use
-                    href="#box-container"
-                  />
-                </svg>
-              </span>
+                <use
+                  href="#box-container"
+                />
+              </svg>
             </span>
-            <span
-              class="text-4 text-secondary font-weight-semi-bold"
-            >
-              ACCOUNTS
-            </span>
-          </div>
+          </span>
+          <span
+            class="text-4 text-secondary font-weight-semi-bold"
+          >
+            ACCOUNTS
+          </span>
         </div>
         <div
           class="card card-root"

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
@@ -19,11 +19,10 @@ import {
 	ProfileTypes,
 	RelationalOperators
 } from 'segment/segment-editor/dynamic/utils/constants';
-import {FilterByType, FilterOptionType, RangeSelectors} from 'shared/types';
-import {getSafeRangeSelectors} from 'shared/util/util';
+import {FilterByType, FilterInputType, FilterOptionType} from 'shared/types';
 import {IndividualsListCDPColumns} from 'shared/util/table-columns';
 import {Map, Set} from 'immutable';
-import {Sizes} from 'shared/util/constants';
+import {RangeKeyTimeRanges, Sizes} from 'shared/util/constants';
 import {useParams} from 'react-router-dom';
 import {useRequest} from 'shared/hooks/useRequest';
 import {useStatefulPagination} from 'shared/hooks/useStatefulPagination';
@@ -57,6 +56,45 @@ const ORDER_BY_OPTIONS = [
 
 const DEFAULT_FILTER_BY_OPTIONS: FilterOptionType[] = [
 	{
+		key: 'activeUsers',
+		label: Liferay.Language.get('active-individuals'),
+		type: 'radio' as FilterInputType,
+		values: [
+			{
+				label: Liferay.Language.get('last-24-hours'),
+				value: RangeKeyTimeRanges.Last24Hours
+			},
+			{
+				label: Liferay.Language.get('yesterday'),
+				value: RangeKeyTimeRanges.Yesterday
+			},
+			{
+				label: Liferay.Language.get('last-seven-days'),
+				value: RangeKeyTimeRanges.Last7Days
+			},
+			{
+				label: Liferay.Language.get('last-28-days'),
+				value: RangeKeyTimeRanges.Last28Days
+			},
+			{
+				label: Liferay.Language.get('last-30-days'),
+				value: RangeKeyTimeRanges.Last30Days
+			},
+			{
+				label: Liferay.Language.get('last-90-days'),
+				value: RangeKeyTimeRanges.Last90Days
+			},
+			{
+				label: Liferay.Language.get('last-180-days'),
+				value: RangeKeyTimeRanges.Last180Days
+			},
+			{
+				label: Liferay.Language.get('last-year'),
+				value: RangeKeyTimeRanges.LastYear
+			}
+		]
+	},
+	{
 		key: 'profileTypes',
 		label: Liferay.Language.get('profile-type'),
 		values: [
@@ -67,20 +105,6 @@ const DEFAULT_FILTER_BY_OPTIONS: FilterOptionType[] = [
 			{
 				label: Liferay.Language.get('anonymous'),
 				value: ProfileTypes.ANONYMOUS
-			}
-		]
-	},
-	{
-		key: 'activityStatus',
-		label: Liferay.Language.get('activity-status'),
-		values: [
-			{
-				label: Liferay.Language.get('active'),
-				value: 'ACTIVE'
-			},
-			{
-				label: Liferay.Language.get('inactive'),
-				value: 'INACTIVE'
 			}
 		]
 	}
@@ -99,22 +123,15 @@ function transformCountriesInQueryString(countries: string[]) {
 		.join(Conjunctions.Or);
 }
 
-interface IIndividualsList {
-	rangeSelectors: RangeSelectors;
-}
-
-const IndividualsList: React.FC<IIndividualsList> = ({rangeSelectors}) => {
+const IndividualsList: React.FC = () => {
 	const {channelId = '', groupId = ''} = useParams<{
 		channelId: string;
 		groupId: string;
 	}>();
 
-	const {rangeEnd, rangeKey, rangeStart} =
-		getSafeRangeSelectors(rangeSelectors);
-
 	const paginationParams = useStatefulPagination(undefined, {
 		initialFilterBy: Map({
-			activityStatus: Set(['ACTIVE'])
+			activeUsers: Set([RangeKeyTimeRanges.Last30Days])
 		}) as FilterByType,
 		initialOrderIOMap: createOrderIOMap(NAME)
 	});
@@ -148,14 +165,12 @@ const IndividualsList: React.FC<IIndividualsList> = ({rangeSelectors}) => {
 		return DEFAULT_FILTER_BY_OPTIONS;
 	}, [countriesData, countriesLoading]);
 
-	const activityStatusValues =
-		paginationParams.filterBy.get('activityStatus');
+	const activeUsersValue =
+		paginationParams.filterBy.get('activeUsers')?.first() ?? null;
+
+	const rangeKey = activeUsersValue ? parseInt(activeUsersValue) : null;
 
 	const selectedFilters = {
-		activityStatus:
-			activityStatusValues?.size === 2
-				? undefined
-				: activityStatusValues?.first(),
 		filter: transformCountriesInQueryString(
 			paginationParams.filterBy.get('countries')?.toArray()
 		),
@@ -213,21 +228,19 @@ const IndividualsList: React.FC<IIndividualsList> = ({rangeSelectors}) => {
 							IndividualsListCDPColumns.country,
 							IndividualsListCDPColumns.firstSeen,
 							IndividualsListCDPColumns.lastActive,
-							IndividualsListCDPColumns.profileType,
-							IndividualsListCDPColumns.activityStatus
+							IndividualsListCDPColumns.profileType
 						]}
 						dataSourceFn={API.individuals.search}
 						dataSourceParams={{
-							activityStatus: selectedFilters.activityStatus,
 							channelId,
 							filter: selectedFilters.filter,
 							groupId,
 							profileTypes: selectedFilters.profileTypes.length
 								? selectedFilters.profileTypes
 								: undefined,
-							rangeEnd,
+							rangeEnd: null,
 							rangeKey,
-							rangeStart
+							rangeStart: null
 						}}
 						filterByOptions={FILTER_BY_OPTIONS}
 						key='individuals-list-table'

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
@@ -9,18 +9,16 @@ import IndividualsList from './IndividualsList';
 import Loading from 'shared/components/Loading';
 import MetricCard from 'shared/components/MetricCard';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
-import React, {useState} from 'react';
+import React from 'react';
 import URLConstants from 'shared/util/url-constants';
 import {Text as ClayText} from '@clayui/core';
 import {CSVType} from 'shared/components/download-report/utils';
 import {DownloadStaticCSVReport} from 'shared/components/download-report/DownloadStaticCSVReport';
-import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
 import {INTERVAL_KEY_MAP} from 'shared/util/time';
 import {isNil} from 'lodash';
-import {RangeKeyTimeRanges, Sizes} from 'shared/util/constants';
-import {RangeSelectors} from 'shared/types';
 import {Routes, toRoute} from 'shared/util/router';
 import {SectionHeader} from 'shared/components/SectionHeader';
+import {Sizes} from 'shared/util/constants';
 import {sub} from 'shared/util/lang';
 import {toThousands} from 'shared/util/numbers';
 import {useCurrentUser} from 'shared/hooks/useCurrentUser';
@@ -134,12 +132,6 @@ const IndividualsOverviewCDP = () => {
 
 	const authorized = currentUser.isAdmin();
 
-	const [rangeSelectors, setRangeSelectors] = useState<RangeSelectors>({
-		rangeEnd: null,
-		rangeKey: RangeKeyTimeRanges.Last30Days,
-		rangeStart: null
-	});
-
 	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
 		dataSourceFn: API.dataSource.search,
 		variables: {
@@ -152,7 +144,7 @@ const IndividualsOverviewCDP = () => {
 		variables: {
 			channelId,
 			interval: INTERVAL_KEY_MAP.week,
-			rangeKey: Number(RangeKeyTimeRanges.Last30Days)
+			rangeKey: 30
 		}
 	});
 
@@ -246,21 +238,12 @@ const IndividualsOverviewCDP = () => {
 							</ClayLayout.Col>
 						</ClayLayout.Row>
 
-						<div className='align-items-center d-flex justify-content-between mb-3'>
-							<SectionHeader
-								className='mb-0'
-								icon='box-container'
-								title={Liferay.Language.get('individuals')}
-							/>
+						<SectionHeader
+							icon='box-container'
+							title={Liferay.Language.get('individuals')}
+						/>
 
-							<DropdownRangeKey
-								legacy={false}
-								onRangeSelectorChange={setRangeSelectors}
-								rangeSelectors={rangeSelectors}
-							/>
-						</div>
-
-						<IndividualsList rangeSelectors={rangeSelectors} />
+						<IndividualsList />
 					</>
 				)}
 			</BasePage.Body>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
@@ -1,8 +1,12 @@
 import * as API from 'shared/api';
+import * as useStatefulPaginationModule from 'shared/hooks/useStatefulPagination';
 
 import IndividualsList from '../IndividualsList';
 import React from 'react';
 import {createMemoryHistory} from 'history';
+import {createOrderIOMap, NAME} from 'shared/util/pagination';
+import {Map, Set} from 'immutable';
+import {RangeKeyTimeRanges} from 'shared/util/constants';
 import {render} from '@testing-library/react';
 import {Router} from 'react-router';
 import {waitForLoadingToBeRemoved} from 'test/helpers';
@@ -140,5 +144,109 @@ describe('Individuals List', () => {
 				rangeStart: null
 			})
 		);
+	});
+
+	it('does not pass activityStatus to the search API', async () => {
+		(API.individuals.search as jest.Mock).mockReturnValue(
+			Promise.resolve({items: [], total: 0})
+		);
+
+		const history = createMemoryHistory();
+
+		render(
+			<Router history={history}>
+				<IndividualsList />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		const callArgs = (API.individuals.search as jest.Mock).mock.calls[0][0];
+
+		expect(callArgs.activityStatus).toBeUndefined();
+	});
+
+	it('passes the selected range key when activeUsers filter changes', async () => {
+		(API.individuals.search as jest.Mock).mockReturnValue(
+			Promise.resolve({items: [], total: 0})
+		);
+
+		const spy = jest
+			.spyOn(useStatefulPaginationModule, 'useStatefulPagination')
+			.mockReturnValue({
+				delta: 20,
+				filterBy: Map({
+					activeUsers: Set([RangeKeyTimeRanges.Last7Days])
+				}) as any,
+				onDeltaChange: jest.fn(),
+				onFilterByChange: jest.fn(),
+				onOrderIOMapChange: jest.fn(),
+				onPageChange: jest.fn(),
+				onQueryChange: jest.fn(),
+				orderIOMap: createOrderIOMap(NAME),
+				page: 1,
+				query: '',
+				resetPage: jest.fn()
+			});
+
+		const history = createMemoryHistory();
+
+		render(
+			<Router history={history}>
+				<IndividualsList />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		expect(API.individuals.search as jest.Mock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				rangeKey: 7
+			})
+		);
+
+		spy.mockRestore();
+	});
+
+	it('passes null rangeKey when activeUsers filter is cleared', async () => {
+		(API.individuals.search as jest.Mock).mockReturnValue(
+			Promise.resolve({items: [], total: 0})
+		);
+
+		const spy = jest
+			.spyOn(useStatefulPaginationModule, 'useStatefulPagination')
+			.mockReturnValue({
+				delta: 20,
+				filterBy: Map({
+					activeUsers: Set([])
+				}) as any,
+				onDeltaChange: jest.fn(),
+				onFilterByChange: jest.fn(),
+				onOrderIOMapChange: jest.fn(),
+				onPageChange: jest.fn(),
+				onQueryChange: jest.fn(),
+				orderIOMap: createOrderIOMap(NAME),
+				page: 1,
+				query: '',
+				resetPage: jest.fn()
+			});
+
+		const history = createMemoryHistory();
+
+		render(
+			<Router history={history}>
+				<IndividualsList />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		expect(API.individuals.search as jest.Mock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				rangeKey: null
+			})
+		);
+
+		spy.mockRestore();
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
@@ -1,21 +1,11 @@
 import * as API from 'shared/api';
-import * as useStatefulPaginationModule from 'shared/hooks/useStatefulPagination';
 
 import IndividualsList from '../IndividualsList';
 import React from 'react';
 import {createMemoryHistory} from 'history';
-import {createOrderIOMap, NAME} from 'shared/util/pagination';
-import {Map, Set} from 'immutable';
-import {RangeKeyTimeRanges} from 'shared/util/constants';
 import {render} from '@testing-library/react';
 import {Router} from 'react-router';
 import {waitForLoadingToBeRemoved} from 'test/helpers';
-
-const defaultRangeSelectors = {
-	rangeEnd: null,
-	rangeKey: RangeKeyTimeRanges.Last30Days,
-	rangeStart: null
-};
 
 jest.unmock('react-dom');
 
@@ -43,7 +33,6 @@ describe('Individuals List', () => {
 					{
 						accountName: 'Liferay Inc.',
 						activitiesCount: 8,
-						activityStatus: 'ACTIVE',
 						dateCreated: 1769697362927,
 						firstActivityDate: 1769697128235,
 						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c1',
@@ -58,7 +47,6 @@ describe('Individuals List', () => {
 					{
 						accountName: 'Liferay',
 						activitiesCount: 8,
-						activityStatus: 'ACTIVE',
 						dateCreated: 1769697362927,
 						firstActivityDate: 1769697128235,
 						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c3',
@@ -72,7 +60,6 @@ describe('Individuals List', () => {
 					},
 					{
 						activitiesCount: 3,
-						activityStatus: 'INACTIVE',
 						dateCreated: 1769697362927,
 						firstActivityDate: 1769697128235,
 						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c2',
@@ -90,7 +77,7 @@ describe('Individuals List', () => {
 
 		const {getByText} = render(
 			<Router history={history}>
-				<IndividualsList rangeSelectors={defaultRangeSelectors} />
+				<IndividualsList />
 			</Router>
 		);
 
@@ -110,7 +97,7 @@ describe('Individuals List', () => {
 
 		const {getByText} = render(
 			<Router history={history}>
-				<IndividualsList rangeSelectors={defaultRangeSelectors} />
+				<IndividualsList />
 			</Router>
 		);
 
@@ -129,7 +116,7 @@ describe('Individuals List', () => {
 		).toBeInTheDocument();
 	});
 
-	it('passes range params to the search API', async () => {
+	it('passes Last 30 Days as the default range key to the search API', async () => {
 		// @ts-ignore
 		API.individuals.search.mockReturnValue(
 			Promise.resolve({items: [], total: 0})
@@ -139,7 +126,7 @@ describe('Individuals List', () => {
 
 		render(
 			<Router history={history}>
-				<IndividualsList rangeSelectors={defaultRangeSelectors} />
+				<IndividualsList />
 			</Router>
 		);
 
@@ -153,136 +140,5 @@ describe('Individuals List', () => {
 				rangeStart: null
 			})
 		);
-	});
-
-	it('passes activityStatus ACTIVE to the search API by default', async () => {
-		(API.individuals.search as jest.Mock).mockReturnValue(
-			Promise.resolve({items: [], total: 0})
-		);
-
-		const history = createMemoryHistory();
-
-		render(
-			<Router history={history}>
-				<IndividualsList rangeSelectors={defaultRangeSelectors} />
-			</Router>
-		);
-
-		await waitForLoadingToBeRemoved(document.body);
-
-		expect(API.individuals.search as jest.Mock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				activityStatus: 'ACTIVE'
-			})
-		);
-	});
-
-	it('renders the activity status column header', async () => {
-		(API.individuals.search as jest.Mock).mockReturnValue(
-			Promise.resolve({items: [], total: 0})
-		);
-
-		const history = createMemoryHistory();
-
-		const {getByText} = render(
-			<Router history={history}>
-				<IndividualsList rangeSelectors={defaultRangeSelectors} />
-			</Router>
-		);
-
-		await waitForLoadingToBeRemoved(document.body);
-
-		expect(getByText('Activity Status')).toBeInTheDocument();
-	});
-
-	it('renders active and inactive activity status labels', async () => {
-		(API.individuals.search as jest.Mock).mockReturnValue(
-			Promise.resolve({
-				items: [
-					{
-						activitiesCount: 1,
-						activityStatus: 'ACTIVE',
-						dateCreated: 1769697362927,
-						firstActivityDate: 1769697128235,
-						id: 'id-active',
-						lastActivityDate: 1769697160365,
-						name: 'Active User',
-						profileType: 'KNOWN',
-						properties: {}
-					},
-					{
-						activitiesCount: 0,
-						activityStatus: 'INACTIVE',
-						dateCreated: 1769697362927,
-						firstActivityDate: 1769697128235,
-						id: 'id-inactive',
-						lastActivityDate: 1769697160365,
-						name: 'Inactive User',
-						profileType: 'KNOWN',
-						properties: {}
-					}
-				],
-				total: 2
-			})
-		);
-
-		const history = createMemoryHistory();
-
-		render(
-			<Router history={history}>
-				<IndividualsList rangeSelectors={defaultRangeSelectors} />
-			</Router>
-		);
-
-		await waitForLoadingToBeRemoved(document.body);
-
-		expect(
-			document.querySelector('.label-success .label-item')
-		).toHaveTextContent('Active');
-
-		expect(
-			document.querySelector('.label-secondary .label-item')
-		).toHaveTextContent('Inactive');
-	});
-
-	it('passes undefined activityStatus when both active and inactive are selected', async () => {
-		(API.individuals.search as jest.Mock).mockClear();
-		(API.individuals.search as jest.Mock).mockReturnValue(
-			Promise.resolve({items: [], total: 0})
-		);
-
-		const spy = jest
-			.spyOn(useStatefulPaginationModule, 'useStatefulPagination')
-			.mockReturnValue({
-				delta: 20,
-				filterBy: Map({
-					activityStatus: Set(['ACTIVE', 'INACTIVE'])
-				}) as any,
-				onDeltaChange: jest.fn(),
-				onFilterByChange: jest.fn(),
-				onOrderIOMapChange: jest.fn(),
-				onPageChange: jest.fn(),
-				onQueryChange: jest.fn(),
-				orderIOMap: createOrderIOMap(NAME),
-				page: 1,
-				query: '',
-				resetPage: jest.fn()
-			});
-
-		const history = createMemoryHistory();
-
-		render(
-			<Router history={history}>
-				<IndividualsList rangeSelectors={defaultRangeSelectors} />
-			</Router>
-		);
-
-		await waitForLoadingToBeRemoved(document.body);
-
-		const callArgs = (API.individuals.search as jest.Mock).mock.calls[0][0];
-
-		expect(callArgs.activityStatus).toBeUndefined();
-
-		spy.mockRestore();
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
@@ -146,26 +146,6 @@ describe('Individuals List', () => {
 		);
 	});
 
-	it('does not pass activityStatus to the search API', async () => {
-		(API.individuals.search as jest.Mock).mockReturnValue(
-			Promise.resolve({items: [], total: 0})
-		);
-
-		const history = createMemoryHistory();
-
-		render(
-			<Router history={history}>
-				<IndividualsList />
-			</Router>
-		);
-
-		await waitForLoadingToBeRemoved(document.body);
-
-		const callArgs = (API.individuals.search as jest.Mock).mock.calls[0][0];
-
-		expect(callArgs.activityStatus).toBeUndefined();
-	});
-
 	it('passes the selected range key when activeUsers filter changes', async () => {
 		(API.individuals.search as jest.Mock).mockReturnValue(
 			Promise.resolve({items: [], total: 0})

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
@@ -36,10 +36,6 @@ jest.mock('react-router-dom', () => ({
 	})
 }));
 
-jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
-	DropdownRangeKey: () => null
-}));
-
 jest.mock('../IndividualsList', () => ({
 	__esModule: true,
 	default: () => null

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 import {
 	columns,
 	FrontendDataSet,
-	pagination
+	pagination,
+	rangeSelectors
 } from 'shared/components/FrontendDataSet';
 import {
 	LifecycleStages,
@@ -14,41 +15,6 @@ import {RangeKeyTimeRanges} from 'shared/util/constants';
 import {Routes} from 'shared/util/router';
 import {toThousands} from 'shared/util/numbers';
 import {useRequest} from 'shared/hooks/useRequest';
-
-const activeUsersItems = [
-	{
-		label: Liferay.Language.get('last-24-hours'),
-		value: RangeKeyTimeRanges.Last24Hours
-	},
-	{
-		label: Liferay.Language.get('yesterday'),
-		value: RangeKeyTimeRanges.Yesterday
-	},
-	{
-		label: Liferay.Language.get('last-seven-days'),
-		value: RangeKeyTimeRanges.Last7Days
-	},
-	{
-		label: Liferay.Language.get('last-28-days'),
-		value: RangeKeyTimeRanges.Last28Days
-	},
-	{
-		label: Liferay.Language.get('last-30-days'),
-		value: RangeKeyTimeRanges.Last30Days
-	},
-	{
-		label: Liferay.Language.get('last-90-days'),
-		value: RangeKeyTimeRanges.Last90Days
-	},
-	{
-		label: Liferay.Language.get('last-180-days'),
-		value: RangeKeyTimeRanges.Last180Days
-	},
-	{
-		label: Liferay.Language.get('last-year'),
-		value: RangeKeyTimeRanges.LastYear
-	}
-];
 
 interface IAccountsDataSetProps {
 	accountLifecycleId?: string;
@@ -152,7 +118,7 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 				filters={[
 					{
 						id: 'rangeKey',
-						items: activeUsersItems,
+						items: rangeSelectors,
 						label: Liferay.Language.get('active-individuals'),
 						name: 'rangeKey',
 						preloadedData: buildSelectionPreloadedData(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -11,26 +11,53 @@ import {
 	lifecycleStagesLabelMap
 } from 'contacts/pages/account/utils/constants';
 import {RangeKeyTimeRanges} from 'shared/util/constants';
-import {RangeSelectors} from 'shared/types';
 import {Routes} from 'shared/util/router';
 import {toThousands} from 'shared/util/numbers';
 import {useRequest} from 'shared/hooks/useRequest';
 
-const activityStatusItems = [
-	{label: Liferay.Language.get('active'), value: 'ACTIVE'},
-	{label: Liferay.Language.get('inactive'), value: 'INACTIVE'}
+const activeUsersItems = [
+	{
+		label: Liferay.Language.get('last-24-hours'),
+		value: RangeKeyTimeRanges.Last24Hours
+	},
+	{
+		label: Liferay.Language.get('yesterday'),
+		value: RangeKeyTimeRanges.Yesterday
+	},
+	{
+		label: Liferay.Language.get('last-seven-days'),
+		value: RangeKeyTimeRanges.Last7Days
+	},
+	{
+		label: Liferay.Language.get('last-28-days'),
+		value: RangeKeyTimeRanges.Last28Days
+	},
+	{
+		label: Liferay.Language.get('last-30-days'),
+		value: RangeKeyTimeRanges.Last30Days
+	},
+	{
+		label: Liferay.Language.get('last-90-days'),
+		value: RangeKeyTimeRanges.Last90Days
+	},
+	{
+		label: Liferay.Language.get('last-180-days'),
+		value: RangeKeyTimeRanges.Last180Days
+	},
+	{
+		label: Liferay.Language.get('last-year'),
+		value: RangeKeyTimeRanges.LastYear
+	}
 ];
 
 interface IAccountsDataSetProps {
 	accountLifecycleId?: string;
-	activityStatusFilter?: string;
 	apiURL: string;
 	channelId: string;
 	countryFilter?: string;
 	groupId: string;
 	industryFilter?: string;
 	lifecycleStageFilter?: LifecycleStages;
-	rangeSelectors?: RangeSelectors;
 }
 
 interface ILifecycleStageFieldValue {
@@ -48,18 +75,12 @@ const buildSelectionPreloadedData = (value?: string, label?: string) =>
 
 const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 	accountLifecycleId,
-	activityStatusFilter,
 	apiURL,
 	channelId,
 	countryFilter,
 	groupId,
 	industryFilter,
-	lifecycleStageFilter,
-	rangeSelectors = {
-		rangeEnd: null,
-		rangeKey: RangeKeyTimeRanges.Last30Days,
-		rangeStart: null
-	}
+	lifecycleStageFilter
 }) => {
 	const {data: lifecycleStageFieldValues} = useRequest({
 		dataSourceFn: API.accounts.fetchLifecycleStageFieldValues,
@@ -85,33 +106,11 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 		  )
 		: undefined;
 
-	let rangeSelectorParams = `rangeKey=${rangeSelectors.rangeKey}`;
-
-	if (rangeSelectors.rangeEnd) {
-		rangeSelectorParams += `&rangeEnd=${rangeSelectors.rangeEnd}`;
-	}
-
-	if (rangeSelectors.rangeStart) {
-		rangeSelectorParams += `&rangeStart=${rangeSelectors.rangeStart}`;
-	}
-
-	const rangeApiURL = `${apiURL}?${rangeSelectorParams}`;
-
 	return (
 		<Card minHeight={300}>
 			<FrontendDataSet
-				apiURL={rangeApiURL}
+				apiURL={apiURL}
 				customDataRenderers={{
-					accountActivityStatusRenderer: ({value}: {value: string}) =>
-						value &&
-						columns.cmsLabelRenderer({
-							displayType:
-								value === 'ACTIVE' ? 'success' : 'secondary',
-							label:
-								value === 'ACTIVE'
-									? Liferay.Language.get('active')
-									: Liferay.Language.get('inactive')
-						}),
 					accountLifecycleStageRenderer: ({
 						value
 					}: {
@@ -152,15 +151,13 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 				}}
 				filters={[
 					{
-						id: 'activityStatus',
-						items: activityStatusItems,
-						label: Liferay.Language.get('activity-status'),
-						name: 'activityStatus',
+						id: 'rangeKey',
+						items: activeUsersItems,
+						label: Liferay.Language.get('active-individuals'),
+						name: 'rangeKey',
 						preloadedData: buildSelectionPreloadedData(
-							activityStatusFilter,
-							activityStatusItems.find(
-								({value}) => value === activityStatusFilter
-							)?.label
+							RangeKeyTimeRanges.Last30Days,
+							Liferay.Language.get('last-30-days')
 						),
 						type: 'selection'
 					},
@@ -210,12 +207,10 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 				]}
 				id='accounts-list-dataset'
 				key={[
-					activityStatusFilter,
 					countryFilter,
 					industryFilter,
 					lifecycleStageFilter,
-					lifecycleStages.length,
-					...Object.values(rangeSelectors)
+					lifecycleStages.length
 				].join()}
 				pagination={pagination}
 				showPagination
@@ -281,15 +276,6 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 									fieldName: 'lastEnriched',
 									label: Liferay.Language.get(
 										'last-enriched'
-									),
-									sortable: true
-								},
-								{
-									contentRenderer:
-										'accountActivityStatusRenderer',
-									fieldName: 'activityStatus',
-									label: Liferay.Language.get(
-										'activity-status'
 									),
 									sortable: true
 								}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/FrontendDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/FrontendDataSet.tsx
@@ -1,5 +1,5 @@
 import ClayLink from '@clayui/link';
-import FaroConstants from 'shared/util/constants';
+import FaroConstants, {RangeKeyTimeRanges} from 'shared/util/constants';
 import Label from '@clayui/label';
 import Loading from 'shared/components/Loading';
 import React, {useEffect, useState} from 'react';
@@ -14,6 +14,41 @@ import {toRoute} from 'shared/util/router';
 export * from '@liferay/frontend-data-set-web';
 
 const {cur, delta, deltaValues} = FaroConstants.pagination;
+
+export const rangeSelectors = [
+	{
+		label: Liferay.Language.get('last-24-hours'),
+		value: RangeKeyTimeRanges.Last24Hours
+	},
+	{
+		label: Liferay.Language.get('yesterday'),
+		value: RangeKeyTimeRanges.Yesterday
+	},
+	{
+		label: Liferay.Language.get('last-seven-days'),
+		value: RangeKeyTimeRanges.Last7Days
+	},
+	{
+		label: Liferay.Language.get('last-28-days'),
+		value: RangeKeyTimeRanges.Last28Days
+	},
+	{
+		label: Liferay.Language.get('last-30-days'),
+		value: RangeKeyTimeRanges.Last30Days
+	},
+	{
+		label: Liferay.Language.get('last-90-days'),
+		value: RangeKeyTimeRanges.Last90Days
+	},
+	{
+		label: Liferay.Language.get('last-180-days'),
+		value: RangeKeyTimeRanges.Last180Days
+	},
+	{
+		label: Liferay.Language.get('last-year'),
+		value: RangeKeyTimeRanges.LastYear
+	}
+];
 
 export const pagination = {
 	deltas: deltaValues.map(delta => ({label: delta})),

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -5,12 +5,6 @@ import {LifecycleStages} from 'contacts/pages/account/utils/constants';
 import {RangeKeyTimeRanges} from 'shared/util/constants';
 import {useRequest} from 'shared/hooks/useRequest';
 
-const defaultRangeSelectors = {
-	rangeEnd: null,
-	rangeKey: RangeKeyTimeRanges.Last30Days,
-	rangeStart: null
-};
-
 const DEFAULT_STAGE_ITEMS = [
 	{id: '9990', stageType: LifecycleStages.AWARE},
 	{id: '9991', stageType: LifecycleStages.ENGAGED},
@@ -49,9 +43,6 @@ type FakeFilter = {
 };
 
 type FakeCustomDataRenderers = {
-	accountActivityStatusRenderer: (props: {
-		value: string;
-	}) => React.ReactElement | null | false;
 	accountNameRenderer: (props: {
 		itemData: {id: string | number};
 		value: string;
@@ -100,7 +91,6 @@ describe('AccountsDataSet', () => {
 				apiURL='fake-url'
 				channelId='123'
 				groupId='23'
-				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -110,23 +100,92 @@ describe('AccountsDataSet', () => {
 		);
 	});
 
-	it('should leave activityStatus/country/industry filters without preloadedData when no props are passed', () => {
+	it('should pass the apiURL directly to FrontendDataSet without appending range params', () => {
 		render(
 			<AccountsDataSet
 				apiURL='fake-url'
 				channelId='123'
 				groupId='23'
-				rangeSelectors={defaultRangeSelectors}
+			/>
+		);
+
+		expect(lastApiURL).toBe('fake-url');
+	});
+
+	it('should preload the rangeKey filter with Last 30 Days by default', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+			/>
+		);
+
+		const rangeKeyFilter = lastFilters?.find(f => f.id === 'rangeKey');
+
+		expect(rangeKeyFilter?.preloadedData).toEqual({
+			exclude: false,
+			selectedItems: [
+				{
+					label: 'Last 30 days',
+					value: RangeKeyTimeRanges.Last30Days
+				}
+			]
+		});
+	});
+
+	it('should include all 8 time range options in the rangeKey filter', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+			/>
+		);
+
+		const rangeKeyFilter = lastFilters?.find(f => f.id === 'rangeKey');
+
+		expect(rangeKeyFilter?.items).toHaveLength(8);
+		expect(rangeKeyFilter?.items?.map(i => i.value)).toEqual([
+			RangeKeyTimeRanges.Last24Hours,
+			RangeKeyTimeRanges.Yesterday,
+			RangeKeyTimeRanges.Last7Days,
+			RangeKeyTimeRanges.Last28Days,
+			RangeKeyTimeRanges.Last30Days,
+			RangeKeyTimeRanges.Last90Days,
+			RangeKeyTimeRanges.Last180Days,
+			RangeKeyTimeRanges.LastYear
+		]);
+	});
+
+	it('should not include the activityStatus filter', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
 			/>
 		);
 
 		const activityStatusFilter = lastFilters?.find(
 			f => f.id === 'activityStatus'
 		);
+
+		expect(activityStatusFilter).toBeUndefined();
+	});
+
+	it('should leave country and industry filters without preloadedData when no props are passed', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+			/>
+		);
+
 		const countryFilter = lastFilters?.find(f => f.id === 'country');
 		const industryFilter = lastFilters?.find(f => f.id === 'industry');
 
-		expect(activityStatusFilter?.preloadedData).toBeUndefined();
 		expect(countryFilter?.preloadedData).toBeUndefined();
 		expect(industryFilter?.preloadedData).toBeUndefined();
 	});
@@ -137,7 +196,6 @@ describe('AccountsDataSet', () => {
 				apiURL='fake-url'
 				channelId='123'
 				groupId='23'
-				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -148,27 +206,6 @@ describe('AccountsDataSet', () => {
 		expect(lifecycleStatusFilter).toBeUndefined();
 	});
 
-	it('should preload the activityStatus filter when activityStatusFilter prop is provided', () => {
-		render(
-			<AccountsDataSet
-				activityStatusFilter='ACTIVE'
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-				rangeSelectors={defaultRangeSelectors}
-			/>
-		);
-
-		const activityStatusFilter = lastFilters?.find(
-			f => f.id === 'activityStatus'
-		);
-
-		expect(activityStatusFilter?.preloadedData).toEqual({
-			exclude: false,
-			selectedItems: [{label: 'Active', value: 'ACTIVE'}]
-		});
-	});
-
 	it('should preload the country filter when countryFilter prop is provided', () => {
 		render(
 			<AccountsDataSet
@@ -176,7 +213,6 @@ describe('AccountsDataSet', () => {
 				channelId='123'
 				countryFilter='US'
 				groupId='23'
-				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -195,7 +231,6 @@ describe('AccountsDataSet', () => {
 				channelId='123'
 				groupId='23'
 				industryFilter='Tech'
-				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -214,7 +249,6 @@ describe('AccountsDataSet', () => {
 				apiURL='fake-url'
 				channelId='123'
 				groupId='23'
-				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -238,7 +272,6 @@ describe('AccountsDataSet', () => {
 				channelId='123'
 				groupId='23'
 				lifecycleStageFilter={LifecycleStages.AT_RISK}
-				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -262,7 +295,6 @@ describe('AccountsDataSet', () => {
 				channelId='123'
 				groupId='23'
 				lifecycleStageFilter={LifecycleStages.AT_RISK}
-				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -279,7 +311,6 @@ describe('AccountsDataSet', () => {
 				apiURL='fake-url'
 				channelId='123'
 				groupId='23'
-				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -294,96 +325,5 @@ describe('AccountsDataSet', () => {
 			'href',
 			'/workspace/23/123/contacts/accounts/abc'
 		);
-	});
-
-	it('should append rangeKey as query param when a preset range is provided', () => {
-		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-				rangeSelectors={{
-					rangeEnd: null,
-					rangeKey: RangeKeyTimeRanges.Last30Days,
-					rangeStart: null
-				}}
-			/>
-		);
-
-		expect(lastApiURL).toBe('fake-url?rangeKey=30');
-	});
-
-	it('should append rangeStart and rangeEnd as query params when a custom range is provided', () => {
-		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-				rangeSelectors={{
-					rangeEnd: '2024-01-31',
-					rangeKey: RangeKeyTimeRanges.CustomRange,
-					rangeStart: '2024-01-01'
-				}}
-			/>
-		);
-
-		expect(lastApiURL).toBe(
-			'fake-url?rangeKey=CUSTOM&rangeEnd=2024-01-31&rangeStart=2024-01-01'
-		);
-	});
-
-	it('should render "Active" label for ACTIVE activity status', () => {
-		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-				rangeSelectors={defaultRangeSelectors}
-			/>
-		);
-
-		const {getByText} = render(
-			lastCustomDataRenderers!.accountActivityStatusRenderer({
-				value: 'ACTIVE'
-			}) as React.ReactElement
-		);
-
-		expect(getByText('Active')).toBeInTheDocument();
-	});
-
-	it('should render "Inactive" label for INACTIVE activity status', () => {
-		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-				rangeSelectors={defaultRangeSelectors}
-			/>
-		);
-
-		const {getByText} = render(
-			lastCustomDataRenderers!.accountActivityStatusRenderer({
-				value: 'INACTIVE'
-			}) as React.ReactElement
-		);
-
-		expect(getByText('Inactive')).toBeInTheDocument();
-	});
-
-	it('should render nothing when activity status value is empty', () => {
-		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-				rangeSelectors={defaultRangeSelectors}
-			/>
-		);
-
-		const result = lastCustomDataRenderers!.accountActivityStatusRenderer({
-			value: ''
-		});
-
-		expect(result).toBeFalsy();
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -142,18 +142,6 @@ describe('AccountsDataSet', () => {
 		]);
 	});
 
-	it('should not include the activityStatus filter', () => {
-		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
-		);
-
-		const activityStatusFilter = lastFilters?.find(
-			f => f.id === 'activityStatus'
-		);
-
-		expect(activityStatusFilter).toBeUndefined();
-	});
-
 	it('should leave country and industry filters without preloadedData when no props are passed', () => {
 		render(
 			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -87,11 +87,7 @@ describe('AccountsDataSet', () => {
 
 	it('should render the FrontendDataSet with id "accounts-list-dataset"', () => {
 		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-			/>
+			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
 		);
 
 		expect(screen.getByTestId('fds-component')).toHaveAttribute(
@@ -102,11 +98,7 @@ describe('AccountsDataSet', () => {
 
 	it('should pass the apiURL directly to FrontendDataSet without appending range params', () => {
 		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-			/>
+			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
 		);
 
 		expect(lastApiURL).toBe('fake-url');
@@ -114,11 +106,7 @@ describe('AccountsDataSet', () => {
 
 	it('should preload the rangeKey filter with Last 30 Days by default', () => {
 		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-			/>
+			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
 		);
 
 		const rangeKeyFilter = lastFilters?.find(f => f.id === 'rangeKey');
@@ -136,11 +124,7 @@ describe('AccountsDataSet', () => {
 
 	it('should include all 8 time range options in the rangeKey filter', () => {
 		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-			/>
+			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
 		);
 
 		const rangeKeyFilter = lastFilters?.find(f => f.id === 'rangeKey');
@@ -160,11 +144,7 @@ describe('AccountsDataSet', () => {
 
 	it('should not include the activityStatus filter', () => {
 		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-			/>
+			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
 		);
 
 		const activityStatusFilter = lastFilters?.find(
@@ -176,11 +156,7 @@ describe('AccountsDataSet', () => {
 
 	it('should leave country and industry filters without preloadedData when no props are passed', () => {
 		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-			/>
+			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
 		);
 
 		const countryFilter = lastFilters?.find(f => f.id === 'country');
@@ -192,11 +168,7 @@ describe('AccountsDataSet', () => {
 
 	it('should omit the lifecycleStatus filter when accountLifecycleId is not provided', () => {
 		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-			/>
+			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
 		);
 
 		const lifecycleStatusFilter = lastFilters?.find(
@@ -307,11 +279,7 @@ describe('AccountsDataSet', () => {
 
 	it('should render the account name link with channelId in the href', () => {
 		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-			/>
+			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
 		);
 
 		const {container} = render(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/table-columns.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/table-columns.tsx
@@ -295,36 +295,6 @@ export const IndividualsListCDPColumns = {
 		label: Liferay.Language.get('account-name'),
 		sortable: true
 	},
-	activityStatus: {
-		accessor: 'activityStatus',
-		cellRenderer: ({
-			className,
-			data: {activityStatus}
-		}: {
-			className?: string;
-			data: {activityStatus: string};
-		}) => (
-			<td className={getCN('name-cell-root', className)}>
-				{activityStatus && (
-					<Label
-						display={
-							activityStatus === 'ACTIVE'
-								? 'success'
-								: 'secondary'
-						}
-						size='lg'
-						uppercase
-					>
-						{activityStatus === 'ACTIVE'
-							? Liferay.Language.get('active')
-							: Liferay.Language.get('inactive')}
-					</Label>
-				)}
-			</td>
-		),
-		label: Liferay.Language.get('activity-status'),
-		sortable: true
-	},
 	country: {
 		accessor: 'countries',
 		cellRenderer: ({


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91079
https://liferay.atlassian.net/browse/LPD-91083

## What Is Being Fixed

The individuals list and accounts list pages each had a standalone time range dropdown (DropdownRangeKey) above the table and a separate activity status filter (Active/Inactive) in the filter panel. These two controls were redundant and inconsistent with the rest of the filter UX.

## How It Is Being Fixed

For both pages, the DropdownRangeKey and the activity status filter are removed. A new "Active Users" filter replaces them, offering the same time range options (Last 24 Hours through Last Year) with Last 30 Days selected by default, preserving the previous behavior.

For the individuals list (LPD-91079), the new filter uses the existing `SearchableEntityTable` radio filter system. The selected value is mapped to the `rangeKey` integer parameter sent to the API.

For the accounts list (LPD-91083), the new filter is integrated directly into `FrontendDataSet`'s filter system as a `selection` filter named `rangeKey`, so the selected value is sent to the API as a query param without any extra transformation.

The `activityStatus` column is also removed from both tables. A new `active-users` language key is added and locale files are regenerated.

## PR Check

**pr-check: PASS** — tested on `f64a66e5b9a05fbbbfccaabfba87f960d74f47ea`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Structural Smoke | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f64a66e5b9a05fbbbfccaabfba87f960d74f47ea"} -->