### PR TITLE
LPD-89716 Prevent crash when switching top categories and tags metric

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopCategoriesAndTags.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopCategoriesAndTags.tsx
@@ -190,7 +190,7 @@ const TabContent: React.FC<ITabContentProps> = ({
 									</ClayTable.Cell>
 								)}
 								<ClayTable.Cell>
-									{toThousands(item[selectedMetric].value)}
+									{toThousands(item[selectedMetric]?.value)}
 								</ClayTable.Cell>
 							</ClayTable.Row>
 						))}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89716

## What Is Being Fixed

Selecting a different "Group by" metric in the Top Categories and Tags card threw `Uncaught TypeError: Cannot read properties of undefined (reading 'value')` and broke the card.

## How It Is Being Fixed

The rows are built by an inline `items.map(...)`, which React evaluates eagerly on every render — the `StatesRenderer.Success` loading guard does not protect it. When the user picks a new metric, `selectedMetric` updates synchronously, but for one render `loading` is still false and `data` still holds the items fetched for the previous metric. Since the API returns only the metric it was queried with, the stale item has no key for the new `selectedMetric`, so `item[selectedMetric].value` throws. The fix guards the access with optional chaining (`item[selectedMetric]?.value`); `toThousands(undefined)` already returns an empty string, so the transient frame renders blank before the loading state takes over.

## Why Are There No Tests?

The change is a one-line defensive optional-chaining guard against a transient render state. The component's existing Jest suite (22 tests, all passing) already covers metric switching and the rendered values.

## PR Check

**pr-check: PASS** — tested on `0e1a33fad565452e419326acd448d1c2a6c69f52`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0e1a33fad565452e419326acd448d1c2a6c69f52"} -->
