### PR TITLE
LPD-93339 Show a not-found page for a non-existing account id

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
@@ -2,11 +2,12 @@ import * as API from 'shared/api';
 import * as breadcrumbs from 'shared/util/breadcrumbs';
 import BasePage from 'shared/components/base-page';
 import BundleRouter from 'route-middleware/BundleRouter';
+import ErrorPage from 'shared/pages/ErrorPage';
 import Loading from 'shared/components/Loading';
 import React, {lazy, Suspense, useContext} from 'react';
 import RouteNotFound from 'shared/components/RouteNotFound';
+import {ACCOUNTS, Routes, toRoute} from 'shared/util/router';
 import {ChannelContext} from 'shared/context/channel';
-import {Routes} from 'shared/util/router';
 import {Switch, useParams} from 'react-router-dom';
 import {useRequest} from 'shared/hooks/useRequest';
 
@@ -35,13 +36,34 @@ const AccountProfileRoutes = () => {
 
 	const {channelId, groupId, id} = useParams();
 
-	const {data, loading} = useRequest({
+	const {data, error, loading} = useRequest({
 		dataSourceFn: API.accounts.fetch,
 		variables: {accountId: id!, channelId: channelId!, groupId: groupId!}
 	});
 
+	if (loading) {
+		return <Loading />;
+	}
+
+	if (error || !data) {
+		return (
+			<ErrorPage
+				href={toRoute(Routes.CONTACTS_LIST_ENTITY, {
+					channelId: channelId!,
+					groupId: groupId!,
+					type: ACCOUNTS
+				})}
+				linkLabel={Liferay.Language.get('go-to-accounts')}
+				message={Liferay.Language.get(
+					'the-account-you-are-looking-for-does-not-exist'
+				)}
+				subtitle={Liferay.Language.get('account-not-found')}
+			/>
+		);
+	}
+
 	const accountName: string =
-		data?.accountName || Liferay.Language.get('account');
+		data.accountName || Liferay.Language.get('account');
 
 	return (
 		<BasePage

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/ProfileRoutes.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/ProfileRoutes.tsx
@@ -1,0 +1,143 @@
+import mockStore from 'test/mock-store';
+import ProfileRoutes from '../ProfileRoutes';
+import React from 'react';
+import {ChannelContext} from 'shared/context/channel';
+import {cleanup, render, screen} from '@testing-library/react';
+import {createMemoryHistory} from 'history';
+import {mockChannelContext} from 'test/mock-channel-context';
+import {Provider} from 'react-redux';
+import {Router} from 'react-router-dom';
+import {useRequest} from 'shared/hooks/useRequest';
+
+jest.unmock('react-dom');
+
+jest.mock('shared/hooks/useRequest', () => ({
+	useRequest: jest.fn()
+}));
+
+jest.mock('shared/util/breadcrumbs', () => ({
+	getAccounts: jest.fn(() => ({active: false, label: 'Accounts'})),
+	getEntityName: jest.fn(({label}: {label?: string} = {}) => ({
+		active: true,
+		label
+	})),
+	getHome: jest.fn(({label}: {label?: string} = {}) => ({
+		active: false,
+		label: label || 'Home'
+	}))
+}));
+
+jest.mock('react-router-dom', () => ({
+	...jest.requireActual('react-router-dom'),
+	useParams: () => ({
+		channelId: '123',
+		groupId: '23',
+		id: 'acc-1'
+	})
+}));
+
+jest.mock('../Activities', () => ({
+	__esModule: true,
+	default: () => <div data-testid='account-activities' />
+}));
+
+jest.mock('../Profile', () => ({
+	__esModule: true,
+	default: () => <div data-testid='account-profile' />
+}));
+
+const mockedUseRequest = useRequest as jest.Mock;
+
+const store = mockStore();
+
+const renderProfileRoutes = (
+	history = createMemoryHistory({
+		initialEntries: ['/workspace/23/123/accounts/acc-1']
+	})
+) =>
+	render(
+		<Provider store={store}>
+			<ChannelContext.Provider value={mockChannelContext() as any}>
+				<Router history={history}>
+					<ProfileRoutes />
+				</Router>
+			</ChannelContext.Provider>
+		</Provider>
+	);
+
+describe('AccountProfileRoutes', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	afterEach(cleanup);
+
+	it('renders a loading indicator while the account request is in flight', () => {
+		mockedUseRequest.mockReturnValue({
+			data: null,
+			error: false,
+			loading: true
+		});
+
+		const {container} = renderProfileRoutes();
+
+		expect(container.querySelector('.loading-root')).toBeInTheDocument();
+		expect(screen.queryByText('Account Not Found')).not.toBeInTheDocument();
+	});
+
+	it('renders the not-found error page when the account request errors', () => {
+		mockedUseRequest.mockReturnValue({
+			data: null,
+			error: true,
+			loading: false
+		});
+
+		renderProfileRoutes();
+
+		expect(screen.getByText('Account Not Found')).toBeInTheDocument();
+		expect(
+			screen.getByText('The account you are looking for does not exist.')
+		).toBeInTheDocument();
+		expect(screen.getByText('Go to Accounts')).toBeInTheDocument();
+	});
+
+	it('renders the not-found error page when the account does not exist', () => {
+		mockedUseRequest.mockReturnValue({
+			data: null,
+			error: false,
+			loading: false
+		});
+
+		renderProfileRoutes();
+
+		expect(screen.getByText('Account Not Found')).toBeInTheDocument();
+	});
+
+	it('points the error page link back to the accounts list', () => {
+		mockedUseRequest.mockReturnValue({
+			data: null,
+			error: true,
+			loading: false
+		});
+
+		renderProfileRoutes();
+
+		expect(screen.getByText('Go to Accounts').closest('a')).toHaveAttribute(
+			'href',
+			expect.stringContaining('accounts')
+		);
+	});
+
+	it('renders the account page when the account exists', () => {
+		mockedUseRequest.mockReturnValue({
+			data: {accountName: 'Acme Corp'},
+			error: false,
+			loading: false
+		});
+
+		renderProfileRoutes();
+
+		expect(screen.getAllByText('Acme Corp').length).toBeGreaterThan(0);
+		expect(screen.queryByText('Account Not Found')).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93339

## What Is Being Fixed

Navigating to an account route with an id that does not resolve (for example `/contacts/accounts/<bad-id>`) rendered the full account page with empty-state cards and a fallback "Account" title instead of a not-found page. The account fetch error was ignored, so a non-existing account looked like a real but empty account. The individual route already returns a not-found page in the same situation, so the two routes behaved inconsistently.

## How It Is Being Fixed

`AccountProfileRoutes` now reads the error state from the account request (`useRequest`) and renders the shared `ErrorPage` — with the account-not-found copy and a link back to the accounts list — when the request errors or returns no account, mirroring how the individual profile route handles a missing entity. The change is hook-based, with no new HOC. A new `ProfileRoutes` test covers the loading, error, missing-data, error-page-link, and success cases.

## PR Check

**pr-check: SKIPPED** — Structural Smoke fails only on pre-existing baseline checks unrelated to this JS-only change (Log4jConfigUtil Whip code-coverage shortfall; LibraryReferenceTest missing `lib/development/spring-instrument-tomcat.jar` references). Source Format, JavaScript Unit Tests, and Per-Module Deploy all pass.

<!-- pr-check {"reason": "Structural Smoke fails only on pre-existing baseline checks unrelated to this JS-only change (Log4jConfigUtil Whip code-coverage shortfall; LibraryReferenceTest missing lib/development/spring-instrument-tomcat.jar references). Source Format, JavaScript Unit Tests, and Per-Module Deploy all pass.", "result": "skipped", "sha": "8069986fff46c3ff80b3c7e5345a951af7db11e0"} -->
