### PR TITLE
LPD-94044 backport | faro-v4.15.x

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/ContextualInformation.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/ContextualInformation.tsx
@@ -49,12 +49,10 @@ function formatTimeZoneOffset(timeZoneOffset?: string, region?: string) {
 }
 
 interface IContextualInfoProps {
-	children?: React.ReactNode;
 	contactId?: string;
 	contextData: Map<string, any>;
 	email?: string;
 	loading?: boolean;
-	showEmptyState?: boolean;
 	userId?: string;
 	uuid?: string;
 }
@@ -77,12 +75,10 @@ const CONTEXTUAL_INFO_LABEL_MAP: Record<string, string> = {
 };
 
 const ContextualInformation: React.FC<IContextualInfoProps> = ({
-	children: emptyState,
 	contactId,
 	contextData,
 	email,
 	loading = false,
-	showEmptyState = false,
 	userId,
 	uuid
 }) => {
@@ -112,16 +108,12 @@ const ContextualInformation: React.FC<IContextualInfoProps> = ({
 				title={Liferay.Language.get('contextual-information')}
 			/>
 
-			{showEmptyState && !loading ? (
-				emptyState
-			) : (
-				<GeneralInfoSection
-					config={contextualInfoConfig}
-					getValue={getValue}
-					languageMap={CONTEXTUAL_INFO_LABEL_MAP}
-					loading={loading}
-				/>
-			)}
+			<GeneralInfoSection
+				config={contextualInfoConfig}
+				getValue={getValue}
+				languageMap={CONTEXTUAL_INFO_LABEL_MAP}
+				loading={loading}
+			/>
 		</>
 	);
 };

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/__tests__/ContextualInformation.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/components/__tests__/ContextualInformation.tsx
@@ -28,20 +28,6 @@ describe('ContextualInformation', () => {
 		expect(container).toMatchSnapshot();
 	});
 
-	it('should render the empty state when showEmptyState is true', () => {
-		const {getByText, queryByText} = render(
-			<ContextualInformation
-				contextData={fromJS(mockContext)}
-				showEmptyState
-			>
-				<div>{'empty state rendered'}</div>
-			</ContextualInformation>
-		);
-
-		expect(getByText('empty state rendered')).toBeTruthy();
-		expect(queryByText('browser')).toBeNull();
-	});
-
 	it('should correctly format the time zone offset string', () => {
 		const {getByText} = render(
 			<ContextualInformation contextData={fromJS(mockContext)} />

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/hoc/ProfileCardCDP.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/hoc/ProfileCardCDP.tsx
@@ -14,17 +14,11 @@ interface IProfileCardCDP extends React.HTMLAttributes<HTMLElement> {
 	channelId: string;
 	entity: Individual;
 	groupId: string;
-	showEmptyState?: boolean;
 	tabId: string;
 	timeZoneId: string;
 }
 
-const ProfileCardCDP: React.FC<IProfileCardCDP> = ({
-	children: emptyState,
-	showEmptyState,
-	tabId,
-	...props
-}) => {
+const ProfileCardCDP: React.FC<IProfileCardCDP> = ({tabId, ...props}) => {
 	const history = useHistory();
 
 	const {
@@ -46,71 +40,67 @@ const ProfileCardCDP: React.FC<IProfileCardCDP> = ({
 				title={Liferay.Language.get('interaction-history')}
 			/>
 
-			{showEmptyState ? (
-				emptyState
-			) : (
-				<BaseCard
-					className='individual-profile-card-root page-display'
-					description={Liferay.Language.get(
-						'displays-a-chronological-timeline-of-events-within-the-selected-timeframe-including-session-context'
-					)}
-					headerProps={{
-						showRangeKey: true,
-						tabId
-					}}
-					label={Liferay.Language.get('individual-events')}
-					legacyDropdownRangeKey={false}
-					showInterval
-				>
-					{({
-						interval,
-						onChangeInterval,
-						onRangeSelectorsChange,
-						rangeSelectors
-					}) => (
-						<ProfileCardWithDataCDP
-							{...props}
-							delta={delta}
-							interval={interval}
-							onChangeInterval={onChangeInterval}
-							onDeltaChange={onDeltaChange}
-							onPageChange={onPageChange}
-							onQueryChange={query => {
-								history.push(
-									setUriQueryValues(
-										pickBy({query}),
-										removeUriQueryParam(
-											window.location.href,
-											'query'
-										)
+			<BaseCard
+				className='individual-profile-card-root page-display'
+				description={Liferay.Language.get(
+					'displays-a-chronological-timeline-of-events-within-the-selected-timeframe-including-session-context'
+				)}
+				headerProps={{
+					showRangeKey: true,
+					tabId
+				}}
+				label={Liferay.Language.get('individual-events')}
+				legacyDropdownRangeKey={false}
+				showInterval
+			>
+				{({
+					interval,
+					onChangeInterval,
+					onRangeSelectorsChange,
+					rangeSelectors
+				}) => (
+					<ProfileCardWithDataCDP
+						{...props}
+						delta={delta}
+						interval={interval}
+						onChangeInterval={onChangeInterval}
+						onDeltaChange={onDeltaChange}
+						onPageChange={onPageChange}
+						onQueryChange={query => {
+							history.push(
+								setUriQueryValues(
+									pickBy({query}),
+									removeUriQueryParam(
+										window.location.href,
+										'query'
 									)
-								);
+								)
+							);
 
-								onQueryChange(query);
-							}}
-							onRangeSelectorsChange={rangeSelectors => {
-								history.push(
-									setUriQueryValues(
-										pickBy(rangeSelectors),
-										removeUriQueryParam(
-											window.location.href,
-											'rangeEnd',
-											'rangeStart'
-										)
+							onQueryChange(query);
+						}}
+						onRangeSelectorsChange={rangeSelectors => {
+							history.push(
+								setUriQueryValues(
+									pickBy(rangeSelectors),
+									removeUriQueryParam(
+										window.location.href,
+										'rangeEnd',
+										'rangeStart'
 									)
-								);
+								)
+							);
 
-								onRangeSelectorsChange(rangeSelectors);
-							}}
-							page={page}
-							query={query}
-							rangeSelectors={rangeSelectors}
-							resetPage={resetPage}
-							tabId={tabId}
-						/>
-					)}
-				</BaseCard>
-			)}
+							onRangeSelectorsChange(rangeSelectors);
+						}}
+						page={page}
+						query={query}
+						rangeSelectors={rangeSelectors}
+						resetPage={resetPage}
+						tabId={tabId}
+					/>
+				)}
+			</BaseCard>
 		</>
 	);
 };

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/OverviewCDP.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/OverviewCDP.jsx
@@ -1,147 +1,26 @@
-import * as API from 'shared/api';
-import Card from 'shared/components/Card';
-import ClayIcon from '@clayui/icon';
-import ClayLink from '@clayui/link';
 import ContextualInformation from '../components/ContextualInformation';
-import NoResultsDisplay from 'shared/components/NoResultsDisplay';
 import ProfileCardCDP from '../hoc/ProfileCardCDP';
 import React from 'react';
-import URLConstants from 'shared/util/url-constants';
 import {connect} from 'react-redux';
-import {Routes, toRoute} from 'shared/util/router';
-import {useCurrentUser} from 'shared/hooks/useCurrentUser';
-import {useDataSources} from 'shared/context/dataSources';
-import {useRequest} from 'shared/hooks/useRequest';
-
-const OverviewCDPEmptyState = ({
-	authorized,
-	dataSourceData,
-	groupId,
-	hasConnectedDataSources,
-	pageDisplay = true
-}) => {
-	const noSitesSelected = !dataSourceData?.items?.some(
-		dataSource => dataSource.sitesSelected
-	);
-
-	if (noSitesSelected) {
-		return (
-			<Card pageDisplay={pageDisplay}>
-				<Card.Body>
-					<NoResultsDisplay
-						description={
-							<>
-								{authorized
-									? Liferay.Language.get(
-											'connect-a-data-source-containing-site-data'
-									  )
-									: Liferay.Language.get(
-											'contact-an-administrator-to-connect-a-data-source-containing-site-data'
-									  )}
-
-								<ClayLink
-									className='d-block mb-3'
-									decoration='underline'
-									href={URLConstants.DataSourceConnection}
-									key='DOCUMENTATION'
-									target='_blank'
-								>
-									{Liferay.Language.get(
-										'learn-more-about-data-sources'
-									)}
-
-									<span className='inline-item inline-item-after'>
-										<ClayIcon
-											fontSize={8}
-											symbol='shortcut'
-										/>
-									</span>
-								</ClayLink>
-							</>
-						}
-						primary
-						title={Liferay.Language.get('no-site-data-synced')}
-					>
-						{authorized && !hasConnectedDataSources && (
-							<ClayLink
-								button
-								className='button-root mt-1'
-								displayType='primary'
-								href={toRoute(
-									Routes.SETTINGS_DATA_SOURCE_LIST,
-									{
-										groupId
-									}
-								)}
-							>
-								{Liferay.Language.get('connect-data-source')}
-							</ClayLink>
-						)}
-					</NoResultsDisplay>
-				</Card.Body>
-			</Card>
-		);
-	}
-
-	return null;
-};
 
 const Overview = ({channelId, groupId, individual, tabId, timeZoneId}) => {
-	const currentUser = useCurrentUser();
-
-	const authorized = currentUser.isAdmin();
-
-	const dataSourceStates = useDataSources();
-
-	const {data: dataSourceData, loading: dataSourceLoading} = useRequest({
-		dataSourceFn: API.dataSource.search,
-		variables: {
-			delta: 500,
-			groupId
-		}
-	});
-
-	const sitesSelected = dataSourceData?.items?.some(
-		dataSource => dataSource.sitesSelected
-	);
-
-	const showEmptyState = !dataSourceLoading && !sitesSelected;
-
 	return (
 		<div className='overview-column-main'>
 			<ContextualInformation
 				contactId={individual.get('id')}
 				contextData={individual.get('context')}
 				email={individual.getIn(['properties', 'email'])}
-				loading={dataSourceLoading}
-				showEmptyState={showEmptyState}
 				userId={individual.getIn(['properties', 'userId'])}
 				uuid={individual.getIn(['properties', 'uuid'])}
-			>
-				<OverviewCDPEmptyState
-					authorized={authorized}
-					dataSourceData={dataSourceData}
-					groupId={groupId}
-					hasConnectedDataSources={!dataSourceStates.empty}
-					pageDisplay={false}
-				/>
-			</ContextualInformation>
+			/>
 
 			<ProfileCardCDP
 				channelId={channelId}
 				entity={individual}
 				groupId={groupId}
-				showEmptyState={showEmptyState}
 				tabId={tabId}
 				timeZoneId={timeZoneId}
-			>
-				<OverviewCDPEmptyState
-					authorized={authorized}
-					dataSourceData={dataSourceData}
-					groupId={groupId}
-					hasConnectedDataSources={!dataSourceStates.empty}
-				/>
-			</ProfileCardCDP>
+			/>
 		</div>
 	);
 };

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/__tests__/OverviewCDP.jsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/profile/pages/__tests__/OverviewCDP.jsx
@@ -6,39 +6,18 @@ import {cleanup, render} from '@testing-library/react';
 import {Individual} from 'shared/util/records';
 import {Provider} from 'react-redux';
 import {StaticRouter} from 'react-router';
-import {useCurrentUser} from 'shared/hooks/useCurrentUser';
-import {useDataSources} from 'shared/context/dataSources';
-import {useRequest} from 'shared/hooks/useRequest';
 
 jest.unmock('react-dom');
 
-jest.mock('shared/hooks/useCurrentUser', () => ({
-	useCurrentUser: jest.fn()
-}));
-
-jest.mock('shared/context/dataSources', () => ({
-	useDataSources: jest.fn()
-}));
-
-jest.mock('shared/hooks/useRequest', () => ({
-	useRequest: jest.fn()
-}));
-
 jest.mock('../../components/ContextualInformation', () => ({
 	__esModule: true,
-	default: ({children, showEmptyState}) =>
-		showEmptyState ? <>{children}</> : null
+	default: () => <div>{'ContextualInformation'}</div>
 }));
 
 jest.mock('../../hoc/ProfileCardCDP', () => ({
 	__esModule: true,
-	default: ({children, showEmptyState}) =>
-		showEmptyState ? <>{children}</> : null
+	default: () => <div>{'ProfileCardCDP'}</div>
 }));
-
-const mockedUseCurrentUser = useCurrentUser;
-const mockedUseDataSource = useDataSources;
-const mockedUseRequest = useRequest;
 
 const mockIndividual = data.getImmutableMock(Individual, data.mockIndividual);
 
@@ -53,33 +32,20 @@ const renderComponent = () =>
 
 describe('IndividualOverview', () => {
 	afterEach(() => {
-		jest.clearAllMocks();
 		cleanup();
 	});
 
-	it('should show connect data source button when no data sources exist', () => {
-		mockedUseCurrentUser.mockReturnValue({isAdmin: () => true});
-		mockedUseDataSource.mockReturnValue({empty: true});
-		mockedUseRequest.mockReturnValue({
-			data: {items: [], total: 0},
-			loading: false
-		});
+	it('should render the contextual information and profile card sections', () => {
+		const {getByText} = renderComponent();
 
-		const {getAllByText} = renderComponent();
-
-		expect(getAllByText('Connect Data Source').length).toBeGreaterThan(0);
+		expect(getByText('ContextualInformation')).toBeTruthy();
+		expect(getByText('ProfileCardCDP')).toBeTruthy();
 	});
 
-	it('should not show connect data source button when connected but no site data synced', () => {
-		mockedUseCurrentUser.mockReturnValue({isAdmin: () => true});
-		mockedUseDataSource.mockReturnValue({empty: false});
-		mockedUseRequest.mockReturnValue({
-			data: {items: [{sitesSelected: false}], total: 1},
-			loading: false
-		});
-
+	it('should not render the no site data synced empty state', () => {
 		const {queryByText} = renderComponent();
 
+		expect(queryByText('No Site Data Synced')).not.toBeInTheDocument();
 		expect(queryByText('Connect Data Source')).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Backport of LPD-94044 to faro-v4.15.x.

## What Is Being Backported

`LPD-94044 remove emptyState` — removes the empty state handling from the individual profile contextual information and overview pages.

## Cherry-picked Commits

- `0bfc2f8 LPD-94044 remove emptyState`