### PR TITLE
LPD-93534 Change AccountDetails.Field dataSourceId from Long to String

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/AccountDetails.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/AccountDetails.java
@@ -23,7 +23,7 @@ public class AccountDetails {
 
 	public static class Field {
 
-		public Long getDataSourceId() {
+		public String getDataSourceId() {
 			return _dataSourceId;
 		}
 
@@ -47,7 +47,7 @@ public class AccountDetails {
 			return _value;
 		}
 
-		public void setDataSourceId(Long dataSourceId) {
+		public void setDataSourceId(String dataSourceId) {
 			_dataSourceId = dataSourceId;
 		}
 
@@ -71,7 +71,7 @@ public class AccountDetails {
 			_value = value;
 		}
 
-		private Long _dataSourceId;
+		private String _dataSourceId;
 		private String _dataSourceName;
 		private Date _modifiedDate;
 		private String _name;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93534

## What Is Being Fixed

`AccountDetails.Field` in the osb-faro engine client declared `dataSourceId` as a `Long`, while every other engine client model (`Asset`, `Field`, `Individual`, `Organization`, `PageVisited`) declares it as a `String`. The analytics engine serializes data source IDs as strings, so the `Long` declaration mismatched the payloads this DTO maps.

## How It Is Being Fixed

The getter, setter, and backing field on `AccountDetails.Field` now use `String`, aligning the model with the rest of the engine client. No caller reads or writes `dataSourceId` on this model, so no consumer changes are needed — the engine client, mock engine client, and osb-faro-web all still deploy cleanly.

## Why Are There No Tests?

`AccountDetails.Field` is a plain data model; changing `dataSourceId` from `Long` to `String` has no logic to test.

## PR Check

**pr-check: PASS** — tested on `d867d747cac980748c8cbae4aeade094152b1212`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

Structural Smoke note: the only observed failure was `Log4jConfigUtilTest`'s Whip coverage assertion on `Log4jConfigUtil#getPriority(String)`, added upstream in LPD-70455 without coverage — pre-existing baseline drift unrelated to this branch.

<!-- pr-check {"result": "success", "sha": "d867d747cac980748c8cbae4aeade094152b1212"} -->