### PR TITLE
[BACKPORT] [faro-v4.15.x] LPD-93346 LPD-93564 Hide event URL for all webhook activities and fix data source label in VerticalTimeline

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
@@ -32,7 +32,7 @@ const DEVICE_ICONS_MAP = {
 const LIFERAY_DXP_APPLICATION_IDS = new Set([
 	'Blog',
 	'Comment',
-	'Custom',
+	'CustomEvent',
 	'Document',
 	'Form',
 	'Layout',

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
@@ -153,6 +153,25 @@ const DefaultComponent = props => (
 	</StaticRouter>
 );
 
+const createDataSourceItem = ({applicationId, userAgent}) => ({
+	applicationId,
+	attributes: {
+		header: 'Session Attributes'
+	},
+	browserName: 'Firefox',
+	device: 'Desktop',
+	nestedItems: [
+		{
+			subtitle: 'www.liferay.com/testing',
+			time: 1518648993917,
+			title: 'Visited Liferay: Testing'
+		}
+	],
+	time: 1518648993917,
+	title: 'Opened Email',
+	userAgent
+});
+
 describe('VerticalTimeline', () => {
 	afterEach(cleanup);
 
@@ -204,5 +223,57 @@ describe('VerticalTimeline', () => {
 		);
 
 		expect(sessionAttributes).toHaveTextContent(SESSION_ATTRIBUTES_TITLE);
+	});
+
+	it('should display the "DXP" label for Liferay DXP data sources', () => {
+		['CustomEvent', 'WebContent'].forEach(applicationId => {
+			const {getByText, unmount} = render(
+				<DefaultComponent
+					items={[
+						createDataSourceItem({
+							applicationId,
+							userAgent:
+								'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'
+						})
+					]}
+				/>
+			);
+
+			expect(getByText('DXP')).toBeInTheDocument();
+
+			unmount();
+		});
+	});
+
+	it('should display the application ID label for the HubSpot webhook data source', () => {
+		const {getByText, queryByText} = render(
+			<DefaultComponent
+				items={[
+					createDataSourceItem({
+						applicationId: 'Hubspot',
+						userAgent: 'HubSpot Webhook'
+					})
+				]}
+			/>
+		);
+
+		expect(getByText('HUBSPOT')).toBeInTheDocument();
+		expect(queryByText('DXP')).not.toBeInTheDocument();
+	});
+
+	it('should display the application ID label for the Marketo webhook data source', () => {
+		const {getByText, queryByText} = render(
+			<DefaultComponent
+				items={[
+					createDataSourceItem({
+						applicationId: 'Marketo',
+						userAgent: 'Marketo Webhook'
+					})
+				]}
+			/>
+		);
+
+		expect(getByText('MARKETO')).toBeInTheDocument();
+		expect(queryByText('DXP')).not.toBeInTheDocument();
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/activities.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/__tests__/activities.jsx
@@ -67,18 +67,35 @@ describe('activities', () => {
 			]);
 		});
 
-		it('should not set subtitle for HubSpot events', () => {
-			const result = formatEvents([
-				{
-					applicationId: 'HubSpot',
-					assetTitle: null,
-					canonicalUrl: 'https://hubspot.com',
-					eventId: 'emailView',
-					name: 'emailView'
-				}
-			]);
+		it('should not set subtitle for webhook events regardless of provider', () => {
+			const hubSpotResult = formatEvents(
+				[
+					{
+						applicationId: 'HubSpot',
+						assetTitle: null,
+						canonicalUrl: 'https://hubspot.com',
+						eventId: 'emailView',
+						name: 'emailView'
+					}
+				],
+				'HubSpot Webhook'
+			);
 
-			expect(result[0].subtitle).toBeUndefined();
+			const marketoResult = formatEvents(
+				[
+					{
+						applicationId: 'Marketo',
+						assetTitle: null,
+						canonicalUrl: 'https://marketo.com',
+						eventId: 'emailView',
+						name: 'emailView'
+					}
+				],
+				'Marketo Webhook'
+			);
+
+			expect(hubSpotResult[0].subtitle).toBeUndefined();
+			expect(marketoResult[0].subtitle).toBeUndefined();
 		});
 
 		it('should transform properties array into an object in attributes', () => {

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/activities.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/activities.tsx
@@ -94,8 +94,13 @@ export const buildLegendItems = ({
  * @param {Array} events Array of UserSessions events.
  * @returns {Array.<Object>} Array of objects for a vertical timeline.
  */
-export const formatEvents = (events: UserSessionEvent[]): Array<SessionEvent> =>
-	events.map(
+export const formatEvents = (
+	events: UserSessionEvent[],
+	userAgent?: string
+): Array<SessionEvent> => {
+	const isWebhook = userAgent?.toLowerCase().includes('webhook');
+
+	return events.map(
 		({
 			applicationId,
 			assetTitle,
@@ -120,14 +125,14 @@ export const formatEvents = (events: UserSessionEvent[]): Array<SessionEvent> =>
 				})
 			},
 			description: assetTitle,
-			subtitle:
-				applicationId !== 'HubSpot'
-					? getSafeDecodedURIComponent(canonicalUrl)
-					: undefined,
+			subtitle: !isWebhook
+				? getSafeDecodedURIComponent(canonicalUrl)
+				: undefined,
 			time: moment(createDate),
 			title: name
 		})
 	);
+};
 
 /**
  * Formats datetime to today or the current date.
@@ -189,7 +194,8 @@ export const formatSessions = (
 					device: deviceType,
 					endTime: completeDate,
 					nestedItems: formatEvents(
-						events as unknown as UserSessionEvent[]
+						events as unknown as UserSessionEvent[],
+						userAgent
 					),
 					time: createDate,
 					userAgent


### PR DESCRIPTION
## Summary

Backport of:
- https://github.com/liferay-ac/liferay-portal/pull/3447
- https://github.com/liferay-ac/liferay-portal/pull/3449