### PR TITLE
LPD-92553 Prevent lifecycle filter dropdown from overflowing

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/FieldValueFilter.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/FieldValueFilter.tsx
@@ -95,6 +95,7 @@ const FieldValueFilter = ({
 			searchable
 			selectedKey={filters[filterKey] || ALL_VALUES_KEY}
 			triggerIcon='caret-bottom'
+			width={50}
 		>
 			<Option key={ALL_VALUES_KEY}>
 				{sub(Liferay.Language.get('all-x'), [entityLabel])}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/__tests__/FieldValueFilter.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/lifecycle/components/__tests__/FieldValueFilter.tsx
@@ -1,6 +1,6 @@
 import FieldValueFilter from '../FieldValueFilter';
 import React from 'react';
-import {cleanup, render} from '@testing-library/react';
+import {cleanup, fireEvent, render} from '@testing-library/react';
 import {LifecycleContextProvider} from '../../context/LifecycleContext';
 
 jest.unmock('react-dom');
@@ -58,6 +58,28 @@ describe('FieldValueFilter', () => {
 		expect(
 			getByRole('combobox', {name: 'Filter By Industries'})
 		).toBeInTheDocument();
+	});
+
+	it('should constrain the dropdown menu width so long values do not overflow', () => {
+		const useRequest = require('shared/hooks/useRequest');
+
+		useRequest.useRequest = jest.fn(() => ({
+			data: {
+				items: [
+					'A very very very long industry value that would overflow the filter'
+				]
+			},
+			loading: false
+		}));
+
+		const {baseElement, getByRole} = renderFilter();
+
+		fireEvent.click(getByRole('combobox', {name: 'Filter By Industries'}));
+
+		const menu = baseElement.querySelector('.dropdown-menu');
+
+		expect(menu).toBeInTheDocument();
+		expect(menu).toHaveStyle({maxWidth: 'none', width: '50px'});
 	});
 
 	it('should pass the fieldMappingFieldName through to the request', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92553

## What Is Being Fixed

In the Lifecycle report, the field value filter renders its selectable
values in a dropdown whose width grows to fit the longest option. Long
values (for example, verbose industry names) stretched the dropdown
beyond the standard container width, breaking the layout.

## How It Is Being Fixed

The `FieldValueFilter` picker now passes an explicit `width={50}` so the
dropdown menu is constrained to a fixed width and long values wrap
instead of overflowing the container.

## PR Check

**pr-check: PASS** — tested on `e8de15345fcb8bcc7430df6a2bd67f68335c690f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e8de15345fcb8bcc7430df6a2bd67f68335c690f"} -->
