### PR TITLE
LPD-94159 Show a loading indicator while account attributes load

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountDetailsModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountDetailsModal.tsx
@@ -1,5 +1,6 @@
 import * as API from 'shared/api';
 import ClayModal, {useModal} from '@clayui/modal';
+import Loading from 'shared/components/Loading';
 import React from 'react';
 import {columns, FrontendDataSet} from 'shared/components/FrontendDataSet';
 import {Routes} from 'shared/util/router';
@@ -35,7 +36,7 @@ const AccountDetailsModal: React.FC<IAccountDetailsModalProps> = ({
 	}>();
 	const {observer} = useModal({onClose});
 
-	const {data} = useRequest({
+	const {data, loading} = useRequest({
 		dataSourceFn: API.accounts.fetchDetails,
 		variables: {accountId, channelId, groupId}
 	});
@@ -51,89 +52,106 @@ const AccountDetailsModal: React.FC<IAccountDetailsModalProps> = ({
 			</ClayModal.Header>
 
 			<ClayModal.Body className='px-0'>
-				<FrontendDataSet
-					customDataRenderers={{
-						attributeNameAndValueRenderer: ({
-							itemData,
-							value
-						}: {
-							itemData: {value?: string};
-							value: string;
-						}) =>
-							columns.attributeNameAndValue({
-								attributeName: value,
-								value: itemData.value ?? ''
-							}),
-						dataSourceRenderer: ({
-							itemData,
-							value
-						}: {
-							itemData: {dataSourceId?: string};
-							value: string;
-						}) =>
-							columns.nameAndLinkRenderer({
-								channelId,
-								groupId,
-								itemData: {
-									id: itemData.dataSourceId ?? ''
-								},
-								route: Routes.SETTINGS_DATA_SOURCE,
+				{loading ? (
+					<div
+						className='align-items-center d-flex justify-content-center'
+						style={{minHeight: 400}}
+					>
+						<Loading center={false} />
+					</div>
+				) : (
+					<FrontendDataSet
+						customDataRenderers={{
+							attributeNameAndValueRenderer: ({
+								itemData,
 								value
-							}),
-						lastModifiedRenderer: ({value}: {value: string}) =>
-							columns.dateRenderer({
-								itemData: {},
+							}: {
+								itemData: {value?: string};
+								value: string;
+							}) =>
+								columns.attributeNameAndValue({
+									attributeName: value,
+									value: itemData.value ?? ''
+								}),
+							dataSourceRenderer: ({
+								itemData,
 								value
-							})
-					}}
-					id={FDS_ID}
-					items={items}
-					onItemsPropSearch={(
-						item: IAccountDetailsField,
-						query: string
-					) => item.name.toLowerCase().includes(query.toLowerCase())}
-					views={[
-						{
-							contentRenderer: 'table',
-							default: true,
-							label: Liferay.Language.get('default-view'),
-							name: 'table',
-							schema: {
-								fields: [
-									{
-										contentRenderer:
-											'attributeNameAndValueRenderer',
-										fieldName: 'name',
-										label: `${Liferay.Language.get(
-											'attribute-name'
-										)} | ${Liferay.Language.get('value')}`
+							}: {
+								itemData: {dataSourceId?: string};
+								value: string;
+							}) =>
+								columns.nameAndLinkRenderer({
+									channelId,
+									groupId,
+									itemData: {
+										id: itemData.dataSourceId ?? ''
 									},
-									{
-										fieldName: 'sourceName',
-										label: Liferay.Language.get(
-											'source-name'
-										)
-									},
-									{
-										contentRenderer: 'dataSourceRenderer',
-										fieldName: 'dataSourceName',
-										label: Liferay.Language.get(
-											'data-source'
-										)
-									},
-									{
-										contentRenderer: 'lastModifiedRenderer',
-										fieldName: 'modifiedDate',
-										label: Liferay.Language.get(
-											'last-modified'
-										)
-									}
-								]
-							},
-							thumbnail: 'table'
+									route: Routes.SETTINGS_DATA_SOURCE,
+									value
+								}),
+							lastModifiedRenderer: ({value}: {value: string}) =>
+								columns.dateRenderer({
+									itemData: {},
+									value
+								})
+						}}
+						id={FDS_ID}
+						items={items}
+						onItemsPropSearch={(
+							item: IAccountDetailsField,
+							query: string
+						) =>
+							item.name
+								.toLowerCase()
+								.includes(query.toLowerCase())
 						}
-					]}
-				/>
+						views={[
+							{
+								contentRenderer: 'table',
+								default: true,
+								label: Liferay.Language.get('default-view'),
+								name: 'table',
+								schema: {
+									fields: [
+										{
+											contentRenderer:
+												'attributeNameAndValueRenderer',
+											fieldName: 'name',
+											label: `${Liferay.Language.get(
+												'attribute-name'
+											)} | ${Liferay.Language.get(
+												'value'
+											)}`
+										},
+										{
+											fieldName: 'sourceName',
+											label: Liferay.Language.get(
+												'source-name'
+											)
+										},
+										{
+											contentRenderer:
+												'dataSourceRenderer',
+											fieldName: 'dataSourceName',
+											label: Liferay.Language.get(
+												'data-source'
+											)
+										},
+										{
+											contentRenderer:
+												'lastModifiedRenderer',
+											fieldName: 'modifiedDate',
+											label: Liferay.Language.get(
+												'last-modified'
+											)
+										}
+									]
+								},
+								thumbnail: 'table'
+							}
+						]}
+					/>
+				)}
 			</ClayModal.Body>
 		</ClayModal>
 	);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/AccountDetailsModal.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/AccountDetailsModal.tsx
@@ -141,6 +141,15 @@ describe('AccountDetailsModal', () => {
 		expect(screen.queryAllByTestId('fds-item')).toHaveLength(0);
 	});
 
+	it('should render a loading indicator instead of the data set while the request is loading', () => {
+		mockedUseRequest.mockReturnValue({data: undefined, loading: true});
+
+		const {container} = renderModal();
+
+		expect(screen.queryByTestId('fds-component')).not.toBeInTheDocument();
+		expect(container.querySelector('.loading-root')).toBeInTheDocument();
+	});
+
 	it('should not offer any column as sortable since the data set is fed a static items array', () => {
 		renderModal();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94159

## What Is Being Fixed

In an account's Profile tab, the "View All" modal opened from the "General Account Information" card briefly rendered the data set's empty state ("No results found") while the account details request was still in flight, before the attributes table appeared.

## How It Is Being Fixed

The modal fed the data set an empty items array while the request was loading, so the data set showed its empty state until the data arrived. The data set is now gated behind the request's loading state: while loading, the modal renders a loading indicator inside a min-height container so it is not cramped, and the data set mounts only once the attributes are ready. A unit test covers the loading branch.

## PR Check

**pr-check: PASS** — tested on `32b5177bdb7b84ad4672413e402bf28c652a0c9e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "32b5177bdb7b84ad4672413e402bf28c652a0c9e"} -->
