### PR TITLE
LPD-92183 | faro-v4.15.x Mint data source OAuth2 token in process to fix 500

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
@@ -6,13 +6,13 @@
 package com.liferay.osb.faro.web.internal.controller.main;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.oauth.client.LocalOAuthClient;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
-import com.liferay.osb.faro.util.FaroPropsValues;
 import com.liferay.osb.faro.web.internal.application.ApiApplication;
 import com.liferay.osb.faro.web.internal.controller.BaseFaroController;
 import com.liferay.osb.faro.web.internal.controller.FaroController;
@@ -57,16 +57,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.apache.http.HttpStatus;
-import org.apache.http.StatusLine;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -115,34 +105,39 @@ public class OAuth2FaroController extends BaseFaroController {
 			}
 		}
 
-		synchronized (this) {
-			try {
-				if (expiresIn == null) {
-					expiresIn = 3153600000L;
-				}
-
-				AccessTokenExpiresInUtil.setExpiresIn(expiresIn);
-
-				JSONObject jsonObject = _jsonFactory.createJSONObject(
-					_invokeOAuth2Endpoint(
-						oAuth2Application.getClientId(),
-						oAuth2Application.getClientSecret()));
-
-				OAuth2Authorization oAuth2Authorization =
-					_fetchUserOAuth2AuthorizationByAccessToken(
-						jsonObject.getString("access_token"));
-
-				_setOAuth2AuthorizationGroupId(groupId, oAuth2Authorization);
-
-				if (Validator.isNotNull(type)) {
-					_setOAuth2AuthorizationType(oAuth2Authorization, type);
-				}
-
-				return _mapTokenDisplay(oAuth2Authorization);
+		try {
+			if (expiresIn == null) {
+				expiresIn = 3153600000L;
 			}
-			finally {
-				AccessTokenExpiresInUtil.removeExpiresIn();
+
+			AccessTokenExpiresInUtil.setExpiresIn(expiresIn);
+
+			String tokensJSON = _localOAuthClient.requestTokens(
+				oAuth2Application,
+				oAuth2Application.getClientCredentialUserId());
+
+			if (tokensJSON == null) {
+				throw new PortalException(
+					"Unable to create access token for OAuth2 application " +
+						oAuth2Application.getOAuth2ApplicationId());
 			}
+
+			JSONObject jsonObject = _jsonFactory.createJSONObject(tokensJSON);
+
+			OAuth2Authorization oAuth2Authorization =
+				_fetchUserOAuth2AuthorizationByAccessToken(
+					jsonObject.getString("access_token"));
+
+			_setOAuth2AuthorizationGroupId(groupId, oAuth2Authorization);
+
+			if (Validator.isNotNull(type)) {
+				_setOAuth2AuthorizationType(oAuth2Authorization, type);
+			}
+
+			return _mapTokenDisplay(oAuth2Authorization);
+		}
+		finally {
+			AccessTokenExpiresInUtil.removeExpiresIn();
 		}
 	}
 
@@ -325,41 +320,6 @@ public class OAuth2FaroController extends BaseFaroController {
 			});
 	}
 
