### PR TITLE
LPD-93346 Hide event URL for all webhook activities, not just HubSpot

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/activities.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/activities.jsx
@@ -67,18 +67,35 @@ describe('activities', () => {
 			]);
 		});
 
-		it('should not set subtitle for HubSpot events', () => {
-			const result = formatEvents([
-				{
-					applicationId: 'HubSpot',
-					assetTitle: null,
-					canonicalUrl: 'https://hubspot.com',
-					eventId: 'emailView',
-					name: 'emailView'
-				}
-			]);
+		it('should not set subtitle for webhook events regardless of provider', () => {
+			const hubSpotResult = formatEvents(
+				[
+					{
+						applicationId: 'HubSpot',
+						assetTitle: null,
+						canonicalUrl: 'https://hubspot.com',
+						eventId: 'emailView',
+						name: 'emailView'
+					}
+				],
+				'HubSpot Webhook'
+			);
 
-			expect(result[0].subtitle).toBeUndefined();
+			const marketoResult = formatEvents(
+				[
+					{
+						applicationId: 'Marketo',
+						assetTitle: null,
+						canonicalUrl: 'https://marketo.com',
+						eventId: 'emailView',
+						name: 'emailView'
+					}
+				],
+				'Marketo Webhook'
+			);
+
+			expect(hubSpotResult[0].subtitle).toBeUndefined();
+			expect(marketoResult[0].subtitle).toBeUndefined();
 		});
 
 		it('should transform properties array into an object in attributes', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/activities.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/activities.tsx
@@ -94,8 +94,13 @@ export const buildLegendItems = ({
  * @param {Array} events Array of UserSessions events.
  * @returns {Array.<Object>} Array of objects for a vertical timeline.
  */
-export const formatEvents = (events: UserSessionEvent[]): Array<SessionEvent> =>
-	events.map(
+export const formatEvents = (
+	events: UserSessionEvent[],
+	userAgent?: string
+): Array<SessionEvent> => {
+	const isWebhook = userAgent?.toLowerCase().includes('webhook');
+
+	return events.map(
 		({
 			applicationId,
 			assetTitle,
@@ -120,14 +125,14 @@ export const formatEvents = (events: UserSessionEvent[]): Array<SessionEvent> =>
 				})
 			},
 			description: assetTitle,
-			subtitle:
-				applicationId !== 'HubSpot'
-					? getSafeDecodedURIComponent(canonicalUrl)
-					: undefined,
+			subtitle: !isWebhook
+				? getSafeDecodedURIComponent(canonicalUrl)
+				: undefined,
 			time: moment(createDate),
 			title: name
 		})
 	);
+};
 
 /**
  * Formats datetime to today or the current date.
@@ -189,7 +194,8 @@ export const formatSessions = (
 					device: deviceType,
 					endTime: completeDate,
 					nestedItems: formatEvents(
-						events as unknown as UserSessionEvent[]
+						events as unknown as UserSessionEvent[],
+						userAgent
 					),
 					time: createDate,
 					userAgent


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93346

## What Is Being Fixed

The individual events timeline displayed the event URL for Marketo webhook activities. The URL subtitle was only suppressed when an event's applicationId was exactly 'HubSpot', so webhook events from any other provider — Marketo, for example — still leaked their canonical URL into the timeline.

## How It Is Being Fixed

formatEvents now decides whether to show the URL subtitle based on whether the session's userAgent identifies a webhook, instead of hardcoding the 'HubSpot' applicationId. A new optional userAgent argument is threaded from formatSessions into formatEvents, and the subtitle is omitted whenever the userAgent contains "webhook" (case-insensitive). This covers HubSpot, Marketo, and any future webhook provider uniformly.

## PR Check

**pr-check: SKIPPED** — Branch-relevant validations (Source Format, Per-Module Deploy, JavaScript Unit Tests — 11/11) passed. The only failures were pre-existing local-checkout baseline drift in Structural Smoke (Log4jConfigUtil coverage threshold; missing spring-instrument-tomcat.jar lib references), unrelated to this JS-only change.

<!-- pr-check {"reason": "Only failures were pre-existing local-checkout baseline drift in Structural Smoke, unrelated to this JS-only change; Source Format, Per-Module Deploy, and JavaScript Unit Tests passed.", "result": "skipped", "sha": "cd9b0dee0068909f51d1f52f15b292397216953a"} -->
