### PR TITLE
LPD-94517 Fix Liferay link on the workspaces base page

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/BasePage.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/BasePage.tsx
@@ -97,7 +97,7 @@ export class WorkspacesBasePage extends React.Component<IWorkspacesBasePageProps
 
 					<div className='header-container'>
 						<ClayLink
-							href='https://liferay-portal.com'
+							href='https://liferay.com'
 							target='_blank'
 						>
 							<ClayIcon

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/__snapshots__/ActivatingDisplay.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/__snapshots__/ActivatingDisplay.jsx.snap
@@ -10,7 +10,7 @@ exports[`ActivatingDisplay should render 1`] = `
     >
       <a
         class=""
-        href="https://liferay-portal.com"
+        href="https://liferay.com"
         rel="noreferrer noopener"
         target="_blank"
       >

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/__snapshots__/BasePage.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/__snapshots__/BasePage.jsx.snap
@@ -10,7 +10,7 @@ exports[`WorkspacesBasePage should render 1`] = `
     >
       <a
         class=""
-        href="https://liferay-portal.com"
+        href="https://liferay.com"
         rel="noreferrer noopener"
         target="_blank"
       >

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/__snapshots__/ErrorDisplay.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/__snapshots__/ErrorDisplay.jsx.snap
@@ -10,7 +10,7 @@ exports[`WorkspacesErrorDisplay should render 1`] = `
     >
       <a
         class=""
-        href="https://liferay-portal.com"
+        href="https://liferay.com"
         rel="noreferrer noopener"
         target="_blank"
       >

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/__snapshots__/SuccessDisplay.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/__snapshots__/SuccessDisplay.jsx.snap
@@ -10,7 +10,7 @@ exports[`WorkspacesSuccessDisplay should render 1`] = `
     >
       <a
         class=""
-        href="https://liferay-portal.com"
+        href="https://liferay.com"
         rel="noreferrer noopener"
         target="_blank"
       >

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/__snapshots__/CheckProjectState.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/hoc/__tests__/__snapshots__/CheckProjectState.jsx.snap
@@ -10,7 +10,7 @@ exports[`SuccessDisplayIf should render a scheduled maintenance error page if th
     >
       <a
         class=""
-        href="https://liferay-portal.com"
+        href="https://liferay.com"
         rel="noreferrer noopener"
         target="_blank"
       >
@@ -111,7 +111,7 @@ exports[`SuccessDisplayIf should render activating display if project state is "
     >
       <a
         class=""
-        href="https://liferay-portal.com"
+        href="https://liferay.com"
         rel="noreferrer noopener"
         target="_blank"
       >
@@ -254,7 +254,7 @@ exports[`SuccessDisplayIf should render activating display if project state is "
     >
       <a
         class=""
-        href="https://liferay-portal.com"
+        href="https://liferay.com"
         rel="noreferrer noopener"
         target="_blank"
       >
@@ -379,7 +379,7 @@ exports[`SuccessDisplayIf should render an unavailable error page if the project
     >
       <a
         class=""
-        href="https://liferay-portal.com"
+        href="https://liferay.com"
         rel="noreferrer noopener"
         target="_blank"
       >

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/pages/__tests__/__snapshots__/WorkspaceNotFound.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/pages/__tests__/__snapshots__/WorkspaceNotFound.jsx.snap
@@ -10,7 +10,7 @@ exports[`WorkspaceNotFound should render 1`] = `
     >
       <a
         class=""
-        href="https://liferay-portal.com"
+        href="https://liferay.com"
         rel="noreferrer noopener"
         target="_blank"
       >

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/pages/__tests__/__snapshots__/Workspaces.jsx.snap
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/pages/__tests__/__snapshots__/Workspaces.jsx.snap
@@ -13,7 +13,7 @@ exports[`Workspaces should render a list of projects if there is only one projec
       >
         <a
           class=""
-          href="https://liferay-portal.com"
+          href="https://liferay.com"
           rel="noreferrer noopener"
           target="_blank"
         >
@@ -188,7 +188,7 @@ exports[`Workspaces should render empty state 1`] = `
       >
         <a
           class=""
-          href="https://liferay-portal.com"
+          href="https://liferay.com"
           rel="noreferrer noopener"
           target="_blank"
         >
@@ -349,7 +349,7 @@ exports[`Workspaces should render with a message that all basic tier plans have 
       >
         <a
           class=""
-          href="https://liferay-portal.com"
+          href="https://liferay.com"
           rel="noreferrer noopener"
           target="_blank"
         >
@@ -574,7 +574,7 @@ exports[`Workspaces should render with a message that one or more basic tier wor
       >
         <a
           class=""
-          href="https://liferay-portal.com"
+          href="https://liferay.com"
           rel="noreferrer noopener"
           target="_blank"
         >


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94517

## What Is Being Fixed

The Liferay logo on the workspaces base page (the screen shown while a workspace is activating, errored, or not found) linked to `https://liferay-portal.com`, a domain Liferay does not own, instead of the official site.

## How It Is Being Fixed

The link target in `BasePage.tsx` is updated to `https://liferay.com`, and the Jest snapshots that render the page in each state are regenerated to assert the new URL.

## PR Check

**pr-check: PASS** — tested on `16c8f67c4c4c4452cf01a649978b856d4ec45ad3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "16c8f67c4c4c4452cf01a649978b856d4ec45ad3"} -->