### PR TITLE
LPD-93571 Add accessible names to lifecycle filter triggers

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/FieldValueFilter.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/FieldValueFilter.tsx
@@ -74,6 +74,11 @@ const FieldValueFilter = ({
 
 	return (
 		<Picker
+			aria-label={
+				sub(Liferay.Language.get('filter-by-x'), [
+					entityLabel
+				]) as string
+			}
 			as={TriggerButton}
 			buttonClassName={className}
 			className='ml-3'

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/__tests__/FieldValueFilter.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/__tests__/FieldValueFilter.tsx
@@ -46,6 +46,20 @@ describe('FieldValueFilter', () => {
 		expect(getByText('All Industries')).toBeInTheDocument();
 	});
 
+	it('should expose an accessible name on the filter trigger', () => {
+		const useRequest = require('shared/hooks/useRequest');
+		useRequest.useRequest = jest.fn(() => ({
+			data: {items: ['Tech', 'Finance']},
+			loading: false
+		}));
+
+		const {getByRole} = renderFilter();
+
+		expect(
+			getByRole('combobox', {name: 'Filter By Industries'})
+		).toBeInTheDocument();
+	});
+
 	it('should pass the fieldMappingFieldName through to the request', () => {
 		const useRequest = require('shared/hooks/useRequest');
 		const spy = jest.fn(() => ({data: {items: []}, loading: false}));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93571

## What Is Being Fixed

The Industry and Country filters on the Lifecycles dashboard render as `role="combobox"` trigger buttons with no accessible name. axe-core flags both with the `button-name` rule at critical impact, and a screen reader announces them as unnamed comboboxes, so an assistive-technology user cannot tell what either filter controls.

## How It Is Being Fixed

`FieldValueFilter` now passes an `aria-label` to the Clay `Picker` — "Filter By Industries" / "Filter By Countries", built from the existing `entityLabel` and the `filter-by-x` language key — which Clay applies to the combobox trigger. This matches the established pattern in the codebase (for example `ExperienceDropdown`). A unit test asserts the trigger exposes the accessible name.

## PR Check

**pr-check: SKIPPED** — Full pr-check run: Source Format, Per-Module Deploy, and JavaScript Unit Tests pass. Structural Smoke fails only on pre-existing baseline checks unrelated to this JS-only change (Log4jConfigUtil Whip code-coverage shortfall; LibraryReferenceTest missing `lib/development/spring-instrument-tomcat.jar` references in `.classpath`/`nbproject`/`versions.xml`).

<!-- pr-check {"reason": "Full pr-check run: Source Format, Per-Module Deploy, and JavaScript Unit Tests pass. Structural Smoke fails only on pre-existing baseline checks unrelated to this JS-only change (Log4jConfigUtil Whip code-coverage shortfall; LibraryReferenceTest missing lib/development/spring-instrument-tomcat.jar references).", "result": "skipped", "sha": "ff9bd6247672c7c9d0b6c7a4185fbe38fc1c1d1f"} -->
