### PR TITLE
LPD-94333 Fix segments delete test after Delete Property rename

### DIFF
--- a/modules/test/playwright/tests/segments-web/main/pages/SegmentsPage.ts
+++ b/modules/test/playwright/tests/segments-web/main/pages/SegmentsPage.ts
@@ -188,12 +188,12 @@ export class SegmentsPage {
 	}
 
 	async deleteProperty() {
-		const deleteButton = this.page.getByTitle('Delete Segment Property');
+		const deleteButton = this.page.getByTitle('Delete Property');
 		await deleteButton.click();
 	}
 
 	async deleteUnavailableProperty() {
-		const deleteButton = this.page.getByText('Delete Segment Property');
+		const deleteButton = this.page.getByText('Delete Property');
 		await deleteButton.click();
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94333

## What Is Being Fixed

The Playwright test "Can edit segment with a select input" in segments-web/main/segmentation.spec.ts timed out when deleting a segment property. The SegmentsPage page object located the delete button by its title "Delete Segment Property", but LPD-91680 renamed that button's label (title and aria-label) from "delete-segment-property" to "delete-property" ("Delete Property"). The old title no longer exists in the DOM, so the locator never matched and the click waited until the test timed out.

## How It Is Being Fixed

Update the two stale locators in SegmentsPage — deleteProperty() (getByTitle) and deleteUnavailableProperty() (getByText) — to target "Delete Property", matching the current label. Verified the affected test passes against a running portal.

## Why Are There No Tests?

The change only repairs the locators of an existing Playwright test's page object to match a prior UI label rename; no production behavior changed. The fixed test itself is the coverage, and it now passes.

## PR Check

**pr-check: PASS** — tested on `da68e2ad9fdb35c003810addb29a53e592ca4159`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "da68e2ad9fdb35c003810addb29a53e592ca4159"} -->
