### PR TITLE
LPD-91079 LPD-91083 faro-v4.15.x Revert active users filter changes

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
@@ -5,10 +5,13 @@ import BasePage from 'shared/components/base-page';
 import Link from '@clayui/link';
 import Loading from 'shared/components/Loading';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
-import React from 'react';
+import React, {useState} from 'react';
 import TotalAccounts from 'contacts/components/account/TotalAccounts';
 import URLConstants from 'shared/util/url-constants';
+import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
 import {isNil} from 'lodash/fp';
+import {RangeKeyTimeRanges} from 'shared/util/constants';
+import {RangeSelectors} from 'shared/types';
 import {Routes, toRoute} from 'shared/util/router';
 import {SectionHeader} from 'shared/components/SectionHeader';
 import {Sizes} from 'shared/util/constants';
@@ -24,6 +27,12 @@ interface IListProps {
 const List: React.FC<IListProps> = ({channelId, groupId}) => {
 	const currentUser = useCurrentUser();
 	const {selectedChannel} = useChannelContext();
+
+	const [rangeSelectors, setRangeSelectors] = useState<RangeSelectors>({
+		rangeEnd: null,
+		rangeKey: RangeKeyTimeRanges.Last30Days,
+		rangeStart: null
+	});
 
 	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
 		dataSourceFn: API.dataSource.fetchChannels,
@@ -115,16 +124,27 @@ const List: React.FC<IListProps> = ({channelId, groupId}) => {
 					<>
 						<TotalAccounts groupId={groupId} />
 
-						<SectionHeader
-							icon='box-container'
-							title={Liferay.Language.get('accounts')}
-						/>
+						<div className='align-items-center d-flex justify-content-between mb-3'>
+							<SectionHeader
+								className='mb-0'
+								icon='box-container'
+								title={Liferay.Language.get('accounts')}
+							/>
+
+							<DropdownRangeKey
+								legacy={false}
+								onRangeSelectorChange={setRangeSelectors}
+								rangeSelectors={rangeSelectors}
+							/>
+						</div>
 
 						<AccountsDataSet
+							activityStatusFilter='ACTIVE'
 							apiURL={`/o/faro/contacts/${groupId}/account/search`}
 							channelId={channelId}
 							groupId={groupId}
 							queryParams={{channelId}}
+							rangeSelectors={rangeSelectors}
 						/>
 					</>
 				) : (

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/List.tsx
@@ -31,6 +31,10 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 	}
 }));
 
+jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
+	DropdownRangeKey: () => null
+}));
+
 jest.mock('shared/hooks/useRequest', () => ({
 	useRequest: jest.fn()
 }));
@@ -152,14 +156,16 @@ describe('List', () => {
 			expect(screen.getByTestId('fds-component')).toHaveAttribute('id');
 		});
 
