### PR TITLE
LPD-93564 Show DXP label instead of CUSTOMEVENT for custom events

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
@@ -32,7 +32,7 @@ const DEVICE_ICONS_MAP = {
 const LIFERAY_DXP_APPLICATION_IDS = new Set([
 	'Blog',
 	'Comment',
-	'Custom',
+	'CustomEvent',
 	'Document',
 	'Form',
 	'Layout',

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
@@ -153,6 +153,25 @@ const DefaultComponent = props => (
 	</StaticRouter>
 );
 
+const createDataSourceItem = ({applicationId, userAgent}) => ({
+	applicationId,
+	attributes: {
+		header: 'Session Attributes'
+	},
+	browserName: 'Firefox',
+	device: 'Desktop',
+	nestedItems: [
+		{
+			subtitle: 'www.liferay.com/testing',
+			time: 1518648993917,
+			title: 'Visited Liferay: Testing'
+		}
+	],
+	time: 1518648993917,
+	title: 'Opened Email',
+	userAgent
+});
+
 describe('VerticalTimeline', () => {
 	afterEach(cleanup);
 
@@ -204,5 +223,57 @@ describe('VerticalTimeline', () => {
 		);
 
 		expect(sessionAttributes).toHaveTextContent(SESSION_ATTRIBUTES_TITLE);
+	});
+
+	it('should display the "DXP" label for Liferay DXP data sources', () => {
+		['CustomEvent', 'WebContent'].forEach(applicationId => {
+			const {getByText, unmount} = render(
+				<DefaultComponent
+					items={[
+						createDataSourceItem({
+							applicationId,
+							userAgent:
+								'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'
+						})
+					]}
+				/>
+			);
+
+			expect(getByText('DXP')).toBeInTheDocument();
+
+			unmount();
+		});
+	});
+
+	it('should display the application ID label for the HubSpot webhook data source', () => {
+		const {getByText, queryByText} = render(
+			<DefaultComponent
+				items={[
+					createDataSourceItem({
+						applicationId: 'Hubspot',
+						userAgent: 'HubSpot Webhook'
+					})
+				]}
+			/>
+		);
+
+		expect(getByText('HUBSPOT')).toBeInTheDocument();
+		expect(queryByText('DXP')).not.toBeInTheDocument();
+	});
+
+	it('should display the application ID label for the Marketo webhook data source', () => {
+		const {getByText, queryByText} = render(
+			<DefaultComponent
+				items={[
+					createDataSourceItem({
+						applicationId: 'Marketo',
+						userAgent: 'Marketo Webhook'
+					})
+				]}
+			/>
+		);
+
+		expect(getByText('MARKETO')).toBeInTheDocument();
+		expect(queryByText('DXP')).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93564

## What Is Being Fixed

In the individual events timeline, custom events were labeled "CUSTOMEVENT" instead of "DXP". The `LIFERAY_DXP_APPLICATION_IDS` set in `VerticalTimeline` listed the application ID as `Custom`, but the application ID emitted for custom events is `CustomEvent`. Because the value never matched, `normalizeApplicationId` fell through and rendered the raw application ID in uppercase rather than the expected `DXP` label.

## How It Is Being Fixed

The entry in `LIFERAY_DXP_APPLICATION_IDS` is corrected from `Custom` to `CustomEvent`, so custom events now match the DXP application ID set and render the `DXP` label like the other first-party data sources. New unit tests cover the label logic: DXP application IDs such as `CustomEvent` and `WebContent` render `DXP`, while webhook data sources such as HubSpot and Marketo render their own application ID and never fall back to `DXP`.

## PR Check

**pr-check: SKIPPED** — Only environmental failures unrelated to the diff: Structural Smoke (portal-core LibraryReferenceTest / Log4jConfigUtilTest baseline drift in the local checkout) and Per-Module Deploy (the module compiled and bundled; only the post-deploy moveToDocker step failed because no local `faro` Docker container is running). Source Format and JavaScript Unit Tests passed.

<!-- pr-check {"reason": "Only environmental failures unrelated to the diff: Structural Smoke (portal-core baseline drift) and Per-Module Deploy (moveToDocker, no local faro container). Source Format and JavaScript Unit Tests passed.", "result": "skipped", "sha": "e0f233951c7368c1464cafde6e5dba7d25c4ad99"} -->
