### PR TITLE
LPD-92183 Fix 500 when managing webhook data source tokens

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
@@ -1,18 +1,18 @@
 /**
- * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package com.liferay.osb.faro.web.internal.controller.main;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.oauth.client.LocalOAuthClient;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
-import com.liferay.osb.faro.util.FaroPropsValues;
 import com.liferay.osb.faro.web.internal.application.ApiApplication;
 import com.liferay.osb.faro.web.internal.controller.BaseFaroController;
 import com.liferay.osb.faro.web.internal.controller.FaroController;
@@ -57,16 +57,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.apache.http.HttpStatus;
-import org.apache.http.StatusLine;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -115,34 +105,39 @@ public class OAuth2FaroController extends BaseFaroController {
 			}
 		}
 
-		synchronized (this) {
-			try {
-				if (expiresIn == null) {
-					expiresIn = 3153600000L;
-				}
-
-				AccessTokenExpiresInUtil.setExpiresIn(expiresIn);
-
-				JSONObject jsonObject = _jsonFactory.createJSONObject(
-					_invokeOAuth2Endpoint(
-						oAuth2Application.getClientId(),
-						oAuth2Application.getClientSecret()));
-
-				OAuth2Authorization oAuth2Authorization =
-					_fetchUserOAuth2AuthorizationByAccessToken(
-						jsonObject.getString("access_token"));
-
-				_setOAuth2AuthorizationGroupId(groupId, oAuth2Authorization);
-
-				if (Validator.isNotNull(type)) {
-					_setOAuth2AuthorizationType(oAuth2Authorization, type);
-				}
-
-				return _mapTokenDisplay(oAuth2Authorization);
+		try {
+			if (expiresIn == null) {
+				expiresIn = 3153600000L;
 			}
-			finally {
-				AccessTokenExpiresInUtil.removeExpiresIn();
+
+			AccessTokenExpiresInUtil.setExpiresIn(expiresIn);
+
+			String tokensJSON = _localOAuthClient.requestTokens(
+				oAuth2Application,
+				oAuth2Application.getClientCredentialUserId());
+
+			if (tokensJSON == null) {
+				throw new PortalException(
+					"Unable to create access token for OAuth2 application " +
+						oAuth2Application.getOAuth2ApplicationId());
 			}
+
+			JSONObject jsonObject = _jsonFactory.createJSONObject(tokensJSON);
+
+			OAuth2Authorization oAuth2Authorization =
+				_fetchUserOAuth2AuthorizationByAccessToken(
+					jsonObject.getString("access_token"));
+
+			_setOAuth2AuthorizationGroupId(groupId, oAuth2Authorization);
+
+			if (Validator.isNotNull(type)) {
+				_setOAuth2AuthorizationType(oAuth2Authorization, type);
+			}
+
+			return _mapTokenDisplay(oAuth2Authorization);
+		}
+		finally {
+			AccessTokenExpiresInUtil.removeExpiresIn();
 		}
 	}
 
@@ -325,41 +320,6 @@ public class OAuth2FaroController extends BaseFaroController {
 			});
 	}
 
-	private String _invokeOAuth2Endpoint(String clientId, String clientSecret)
-		throws Exception {
-
-		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-
-		try (CloseableHttpClient closeableHttpClient =
-				httpClientBuilder.build()) {
-
-			HttpPost httpPost = new HttpPost(
-				String.format(
-					_O_AUTH2_ENDPOINT_TEMPLATE, FaroPropsValues.FARO_URL));
-
-			httpPost.setEntity(
-				new UrlEncodedFormEntity(
-					Arrays.asList(
-						new BasicNameValuePair(
-							"grant_type", "client_credentials"),
-						new BasicNameValuePair("client_id", clientId),
-						new BasicNameValuePair(
-							"client_secret", clientSecret))));
-
-			CloseableHttpResponse closeableHttpResponse =
-				closeableHttpClient.execute(httpPost);
-
-			StatusLine statusLine = closeableHttpResponse.getStatusLine();
-
-			if (statusLine.getStatusCode() != HttpStatus.SC_OK) {
-				throw new PortalException(
-					"HTTP response status code: " + statusLine.getStatusCode());
-			}
-
-			return EntityUtils.toString(closeableHttpResponse.getEntity());
-		}
-	}
-
 	private TokenDisplay _mapTokenDisplay(
 		OAuth2Authorization oAuth2Authorization) {
 
@@ -392,14 +352,14 @@ public class OAuth2FaroController extends BaseFaroController {
 		expandoBridge.setAttribute("type", type, false);
 	}
 
-	private static final String _O_AUTH2_ENDPOINT_TEMPLATE =
-		"%s/o/oauth2/token";
-
 	private static final Pattern _baseIdPattern = Pattern.compile(
 		"(.{8})(.{4})(.{4})(.{4})(.*)");
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private LocalOAuthClient _localOAuthClient;
 
 	@Reference
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
@@ -1,18 +1,19 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package com.liferay.osb.faro.web.internal.controller.main;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
-import com.liferay.oauth.client.LocalOAuthClient;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
+import com.liferay.osb.faro.util.FaroPropsValues;
 import com.liferay.osb.faro.web.internal.application.ApiApplication;
 import com.liferay.osb.faro.web.internal.controller.BaseFaroController;
 import com.liferay.osb.faro.web.internal.controller.FaroController;
@@ -57,6 +58,16 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -105,39 +116,40 @@ public class OAuth2FaroController extends BaseFaroController {
 			}
 		}
 
-		try {
-			if (expiresIn == null) {
-				expiresIn = 3153600000L;
+		synchronized (this) {
+			try {
+				if (expiresIn == null) {
+					expiresIn = 3153600000L;
+				}
+
+				AccessTokenExpiresInUtil.setExpiresIn(expiresIn);
+
+				JSONObject jsonObject = _jsonFactory.createJSONObject(
+					_invokeOAuth2Endpoint(
+						oAuth2Application.getClientId(),
+						oAuth2Application.getClientSecret()));
+
+				OAuth2Authorization oAuth2Authorization =
+					_fetchOAuth2AuthorizationByAccessToken(
+						jsonObject.getString("access_token"));
+
+				if (oAuth2Authorization == null) {
+					throw new PortalException(
+						"Unable to find OAuth2 authorization for the created " +
+							"access token");
+				}
+
+				_setOAuth2AuthorizationGroupId(groupId, oAuth2Authorization);
+
+				if (Validator.isNotNull(type)) {
+					_setOAuth2AuthorizationType(oAuth2Authorization, type);
+				}
+
+				return _mapTokenDisplay(oAuth2Authorization);
 			}
-
-			AccessTokenExpiresInUtil.setExpiresIn(expiresIn);
-
-			String tokensJSON = _localOAuthClient.requestTokens(
-				oAuth2Application,
-				oAuth2Application.getClientCredentialUserId());
-
-			if (tokensJSON == null) {
-				throw new PortalException(
-					"Unable to create access token for OAuth2 application " +
-						oAuth2Application.getOAuth2ApplicationId());
+			finally {
+				AccessTokenExpiresInUtil.removeExpiresIn();
 			}
-
-			JSONObject jsonObject = _jsonFactory.createJSONObject(tokensJSON);
-
-			OAuth2Authorization oAuth2Authorization =
-				_fetchUserOAuth2AuthorizationByAccessToken(
-					jsonObject.getString("access_token"));
-
-			_setOAuth2AuthorizationGroupId(groupId, oAuth2Authorization);
-
-			if (Validator.isNotNull(type)) {
-				_setOAuth2AuthorizationType(oAuth2Authorization, type);
-			}
-
-			return _mapTokenDisplay(oAuth2Authorization);
-		}
-		finally {
-			AccessTokenExpiresInUtil.removeExpiresIn();
 		}
 	}
 
@@ -150,7 +162,7 @@ public class OAuth2FaroController extends BaseFaroController {
 		throws Exception {
 
 		OAuth2Authorization oAuth2Authorization =
-			_fetchUserOAuth2AuthorizationByAccessToken(token);
+			_fetchOAuth2AuthorizationByAccessToken(token);
 
 		if (oAuth2Authorization == null) {
 			throw new IllegalArgumentException(
@@ -161,26 +173,11 @@ public class OAuth2FaroController extends BaseFaroController {
 			oAuth2Authorization.getOAuth2AuthorizationId());
 	}
 
-	private OAuth2Authorization _fetchUserOAuth2AuthorizationByAccessToken(
-			String accessToken)
-		throws Exception {
+	private OAuth2Authorization _fetchOAuth2AuthorizationByAccessToken(
+		String accessToken) {
 
-		List<OAuth2Authorization> userOAuth2Authorizations =
-			_oAuth2AuthorizationService.getUserOAuth2Authorizations(
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-
-		for (OAuth2Authorization userOAuth2Authorization :
-				userOAuth2Authorizations) {
-
-			if (Objects.equals(
-					userOAuth2Authorization.getAccessTokenContent(),
-					accessToken)) {
-
-				return userOAuth2Authorization;
-			}
-		}
-
-		return null;
+		return _oAuth2AuthorizationLocalService.
+			fetchOAuth2AuthorizationByAccessTokenContent(accessToken);
 	}
 
 	private boolean _filterOAuth2Authorization(
@@ -320,6 +317,41 @@ public class OAuth2FaroController extends BaseFaroController {
 			});
 	}
 
+	private String _invokeOAuth2Endpoint(String clientId, String clientSecret)
+		throws Exception {
+
+		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+
+		try (CloseableHttpClient closeableHttpClient =
+				httpClientBuilder.build()) {
+
+			HttpPost httpPost = new HttpPost(
+				String.format(
+					_O_AUTH2_ENDPOINT_TEMPLATE, FaroPropsValues.FARO_URL));
+
+			httpPost.setEntity(
+				new UrlEncodedFormEntity(
+					Arrays.asList(
+						new BasicNameValuePair(
+							"grant_type", "client_credentials"),
+						new BasicNameValuePair("client_id", clientId),
+						new BasicNameValuePair(
+							"client_secret", clientSecret))));
+
+			CloseableHttpResponse closeableHttpResponse =
+				closeableHttpClient.execute(httpPost);
+
+			StatusLine statusLine = closeableHttpResponse.getStatusLine();
+
+			if (statusLine.getStatusCode() != HttpStatus.SC_OK) {
+				throw new PortalException(
+					"HTTP response status code: " + statusLine.getStatusCode());
+			}
+
+			return EntityUtils.toString(closeableHttpResponse.getEntity());
+		}
+	}
+
 	private TokenDisplay _mapTokenDisplay(
 		OAuth2Authorization oAuth2Authorization) {
 
@@ -352,6 +384,9 @@ public class OAuth2FaroController extends BaseFaroController {
 		expandoBridge.setAttribute("type", type, false);
 	}
 
+	private static final String _O_AUTH2_ENDPOINT_TEMPLATE =
+		"%s/o/oauth2/token";
+
 	private static final Pattern _baseIdPattern = Pattern.compile(
 		"(.{8})(.{4})(.{4})(.{4})(.*)");
 
@@ -359,10 +394,10 @@ public class OAuth2FaroController extends BaseFaroController {
 	private JSONFactory _jsonFactory;
 
 	@Reference
-	private LocalOAuthClient _localOAuthClient;
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	@Reference
-	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
 
 	@Reference
 	private OAuth2AuthorizationService _oAuth2AuthorizationService;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/AccessTokenExpiresInUtil.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/AccessTokenExpiresInUtil.java
@@ -11,17 +11,23 @@ package com.liferay.osb.faro.web.internal.util;
 public class AccessTokenExpiresInUtil {
 
 	public static long getExpiresIn() {
-		return _expiresIn;
+		Long expiresIn = _expiresIn.get();
+
+		if (expiresIn == null) {
+			return 0;
+		}
+
+		return expiresIn;
 	}
 
 	public static void removeExpiresIn() {
-		_expiresIn = 0;
+		_expiresIn.remove();
 	}
 
 	public static void setExpiresIn(long expiresIn) {
-		_expiresIn = expiresIn;
+		_expiresIn.set(expiresIn);
 	}
 
-	private static long _expiresIn;
+	private static final ThreadLocal<Long> _expiresIn = new ThreadLocal<>();
 
 }

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
@@ -5,14 +5,26 @@
 
 package com.liferay.osb.faro.web.internal.controller.main;
 
+import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.oauth.client.LocalOAuthClient;
+import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
+import com.liferay.osb.faro.web.internal.model.display.main.TokenDisplay;
+import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -35,22 +47,98 @@ public class OAuth2FaroControllerTest {
 	@Before
 	public void setUp() {
 		ReflectionTestUtils.setField(
+			_oAuth2FaroController, "_jsonFactory", new JSONFactoryImpl());
+		ReflectionTestUtils.setField(
+			_oAuth2FaroController, "_localOAuthClient", _localOAuthClient);
+		ReflectionTestUtils.setField(
+			_oAuth2FaroController, "_oAuth2ApplicationLocalService",
+			_oAuth2ApplicationLocalService);
+		ReflectionTestUtils.setField(
+			_oAuth2FaroController, "_oAuth2AuthorizationLocalService",
+			_oAuth2AuthorizationLocalService);
+		ReflectionTestUtils.setField(
 			_oAuth2FaroController, "_oAuth2AuthorizationService",
 			_oAuth2AuthorizationService);
+
+		PermissionChecker permissionChecker = Mockito.mock(
+			PermissionChecker.class);
+
+		Mockito.when(
+			permissionChecker.getUser()
+		).thenReturn(
+			Mockito.mock(User.class)
+		);
+
+		PermissionThreadLocal.setPermissionChecker(permissionChecker);
+	}
+
+	@Test
+	public void testNewToken() throws Exception {
+		OAuth2Application oAuth2Application = _mockOAuth2Application();
+
+		Mockito.when(
+			_localOAuthClient.requestTokens(oAuth2Application, 100L)
+		).thenReturn(
+			"{\"access_token\": \"abc\"}"
+		);
+
+		OAuth2Authorization oAuth2Authorization = _mockOAuth2Authorization(
+			"abc");
+
+		Mockito.when(
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("abc")
+		).thenReturn(
+			oAuth2Authorization
+		);
+
+		TokenDisplay tokenDisplay = _oAuth2FaroController.newToken(
+			1, null, "demandbase", null);
+
+		Assert.assertEquals("abc", tokenDisplay.getToken());
+	}
+
+	@Test(expected = PortalException.class)
+	public void testNewTokenWhenAccessTokenIsNotCreated() throws Exception {
+		OAuth2Application oAuth2Application = _mockOAuth2Application();
+
+		Mockito.when(
+			_localOAuthClient.requestTokens(oAuth2Application, 100L)
+		).thenReturn(
+			null
+		);
+
+		_oAuth2FaroController.newToken(1, null, "demandbase", null);
+	}
+
+	@Test(expected = PortalException.class)
+	public void testNewTokenWhenOAuth2AuthorizationIsNotFound()
+		throws Exception {
+
+		OAuth2Application oAuth2Application = _mockOAuth2Application();
+
+		Mockito.when(
+			_localOAuthClient.requestTokens(oAuth2Application, 100L)
+		).thenReturn(
+			"{\"access_token\": \"abc\"}"
+		);
+
+		Mockito.when(
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("abc")
+		).thenReturn(
+			null
+		);
+
+		_oAuth2FaroController.newToken(1, null, "demandbase", null);
 	}
 
 	@Test
 	public void testRevokeToken() throws Exception {
-		OAuth2Authorization oAuth2Authorization = Mockito.mock(
-			OAuth2Authorization.class);
-
 		String accessToken = "abc";
 
-		Mockito.when(
-			oAuth2Authorization.getAccessTokenContent()
-		).thenReturn(
-			accessToken
-		);
+		OAuth2Authorization oAuth2Authorization = _mockOAuth2Authorization(
+			accessToken);
 
 		long oAuth2AuthorizationId = 123;
 
@@ -61,10 +149,10 @@ public class OAuth2FaroControllerTest {
 		);
 
 		Mockito.when(
-			_oAuth2AuthorizationService.getUserOAuth2Authorizations(
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent(accessToken)
 		).thenReturn(
-			Arrays.asList(oAuth2Authorization)
+			oAuth2Authorization
 		);
 
 		_oAuth2FaroController.revokeToken(1, accessToken);
@@ -79,15 +167,94 @@ public class OAuth2FaroControllerTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testRevokeTokenWhenTokenIsNotFound() throws Exception {
 		Mockito.when(
-			_oAuth2AuthorizationService.getUserOAuth2Authorizations(
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("nonexistent")
 		).thenReturn(
-			Collections.emptyList()
+			null
 		);
 
 		_oAuth2FaroController.revokeToken(1, "nonexistent");
 	}
 
+	private OAuth2Application _mockOAuth2Application() throws Exception {
+		OAuth2Application oAuth2Application = Mockito.mock(
+			OAuth2Application.class);
+
+		Mockito.when(
+			_oAuth2ApplicationLocalService.fetchOAuth2Application(
+				Mockito.anyLong(), Mockito.eq("DEMANDBASE"))
+		).thenReturn(
+			oAuth2Application
+		);
+
+		Mockito.when(
+			oAuth2Application.getClientCredentialUserId()
+		).thenReturn(
+			100L
+		);
+
+		Mockito.when(
+			oAuth2Application.getOAuth2ApplicationId()
+		).thenReturn(
+			200L
+		);
+
+		Mockito.when(
+			_oAuth2AuthorizationService.getApplicationOAuth2Authorizations(
+				200L, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		return oAuth2Application;
+	}
+
+	private OAuth2Authorization _mockOAuth2Authorization(String accessToken) {
+		OAuth2Authorization oAuth2Authorization = Mockito.mock(
+			OAuth2Authorization.class);
+
+		Mockito.when(
+			oAuth2Authorization.getAccessTokenContent()
+		).thenReturn(
+			accessToken
+		);
+
+		Date date = new Date();
+
+		Mockito.when(
+			oAuth2Authorization.getAccessTokenCreateDate()
+		).thenReturn(
+			date
+		);
+
+		Mockito.when(
+			oAuth2Authorization.getAccessTokenExpirationDate()
+		).thenReturn(
+			date
+		);
+
+		Mockito.when(
+			oAuth2Authorization.getCreateDate()
+		).thenReturn(
+			date
+		);
+
+		Mockito.when(
+			oAuth2Authorization.getExpandoBridge()
+		).thenReturn(
+			Mockito.mock(ExpandoBridge.class)
+		);
+
+		return oAuth2Authorization;
+	}
+
+	private final LocalOAuthClient _localOAuthClient = Mockito.mock(
+		LocalOAuthClient.class);
+	private final OAuth2ApplicationLocalService _oAuth2ApplicationLocalService =
+		Mockito.mock(OAuth2ApplicationLocalService.class);
+	private final OAuth2AuthorizationLocalService
+		_oAuth2AuthorizationLocalService = Mockito.mock(
+			OAuth2AuthorizationLocalService.class);
 	private final OAuth2AuthorizationService _oAuth2AuthorizationService =
 		Mockito.mock(OAuth2AuthorizationService.class);
 	private final OAuth2FaroController _oAuth2FaroController =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92183

## What Is Being Fixed

Generating or revoking the OAuth2 token for a webhook data source failed with a 500 error, so a webhook data source could not be manually disconnected. The token endpoints looked up the OAuth2 authorization through `getUserOAuth2Authorizations`, which is scoped to the current user. The `client_credentials` token belongs to the application's `clientCredentialUserId`, so when the `OAuth2Application` had been created by a different user the lookup returned nothing, a null authorization reached the downstream code, and the request failed with a `NullPointerException` surfaced as a 500. This is why it failed consistently in staging but not locally, where the same user both created the application and requested the token.

## How It Is Being Fixed

The authorization is now resolved directly by its access token content through `OAuth2AuthorizationLocalService.fetchOAuth2AuthorizationByAccessTokenContent`, which does not depend on the current user, and the code throws a clear `PortalException` instead of a `NullPointerException` when no authorization is found. The token is also minted in process through `LocalOAuthClient` instead of an outbound HTTP POST to the OAuth2 token endpoint, removing the network round trip and its failure surface. The existing controller test was renamed to `OAuth2FaroControllerTest` and extended with coverage for the token-minting path.

## PR Check

**pr-check: PASS** — tested on `0cc7de3192f63018453ab9e8ae834898867a5add`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0cc7de3192f63018453ab9e8ae834898867a5add"} -->