-		it('should preload the rangeKey filter with Last 30 Days by default', () => {
+		it('should pass activityStatusFilter "ACTIVE" to AccountsDataSet by default', () => {
 			renderList();
 
-			const rangeKeyFilter = lastFilters?.find(f => f.id === 'rangeKey');
+			const activityStatusFilter = lastFilters?.find(
+				f => f.id === 'activityStatus'
+			);
 
-			expect(rangeKeyFilter?.preloadedData).toEqual({
+			expect(activityStatusFilter?.preloadedData).toEqual({
 				exclude: false,
-				selectedItems: [{label: 'Last 30 days', value: '30'}]
+				selectedItems: [{label: 'Active', value: 'ACTIVE'}]
 			});
 		});
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
@@ -242,29 +242,33 @@ exports[`List rendering should match the snapshot 1`] = `
           </div>
         </div>
         <div
-          class="mb-3"
+          class="align-items-center d-flex justify-content-between mb-3"
         >
-          <span
-            class="mr-2"
+          <div
+            class="mb-0"
           >
             <span
-              class="text-4 text-secondary"
+              class="mr-2"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-box-container"
-                role="presentation"
+              <span
+                class="text-4 text-secondary"
               >
-                <use
-                  href="#box-container"
-                />
-              </svg>
+                <svg
+                  class="lexicon-icon lexicon-icon-box-container"
+                  role="presentation"
+                >
+                  <use
+                    href="#box-container"
+                  />
+                </svg>
+              </span>
             </span>
-          </span>
-          <span
-            class="text-4 text-secondary font-weight-semi-bold"
-          >
-            ACCOUNTS
-          </span>
+            <span
+              class="text-4 text-secondary font-weight-semi-bold"
+            >
+              ACCOUNTS
+            </span>
+          </div>
         </div>
         <div
           class="card card-root"

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
@@ -19,10 +19,11 @@ import {
 	ProfileTypes,
 	RelationalOperators
 } from 'segment/segment-editor/dynamic/utils/constants';
-import {FilterByType, FilterInputType, FilterOptionType} from 'shared/types';
+import {FilterByType, FilterOptionType, RangeSelectors} from 'shared/types';
+import {getSafeRangeSelectors} from 'shared/util/util';
 import {IndividualsListCDPColumns} from 'shared/util/table-columns';
 import {Map, Set} from 'immutable';
-import {RangeKeyTimeRanges, Sizes} from 'shared/util/constants';
+import {Sizes} from 'shared/util/constants';
 import {useParams} from 'react-router-dom';
 import {useRequest} from 'shared/hooks/useRequest';
 import {useStatefulPagination} from 'shared/hooks/useStatefulPagination';
@@ -56,45 +57,6 @@ const ORDER_BY_OPTIONS = [
 
 const DEFAULT_FILTER_BY_OPTIONS: FilterOptionType[] = [
 	{
-		key: 'activeUsers',
-		label: Liferay.Language.get('active-individuals'),
-		type: 'radio' as FilterInputType,
-		values: [
-			{
-				label: Liferay.Language.get('last-24-hours'),
-				value: RangeKeyTimeRanges.Last24Hours
-			},
-			{
-				label: Liferay.Language.get('yesterday'),
-				value: RangeKeyTimeRanges.Yesterday
-			},
-			{
-				label: Liferay.Language.get('last-seven-days'),
-				value: RangeKeyTimeRanges.Last7Days
-			},
-			{
-				label: Liferay.Language.get('last-28-days'),
-				value: RangeKeyTimeRanges.Last28Days
-			},
-			{
-				label: Liferay.Language.get('last-30-days'),
-				value: RangeKeyTimeRanges.Last30Days
-			},
-			{
-				label: Liferay.Language.get('last-90-days'),
-				value: RangeKeyTimeRanges.Last90Days
-			},
-			{
-				label: Liferay.Language.get('last-180-days'),
-				value: RangeKeyTimeRanges.Last180Days
-			},
-			{
-				label: Liferay.Language.get('last-year'),
-				value: RangeKeyTimeRanges.LastYear
-			}
-		]
-	},
-	{
 		key: 'profileTypes',
 		label: Liferay.Language.get('profile-type'),
 		values: [
@@ -105,6 +67,20 @@ const DEFAULT_FILTER_BY_OPTIONS: FilterOptionType[] = [
 			{
 				label: Liferay.Language.get('anonymous'),
 				value: ProfileTypes.ANONYMOUS
+			}
+		]
+	},
+	{
+		key: 'activityStatus',
+		label: Liferay.Language.get('activity-status'),
+		values: [
+			{
+				label: Liferay.Language.get('active'),
+				value: 'ACTIVE'
+			},
+			{
+				label: Liferay.Language.get('inactive'),
+				value: 'INACTIVE'
 			}
 		]
 	}
@@ -123,15 +99,22 @@ function transformCountriesInQueryString(countries: string[]) {
 		.join(Conjunctions.Or);
 }
 
-const IndividualsList: React.FC = () => {
+interface IIndividualsList {
+	rangeSelectors: RangeSelectors;
+}
+
+const IndividualsList: React.FC<IIndividualsList> = ({rangeSelectors}) => {
 	const {channelId = '', groupId = ''} = useParams<{
 		channelId: string;
 		groupId: string;
 	}>();
 
+	const {rangeEnd, rangeKey, rangeStart} =
+		getSafeRangeSelectors(rangeSelectors);
+
 	const paginationParams = useStatefulPagination(undefined, {
 		initialFilterBy: Map({
-			activeUsers: Set([RangeKeyTimeRanges.Last30Days])
+			activityStatus: Set(['ACTIVE'])
 		}) as FilterByType,
 		initialOrderIOMap: createOrderIOMap(NAME)
 	});
@@ -165,12 +148,14 @@ const IndividualsList: React.FC = () => {
 		return DEFAULT_FILTER_BY_OPTIONS;
 	}, [countriesData, countriesLoading]);
 
-	const activeUsersValue =
-		paginationParams.filterBy.get('activeUsers')?.first() ?? null;
-
-	const rangeKey = activeUsersValue ? parseInt(activeUsersValue) : null;
+	const activityStatusValues =
+		paginationParams.filterBy.get('activityStatus');
 
 	const selectedFilters = {
+		activityStatus:
+			activityStatusValues?.size === 2
+				? undefined
+				: activityStatusValues?.first(),
 		filter: transformCountriesInQueryString(
 			paginationParams.filterBy.get('countries')?.toArray()
 		),
@@ -228,19 +213,21 @@ const IndividualsList: React.FC = () => {
 							IndividualsListCDPColumns.country,
 							IndividualsListCDPColumns.firstSeen,
 							IndividualsListCDPColumns.lastActive,
-							IndividualsListCDPColumns.profileType
+							IndividualsListCDPColumns.profileType,
+							IndividualsListCDPColumns.activityStatus
 						]}
 						dataSourceFn={API.individuals.search}
 						dataSourceParams={{
+							activityStatus: selectedFilters.activityStatus,
 							channelId,
 							filter: selectedFilters.filter,
 							groupId,
 							profileTypes: selectedFilters.profileTypes.length
 								? selectedFilters.profileTypes
 								: undefined,
-							rangeEnd: null,
+							rangeEnd,
 							rangeKey,
-							rangeStart: null
+							rangeStart
 						}}
 						filterByOptions={FILTER_BY_OPTIONS}
 						key='individuals-list-table'

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
@@ -9,16 +9,18 @@ import IndividualsList from './IndividualsList';
 import Loading from 'shared/components/Loading';
 import MetricCard from 'shared/components/MetricCard';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
-import React from 'react';
+import React, {useState} from 'react';
 import URLConstants from 'shared/util/url-constants';
 import {Text as ClayText} from '@clayui/core';
 import {CSVType} from 'shared/components/download-report/utils';
 import {DownloadStaticCSVReport} from 'shared/components/download-report/DownloadStaticCSVReport';
+import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
 import {INTERVAL_KEY_MAP} from 'shared/util/time';
 import {isNil} from 'lodash';
+import {RangeKeyTimeRanges, Sizes} from 'shared/util/constants';
+import {RangeSelectors} from 'shared/types';
 import {Routes, toRoute} from 'shared/util/router';
 import {SectionHeader} from 'shared/components/SectionHeader';
-import {Sizes} from 'shared/util/constants';
 import {sub} from 'shared/util/lang';
 import {toThousands} from 'shared/util/numbers';
 import {useCurrentUser} from 'shared/hooks/useCurrentUser';
@@ -132,6 +134,12 @@ const IndividualsOverviewCDP = () => {
 
 	const authorized = currentUser.isAdmin();
 
+	const [rangeSelectors, setRangeSelectors] = useState<RangeSelectors>({
+		rangeEnd: null,
+		rangeKey: RangeKeyTimeRanges.Last30Days,
+		rangeStart: null
+	});
+
 	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
 		dataSourceFn: API.dataSource.search,
 		variables: {
@@ -144,7 +152,7 @@ const IndividualsOverviewCDP = () => {
 		variables: {
 			channelId,
 			interval: INTERVAL_KEY_MAP.week,
-			rangeKey: 30
+			rangeKey: Number(RangeKeyTimeRanges.Last30Days)
 		}
 	});
 
@@ -238,12 +246,21 @@ const IndividualsOverviewCDP = () => {
 							</ClayLayout.Col>
 						</ClayLayout.Row>
 
-						<SectionHeader
-							icon='box-container'
-							title={Liferay.Language.get('individuals')}
-						/>
+						<div className='align-items-center d-flex justify-content-between mb-3'>
+							<SectionHeader
+								className='mb-0'
+								icon='box-container'
+								title={Liferay.Language.get('individuals')}
+							/>
 
-						<IndividualsList />
+							<DropdownRangeKey
+								legacy={false}
+								onRangeSelectorChange={setRangeSelectors}
+								rangeSelectors={rangeSelectors}
+							/>
+						</div>
+
+						<IndividualsList rangeSelectors={rangeSelectors} />
 					</>
 				)}
 			</BasePage.Body>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
@@ -1,11 +1,21 @@
 import * as API from 'shared/api';
+import * as useStatefulPaginationModule from 'shared/hooks/useStatefulPagination';
 
 import IndividualsList from '../IndividualsList';
 import React from 'react';
 import {createMemoryHistory} from 'history';
+import {createOrderIOMap, NAME} from 'shared/util/pagination';
+import {Map, Set} from 'immutable';
+import {RangeKeyTimeRanges} from 'shared/util/constants';
 import {render} from '@testing-library/react';
 import {Router} from 'react-router';
 import {waitForLoadingToBeRemoved} from 'test/helpers';
+
+const defaultRangeSelectors = {
+	rangeEnd: null,
+	rangeKey: RangeKeyTimeRanges.Last30Days,
+	rangeStart: null
+};
 
 jest.unmock('react-dom');
 
@@ -33,6 +43,7 @@ describe('Individuals List', () => {
 					{
 						accountName: 'Liferay Inc.',
 						activitiesCount: 8,
+						activityStatus: 'ACTIVE',
 						dateCreated: 1769697362927,
 						firstActivityDate: 1769697128235,
 						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c1',
@@ -47,6 +58,7 @@ describe('Individuals List', () => {
 					{
 						accountName: 'Liferay',
 						activitiesCount: 8,
+						activityStatus: 'ACTIVE',
 						dateCreated: 1769697362927,
 						firstActivityDate: 1769697128235,
 						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c3',
@@ -60,6 +72,7 @@ describe('Individuals List', () => {
 					},
 					{
 						activitiesCount: 3,
+						activityStatus: 'INACTIVE',
 						dateCreated: 1769697362927,
 						firstActivityDate: 1769697128235,
 						id: '47ff64395860b1d498241d907069f649b98c198a95b3ba5303b87094058590c2',
@@ -77,7 +90,7 @@ describe('Individuals List', () => {
 
 		const {getByText} = render(
 			<Router history={history}>
-				<IndividualsList />
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
 			</Router>
 		);
 
@@ -97,7 +110,7 @@ describe('Individuals List', () => {
 
 		const {getByText} = render(
 			<Router history={history}>
-				<IndividualsList />
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
 			</Router>
 		);
 
@@ -116,7 +129,7 @@ describe('Individuals List', () => {
 		).toBeInTheDocument();
 	});
 
-	it('passes Last 30 Days as the default range key to the search API', async () => {
+	it('passes range params to the search API', async () => {
 		// @ts-ignore
 		API.individuals.search.mockReturnValue(
 			Promise.resolve({items: [], total: 0})
@@ -126,7 +139,7 @@ describe('Individuals List', () => {
 
 		render(
 			<Router history={history}>
-				<IndividualsList />
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
 			</Router>
 		);
 
@@ -140,5 +153,136 @@ describe('Individuals List', () => {
 				rangeStart: null
 			})
 		);
+	});
+
+	it('passes activityStatus ACTIVE to the search API by default', async () => {
+		(API.individuals.search as jest.Mock).mockReturnValue(
+			Promise.resolve({items: [], total: 0})
+		);
+
+		const history = createMemoryHistory();
+
+		render(
+			<Router history={history}>
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		expect(API.individuals.search as jest.Mock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				activityStatus: 'ACTIVE'
+			})
+		);
+	});
+
+	it('renders the activity status column header', async () => {
+		(API.individuals.search as jest.Mock).mockReturnValue(
+			Promise.resolve({items: [], total: 0})
+		);
+
+		const history = createMemoryHistory();
+
+		const {getByText} = render(
+			<Router history={history}>
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		expect(getByText('Activity Status')).toBeInTheDocument();
+	});
+
+	it('renders active and inactive activity status labels', async () => {
+		(API.individuals.search as jest.Mock).mockReturnValue(
+			Promise.resolve({
+				items: [
+					{
+						activitiesCount: 1,
+						activityStatus: 'ACTIVE',
+						dateCreated: 1769697362927,
+						firstActivityDate: 1769697128235,
+						id: 'id-active',
+						lastActivityDate: 1769697160365,
+						name: 'Active User',
+						profileType: 'KNOWN',
+						properties: {}
+					},
+					{
+						activitiesCount: 0,
+						activityStatus: 'INACTIVE',
+						dateCreated: 1769697362927,
+						firstActivityDate: 1769697128235,
+						id: 'id-inactive',
+						lastActivityDate: 1769697160365,
+						name: 'Inactive User',
+						profileType: 'KNOWN',
+						properties: {}
+					}
+				],
+				total: 2
+			})
+		);
+
+		const history = createMemoryHistory();
+
+		render(
+			<Router history={history}>
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		expect(
+			document.querySelector('.label-success .label-item')
+		).toHaveTextContent('Active');
+
+		expect(
+			document.querySelector('.label-secondary .label-item')
+		).toHaveTextContent('Inactive');
+	});
+
+	it('passes undefined activityStatus when both active and inactive are selected', async () => {
+		(API.individuals.search as jest.Mock).mockClear();
+		(API.individuals.search as jest.Mock).mockReturnValue(
+			Promise.resolve({items: [], total: 0})
+		);
+
+		const spy = jest
+			.spyOn(useStatefulPaginationModule, 'useStatefulPagination')
+			.mockReturnValue({
+				delta: 20,
+				filterBy: Map({
+					activityStatus: Set(['ACTIVE', 'INACTIVE'])
+				}) as any,
+				onDeltaChange: jest.fn(),
+				onFilterByChange: jest.fn(),
+				onOrderIOMapChange: jest.fn(),
+				onPageChange: jest.fn(),
+				onQueryChange: jest.fn(),
+				orderIOMap: createOrderIOMap(NAME),
+				page: 1,
+				query: '',
+				resetPage: jest.fn()
+			});
+
+		const history = createMemoryHistory();
+
+		render(
+			<Router history={history}>
+				<IndividualsList rangeSelectors={defaultRangeSelectors} />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		const callArgs = (API.individuals.search as jest.Mock).mock.calls[0][0];
+
+		expect(callArgs.activityStatus).toBeUndefined();
+
+		spy.mockRestore();
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
@@ -146,6 +146,26 @@ describe('Individuals List', () => {
 		);
 	});
 
+	it('does not pass activityStatus to the search API', async () => {
+		(API.individuals.search as jest.Mock).mockReturnValue(
+			Promise.resolve({items: [], total: 0})
+		);
+
+		const history = createMemoryHistory();
+
+		render(
+			<Router history={history}>
+				<IndividualsList />
+			</Router>
+		);
+
+		await waitForLoadingToBeRemoved(document.body);
+
+		const callArgs = (API.individuals.search as jest.Mock).mock.calls[0][0];
+
+		expect(callArgs.activityStatus).toBeUndefined();
+	});
+
 	it('passes the selected range key when activeUsers filter changes', async () => {
 		(API.individuals.search as jest.Mock).mockReturnValue(
 			Promise.resolve({items: [], total: 0})

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsList.tsx
@@ -1,12 +1,8 @@
 import * as API from 'shared/api';
-import * as useStatefulPaginationModule from 'shared/hooks/useStatefulPagination';
 
 import IndividualsList from '../IndividualsList';
 import React from 'react';
 import {createMemoryHistory} from 'history';
-import {createOrderIOMap, NAME} from 'shared/util/pagination';
-import {Map, Set} from 'immutable';
-import {RangeKeyTimeRanges} from 'shared/util/constants';
 import {render} from '@testing-library/react';
 import {Router} from 'react-router';
 import {waitForLoadingToBeRemoved} from 'test/helpers';
@@ -144,109 +140,5 @@ describe('Individuals List', () => {
 				rangeStart: null
 			})
 		);
-	});
-
-	it('does not pass activityStatus to the search API', async () => {
-		(API.individuals.search as jest.Mock).mockReturnValue(
-			Promise.resolve({items: [], total: 0})
-		);
-
-		const history = createMemoryHistory();
-
-		render(
-			<Router history={history}>
-				<IndividualsList />
-			</Router>
-		);
-
-		await waitForLoadingToBeRemoved(document.body);
-
-		const callArgs = (API.individuals.search as jest.Mock).mock.calls[0][0];
-
-		expect(callArgs.activityStatus).toBeUndefined();
-	});
-
-	it('passes the selected range key when activeUsers filter changes', async () => {
-		(API.individuals.search as jest.Mock).mockReturnValue(
-			Promise.resolve({items: [], total: 0})
-		);
-
-		const spy = jest
-			.spyOn(useStatefulPaginationModule, 'useStatefulPagination')
-			.mockReturnValue({
-				delta: 20,
-				filterBy: Map({
-					activeUsers: Set([RangeKeyTimeRanges.Last7Days])
-				}) as any,
-				onDeltaChange: jest.fn(),
-				onFilterByChange: jest.fn(),
-				onOrderIOMapChange: jest.fn(),
-				onPageChange: jest.fn(),
-				onQueryChange: jest.fn(),
-				orderIOMap: createOrderIOMap(NAME),
-				page: 1,
-				query: '',
-				resetPage: jest.fn()
-			});
-
-		const history = createMemoryHistory();
-
-		render(
-			<Router history={history}>
-				<IndividualsList />
-			</Router>
-		);
-
-		await waitForLoadingToBeRemoved(document.body);
-
-		expect(API.individuals.search as jest.Mock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				rangeKey: 7
-			})
-		);
-
-		spy.mockRestore();
-	});
-
-	it('passes null rangeKey when activeUsers filter is cleared', async () => {
-		(API.individuals.search as jest.Mock).mockReturnValue(
-			Promise.resolve({items: [], total: 0})
-		);
-
-		const spy = jest
-			.spyOn(useStatefulPaginationModule, 'useStatefulPagination')
-			.mockReturnValue({
-				delta: 20,
-				filterBy: Map({
-					activeUsers: Set([])
-				}) as any,
-				onDeltaChange: jest.fn(),
-				onFilterByChange: jest.fn(),
-				onOrderIOMapChange: jest.fn(),
-				onPageChange: jest.fn(),
-				onQueryChange: jest.fn(),
-				orderIOMap: createOrderIOMap(NAME),
-				page: 1,
-				query: '',
-				resetPage: jest.fn()
-			});
-
-		const history = createMemoryHistory();
-
-		render(
-			<Router history={history}>
-				<IndividualsList />
-			</Router>
-		);
-
-		await waitForLoadingToBeRemoved(document.body);
-
-		expect(API.individuals.search as jest.Mock).toHaveBeenCalledWith(
-			expect.objectContaining({
-				rangeKey: null
-			})
-		);
-
-		spy.mockRestore();
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
@@ -36,6 +36,10 @@ jest.mock('react-router-dom', () => ({
 	})
 }));
 
+jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
+	DropdownRangeKey: () => null
+}));
+
 jest.mock('../IndividualsList', () => ({
 	__esModule: true,
 	default: () => null

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -11,47 +11,19 @@ import {
 	lifecycleStagesLabelMap
 } from 'contacts/pages/account/utils/constants';
 import {RangeKeyTimeRanges} from 'shared/util/constants';
+import {RangeSelectors} from 'shared/types';
 import {Routes} from 'shared/util/router';
 import {toThousands} from 'shared/util/numbers';
 import {useRequest} from 'shared/hooks/useRequest';
 
-const activeUsersItems = [
-	{
-		label: Liferay.Language.get('last-24-hours'),
-		value: RangeKeyTimeRanges.Last24Hours
-	},
-	{
-		label: Liferay.Language.get('yesterday'),
-		value: RangeKeyTimeRanges.Yesterday
-	},
-	{
-		label: Liferay.Language.get('last-seven-days'),
-		value: RangeKeyTimeRanges.Last7Days
-	},
-	{
-		label: Liferay.Language.get('last-28-days'),
-		value: RangeKeyTimeRanges.Last28Days
-	},
-	{
-		label: Liferay.Language.get('last-30-days'),
-		value: RangeKeyTimeRanges.Last30Days
-	},
-	{
-		label: Liferay.Language.get('last-90-days'),
-		value: RangeKeyTimeRanges.Last90Days
-	},
-	{
-		label: Liferay.Language.get('last-180-days'),
-		value: RangeKeyTimeRanges.Last180Days
-	},
-	{
-		label: Liferay.Language.get('last-year'),
-		value: RangeKeyTimeRanges.LastYear
-	}
+const activityStatusItems = [
+	{label: Liferay.Language.get('active'), value: 'ACTIVE'},
+	{label: Liferay.Language.get('inactive'), value: 'INACTIVE'}
 ];
 
 interface IAccountsDataSetProps {
 	accountLifecycleId?: string;
+	activityStatusFilter?: string;
 	apiURL: string;
 	channelId: string;
 	countryFilter?: string;
@@ -59,6 +31,7 @@ interface IAccountsDataSetProps {
 	industryFilter?: string;
 	lifecycleStageFilter?: LifecycleStages;
 	queryParams?: Record<string, string>;
+	rangeSelectors?: RangeSelectors;
 }
 
 interface ILifecycleStageFieldValue {
@@ -76,13 +49,19 @@ const buildSelectionPreloadedData = (value?: string, label?: string) =>
 
 const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 	accountLifecycleId,
+	activityStatusFilter,
 	apiURL,
 	channelId,
 	countryFilter,
 	groupId,
 	industryFilter,
 	lifecycleStageFilter,
-	queryParams
+	queryParams,
+	rangeSelectors = {
+		rangeEnd: null,
+		rangeKey: RangeKeyTimeRanges.Last30Days,
+		rangeStart: null
+	}
 }) => {
 	const snapshots = useSnapshots('accounts-list-dataset');
 
@@ -110,16 +89,38 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 		  )
 		: undefined;
 
-	const finalApiURL = queryParams
-		? `${apiURL}?${new URLSearchParams(queryParams)}`
-		: apiURL;
+	let rangeSelectorParams = `rangeKey=${rangeSelectors.rangeKey}`;
+
+	if (rangeSelectors.rangeEnd) {
+		rangeSelectorParams += `&rangeEnd=${rangeSelectors.rangeEnd}`;
+	}
+
+	if (rangeSelectors.rangeStart) {
+		rangeSelectorParams += `&rangeStart=${rangeSelectors.rangeStart}`;
+	}
+
+	const queryParamsString = queryParams
+		? `&${new URLSearchParams(queryParams)}`
+		: '';
+
+	const rangeApiURL = `${apiURL}?${rangeSelectorParams}${queryParamsString}`;
 
 	return (
 		<Card>
 			<FrontendDataSet
-				apiURL={finalApiURL}
+				apiURL={rangeApiURL}
 				configInURLBehavior={EConfigInURLBehavior.OFF}
 				customDataRenderers={{
+					accountActivityStatusRenderer: ({value}: {value: string}) =>
+						value &&
+						columns.cmsLabelRenderer({
+							displayType:
+								value === 'ACTIVE' ? 'success' : 'secondary',
+							label:
+								value === 'ACTIVE'
+									? Liferay.Language.get('active')
+									: Liferay.Language.get('inactive')
+						}),
 					accountLifecycleStageRenderer: ({
 						value
 					}: {
@@ -160,13 +161,15 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 				}}
 				filters={[
 					{
-						id: 'rangeKey',
-						items: activeUsersItems,
-						label: Liferay.Language.get('active-individuals'),
-						name: 'rangeKey',
+						id: 'activityStatus',
+						items: activityStatusItems,
+						label: Liferay.Language.get('activity-status'),
+						name: 'activityStatus',
 						preloadedData: buildSelectionPreloadedData(
-							RangeKeyTimeRanges.Last30Days,
-							Liferay.Language.get('last-30-days')
+							activityStatusFilter,
+							activityStatusItems.find(
+								({value}) => value === activityStatusFilter
+							)?.label
 						),
 						type: 'selection'
 					},
@@ -216,10 +219,12 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 				]}
 				id='accounts-list-dataset'
 				key={[
+					activityStatusFilter,
 					countryFilter,
 					industryFilter,
 					lifecycleStageFilter,
-					lifecycleStages.length
+					lifecycleStages.length,
+					...Object.values(rangeSelectors)
 				].join()}
 				pagination={pagination}
 				showPagination
@@ -286,6 +291,15 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 									fieldName: 'lastEnriched',
 									label: Liferay.Language.get(
 										'last-enriched'
+									),
+									sortable: true
+								},
+								{
+									contentRenderer:
+										'accountActivityStatusRenderer',
+									fieldName: 'activityStatus',
+									label: Liferay.Language.get(
+										'activity-status'
 									),
 									sortable: true
 								}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -1,12 +1,7 @@
 import * as API from 'shared/api';
 import Card from 'shared/components/Card';
 import React from 'react';
-import {
-	columns,
-	pagination,
-	rangeSelectors,
-	useSnapshots
-} from 'shared/util/frontend-data-set';
+import {columns, pagination, useSnapshots} from 'shared/util/frontend-data-set';
 import {
 	EConfigInURLBehavior,
 	FrontendDataSet
@@ -19,6 +14,41 @@ import {RangeKeyTimeRanges} from 'shared/util/constants';
 import {Routes} from 'shared/util/router';
 import {toThousands} from 'shared/util/numbers';
 import {useRequest} from 'shared/hooks/useRequest';
+
+const activeUsersItems = [
+	{
+		label: Liferay.Language.get('last-24-hours'),
+		value: RangeKeyTimeRanges.Last24Hours
+	},
+	{
+		label: Liferay.Language.get('yesterday'),
+		value: RangeKeyTimeRanges.Yesterday
+	},
+	{
+		label: Liferay.Language.get('last-seven-days'),
+		value: RangeKeyTimeRanges.Last7Days
+	},
+	{
+		label: Liferay.Language.get('last-28-days'),
+		value: RangeKeyTimeRanges.Last28Days
+	},
+	{
+		label: Liferay.Language.get('last-30-days'),
+		value: RangeKeyTimeRanges.Last30Days
+	},
+	{
+		label: Liferay.Language.get('last-90-days'),
+		value: RangeKeyTimeRanges.Last90Days
+	},
+	{
+		label: Liferay.Language.get('last-180-days'),
+		value: RangeKeyTimeRanges.Last180Days
+	},
+	{
+		label: Liferay.Language.get('last-year'),
+		value: RangeKeyTimeRanges.LastYear
+	}
+];
 
 interface IAccountsDataSetProps {
 	accountLifecycleId?: string;
@@ -131,7 +161,7 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 				filters={[
 					{
 						id: 'rangeKey',
-						items: rangeSelectors,
+						items: activeUsersItems,
 						label: Liferay.Language.get('active-individuals'),
 						name: 'rangeKey',
 						preloadedData: buildSelectionPreloadedData(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -142,6 +142,18 @@ describe('AccountsDataSet', () => {
 		]);
 	});
 
+	it('should not include the activityStatus filter', () => {
+		render(
+			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+		);
+
+		const activityStatusFilter = lastFilters?.find(
+			f => f.id === 'activityStatus'
+		);
+
+		expect(activityStatusFilter).toBeUndefined();
+	});
+
 	it('should leave country and industry filters without preloadedData when no props are passed', () => {
 		render(
 			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -5,6 +5,12 @@ import {LifecycleStages} from 'contacts/pages/account/utils/constants';
 import {RangeKeyTimeRanges} from 'shared/util/constants';
 import {useRequest} from 'shared/hooks/useRequest';
 
+const defaultRangeSelectors = {
+	rangeEnd: null,
+	rangeKey: RangeKeyTimeRanges.Last30Days,
+	rangeStart: null
+};
+
 const DEFAULT_STAGE_ITEMS = [
 	{id: '9990', stageType: LifecycleStages.AWARE},
 	{id: '9991', stageType: LifecycleStages.ENGAGED},
@@ -43,6 +49,9 @@ type FakeFilter = {
 };
 
 type FakeCustomDataRenderers = {
+	accountActivityStatusRenderer: (props: {
+		value: string;
+	}) => React.ReactElement | null | false;
 	accountNameRenderer: (props: {
 		itemData: {id: string | number};
 		value: string;
@@ -91,6 +100,7 @@ describe('AccountsDataSet', () => {
 				apiURL='fake-url'
 				channelId='123'
 				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -100,92 +110,23 @@ describe('AccountsDataSet', () => {
 		);
 	});
 
-	it('should pass the apiURL directly to FrontendDataSet without appending range params', () => {
+	it('should leave activityStatus/country/industry filters without preloadedData when no props are passed', () => {
 		render(
 			<AccountsDataSet
 				apiURL='fake-url'
 				channelId='123'
 				groupId='23'
-			/>
-		);
-
-		expect(lastApiURL).toBe('fake-url');
-	});
-
-	it('should preload the rangeKey filter with Last 30 Days by default', () => {
-		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-			/>
-		);
-
-		const rangeKeyFilter = lastFilters?.find(f => f.id === 'rangeKey');
-
-		expect(rangeKeyFilter?.preloadedData).toEqual({
-			exclude: false,
-			selectedItems: [
-				{
-					label: 'Last 30 days',
-					value: RangeKeyTimeRanges.Last30Days
-				}
-			]
-		});
-	});
-
-	it('should include all 8 time range options in the rangeKey filter', () => {
-		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-			/>
-		);
-
-		const rangeKeyFilter = lastFilters?.find(f => f.id === 'rangeKey');
-
-		expect(rangeKeyFilter?.items).toHaveLength(8);
-		expect(rangeKeyFilter?.items?.map(i => i.value)).toEqual([
-			RangeKeyTimeRanges.Last24Hours,
-			RangeKeyTimeRanges.Yesterday,
-			RangeKeyTimeRanges.Last7Days,
-			RangeKeyTimeRanges.Last28Days,
-			RangeKeyTimeRanges.Last30Days,
-			RangeKeyTimeRanges.Last90Days,
-			RangeKeyTimeRanges.Last180Days,
-			RangeKeyTimeRanges.LastYear
-		]);
-	});
-
-	it('should not include the activityStatus filter', () => {
-		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
 		const activityStatusFilter = lastFilters?.find(
 			f => f.id === 'activityStatus'
 		);
-
-		expect(activityStatusFilter).toBeUndefined();
-	});
-
-	it('should leave country and industry filters without preloadedData when no props are passed', () => {
-		render(
-			<AccountsDataSet
-				apiURL='fake-url'
-				channelId='123'
-				groupId='23'
-			/>
-		);
-
 		const countryFilter = lastFilters?.find(f => f.id === 'country');
 		const industryFilter = lastFilters?.find(f => f.id === 'industry');
 
+		expect(activityStatusFilter?.preloadedData).toBeUndefined();
 		expect(countryFilter?.preloadedData).toBeUndefined();
 		expect(industryFilter?.preloadedData).toBeUndefined();
 	});
@@ -196,6 +137,7 @@ describe('AccountsDataSet', () => {
 				apiURL='fake-url'
 				channelId='123'
 				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -206,6 +148,27 @@ describe('AccountsDataSet', () => {
 		expect(lifecycleStatusFilter).toBeUndefined();
 	});
 
+	it('should preload the activityStatus filter when activityStatusFilter prop is provided', () => {
+		render(
+			<AccountsDataSet
+				activityStatusFilter='ACTIVE'
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
+			/>
+		);
+
+		const activityStatusFilter = lastFilters?.find(
+			f => f.id === 'activityStatus'
+		);
+
+		expect(activityStatusFilter?.preloadedData).toEqual({
+			exclude: false,
+			selectedItems: [{label: 'Active', value: 'ACTIVE'}]
+		});
+	});
+
 	it('should preload the country filter when countryFilter prop is provided', () => {
 		render(
 			<AccountsDataSet
@@ -213,6 +176,7 @@ describe('AccountsDataSet', () => {
 				channelId='123'
 				countryFilter='US'
 				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -231,6 +195,7 @@ describe('AccountsDataSet', () => {
 				channelId='123'
 				groupId='23'
 				industryFilter='Tech'
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -249,6 +214,7 @@ describe('AccountsDataSet', () => {
 				apiURL='fake-url'
 				channelId='123'
 				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -272,6 +238,7 @@ describe('AccountsDataSet', () => {
 				channelId='123'
 				groupId='23'
 				lifecycleStageFilter={LifecycleStages.AT_RISK}
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -295,6 +262,7 @@ describe('AccountsDataSet', () => {
 				channelId='123'
 				groupId='23'
 				lifecycleStageFilter={LifecycleStages.AT_RISK}
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -311,6 +279,7 @@ describe('AccountsDataSet', () => {
 				apiURL='fake-url'
 				channelId='123'
 				groupId='23'
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
@@ -327,16 +296,97 @@ describe('AccountsDataSet', () => {
 		);
 	});
 
-	it('should append queryParams entries to the apiURL', () => {
+	it('should append rangeKey as query param when a preset range is provided', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={{
+					rangeEnd: null,
+					rangeKey: RangeKeyTimeRanges.Last30Days,
+					rangeStart: null
+				}}
+			/>
+		);
+
+		expect(lastApiURL).toBe('fake-url?rangeKey=30');
+	});
+
+	it('should append rangeStart and rangeEnd as query params when a custom range is provided', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				rangeSelectors={{
+					rangeEnd: '2024-01-31',
+					rangeKey: RangeKeyTimeRanges.CustomRange,
+					rangeStart: '2024-01-01'
+				}}
+			/>
+		);
+
+		expect(lastApiURL).toBe(
+			'fake-url?rangeKey=CUSTOM&rangeEnd=2024-01-31&rangeStart=2024-01-01'
+		);
+	});
+
+	it('should append queryParams entries to the apiURL query string', () => {
 		render(
 			<AccountsDataSet
 				apiURL='fake-url'
 				channelId='123'
 				groupId='23'
 				queryParams={{channelId: '123'}}
+				rangeSelectors={defaultRangeSelectors}
 			/>
 		);
 
-		expect(lastApiURL).toBe('fake-url?channelId=123');
+		const {getByText} = render(
+			lastCustomDataRenderers!.accountActivityStatusRenderer({
+				value: 'ACTIVE'
+			}) as React.ReactElement
+		);
+
+		expect(getByText('Active')).toBeInTheDocument();
+	});
+
+	it('should render "Inactive" label for INACTIVE activity status', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				queryParams={{channelId: '123'}}
+				rangeSelectors={defaultRangeSelectors}
+			/>
+		);
+
+		const {getByText} = render(
+			lastCustomDataRenderers!.accountActivityStatusRenderer({
+				value: 'INACTIVE'
+			}) as React.ReactElement
+		);
+
+		expect(getByText('Inactive')).toBeInTheDocument();
+	});
+
+	it('should render nothing when activity status value is empty', () => {
+		render(
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+				queryParams={{channelId: '123'}}
+				rangeSelectors={defaultRangeSelectors}
+			/>
+		);
+
+		const result = lastCustomDataRenderers!.accountActivityStatusRenderer({
+			value: ''
+		});
+
+		expect(result).toBeFalsy();
 	});
 });

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -87,7 +87,11 @@ describe('AccountsDataSet', () => {
 
 	it('should render the FrontendDataSet with id "accounts-list-dataset"', () => {
 		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+			/>
 		);
 
 		expect(screen.getByTestId('fds-component')).toHaveAttribute(
@@ -98,7 +102,11 @@ describe('AccountsDataSet', () => {
 
 	it('should pass the apiURL directly to FrontendDataSet without appending range params', () => {
 		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+			/>
 		);
 
 		expect(lastApiURL).toBe('fake-url');
@@ -106,7 +114,11 @@ describe('AccountsDataSet', () => {
 
 	it('should preload the rangeKey filter with Last 30 Days by default', () => {
 		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+			/>
 		);
 
 		const rangeKeyFilter = lastFilters?.find(f => f.id === 'rangeKey');
@@ -124,7 +136,11 @@ describe('AccountsDataSet', () => {
 
 	it('should include all 8 time range options in the rangeKey filter', () => {
 		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+			/>
 		);
 
 		const rangeKeyFilter = lastFilters?.find(f => f.id === 'rangeKey');
@@ -144,7 +160,11 @@ describe('AccountsDataSet', () => {
 
 	it('should not include the activityStatus filter', () => {
 		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+			/>
 		);
 
 		const activityStatusFilter = lastFilters?.find(
@@ -156,7 +176,11 @@ describe('AccountsDataSet', () => {
 
 	it('should leave country and industry filters without preloadedData when no props are passed', () => {
 		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+			/>
 		);
 
 		const countryFilter = lastFilters?.find(f => f.id === 'country');
@@ -168,7 +192,11 @@ describe('AccountsDataSet', () => {
 
 	it('should omit the lifecycleStatus filter when accountLifecycleId is not provided', () => {
 		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+			/>
 		);
 
 		const lifecycleStatusFilter = lastFilters?.find(
@@ -279,7 +307,11 @@ describe('AccountsDataSet', () => {
 
 	it('should render the account name link with channelId in the href', () => {
 		render(
-			<AccountsDataSet apiURL='fake-url' channelId='123' groupId='23' />
+			<AccountsDataSet
+				apiURL='fake-url'
+				channelId='123'
+				groupId='23'
+			/>
 		);
 
 		const {container} = render(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/frontend-data-set.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/frontend-data-set.tsx
@@ -1,5 +1,5 @@
 import ClayLink from '@clayui/link';
-import FaroConstants, {RangeKeyTimeRanges} from 'shared/util/constants';
+import FaroConstants from 'shared/util/constants';
 import Label from '@clayui/label';
 import React, {useEffect, useState} from 'react';
 import {CUSTOM_DATE_FORMAT, formatUTCDate} from './date';
@@ -7,41 +7,6 @@ import {Text} from '@clayui/core';
 import {toRoute} from './router';
 
 const {cur, delta, deltaValues} = FaroConstants.pagination;
-
-export const rangeSelectors = [
-	{
-		label: Liferay.Language.get('last-24-hours'),
-		value: RangeKeyTimeRanges.Last24Hours
-	},
-	{
-		label: Liferay.Language.get('yesterday'),
-		value: RangeKeyTimeRanges.Yesterday
-	},
-	{
-		label: Liferay.Language.get('last-seven-days'),
-		value: RangeKeyTimeRanges.Last7Days
-	},
-	{
-		label: Liferay.Language.get('last-28-days'),
-		value: RangeKeyTimeRanges.Last28Days
-	},
-	{
-		label: Liferay.Language.get('last-30-days'),
-		value: RangeKeyTimeRanges.Last30Days
-	},
-	{
-		label: Liferay.Language.get('last-90-days'),
-		value: RangeKeyTimeRanges.Last90Days
-	},
-	{
-		label: Liferay.Language.get('last-180-days'),
-		value: RangeKeyTimeRanges.Last180Days
-	},
-	{
-		label: Liferay.Language.get('last-year'),
-		value: RangeKeyTimeRanges.LastYear
-	}
-];
 
 export const pagination = {
 	deltas: deltaValues.map(delta => ({label: delta})),

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/table-columns.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/util/table-columns.tsx
@@ -293,6 +293,36 @@ export const IndividualsListCDPColumns = {
 		label: Liferay.Language.get('account-name'),
 		sortable: true
 	},
+	activityStatus: {
+		accessor: 'activityStatus',
+		cellRenderer: ({
+			className,
+			data: {activityStatus}
+		}: {
+			className?: string;
+			data: {activityStatus: string};
+		}) => (
+			<td className={getCN('name-cell-root', className)}>
+				{activityStatus && (
+					<Label
+						display={
+							activityStatus === 'ACTIVE'
+								? 'success'
+								: 'secondary'
+						}
+						size='lg'
+						uppercase
+					>
+						{activityStatus === 'ACTIVE'
+							? Liferay.Language.get('active')
+							: Liferay.Language.get('inactive')}
+					</Label>
+				)}
+			</td>
+		),
+		label: Liferay.Language.get('activity-status'),
+		sortable: true
+	},
 	country: {
 		accessor: 'countries',
 		cellRenderer: ({


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91079
https://liferay.atlassian.net/browse/LPD-91083

Reverts the active users filter work on `faro-v4.15.x` — 11 commits across LPD-91079 and LPD-91083 that replaced the activity status filter with an active users filter and removed the time range filter on the individuals and accounts pages. This restores the previous filters and the `activityStatus` column/data set behavior on the frontend.