### PR TITLE
LPD-93657 Clamp out-of-range Segments list page to a valid page

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/List.tsx
@@ -60,6 +60,7 @@ import {SegmentStates, SegmentTypes, Sizes} from 'shared/util/constants';
 import {setUriQueryValues} from 'shared/util/router';
 import {sub} from 'shared/util/lang';
 import {useChannelContext} from 'shared/context/channel';
+import {useClampedPage} from 'shared/hooks/useClampedPage';
 import {useCurrentUser} from 'shared/hooks/useCurrentUser';
 import {useQueryPagination} from 'shared/hooks/useQueryPagination';
 import {useRequest} from 'shared/hooks/useRequest';
@@ -205,6 +206,8 @@ export const List: React.FC<IListProps> = ({
 				: undefined
 		}
 	});
+
+	useClampedPage({delta, loading, page, total: data?.total});
 
 	const {
 		data: usageData = [],

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/__tests__/List.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/segment/pages/__tests__/List.jsx
@@ -6,7 +6,8 @@ import React from 'react';
 import {act} from '@testing-library/react';
 import {ChannelContext} from 'shared/context/channel';
 import {cleanup, render, screen} from '@testing-library/react';
-import {MemoryRouter, Route} from 'react-router-dom';
+import {createMemoryHistory} from 'history';
+import {MemoryRouter, Route, Router} from 'react-router-dom';
 import {mockChannelContext} from 'test/mock-channel-context';
 import {Provider} from 'react-redux';
 import {Routes} from 'shared/util/router';
@@ -257,6 +258,55 @@ describe('List', () => {
 		expect(
 			container.querySelector('.sticker-info')
 		).not.toBeInTheDocument();
+	});
+
+	it('should redirect to the last valid page when navigating to an out-of-range page', async () => {
+		API.projects.fetchFeatureUsages.mockResolvedValueOnce([]);
+
+		API.individualSegment.search.mockReturnValue(
+			Promise.resolve({disableSearch: false, items: [], total: 0})
+		);
+
+		const history = createMemoryHistory({
+			initialEntries: [
+				'/workspace/23/123/contacts/segments?delta=20&page=2'
+			]
+		});
+
+		const push = jest.fn();
+
+		history.push = push;
+
+		render(
+			<Provider store={store}>
+				<Router history={history}>
+					<Route path={Routes.CONTACTS_LIST_SEGMENT}>
+						<UnassignedSegmentsContext.Provider
+							value={MOCK_UNASSIGNED_SEGMENTS_CONTEXT}
+						>
+							<ChannelContext.Provider
+								value={mockChannelContext()}
+							>
+								<List
+									channelId='123'
+									currentUser={data.getImmutableMock(
+										User,
+										data.mockUser
+									)}
+									groupId='23'
+								/>
+							</ChannelContext.Provider>
+						</UnassignedSegmentsContext.Provider>
+					</Route>
+				</Router>
+			</Provider>
+		);
+
+		await act(async () => {
+			jest.runAllTimers();
+		});
+
+		expect(push).toHaveBeenCalledWith(expect.stringContaining('page=1'));
 	});
 
 	it('should not show the sequential info icon for batch segments', async () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/__tests__/useClampedPage.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/__tests__/useClampedPage.js
@@ -1,0 +1,121 @@
+import React from 'react';
+import {createMemoryHistory} from 'history';
+import {render} from '@testing-library/react';
+import {Router} from 'react-router-dom';
+import {useClampedPage} from 'shared/hooks/useClampedPage';
+
+jest.unmock('react-dom');
+
+const TestComponent = props => {
+	useClampedPage(props);
+
+	return null;
+};
+
+const renderHook = props => {
+	const history = createMemoryHistory({
+		initialEntries: ['/workspace/23/123/contacts/segments']
+	});
+
+	const push = jest.fn();
+
+	history.push = push;
+
+	render(
+		<Router history={history}>
+			<TestComponent {...props} />
+		</Router>
+	);
+
+	return push;
+};
+
+describe('useClampedPage', () => {
+	it('should redirect to the last valid page when the page is out of range', () => {
+		const push = renderHook({
+			delta: 20,
+			loading: false,
+			page: 2,
+			total: 3
+		});
+
+		expect(push).toHaveBeenCalledWith(expect.stringContaining('page=1'));
+	});
+
+	it('should clamp to the last page that contains results', () => {
+		const push = renderHook({
+			delta: 2,
+			loading: false,
+			page: 10,
+			total: 6
+		});
+
+		expect(push).toHaveBeenCalledWith(expect.stringContaining('page=3'));
+	});
+
+	it('should redirect to page 1 when the page is below the valid range', () => {
+		const push = renderHook({
+			delta: 20,
+			loading: false,
+			page: 0,
+			total: 3
+		});
+
+		expect(push).toHaveBeenCalledWith(expect.stringContaining('page=1'));
+	});
+
+	it('should redirect to page 1 when the page is negative', () => {
+		const push = renderHook({
+			delta: 20,
+			loading: false,
+			page: -5,
+			total: 3
+		});
+
+		expect(push).toHaveBeenCalledWith(expect.stringContaining('page=1'));
+	});
+
+	it('should redirect to page 1 when there are no results at all', () => {
+		const push = renderHook({
+			delta: 20,
+			loading: false,
+			page: 3,
+			total: 0
+		});
+
+		expect(push).toHaveBeenCalledWith(expect.stringContaining('page=1'));
+	});
+
+	it('should not redirect when the page is within range', () => {
+		const push = renderHook({
+			delta: 20,
+			loading: false,
+			page: 1,
+			total: 3
+		});
+
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it('should not redirect while the request is still loading', () => {
+		const push = renderHook({
+			delta: 20,
+			loading: true,
+			page: 2,
+			total: 3
+		});
+
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it('should not redirect before the total is known', () => {
+		const push = renderHook({
+			delta: 20,
+			loading: false,
+			page: 2,
+			total: undefined
+		});
+
+		expect(push).not.toHaveBeenCalled();
+	});
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useClampedPage.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hooks/useClampedPage.ts
@@ -1,0 +1,48 @@
+import {setUriQueryValue} from 'shared/util/router';
+import {useEffect} from 'react';
+import {useHistory} from 'react-router-dom';
+
+type ClampedPageParams = {
+	delta: number;
+	loading: boolean;
+	page: number;
+	total?: number;
+};
+
+/**
+ * Redirects to the last valid page when the current page is out of range.
+ *
+ * List pages read `page` straight from the URL without any bounds checking, so
+ * a stale or shared link (or a hand-edited `page` param) can request a page
+ * outside the valid range. A page past the end renders the onboarding empty
+ * state even though items exist (LPD-93657); a page below 1 leaves the URL out
+ * of sync with the first page the backend falls back to. Once the request
+ * resolves we know the real `total`, so clamp `page` into
+ * `[1, ceil(total / delta)]` — collapsing to page 1 when there are no results.
+ */
+export const useClampedPage = ({
+	delta,
+	loading,
+	page,
+	total
+}: ClampedPageParams): void => {
+	const history = useHistory();
+
+	useEffect(() => {
+		if (loading || total == null || delta <= 0) {
+			return;
+		}
+
+		const lastPage = total > 0 ? Math.ceil(total / delta) : 1;
+
+		if (page < 1 || page > lastPage) {
+			history.push(
+				setUriQueryValue(
+					window.location.href,
+					'page',
+					Math.min(Math.max(page, 1), lastPage)
+				)
+			);
+		}
+	}, [delta, history, loading, page, total]);
+};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93657

## What Is Being Fixed

On the Segments list, requesting a page outside the valid range via the URL renders the first-run onboarding empty state ("There are no segments found. Create a segment to get started.") even though segments exist. It is reachable through a stale or shared link, or by hand-editing the `page` query parameter. A page past the end (e.g. `?page=2` with a single page of results) makes the backend return an empty result with a total of 0, which the list treats as an empty workspace. A page below 1 (e.g. `?page=0`) leaves the URL out of sync with the first page the backend falls back to.

## How It Is Being Fixed

A new `useClampedPage` hook reads the resolved `total` and `delta` after the request completes and clamps the current page into the valid range `[1, ceil(total / delta)]`, redirecting through the URL when the requested page falls outside it. The Segments list calls the hook after its data request. Because the backend returns a total of 0 for an out-of-range page, the clamp collapses to page 1 in that case, landing the user on the real list instead of the onboarding state. The hook is generic, so other list pages built on the same shared components can adopt it.
