### PR TITLE
LPD-93682 Show only preset periods when expanding the date range filter

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/dropdown-range-key/__tests__/utils.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/dropdown-range-key/__tests__/utils.ts
@@ -258,6 +258,58 @@ describe('getFilteredItems', () => {
 		]);
 	});
 
+	it('see more filtered items excludes ranges without a preset label', () => {
+		expect(
+			getFilteredItems({
+				legacy: false,
+				rangeKey: RangeKeyTimeRanges.Last30Days,
+				retentionPeriod: 13,
+				seeMore: true,
+				timeRange: formatTimeRange([
+					...timeRange,
+					{
+						endDate: '2024-01-15T23:59:59.999999',
+						rangeKey: 'CUSTOM',
+						startDate: '2023-01-15T23:59:59.999999'
+					}
+				])
+			})
+		).toEqual([
+			{
+				description: '15 Jan, 07 PM - 16 Jan, 06 PM',
+				label: 'Last 24 hours',
+				value: '0'
+			},
+			{
+				description: '15 Jan, 12 AM - 15 Jan, 11 PM',
+				label: 'Yesterday',
+				value: '1'
+			},
+			{description: '09 Jan - 15 Jan', label: 'Last 7 days', value: '7'},
+			{
+				description: '19 Dec - 15 Jan',
+				label: 'Last 28 days',
+				value: '28'
+			},
+			{
+				description: '17 Dec - 15 Jan',
+				label: 'Last 30 days',
+				value: '30'
+			},
+			{
+				description: '18 Oct - 15 Jan',
+				label: 'Last 90 days',
+				value: '90'
+			},
+			{
+				description: '20 Jul - 15 Jan',
+				label: 'Last 180 days',
+				value: '180'
+			},
+			{description: '15 Jan - 15 Jan', label: 'Last Year', value: '365'}
+		]);
+	});
+
 	it('see more filtered items with 13 months of retention period', () => {
 		expect(
 			getFilteredItems({

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/dropdown-range-key/utils.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/dropdown-range-key/utils.ts
@@ -92,16 +92,10 @@ const filterLegacyItems = (
 
 const filterMoreItems = (
 	timeRange: Array<TimeRange>,
-	rangeKeys: Array<RangeKeyTimeRanges>,
 	retentionPeriod: number
 ): Array<TimeRange> =>
 	filterItemsByRetention(
-		timeRange.filter(
-			item =>
-				!rangeKeys
-					.filter(value => !rangeKeys.includes(value))
-					.includes(item.value)
-		),
+		timeRange.filter(({label}) => Boolean(label)),
 		retentionPeriod
 	);
 
@@ -145,7 +139,7 @@ export const getFilteredItems: GetFilteredItems = ({
 	}
 
 	if (seeMore) {
-		return filterMoreItems(timeRange, rangeKeys, retentionPeriod);
+		return filterMoreItems(timeRange, retentionPeriod);
 	}
 
 	return filterItems(timeRange, rangeKey, rangeKeys, retentionPeriod);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93682

## What Is Being Fixed

On any dashboard, clicking the "More Preset Periods" option in a date range filter showed an extra item at the top of the dropdown: a bare date range with no label, instead of only the predefined presets.

## How It Is Being Fixed

The "More Preset Periods" branch ran the time ranges through `filterMoreItems`, whose predicate was a tautology — it kept only the range keys absent from the very list it filtered against, which is never any of them. As a result it let through every entry the backend returned, including ranges with no preset label (such as a custom range), which rendered as a label-less date at the top of the menu. The filter now keeps only the entries that map to a predefined preset label, so "See More" expands to the full set of presets and nothing else. A unit test covers the case where an unlabeled range is excluded.

## PR Check

**pr-check: PASS** — tested on `ed1254791b579a0b20d0a59b80a44f8c1072c948`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ed1254791b579a0b20d0a59b80a44f8c1072c948"} -->
