### PR TITLE
LPD-94184 Pass includeWebhookEvents param in Accounts queries

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/AccountEventMetricQuery.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/AccountEventMetricQuery.ts
@@ -44,6 +44,7 @@ export default gql`
 			channelId: $channelId
 			entityId: $entityId
 			entityType: $entityType
+			includeWebhookEvents: true
 			interval: $interval
 			keywords: $keywords
 			rangeEnd: $rangeEnd

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/AccountUserSessionQuery.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/AccountUserSessionQuery.ts
@@ -68,6 +68,7 @@ export default gql`
 			channelId: $channelId
 			entityId: $entityId
 			entityType: $entityType
+			includeWebhookEvents: true
 			keywords: $keywords
 			page: $page
 			rangeEnd: $rangeEnd

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/__tests__/AccountEventMetricQuery.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/__tests__/AccountEventMetricQuery.ts
@@ -1,0 +1,11 @@
+import AccountEventMetricQuery from '../AccountEventMetricQuery';
+
+describe('AccountEventMetricQuery', () => {
+	const queryString =
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(AccountEventMetricQuery as any).loc?.source?.body ?? '';
+
+	it('should include includeWebhookEvents', () => {
+		expect(queryString).toContain('includeWebhookEvents: true');
+	});
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/__tests__/AccountUserSessionQuery.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/queries/__tests__/AccountUserSessionQuery.ts
@@ -1,0 +1,11 @@
+import AccountUserSessionQuery from '../AccountUserSessionQuery';
+
+describe('AccountUserSessionQuery', () => {
+	const queryString =
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(AccountUserSessionQuery as any).loc?.source?.body ?? '';
+
+	it('should include includeWebhookEvents', () => {
+		expect(queryString).toContain('includeWebhookEvents: true');
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94184

## What Is Being Fixed

The Accounts event-metric and user-session GraphQL queries did not request
webhook events, so webhook-originated activity was excluded from the Accounts
metrics and session listings.

## How It Is Being Fixed

Added the `includeWebhookEvents: true` argument to the `eventMetric` query in
`AccountEventMetricQuery` and the `eventsByUserSessions` query in
`AccountUserSessionQuery`, matching the behavior already used by the
non-account `EventMetricQuery`. Added unit tests asserting each compiled query
includes the parameter, following the existing `DataSourceQuery` test
convention.

## PR Check

**pr-check: SKIPPED** — Per-Module Deploy built the module successfully (compileJava, buildCSS, jar, deploy); only the environmental moveToDocker step failed because Docker is not running, unrelated to the diff. Source Format and JavaScript Unit Tests passed.

<!-- pr-check {"reason": "Per-Module Deploy built successfully; only the environmental moveToDocker step failed because Docker is not running, unrelated to the diff", "result": "skipped", "sha": "31f15a8d7a93fe56f7c84b9af226d0d1788d7120"} -->
