### PR TITLE
LPD-94531 Default the asset summary rangeKey to 90 days

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryCategoryFaroController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryCategoryFaroController.java
@@ -39,7 +39,7 @@ public class AssetSummaryCategoryFaroController extends BaseFaroController {
 				@QueryParam("page") int page,
 				@DefaultValue("20") @QueryParam("pageSize") int pageSize,
 				@QueryParam("rangeEnd") String rangeEnd,
-				@QueryParam("rangeKey") int rangeKey,
+				@DefaultValue("90") @QueryParam("rangeKey") int rangeKey,
 				@QueryParam("rangeStart") String rangeStart,
 				@QueryParam("selectedMetric") String selectedMetric,
 				@DefaultValue(StringPool.BLANK) @QueryParam("sort") String

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryFaroController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryFaroController.java
@@ -39,7 +39,7 @@ public class AssetSummaryFaroController extends BaseFaroController {
 				@QueryParam("objectType") String objectType,
 				@QueryParam("page") int page,
 				@DefaultValue("20") @QueryParam("pageSize") int pageSize,
-				@QueryParam("rangeKey") int rangeKey,
+				@DefaultValue("90") @QueryParam("rangeKey") int rangeKey,
 				@QueryParam("search") String search,
 				@QueryParam("selectedMetric") String selectedMetric,
 				@DefaultValue(StringPool.BLANK) @QueryParam("sort") String

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryTagFaroController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryTagFaroController.java
@@ -39,7 +39,7 @@ public class AssetSummaryTagFaroController extends BaseFaroController {
 				@QueryParam("page") int page,
 				@DefaultValue("20") @QueryParam("pageSize") int pageSize,
 				@QueryParam("rangeEnd") String rangeEnd,
-				@QueryParam("rangeKey") int rangeKey,
+				@DefaultValue("90") @QueryParam("rangeKey") int rangeKey,
 				@QueryParam("rangeStart") String rangeStart,
 				@QueryParam("selectedMetric") String selectedMetric,
 				@DefaultValue(StringPool.BLANK) @QueryParam("sort") String

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryVocabularyFaroController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryVocabularyFaroController.java
@@ -38,7 +38,7 @@ public class AssetSummaryVocabularyFaroController extends BaseFaroController {
 				@QueryParam("page") int page,
 				@DefaultValue("20") @QueryParam("pageSize") int pageSize,
 				@QueryParam("rangeEnd") String rangeEnd,
-				@QueryParam("rangeKey") int rangeKey,
+				@DefaultValue("90") @QueryParam("rangeKey") int rangeKey,
 				@QueryParam("rangeStart") String rangeStart,
 				@DefaultValue(StringPool.BLANK) @QueryParam("sort") String
 					sortString)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94531

## What Is Being Fixed

The asset summary contacts endpoints accepted a `rangeKey` query parameter without a default. When a client omitted it, JAX-RS bound the primitive `int` to `0`, which is not a valid range window and does not match the 90-day default the endpoints are expected to use. The four asset summary controllers (category, tag, vocabulary, and the base asset summary) all shared this gap.

## How It Is Being Fixed

Each controller's `rangeKey` parameter now carries `@DefaultValue("90")`, so an absent `rangeKey` binds to 90 rather than 0. This aligns the default range window with the other query parameters on the same endpoints (which already declare `@DefaultValue`) and makes the four asset summary controllers consistent with one another.

## Why Are There No Tests?

This is a trivial one-line default-value change — adding a `@DefaultValue` annotation to an existing JAX-RS query parameter — too small to warrant a dedicated test.

## PR Check

**pr-check: PASS** — tested on `d52d002f73b9857839307f607224ccadf889fb90`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | BLOCKED (environment) |

<!-- pr-check {"result": "success", "sha": "d52d002f73b9857839307f607224ccadf889fb90"} -->
