### PR TITLE
LPD-93535 Remove non-functional sort on the Data Source column

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountDetailsModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountDetailsModal.tsx
@@ -119,8 +119,7 @@ const AccountDetailsModal: React.FC<IAccountDetailsModalProps> = ({
 										fieldName: 'dataSourceName',
 										label: Liferay.Language.get(
 											'data-source'
-										),
-										sortable: true
+										)
 									},
 									{
 										contentRenderer: 'lastModifiedRenderer',

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/AccountDetailsModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/AccountDetailsModal.tsx
@@ -7,19 +7,23 @@ import {useRequest} from 'shared/hooks/useRequest';
 jest.unmock('react-dom');
 
 let lastOnItemsPropSearch: ((item: any, query: string) => boolean) | undefined;
+let lastViews: any[] | undefined;
 
 jest.mock('@liferay/frontend-data-set-web', () => ({
 	...jest.requireActual('@liferay/frontend-data-set-web'),
 	FrontendDataSet: ({
 		id,
 		items,
-		onItemsPropSearch
+		onItemsPropSearch,
+		views
 	}: {
 		id: string;
 		items: any[];
 		onItemsPropSearch?: (item: any, query: string) => boolean;
+		views?: any[];
 	}) => {
 		lastOnItemsPropSearch = onItemsPropSearch;
+		lastViews = views;
 
 		return (
 			<div data-testid='fds-component' id={id}>
@@ -135,6 +139,14 @@ describe('AccountDetailsModal', () => {
 		renderModal();
 
 		expect(screen.queryAllByTestId('fds-item')).toHaveLength(0);
+	});
+
+	it('should not offer any column as sortable since the data set is fed a static items array', () => {
+		renderModal();
+
+		const fields = lastViews![0].schema.fields;
+
+		expect(fields.every((field: any) => !field.sortable)).toBe(true);
 	});
 
 	it('should match items by name when the data set search has a query', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93535

## What Is Being Fixed

In the account attributes "View All" modal (the General Account Information
card), the Data Source column was marked as sortable, but the table is rendered
from a static client-side items array with no sort handler. Clicking the
column's sort arrow did nothing, so the control was misleading.

## How It Is Being Fixed

Removed the `sortable: true` flag from the Data Source column in
`AccountDetailsModal.tsx`, making it consistent with the modal's other columns,
none of which are sortable. Added a regression test that captures the data set's
view schema and asserts no column is offered as sortable.

## PR Check

**pr-check: SKIPPED** — Source Format, Per-Module Deploy, and JavaScript Unit Tests passed; the only failures were pre-existing baseline Structural Smoke failures (Log4jConfigUtilTest coverage shortfall, LibraryReferenceTest missing spring-instrument-tomcat.jar reference) that this .tsx-only change does not touch.

<!-- pr-check {"reason": "Source Format, Per-Module Deploy, and JavaScript Unit Tests passed; the only failures were pre-existing baseline Structural Smoke failures (Log4jConfigUtilTest coverage shortfall, LibraryReferenceTest missing spring-instrument-tomcat.jar reference) that this .tsx-only change does not touch.", "result": "skipped", "sha": "5245a10af6276a5188e9e219428c0f9a04ed1474"} -->
