### PR TITLE
LPD-94180 Stop retrying analytics SDK messages on 403 responses

### DIFF
--- a/modules/apps/analytics/analytics-client-js/src/queues/baseSendMessageQueue.ts
+++ b/modules/apps/analytics/analytics-client-js/src/queues/baseSendMessageQueue.ts
@@ -37,8 +37,10 @@ class BaseSendMessageQueue extends BaseQueue {
 				.then(() => {
 					this._dequeue(message.id);
 				})
-				.catch((error: {status: number}) => {
-					if (error.status === 400) {
+				.catch((error: {status?: number}) => {
+					const {status} = error || {};
+
+					if (status === 400 || status === 403) {
 						this._dequeue(message.id);
 					}
 

--- a/modules/apps/analytics/analytics-client-js/src/utils/constants.ts
+++ b/modules/apps/analytics/analytics-client-js/src/utils/constants.ts
@@ -5,7 +5,7 @@
 
 // AC Version
 
-export const ANALYTICS_CLIENT_VERSION = '1.3.4';
+export const ANALYTICS_CLIENT_VERSION = '1.3.5';
 
 export const ANALYTICS_BATCH_SEGMENT_EXTERNAL_REFERENCE_CODES =
 	'analyticsBatchSegmentExternalReferenceCodes';

--- a/modules/apps/analytics/analytics-client-js/test/queues/baseSendMessageQueue.ts
+++ b/modules/apps/analytics/analytics-client-js/test/queues/baseSendMessageQueue.ts
@@ -58,4 +58,49 @@ describe('BaseSendMessageQueue', () => {
 
 		expect(messages.length).toEqual(1);
 	});
+
+	it('dequeues the message and does not retry when the response status is 403', async () => {
+		fetchMock.restore();
+		fetchMock.mock(/ac-server/i, 403);
+
+		await baseSendMessageQueue.addItem(
+			getMockItem(1) as unknown as AnalyticsType.Event
+		);
+
+		expect(baseSendMessageQueue.getItems().length).toEqual(1);
+
+		await Promise.allSettled(baseSendMessageQueue.onFlush());
+
+		expect(baseSendMessageQueue.getItems().length).toEqual(0);
+	});
+
+	it('dequeues the message and does not retry when the response status is 400', async () => {
+		fetchMock.restore();
+		fetchMock.mock(/ac-server/i, 400);
+
+		await baseSendMessageQueue.addItem(
+			getMockItem(1) as unknown as AnalyticsType.Event
+		);
+
+		expect(baseSendMessageQueue.getItems().length).toEqual(1);
+
+		await Promise.allSettled(baseSendMessageQueue.onFlush());
+
+		expect(baseSendMessageQueue.getItems().length).toEqual(0);
+	});
+
+	it('keeps the message in the queue to retry when the response status is 500', async () => {
+		fetchMock.restore();
+		fetchMock.mock(/ac-server/i, 500);
+
+		await baseSendMessageQueue.addItem(
+			getMockItem(1) as unknown as AnalyticsType.Event
+		);
+
+		expect(baseSendMessageQueue.getItems().length).toEqual(1);
+
+		await Promise.allSettled(baseSendMessageQueue.onFlush());
+
+		expect(baseSendMessageQueue.getItems().length).toEqual(1);
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94180

## What Is Being Fixed

The Analytics JS SDK (analytics-client-js) re-sends queued messages on the next flush cycle for any failed response other than HTTP 400. As a result, an HTTP 403 (Forbidden) response keeps the message in the queue and the SDK retries it indefinitely on every flush loop instead of dropping it.

## How It Is Being Fixed

`BaseSendMessageQueue.onFlush()` now dequeues the message — stopping the retry — when the response status is 403 as well as 400, treating both as terminal client errors. Transient server errors such as 500 still keep the message in the queue so it is retried on the next flush. The catch handler reads the status defensively, so a timeout (which carries no status) continues to be retried as before. Tests cover the 403 drop, the preserved 400 drop, and the 500 retry.

## PR Check

**pr-check: PASS** — tested on `96d2ddd517478fde10c54b7c7529df787fa41e7c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "96d2ddd517478fde10c54b7c7529df787fa41e7c"} -->