-	private String _invokeOAuth2Endpoint(String clientId, String clientSecret)
-		throws Exception {
-
-		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-
-		try (CloseableHttpClient closeableHttpClient =
-				httpClientBuilder.build()) {
-
-			HttpPost httpPost = new HttpPost(
-				String.format(
-					_O_AUTH2_ENDPOINT_TEMPLATE, FaroPropsValues.FARO_URL));
-
-			httpPost.setEntity(
-				new UrlEncodedFormEntity(
-					Arrays.asList(
-						new BasicNameValuePair(
-							"grant_type", "client_credentials"),
-						new BasicNameValuePair("client_id", clientId),
-						new BasicNameValuePair(
-							"client_secret", clientSecret))));
-
-			CloseableHttpResponse closeableHttpResponse =
-				closeableHttpClient.execute(httpPost);
-
-			StatusLine statusLine = closeableHttpResponse.getStatusLine();
-
-			if (statusLine.getStatusCode() != HttpStatus.SC_OK) {
-				throw new PortalException(
-					"HTTP response status code: " + statusLine.getStatusCode());
-			}
-
-			return EntityUtils.toString(closeableHttpResponse.getEntity());
-		}
-	}
-
 	private TokenDisplay _mapTokenDisplay(
 		OAuth2Authorization oAuth2Authorization) {
 
@@ -392,14 +352,14 @@ public class OAuth2FaroController extends BaseFaroController {
 		expandoBridge.setAttribute("type", type, false);
 	}
 
-	private static final String _O_AUTH2_ENDPOINT_TEMPLATE =
-		"%s/o/oauth2/token";
-
 	private static final Pattern _baseIdPattern = Pattern.compile(
 		"(.{8})(.{4})(.{4})(.{4})(.*)");
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private LocalOAuthClient _localOAuthClient;
 
 	@Reference
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/AccessTokenExpiresInUtil.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/AccessTokenExpiresInUtil.java
@@ -11,17 +11,23 @@ package com.liferay.osb.faro.web.internal.util;
 public class AccessTokenExpiresInUtil {
 
 	public static long getExpiresIn() {
-		return _expiresIn;
+		Long expiresIn = _expiresIn.get();
+
+		if (expiresIn == null) {
+			return 0;
+		}
+
+		return expiresIn;
 	}
 
 	public static void removeExpiresIn() {
-		_expiresIn = 0;
+		_expiresIn.remove();
 	}
 
 	public static void setExpiresIn(long expiresIn) {
-		_expiresIn = expiresIn;
+		_expiresIn.set(expiresIn);
 	}
 
-	private static long _expiresIn;
+	private static final ThreadLocal<Long> _expiresIn = new ThreadLocal<>();
 
 }

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.web.internal.controller.main;
+
+import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class OAuth2FaroControllerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		ReflectionTestUtils.setField(
+			_oAuth2FaroController, "_oAuth2AuthorizationService",
+			_oAuth2AuthorizationService);
+	}
+
+	@Test
+	public void testRevokeToken() throws Exception {
+		OAuth2Authorization oAuth2Authorization = Mockito.mock(
+			OAuth2Authorization.class);
+
+		String accessToken = "abc";
+
+		Mockito.when(
+			oAuth2Authorization.getAccessTokenContent()
+		).thenReturn(
+			accessToken
+		);
+
+		long oAuth2AuthorizationId = 123;
+
+		Mockito.when(
+			oAuth2Authorization.getOAuth2AuthorizationId()
+		).thenReturn(
+			oAuth2AuthorizationId
+		);
+
+		Mockito.when(
+			_oAuth2AuthorizationService.getUserOAuth2Authorizations(
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)
+		).thenReturn(
+			Arrays.asList(oAuth2Authorization)
+		);
+
+		_oAuth2FaroController.revokeToken(1, accessToken);
+
+		Mockito.verify(
+			_oAuth2AuthorizationService
+		).revokeOAuth2Authorization(
+			oAuth2AuthorizationId
+		);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testRevokeTokenWhenTokenIsNotFound() throws Exception {
+		Mockito.when(
+			_oAuth2AuthorizationService.getUserOAuth2Authorizations(
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		_oAuth2FaroController.revokeToken(1, "nonexistent");
+	}
+
+	private final OAuth2AuthorizationService _oAuth2AuthorizationService =
+		Mockito.mock(OAuth2AuthorizationService.class);
+	private final OAuth2FaroController _oAuth2FaroController =
+		new OAuth2FaroController();
+
+}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
@@ -5,14 +5,26 @@
 
 package com.liferay.osb.faro.web.internal.controller.main;
 
+import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.oauth.client.LocalOAuthClient;
+import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
+import com.liferay.osb.faro.web.internal.model.display.main.TokenDisplay;
+import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -35,8 +47,65 @@ public class OAuth2FaroControllerTest {
 	@Before
 	public void setUp() {
 		ReflectionTestUtils.setField(
+			_oAuth2FaroController, "_jsonFactory", new JSONFactoryImpl());
+		ReflectionTestUtils.setField(
+			_oAuth2FaroController, "_localOAuthClient", _localOAuthClient);
+		ReflectionTestUtils.setField(
+			_oAuth2FaroController, "_oAuth2ApplicationLocalService",
+			_oAuth2ApplicationLocalService);
+		ReflectionTestUtils.setField(
 			_oAuth2FaroController, "_oAuth2AuthorizationService",
 			_oAuth2AuthorizationService);
+
+		PermissionChecker permissionChecker = Mockito.mock(
+			PermissionChecker.class);
+
+		Mockito.when(
+			permissionChecker.getUser()
+		).thenReturn(
+			Mockito.mock(User.class)
+		);
+
+		PermissionThreadLocal.setPermissionChecker(permissionChecker);
+	}
+
+	@Test
+	public void testNewToken() throws Exception {
+		OAuth2Application oAuth2Application = _mockOAuth2Application();
+
+		Mockito.when(
+			_localOAuthClient.requestTokens(oAuth2Application, 100L)
+		).thenReturn(
+			"{\"access_token\": \"abc\"}"
+		);
+
+		OAuth2Authorization oAuth2Authorization = _mockOAuth2Authorization(
+			"abc");
+
+		Mockito.when(
+			_oAuth2AuthorizationService.getUserOAuth2Authorizations(
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)
+		).thenReturn(
+			Arrays.asList(oAuth2Authorization)
+		);
+
+		TokenDisplay tokenDisplay = _oAuth2FaroController.newToken(
+			1, null, "demandbase", null);
+
+		Assert.assertEquals("abc", tokenDisplay.getToken());
+	}
+
+	@Test(expected = PortalException.class)
+	public void testNewTokenWhenAccessTokenIsNotCreated() throws Exception {
+		OAuth2Application oAuth2Application = _mockOAuth2Application();
+
+		Mockito.when(
+			_localOAuthClient.requestTokens(oAuth2Application, 100L)
+		).thenReturn(
+			null
+		);
+
+		_oAuth2FaroController.newToken(1, null, "demandbase", null);
 	}
 
 	@Test
@@ -88,6 +157,82 @@ public class OAuth2FaroControllerTest {
 		_oAuth2FaroController.revokeToken(1, "nonexistent");
 	}
 
+	private OAuth2Application _mockOAuth2Application() throws Exception {
+		OAuth2Application oAuth2Application = Mockito.mock(
+			OAuth2Application.class);
+
+		Mockito.when(
+			_oAuth2ApplicationLocalService.fetchOAuth2Application(
+				Mockito.anyLong(), Mockito.eq("DEMANDBASE"))
+		).thenReturn(
+			oAuth2Application
+		);
+
+		Mockito.when(
+			oAuth2Application.getClientCredentialUserId()
+		).thenReturn(
+			100L
+		);
+
+		Mockito.when(
+			oAuth2Application.getOAuth2ApplicationId()
+		).thenReturn(
+			200L
+		);
+
+		Mockito.when(
+			_oAuth2AuthorizationService.getApplicationOAuth2Authorizations(
+				200L, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		return oAuth2Application;
+	}
+
+	private OAuth2Authorization _mockOAuth2Authorization(String accessToken) {
+		OAuth2Authorization oAuth2Authorization = Mockito.mock(
+			OAuth2Authorization.class);
+
+		Mockito.when(
+			oAuth2Authorization.getAccessTokenContent()
+		).thenReturn(
+			accessToken
+		);
+
+		Date date = new Date();
+
+		Mockito.when(
+			oAuth2Authorization.getAccessTokenCreateDate()
+		).thenReturn(
+			date
+		);
+
+		Mockito.when(
+			oAuth2Authorization.getAccessTokenExpirationDate()
+		).thenReturn(
+			date
+		);
+
+		Mockito.when(
+			oAuth2Authorization.getCreateDate()
+		).thenReturn(
+			date
+		);
+
+		Mockito.when(
+			oAuth2Authorization.getExpandoBridge()
+		).thenReturn(
+			Mockito.mock(ExpandoBridge.class)
+		);
+
+		return oAuth2Authorization;
+	}
+
+	private final LocalOAuthClient _localOAuthClient = Mockito.mock(
+		LocalOAuthClient.class);
+	private final OAuth2ApplicationLocalService _oAuth2ApplicationLocalService =
+		Mockito.mock(OAuth2ApplicationLocalService.class);
 	private final OAuth2AuthorizationService _oAuth2AuthorizationService =
 		Mockito.mock(OAuth2AuthorizationService.class);
 	private final OAuth2FaroController _oAuth2FaroController =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92183

## What Is Being Fixed

Backport to faro-v4.15.x. The token generation endpoint minted the access token by making an HTTP call back to FARO_URL/o/oauth2/token. In staging FARO_URL is the public URL behind the load balancer, so that server-side call carried no session and was redirected to the login page; the HTML response was then parsed as JSON, which failed and surfaced as a 500. Demandbase, Marketo, and HubSpot all request their token through this endpoint and failed consistently, while the Liferay data source uses a different path and kept working.

## How It Is Being Fixed

Minting the token in process through LocalOAuthClient removes the HTTP round trip, so the access token is created in the same node and transaction. Because the bearer token provider now runs on the same thread, AccessTokenExpiresInUtil holds the expiration in a ThreadLocal instead of a JVM-wide static, and the synchronized block that guarded that static is no longer needed.

The OAuth2FaroController test was renamed from OAuth2ControllerTest and gained coverage for the in-process token path. On faro-v4.15.x the oauth-client API resolves through release.dxp.api, so no build.gradle dependency change was needed.

## PR Check

**pr-check: SKIPPED** — Backport of already-reviewed LPD-92183 commits onto faro-v4.15.x.

<!-- pr-check {"reason": "Backport of already-reviewed LPD-92183 commits onto faro-v4.15.x.", "result": "skipped", "sha": "f3db5c1a0502f54db9db30c04678c9425ba4dbd4"} -->
