### PR TITLE
LPD-92417 Add performance asset consumption endpoint

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-api/bnd.bnd
+++ b/modules/apps/analytics/analytics-cms-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Analytics CMS REST API
 Bundle-SymbolicName: com.liferay.analytics.cms.rest.api
-Bundle-Version: 4.4.1
+Bundle-Version: 4.5.0
 Export-Package:\
 	com.liferay.analytics.cms.rest.dto.v1_0,\
 	com.liferay.analytics.cms.rest.resource.v1_0

--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/dto/v1_0/PerformanceAssetConsumption.java
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/dto/v1_0/PerformanceAssetConsumption.java
@@ -1,0 +1,370 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+@GraphQLName("PerformanceAssetConsumption")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "PerformanceAssetConsumption")
+public class PerformanceAssetConsumption implements Serializable {
+
+	public static PerformanceAssetConsumption toDTO(String json) {
+		return ObjectMapperUtil.readValue(
+			PerformanceAssetConsumption.class, json);
+	}
+
+	public static PerformanceAssetConsumption unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			PerformanceAssetConsumption.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public PerformanceAssetConsumptionItem[]
+		getPerformanceAssetConsumptionItems() {
+
+		if (_performanceAssetConsumptionItemsSupplier != null) {
+			performanceAssetConsumptionItems =
+				_performanceAssetConsumptionItemsSupplier.get();
+
+			_performanceAssetConsumptionItemsSupplier = null;
+		}
+
+		return performanceAssetConsumptionItems;
+	}
+
+	public void setPerformanceAssetConsumptionItems(
+		PerformanceAssetConsumptionItem[] performanceAssetConsumptionItems) {
+
+		this.performanceAssetConsumptionItems =
+			performanceAssetConsumptionItems;
+
+		_performanceAssetConsumptionItemsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPerformanceAssetConsumptionItems(
+		UnsafeSupplier<PerformanceAssetConsumptionItem[], Exception>
+			performanceAssetConsumptionItemsUnsafeSupplier) {
+
+		_performanceAssetConsumptionItemsSupplier = () -> {
+			try {
+				return performanceAssetConsumptionItemsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected PerformanceAssetConsumptionItem[]
+		performanceAssetConsumptionItems;
+
+	@JsonIgnore
+	private Supplier<PerformanceAssetConsumptionItem[]>
+		_performanceAssetConsumptionItemsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getPerformanceAssetConsumptionItemsCount() {
+		if (_performanceAssetConsumptionItemsCountSupplier != null) {
+			performanceAssetConsumptionItemsCount =
+				_performanceAssetConsumptionItemsCountSupplier.get();
+
+			_performanceAssetConsumptionItemsCountSupplier = null;
+		}
+
+		return performanceAssetConsumptionItemsCount;
+	}
+
+	public void setPerformanceAssetConsumptionItemsCount(
+		Long performanceAssetConsumptionItemsCount) {
+
+		this.performanceAssetConsumptionItemsCount =
+			performanceAssetConsumptionItemsCount;
+
+		_performanceAssetConsumptionItemsCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPerformanceAssetConsumptionItemsCount(
+		UnsafeSupplier<Long, Exception>
+			performanceAssetConsumptionItemsCountUnsafeSupplier) {
+
+		_performanceAssetConsumptionItemsCountSupplier = () -> {
+			try {
+				return performanceAssetConsumptionItemsCountUnsafeSupplier.
+					get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long performanceAssetConsumptionItemsCount;
+
+	@JsonIgnore
+	private Supplier<Long> _performanceAssetConsumptionItemsCountSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getTotalCount() {
+		if (_totalCountSupplier != null) {
+			totalCount = _totalCountSupplier.get();
+
+			_totalCountSupplier = null;
+		}
+
+		return totalCount;
+	}
+
+	public void setTotalCount(Long totalCount) {
+		this.totalCount = totalCount;
+
+		_totalCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTotalCount(
+		UnsafeSupplier<Long, Exception> totalCountUnsafeSupplier) {
+
+		_totalCountSupplier = () -> {
+			try {
+				return totalCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long totalCount;
+
+	@JsonIgnore
+	private Supplier<Long> _totalCountSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PerformanceAssetConsumption)) {
+			return false;
+		}
+
+		PerformanceAssetConsumption performanceAssetConsumption =
+			(PerformanceAssetConsumption)object;
+
+		return Objects.equals(
+			toString(), performanceAssetConsumption.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		PerformanceAssetConsumptionItem[] performanceAssetConsumptionItems =
+			getPerformanceAssetConsumptionItems();
+
+		if (performanceAssetConsumptionItems != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"performanceAssetConsumptionItems\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < performanceAssetConsumptionItems.length; i++) {
+				sb.append(String.valueOf(performanceAssetConsumptionItems[i]));
+
+				if ((i + 1) < performanceAssetConsumptionItems.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Long performanceAssetConsumptionItemsCount =
+			getPerformanceAssetConsumptionItemsCount();
+
+		if (performanceAssetConsumptionItemsCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"performanceAssetConsumptionItemsCount\": ");
+
+			sb.append(performanceAssetConsumptionItemsCount);
+		}
+
+		Long totalCount = getTotalCount();
+
+		if (totalCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalCount\": ");
+
+			sb.append(totalCount);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumption",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1757778872

--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/dto/v1_0/PerformanceAssetConsumptionItem.java
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/dto/v1_0/PerformanceAssetConsumptionItem.java
@@ -1,0 +1,344 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+@GraphQLName("PerformanceAssetConsumptionItem")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "PerformanceAssetConsumptionItem")
+public class PerformanceAssetConsumptionItem implements Serializable {
+
+	public static PerformanceAssetConsumptionItem toDTO(String json) {
+		return ObjectMapperUtil.readValue(
+			PerformanceAssetConsumptionItem.class, json);
+	}
+
+	public static PerformanceAssetConsumptionItem unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			PerformanceAssetConsumptionItem.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getCount() {
+		if (_countSupplier != null) {
+			count = _countSupplier.get();
+
+			_countSupplier = null;
+		}
+
+		return count;
+	}
+
+	public void setCount(Long count) {
+		this.count = count;
+
+		_countSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setCount(UnsafeSupplier<Long, Exception> countUnsafeSupplier) {
+		_countSupplier = () -> {
+			try {
+				return countUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long count;
+
+	@JsonIgnore
+	private Supplier<Long> _countSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getKey() {
+		if (_keySupplier != null) {
+			key = _keySupplier.get();
+
+			_keySupplier = null;
+		}
+
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+
+		_keySupplier = null;
+	}
+
+	@JsonIgnore
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		_keySupplier = () -> {
+			try {
+				return keyUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String key;
+
+	@JsonIgnore
+	private Supplier<String> _keySupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PerformanceAssetConsumptionItem)) {
+			return false;
+		}
+
+		PerformanceAssetConsumptionItem performanceAssetConsumptionItem =
+			(PerformanceAssetConsumptionItem)object;
+
+		return Objects.equals(
+			toString(), performanceAssetConsumptionItem.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		Long count = getCount();
+
+		if (count != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"count\": ");
+
+			sb.append(count);
+		}
+
+		String key = getKey();
+
+		if (key != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"key\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(key));
+
+			sb.append("\"");
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumptionItem",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:1225240740

--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/resource/v1_0/PerformanceAssetConsumptionResource.java
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/resource/v1_0/PerformanceAssetConsumptionResource.java
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumption;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/analytics-cms-rest/v1.0
+ *
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface PerformanceAssetConsumptionResource {
+
+	public PerformanceAssetConsumption getPerformanceAssetConsumption(
+			Long categoryId, Long[] depotEntryIds, String groupBy,
+			Integer rangeKey, Long structureId, Long tagId, Long vocabularyId,
+			Pagination pagination)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public PerformanceAssetConsumptionResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-362814513

--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/resources/com/liferay/analytics/cms/rest/dto/v1_0/packageinfo
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/resources/com/liferay/analytics/cms/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.7.0
+version 2.8.0

--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/resources/com/liferay/analytics/cms/rest/resource/v1_0/packageinfo
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/resources/com/liferay/analytics/cms/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.3.0
+version 4.4.0

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/dto/v1_0/PerformanceAssetConsumption.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/dto/v1_0/PerformanceAssetConsumption.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.dto.v1_0;
+
+import com.liferay.analytics.cms.rest.client.function.UnsafeSupplier;
+import com.liferay.analytics.cms.rest.client.serdes.v1_0.PerformanceAssetConsumptionSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public class PerformanceAssetConsumption implements Cloneable, Serializable {
+
+	public static PerformanceAssetConsumption toDTO(String json) {
+		return PerformanceAssetConsumptionSerDes.toDTO(json);
+	}
+
+	public PerformanceAssetConsumptionItem[]
+		getPerformanceAssetConsumptionItems() {
+
+		return performanceAssetConsumptionItems;
+	}
+
+	public void setPerformanceAssetConsumptionItems(
+		PerformanceAssetConsumptionItem[] performanceAssetConsumptionItems) {
+
+		this.performanceAssetConsumptionItems =
+			performanceAssetConsumptionItems;
+	}
+
+	public void setPerformanceAssetConsumptionItems(
+		UnsafeSupplier<PerformanceAssetConsumptionItem[], Exception>
+			performanceAssetConsumptionItemsUnsafeSupplier) {
+
+		try {
+			performanceAssetConsumptionItems =
+				performanceAssetConsumptionItemsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected PerformanceAssetConsumptionItem[]
+		performanceAssetConsumptionItems;
+
+	public Long getPerformanceAssetConsumptionItemsCount() {
+		return performanceAssetConsumptionItemsCount;
+	}
+
+	public void setPerformanceAssetConsumptionItemsCount(
+		Long performanceAssetConsumptionItemsCount) {
+
+		this.performanceAssetConsumptionItemsCount =
+			performanceAssetConsumptionItemsCount;
+	}
+
+	public void setPerformanceAssetConsumptionItemsCount(
+		UnsafeSupplier<Long, Exception>
+			performanceAssetConsumptionItemsCountUnsafeSupplier) {
+
+		try {
+			performanceAssetConsumptionItemsCount =
+				performanceAssetConsumptionItemsCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long performanceAssetConsumptionItemsCount;
+
+	public Long getTotalCount() {
+		return totalCount;
+	}
+
+	public void setTotalCount(Long totalCount) {
+		this.totalCount = totalCount;
+	}
+
+	public void setTotalCount(
+		UnsafeSupplier<Long, Exception> totalCountUnsafeSupplier) {
+
+		try {
+			totalCount = totalCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long totalCount;
+
+	@Override
+	public PerformanceAssetConsumption clone()
+		throws CloneNotSupportedException {
+
+		return (PerformanceAssetConsumption)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PerformanceAssetConsumption)) {
+			return false;
+		}
+
+		PerformanceAssetConsumption performanceAssetConsumption =
+			(PerformanceAssetConsumption)object;
+
+		return Objects.equals(
+			toString(), performanceAssetConsumption.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return PerformanceAssetConsumptionSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:2091823173

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/dto/v1_0/PerformanceAssetConsumptionItem.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/dto/v1_0/PerformanceAssetConsumptionItem.java
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.dto.v1_0;
+
+import com.liferay.analytics.cms.rest.client.function.UnsafeSupplier;
+import com.liferay.analytics.cms.rest.client.serdes.v1_0.PerformanceAssetConsumptionItemSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public class PerformanceAssetConsumptionItem
+	implements Cloneable, Serializable {
+
+	public static PerformanceAssetConsumptionItem toDTO(String json) {
+		return PerformanceAssetConsumptionItemSerDes.toDTO(json);
+	}
+
+	public Long getCount() {
+		return count;
+	}
+
+	public void setCount(Long count) {
+		this.count = count;
+	}
+
+	public void setCount(UnsafeSupplier<Long, Exception> countUnsafeSupplier) {
+		try {
+			count = countUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long count;
+
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
+	public void setKey(UnsafeSupplier<String, Exception> keyUnsafeSupplier) {
+		try {
+			key = keyUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String key;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
+
+	@Override
+	public PerformanceAssetConsumptionItem clone()
+		throws CloneNotSupportedException {
+
+		return (PerformanceAssetConsumptionItem)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PerformanceAssetConsumptionItem)) {
+			return false;
+		}
+
+		PerformanceAssetConsumptionItem performanceAssetConsumptionItem =
+			(PerformanceAssetConsumptionItem)object;
+
+		return Objects.equals(
+			toString(), performanceAssetConsumptionItem.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return PerformanceAssetConsumptionItemSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-50657789

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/resource/v1_0/PerformanceAssetConsumptionResource.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/resource/v1_0/PerformanceAssetConsumptionResource.java
@@ -1,0 +1,320 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceAssetConsumption;
+import com.liferay.analytics.cms.rest.client.http.HttpInvoker;
+import com.liferay.analytics.cms.rest.client.pagination.Pagination;
+import com.liferay.analytics.cms.rest.client.problem.Problem;
+import com.liferay.analytics.cms.rest.client.serdes.v1_0.PerformanceAssetConsumptionSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public interface PerformanceAssetConsumptionResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public PerformanceAssetConsumption getPerformanceAssetConsumption(
+			Long categoryId, Long[] depotEntryIds, String groupBy,
+			Integer rangeKey, Long structureId, Long tagId, Long vocabularyId,
+			Pagination pagination)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getPerformanceAssetConsumptionHttpResponse(
+			Long categoryId, Long[] depotEntryIds, String groupBy,
+			Integer rangeKey, Long structureId, Long tagId, Long vocabularyId,
+			Pagination pagination)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public PerformanceAssetConsumptionResource build() {
+			return new PerformanceAssetConsumptionResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class PerformanceAssetConsumptionResourceImpl
+		implements PerformanceAssetConsumptionResource {
+
+		public PerformanceAssetConsumption getPerformanceAssetConsumption(
+				Long categoryId, Long[] depotEntryIds, String groupBy,
+				Integer rangeKey, Long structureId, Long tagId,
+				Long vocabularyId, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getPerformanceAssetConsumptionHttpResponse(
+					categoryId, depotEntryIds, groupBy, rangeKey, structureId,
+					tagId, vocabularyId, pagination);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return PerformanceAssetConsumptionSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getPerformanceAssetConsumptionHttpResponse(
+					Long categoryId, Long[] depotEntryIds, String groupBy,
+					Integer rangeKey, Long structureId, Long tagId,
+					Long vocabularyId, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (categoryId != null) {
+				httpInvoker.parameter("categoryId", String.valueOf(categoryId));
+			}
+
+			if (depotEntryIds != null) {
+				for (int i = 0; i < depotEntryIds.length; i++) {
+					httpInvoker.parameter(
+						"depotEntryIds", String.valueOf(depotEntryIds[i]));
+				}
+			}
+
+			if (groupBy != null) {
+				httpInvoker.parameter("groupBy", String.valueOf(groupBy));
+			}
+
+			if (rangeKey != null) {
+				httpInvoker.parameter("rangeKey", String.valueOf(rangeKey));
+			}
+
+			if (structureId != null) {
+				httpInvoker.parameter(
+					"structureId", String.valueOf(structureId));
+			}
+
+			if (tagId != null) {
+				httpInvoker.parameter("tagId", String.valueOf(tagId));
+			}
+
+			if (vocabularyId != null) {
+				httpInvoker.parameter(
+					"vocabularyId", String.valueOf(vocabularyId));
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/analytics-cms-rest/v1.0/performance-asset-consumption");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private PerformanceAssetConsumptionResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			PerformanceAssetConsumptionResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1082966215

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/serdes/v1_0/PerformanceAssetConsumptionItemSerDes.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/serdes/v1_0/PerformanceAssetConsumptionItemSerDes.java
@@ -1,0 +1,275 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.serdes.v1_0;
+
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceAssetConsumptionItem;
+import com.liferay.analytics.cms.rest.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public class PerformanceAssetConsumptionItemSerDes {
+
+	public static PerformanceAssetConsumptionItem toDTO(String json) {
+		PerformanceAssetConsumptionItemJSONParser
+			performanceAssetConsumptionItemJSONParser =
+				new PerformanceAssetConsumptionItemJSONParser();
+
+		return performanceAssetConsumptionItemJSONParser.parseToDTO(json);
+	}
+
+	public static PerformanceAssetConsumptionItem[] toDTOs(String json) {
+		PerformanceAssetConsumptionItemJSONParser
+			performanceAssetConsumptionItemJSONParser =
+				new PerformanceAssetConsumptionItemJSONParser();
+
+		return performanceAssetConsumptionItemJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(
+		PerformanceAssetConsumptionItem performanceAssetConsumptionItem) {
+
+		if (performanceAssetConsumptionItem == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (performanceAssetConsumptionItem.getCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"count\": ");
+
+			sb.append(performanceAssetConsumptionItem.getCount());
+		}
+
+		if (performanceAssetConsumptionItem.getKey() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"key\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(performanceAssetConsumptionItem.getKey()));
+
+			sb.append("\"");
+		}
+
+		if (performanceAssetConsumptionItem.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(performanceAssetConsumptionItem.getTitle()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		PerformanceAssetConsumptionItemJSONParser
+			performanceAssetConsumptionItemJSONParser =
+				new PerformanceAssetConsumptionItemJSONParser();
+
+		return performanceAssetConsumptionItemJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		PerformanceAssetConsumptionItem performanceAssetConsumptionItem) {
+
+		if (performanceAssetConsumptionItem == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (performanceAssetConsumptionItem.getCount() == null) {
+			map.put("count", null);
+		}
+		else {
+			map.put(
+				"count",
+				String.valueOf(performanceAssetConsumptionItem.getCount()));
+		}
+
+		if (performanceAssetConsumptionItem.getKey() == null) {
+			map.put("key", null);
+		}
+		else {
+			map.put(
+				"key",
+				String.valueOf(performanceAssetConsumptionItem.getKey()));
+		}
+
+		if (performanceAssetConsumptionItem.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put(
+				"title",
+				String.valueOf(performanceAssetConsumptionItem.getTitle()));
+		}
+
+		return map;
+	}
+
+	public static class PerformanceAssetConsumptionItemJSONParser
+		extends BaseJSONParser<PerformanceAssetConsumptionItem> {
+
+		@Override
+		protected PerformanceAssetConsumptionItem createDTO() {
+			return new PerformanceAssetConsumptionItem();
+		}
+
+		@Override
+		protected PerformanceAssetConsumptionItem[] createDTOArray(int size) {
+			return new PerformanceAssetConsumptionItem[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "count")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "key")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			PerformanceAssetConsumptionItem performanceAssetConsumptionItem,
+			String jsonParserFieldName, Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "count")) {
+				if (jsonParserFieldValue != null) {
+					performanceAssetConsumptionItem.setCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "key")) {
+				if (jsonParserFieldValue != null) {
+					performanceAssetConsumptionItem.setKey(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					performanceAssetConsumptionItem.setTitle(
+						(String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1984321284

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/serdes/v1_0/PerformanceAssetConsumptionSerDes.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/serdes/v1_0/PerformanceAssetConsumptionSerDes.java
@@ -1,0 +1,330 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.serdes.v1_0;
+
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceAssetConsumption;
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceAssetConsumptionItem;
+import com.liferay.analytics.cms.rest.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public class PerformanceAssetConsumptionSerDes {
+
+	public static PerformanceAssetConsumption toDTO(String json) {
+		PerformanceAssetConsumptionJSONParser
+			performanceAssetConsumptionJSONParser =
+				new PerformanceAssetConsumptionJSONParser();
+
+		return performanceAssetConsumptionJSONParser.parseToDTO(json);
+	}
+
+	public static PerformanceAssetConsumption[] toDTOs(String json) {
+		PerformanceAssetConsumptionJSONParser
+			performanceAssetConsumptionJSONParser =
+				new PerformanceAssetConsumptionJSONParser();
+
+		return performanceAssetConsumptionJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(
+		PerformanceAssetConsumption performanceAssetConsumption) {
+
+		if (performanceAssetConsumption == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (performanceAssetConsumption.getPerformanceAssetConsumptionItems() !=
+				null) {
+
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"performanceAssetConsumptionItems\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < performanceAssetConsumption.
+					 getPerformanceAssetConsumptionItems().length;
+				 i++) {
+
+				sb.append(
+					String.valueOf(
+						performanceAssetConsumption.
+							getPerformanceAssetConsumptionItems()[i]));
+
+				if ((i + 1) < performanceAssetConsumption.
+						getPerformanceAssetConsumptionItems().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (performanceAssetConsumption.
+				getPerformanceAssetConsumptionItemsCount() != null) {
+
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"performanceAssetConsumptionItemsCount\": ");
+
+			sb.append(
+				performanceAssetConsumption.
+					getPerformanceAssetConsumptionItemsCount());
+		}
+
+		if (performanceAssetConsumption.getTotalCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalCount\": ");
+
+			sb.append(performanceAssetConsumption.getTotalCount());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		PerformanceAssetConsumptionJSONParser
+			performanceAssetConsumptionJSONParser =
+				new PerformanceAssetConsumptionJSONParser();
+
+		return performanceAssetConsumptionJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		PerformanceAssetConsumption performanceAssetConsumption) {
+
+		if (performanceAssetConsumption == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (performanceAssetConsumption.getPerformanceAssetConsumptionItems() ==
+				null) {
+
+			map.put("performanceAssetConsumptionItems", null);
+		}
+		else {
+			map.put(
+				"performanceAssetConsumptionItems",
+				String.valueOf(
+					performanceAssetConsumption.
+						getPerformanceAssetConsumptionItems()));
+		}
+
+		if (performanceAssetConsumption.
+				getPerformanceAssetConsumptionItemsCount() == null) {
+
+			map.put("performanceAssetConsumptionItemsCount", null);
+		}
+		else {
+			map.put(
+				"performanceAssetConsumptionItemsCount",
+				String.valueOf(
+					performanceAssetConsumption.
+						getPerformanceAssetConsumptionItemsCount()));
+		}
+
+		if (performanceAssetConsumption.getTotalCount() == null) {
+			map.put("totalCount", null);
+		}
+		else {
+			map.put(
+				"totalCount",
+				String.valueOf(performanceAssetConsumption.getTotalCount()));
+		}
+
+		return map;
+	}
+
+	public static class PerformanceAssetConsumptionJSONParser
+		extends BaseJSONParser<PerformanceAssetConsumption> {
+
+		@Override
+		protected PerformanceAssetConsumption createDTO() {
+			return new PerformanceAssetConsumption();
+		}
+
+		@Override
+		protected PerformanceAssetConsumption[] createDTOArray(int size) {
+			return new PerformanceAssetConsumption[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(
+					jsonParserFieldName, "performanceAssetConsumptionItems")) {
+
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"performanceAssetConsumptionItemsCount")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			PerformanceAssetConsumption performanceAssetConsumption,
+			String jsonParserFieldName, Object jsonParserFieldValue) {
+
+			if (Objects.equals(
+					jsonParserFieldName, "performanceAssetConsumptionItems")) {
+
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					PerformanceAssetConsumptionItem[]
+						performanceAssetConsumptionItemsArray =
+							new PerformanceAssetConsumptionItem
+								[jsonParserFieldValues.length];
+
+					for (int i = 0;
+						 i < performanceAssetConsumptionItemsArray.length;
+						 i++) {
+
+						performanceAssetConsumptionItemsArray[i] =
+							PerformanceAssetConsumptionItemSerDes.toDTO(
+								(String)jsonParserFieldValues[i]);
+					}
+
+					performanceAssetConsumption.
+						setPerformanceAssetConsumptionItems(
+							performanceAssetConsumptionItemsArray);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"performanceAssetConsumptionItemsCount")) {
+
+				if (jsonParserFieldValue != null) {
+					performanceAssetConsumption.
+						setPerformanceAssetConsumptionItemsCount(
+							Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				if (jsonParserFieldValue != null) {
+					performanceAssetConsumption.setTotalCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1746020284

--- a/modules/apps/analytics/analytics-cms-rest-impl/rest-openapi.yaml
+++ b/modules/apps/analytics/analytics-cms-rest-impl/rest-openapi.yaml
@@ -129,6 +129,27 @@ components:
                 vocabulariesCount:
                     format: int64
                     type: integer
+        PerformanceAssetConsumption:
+            properties:
+                performanceAssetConsumptionItems:
+                    items:
+                        $ref: "#/components/schemas/PerformanceAssetConsumptionItem"
+                    type: array
+                performanceAssetConsumptionItemsCount:
+                    format: int64
+                    type: integer
+                totalCount:
+                    format: int64
+                    type: integer
+        PerformanceAssetConsumptionItem:
+            properties:
+                count:
+                    format: int64
+                    type: integer
+                key:
+                    type: string
+                title:
+                    type: string
         PerformanceOverviewMetric:
             properties:
                 downloadsMetric:
@@ -507,6 +528,63 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntryTopPages"
             tags: ["ObjectEntryTopPages"]
+    "/performance-asset-consumption":
+        get:
+            operationId: getPerformanceAssetConsumption
+            parameters:
+                -   in: query
+                    name: categoryId
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: depotEntryIds
+                    schema:
+                        items:
+                            format: int64
+                            type: integer
+                        type: array
+                -   in: query
+                    name: groupBy
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: rangeKey
+                    schema:
+                        type: integer
+                -   in: query
+                    name: structureId
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: tagId
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: vocabularyId
+                    schema:
+                        format: int64
+                        type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PerformanceAssetConsumption"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/PerformanceAssetConsumption"
+            tags: ["PerformanceAssetConsumption"]
     "/performance-overview-metric":
         get:
             operationId: getPerformanceOverviewMetric

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -19,12 +19,20 @@ import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryAcquisitionChannel;
 import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryHistogramMetric;
 import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryMetric;
 import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryTopPages;
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumption;
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumptionItem;
 import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceOverviewMetric;
 import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectDefinitionTable;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
@@ -34,9 +42,12 @@ import com.liferay.portal.kernel.util.Validator;
 import java.net.HttpURLConnection;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Rachael Koestartyo
@@ -44,7 +55,14 @@ import java.util.Map;
 public class AnalyticsCloudClient {
 
 	public AnalyticsCloudClient(Http http) {
+		this(http, null);
+	}
+
+	public AnalyticsCloudClient(
+		Http http, ObjectDefinitionLocalService objectDefinitionLocalService) {
+
 		_http = http;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
 	}
 
 	public List<ObjectEntryAcquisitionChannel>
@@ -64,10 +82,11 @@ public class AnalyticsCloudClient {
 
 			options.setLocation(
 				_getUrl(
-					analyticsConfiguration.liferayAnalyticsDataSourceId(),
-					externalReferenceCode, groupIds,
+					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
+					externalReferenceCode, null, groupIds,
 					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
-					"/acquisition-channels", rangeKey, null));
+					null, null, null, "/acquisition-channels", rangeKey, null,
+					null, null, null));
 
 			String content = _http.URLtoString(options);
 
@@ -125,10 +144,11 @@ public class AnalyticsCloudClient {
 
 			options.setLocation(
 				_getUrl(
-					analyticsConfiguration.liferayAnalyticsDataSourceId(),
-					externalReferenceCode, groupIds,
+					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
+					externalReferenceCode, null, groupIds,
 					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
-					"/overview/histogram", rangeKey, selectedMetrics));
+					null, null, null, "/overview/histogram", rangeKey,
+					selectedMetrics, null, null, null));
 
 			String content = _http.URLtoString(options);
 
@@ -189,10 +209,11 @@ public class AnalyticsCloudClient {
 
 			options.setLocation(
 				_getUrl(
-					analyticsConfiguration.liferayAnalyticsDataSourceId(),
-					externalReferenceCode, groupIds,
+					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
+					externalReferenceCode, null, groupIds,
 					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
-					"/overview", rangeKey, selectedMetrics));
+					null, null, null, "/overview", rangeKey, selectedMetrics,
+					null, null, null));
 
 			String content = _http.URLtoString(options);
 
@@ -252,10 +273,11 @@ public class AnalyticsCloudClient {
 
 			options.setLocation(
 				_getUrl(
-					analyticsConfiguration.liferayAnalyticsDataSourceId(),
-					externalReferenceCode, groupIds,
+					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
+					externalReferenceCode, null, groupIds,
 					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
-					"/appears-on", rangeKey, null));
+					null, null, null, "/appears-on", rangeKey, null, null, null,
+					null));
 
 			String content = _http.URLtoString(options);
 
@@ -299,6 +321,76 @@ public class AnalyticsCloudClient {
 		}
 	}
 
+	public PerformanceAssetConsumption getPerformanceAssetConsumption(
+			AnalyticsConfiguration analyticsConfiguration, Long categoryId,
+			String groupBy, List<Long> groupIds, Locale locale,
+			String metricType, String objectType, int page, Integer rangeKey,
+			int size, Long tagId, Long vocabularyId)
+		throws PortalException {
+
+		try {
+			Http.Options options = _getOptions(analyticsConfiguration);
+
+			options.setLocation(
+				_getUrl(
+					categoryId,
+					analyticsConfiguration.liferayAnalyticsDataSourceId(), null,
+					groupBy, groupIds,
+					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
+					metricType, objectType, page, "/asset-consumption",
+					rangeKey, null, size, tagId, vocabularyId));
+
+			String content = _http.URLtoString(options);
+
+			Http.Response response = options.getResponse();
+
+			if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
+				PerformanceAssetConsumption performanceAssetConsumption = null;
+
+				JsonNode jsonNode = ObjectMapperHolder._objectMapper.readTree(
+					content);
+
+				if (jsonNode != null) {
+					_renameKey(
+						jsonNode, "performanceAssetConsumptionItems",
+						"metrics");
+					_renameKey(
+						jsonNode, "performanceAssetConsumptionItemsCount",
+						"total");
+
+					ObjectReader objectReader =
+						ObjectMapperHolder._objectMapper.readerFor(
+							PerformanceAssetConsumption.class);
+
+					performanceAssetConsumption = objectReader.readValue(
+						jsonNode);
+
+					if (Objects.equals(groupBy, "structure")) {
+						_updatePerformanceAssetConsumptionFromObjectDefinition(
+							locale, performanceAssetConsumption);
+					}
+				}
+
+				return performanceAssetConsumption;
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug("Response code " + response.getResponseCode());
+			}
+
+			throw new PortalException(
+				"Unable to get performance asset consumption");
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			throw new PortalException(
+				"Unable to get performance asset consumption", exception);
+		}
+	}
+
 	public PerformanceOverviewMetric getPerformanceOverviewMetric(
 			AnalyticsConfiguration analyticsConfiguration, List<Long> groupIds,
 			Integer rangeKey)
@@ -309,10 +401,11 @@ public class AnalyticsCloudClient {
 
 			options.setLocation(
 				_getUrl(
-					analyticsConfiguration.liferayAnalyticsDataSourceId(), null,
-					groupIds,
+					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
+					null, null, groupIds,
 					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
-					"/performance-overview-metric", rangeKey, null));
+					null, null, null, "/performance-overview-metric", rangeKey,
+					null, null, null, null));
 
 			String content = _http.URLtoString(options);
 
@@ -400,13 +493,20 @@ public class AnalyticsCloudClient {
 	}
 
 	private String _getUrl(
-		String dataSourceId, String externalReferenceCode, List<Long> groupIds,
-		String liferayAnalyticsFaroBackendURL, String path, Integer rangeKey,
-		String[] selectedMetrics) {
+		Long categoryId, String dataSourceId, String externalReferenceCode,
+		String groupBy, List<Long> groupIds,
+		String liferayAnalyticsFaroBackendURL, String metricType,
+		String objectType, Integer page, String path, Integer rangeKey,
+		String[] selectedMetrics, Integer size, Long tagId, Long vocabularyId) {
 
 		String url = String.join(
 			StringPool.BLANK, liferayAnalyticsFaroBackendURL,
 			"/api/1.0/asset-metric/objectEntry", path);
+
+		if (categoryId != null) {
+			url = HttpComponentsUtil.addParameter(
+				url, "categoryId", categoryId);
+		}
 
 		url = HttpComponentsUtil.addParameter(
 			url, "dataSourceId", dataSourceId);
@@ -416,9 +516,27 @@ public class AnalyticsCloudClient {
 				url, "externalReferenceCode", externalReferenceCode);
 		}
 
+		if (Validator.isNotNull(groupBy)) {
+			url = HttpComponentsUtil.addParameter(url, "groupBy", groupBy);
+		}
+
 		if (!groupIds.isEmpty()) {
 			url = HttpComponentsUtil.addParameter(
 				url, "groupIds", StringUtil.merge(groupIds, StringPool.COMMA));
+		}
+
+		if (Validator.isNotNull(metricType)) {
+			url = HttpComponentsUtil.addParameter(
+				url, "assetSummaryMetricTypeString", metricType);
+		}
+
+		if (Validator.isNotNull(objectType)) {
+			url = HttpComponentsUtil.addParameter(
+				url, "objectType", objectType);
+		}
+
+		if (page != null) {
+			url = HttpComponentsUtil.addParameter(url, "page", page);
 		}
 
 		if (rangeKey != null) {
@@ -426,9 +544,22 @@ public class AnalyticsCloudClient {
 		}
 
 		if (ArrayUtil.isNotEmpty(selectedMetrics)) {
-			return HttpComponentsUtil.addParameter(
+			url = HttpComponentsUtil.addParameter(
 				url, "selectedMetrics",
 				StringUtil.merge(selectedMetrics, StringPool.COMMA));
+		}
+
+		if (size != null) {
+			url = HttpComponentsUtil.addParameter(url, "size", size);
+		}
+
+		if (tagId != null) {
+			url = HttpComponentsUtil.addParameter(url, "tagId", tagId);
+		}
+
+		if (vocabularyId != null) {
+			url = HttpComponentsUtil.addParameter(
+				url, "vocabularyId", vocabularyId);
 		}
 
 		return url;
@@ -463,10 +594,62 @@ public class AnalyticsCloudClient {
 		}
 	}
 
+	private void _updatePerformanceAssetConsumptionFromObjectDefinition(
+		Locale locale,
+		PerformanceAssetConsumption performanceAssetConsumption) {
+
+		PerformanceAssetConsumptionItem[] performanceAssetConsumptionItems =
+			performanceAssetConsumption.getPerformanceAssetConsumptionItems();
+
+		if (ArrayUtil.isEmpty(performanceAssetConsumptionItems)) {
+			return;
+		}
+
+		List<String> names = TransformUtil.transformToList(
+			performanceAssetConsumptionItems,
+			PerformanceAssetConsumptionItem::getTitle);
+
+		Map<String, ObjectDefinition> objectDefinitionsMap = new HashMap<>();
+
+		for (ObjectDefinition objectDefinition :
+				(List<ObjectDefinition>)_objectDefinitionLocalService.dslQuery(
+					DSLQueryFactoryUtil.select(
+						ObjectDefinitionTable.INSTANCE
+					).from(
+						ObjectDefinitionTable.INSTANCE
+					).where(
+						ObjectDefinitionTable.INSTANCE.companyId.eq(
+							CompanyThreadLocal.getCompanyId()
+						).and(
+							ObjectDefinitionTable.INSTANCE.name.in(
+								names.toArray(new String[0]))
+						)
+					))) {
+
+			objectDefinitionsMap.put(
+				objectDefinition.getName(), objectDefinition);
+		}
+
+		for (PerformanceAssetConsumptionItem performanceAssetConsumptionItem :
+				performanceAssetConsumptionItems) {
+
+			ObjectDefinition objectDefinition = objectDefinitionsMap.get(
+				performanceAssetConsumptionItem.getTitle());
+
+			if (objectDefinition != null) {
+				performanceAssetConsumptionItem.setKey(
+					objectDefinition::getExternalReferenceCode);
+				performanceAssetConsumptionItem.setTitle(
+					() -> objectDefinition.getLabel(locale));
+			}
+		}
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		AnalyticsCloudClient.class);
 
 	private final Http _http;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	private static class ObjectMapperHolder {
 

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -47,7 +47,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * @author Rachael Koestartyo
@@ -361,7 +360,7 @@ public class AnalyticsCloudClient {
 					performanceAssetConsumption = objectReader.readValue(
 						jsonNode);
 
-					if (Objects.equals(groupBy, "structure")) {
+					if (StringUtil.equalsIgnoreCase(groupBy, "structure")) {
 						_updatePerformanceAssetConsumptionFromObjectDefinition(
 							locale, performanceAssetConsumption);
 					}

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -82,11 +82,10 @@ public class AnalyticsCloudClient {
 
 			options.setLocation(
 				_getUrl(
-					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
-					externalReferenceCode, null, groupIds,
+					analyticsConfiguration.liferayAnalyticsDataSourceId(),
+					externalReferenceCode, groupIds,
 					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
-					null, null, null, "/acquisition-channels", rangeKey, null,
-					null, null, null));
+					"/acquisition-channels", rangeKey, null));
 
 			String content = _http.URLtoString(options);
 
@@ -144,11 +143,10 @@ public class AnalyticsCloudClient {
 
 			options.setLocation(
 				_getUrl(
-					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
-					externalReferenceCode, null, groupIds,
+					analyticsConfiguration.liferayAnalyticsDataSourceId(),
+					externalReferenceCode, groupIds,
 					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
-					null, null, null, "/overview/histogram", rangeKey,
-					selectedMetrics, null, null, null));
+					"/overview/histogram", rangeKey, selectedMetrics));
 
 			String content = _http.URLtoString(options);
 
@@ -209,11 +207,10 @@ public class AnalyticsCloudClient {
 
 			options.setLocation(
 				_getUrl(
-					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
-					externalReferenceCode, null, groupIds,
+					analyticsConfiguration.liferayAnalyticsDataSourceId(),
+					externalReferenceCode, groupIds,
 					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
-					null, null, null, "/overview", rangeKey, selectedMetrics,
-					null, null, null));
+					"/overview", rangeKey, selectedMetrics));
 
 			String content = _http.URLtoString(options);
 
@@ -273,11 +270,10 @@ public class AnalyticsCloudClient {
 
 			options.setLocation(
 				_getUrl(
-					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
-					externalReferenceCode, null, groupIds,
+					analyticsConfiguration.liferayAnalyticsDataSourceId(),
+					externalReferenceCode, groupIds,
 					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
-					null, null, null, "/appears-on", rangeKey, null, null, null,
-					null));
+					"/appears-on", rangeKey, null));
 
 			String content = _http.URLtoString(options);
 
@@ -401,11 +397,10 @@ public class AnalyticsCloudClient {
 
 			options.setLocation(
 				_getUrl(
-					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
-					null, null, groupIds,
+					analyticsConfiguration.liferayAnalyticsDataSourceId(), null,
+					groupIds,
 					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
-					null, null, null, "/performance-overview-metric", rangeKey,
-					null, null, null, null));
+					"/performance-overview-metric", rangeKey, null));
 
 			String content = _http.URLtoString(options);
 
@@ -508,8 +503,10 @@ public class AnalyticsCloudClient {
 				url, "categoryId", categoryId);
 		}
 
-		url = HttpComponentsUtil.addParameter(
-			url, "dataSourceId", dataSourceId);
+		if (Validator.isNotNull(dataSourceId)) {
+			url = HttpComponentsUtil.addParameter(
+				url, "dataSourceId", dataSourceId);
+		}
 
 		if (Validator.isNotNull(externalReferenceCode)) {
 			url = HttpComponentsUtil.addParameter(
@@ -563,6 +560,17 @@ public class AnalyticsCloudClient {
 		}
 
 		return url;
+	}
+
+	private String _getUrl(
+		String dataSourceId, String externalReferenceCode, List<Long> groupIds,
+		String liferayAnalyticsFaroBackendURL, String path, Integer rangeKey,
+		String[] selectedMetrics) {
+
+		return _getUrl(
+			null, dataSourceId, externalReferenceCode, null, groupIds,
+			liferayAnalyticsFaroBackendURL, null, null, null, path, rangeKey,
+			selectedMetrics, null, null, null);
 	}
 
 	private void _renameKey(JsonNode jsonNode, String newKey, String oldKey) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/BasePerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/BasePerformanceAssetConsumptionResourceImpl.java
@@ -1,0 +1,576 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.internal.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumption;
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceAssetConsumptionResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BasePerformanceAssetConsumptionResourceImpl
+	implements PerformanceAssetConsumptionResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/analytics-cms-rest/v1.0/performance-asset-consumption'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "categoryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "depotEntryIds"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "groupBy"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "rangeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "structureId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "tagId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "vocabularyId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "PerformanceAssetConsumption"
+			)
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/performance-asset-consumption")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public PerformanceAssetConsumption getPerformanceAssetConsumption(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("categoryId")
+			Long categoryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("depotEntryIds")
+			Long[] depotEntryIds,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("groupBy")
+			String groupBy,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("rangeKey")
+			Integer rangeKey,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("structureId")
+			Long structureId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("tagId")
+			Long tagId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("vocabularyId")
+			Long vocabularyId,
+			@jakarta.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return new PerformanceAssetConsumption();
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "analytics-cms-rest";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(
+			BasePerformanceAssetConsumptionResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1718994387

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -103,6 +103,8 @@ public class OpenAPIResourceImpl {
 
 			add(OverviewResourceImpl.class);
 
+			add(PerformanceAssetConsumptionResourceImpl.class);
+
 			add(PerformanceOverviewMetricResourceImpl.class);
 
 			add(OpenAPIResourceImpl.class);
@@ -110,4 +112,4 @@ public class OpenAPIResourceImpl {
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:1295959257
+// LIFERAY-REST-BUILDER-HASH:1523237586

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
@@ -5,9 +5,21 @@
 
 package com.liferay.analytics.cms.rest.internal.resource.v1_0;
 
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumption;
+import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
+import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceAssetConsumptionResource;
+import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.Arrays;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -20,4 +32,51 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 public class PerformanceAssetConsumptionResourceImpl
 	extends BasePerformanceAssetConsumptionResourceImpl {
+
+	@Override
+	public PerformanceAssetConsumption getPerformanceAssetConsumption(
+			Long categoryId, Long[] depotEntryIds, String groupBy,
+			Integer rangeKey, Long structureId, Long tagId, Long vocabularyId,
+			Pagination pagination)
+		throws Exception {
+
+		LicenseManagerUtil.checkFreeTier();
+
+		Long[] groupIds = DepotEntryUtil.getGroupIds(
+			DepotEntryUtil.getDepotEntries(
+				contextCompany.getCompanyId(), depotEntryIds));
+
+		String objectType = null;
+
+		if (structureId != null) {
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.fetchObjectDefinition(
+					structureId);
+
+			if (objectDefinition != null) {
+				objectType = objectDefinition.getName();
+			}
+		}
+
+		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
+			_http, _objectDefinitionLocalService);
+
+		return analyticsCloudClient.getPerformanceAssetConsumption(
+			_analyticsSettingsManager.getAnalyticsConfiguration(
+				contextCompany.getCompanyId()),
+			categoryId, groupBy, Arrays.asList(groupIds),
+			contextAcceptLanguage.getPreferredLocale(), "viewsMetric",
+			objectType, pagination.getPage(), rangeKey,
+			pagination.getPageSize(), tagId, vocabularyId);
+	}
+
+	@Reference
+	private AnalyticsSettingsManager _analyticsSettingsManager;
+
+	@Reference
+	private Http _http;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
 }

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.internal.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceAssetConsumptionResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Rachael Koestartyo
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/performance-asset-consumption.properties",
+	scope = ServiceScope.PROTOTYPE,
+	service = PerformanceAssetConsumptionResource.class
+)
+public class PerformanceAssetConsumptionResourceImpl
+	extends BasePerformanceAssetConsumptionResourceImpl {
+}

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
@@ -14,7 +14,10 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.ws.rs.BadRequestException;
 
 import java.util.Arrays;
 
@@ -42,6 +45,8 @@ public class PerformanceAssetConsumptionResourceImpl
 
 		LicenseManagerUtil.checkFreeTier();
 
+		_validateGroupBy(groupBy);
+
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
 			DepotEntryUtil.getDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
@@ -68,6 +73,16 @@ public class PerformanceAssetConsumptionResourceImpl
 			contextAcceptLanguage.getPreferredLocale(), "viewsMetric",
 			objectType, pagination.getPage(), rangeKey,
 			pagination.getPageSize(), tagId, vocabularyId);
+	}
+
+	private void _validateGroupBy(String groupBy) {
+		if (!StringUtil.equalsIgnoreCase(groupBy, "category") &&
+			!StringUtil.equalsIgnoreCase(groupBy, "structure") &&
+			!StringUtil.equalsIgnoreCase(groupBy, "tag") &&
+			!StringUtil.equalsIgnoreCase(groupBy, "vocabulary")) {
+
+			throw new BadRequestException("Invalid group by: " + groupBy);
+		}
 	}
 
 	@Reference

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/factory/PerformanceAssetConsumptionResourceFactoryImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/factory/PerformanceAssetConsumptionResourceFactoryImpl.java
@@ -1,0 +1,347 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.internal.resource.v1_0.factory;
+
+import com.liferay.analytics.cms.rest.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceAssetConsumptionResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/analytics-cms-rest/v1.0/PerformanceAssetConsumption",
+	service = PerformanceAssetConsumptionResource.Factory.class
+)
+@Generated("")
+public class PerformanceAssetConsumptionResourceFactoryImpl
+	implements PerformanceAssetConsumptionResource.Factory {
+
+	@Override
+	public PerformanceAssetConsumptionResource.Builder create() {
+		return new PerformanceAssetConsumptionResource.Builder() {
+
+			@Override
+			public PerformanceAssetConsumptionResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, PerformanceAssetConsumptionResource>
+					performanceAssetConsumptionResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_performanceAssetConsumptionResourceProxyProviderFunction;
+
+				return performanceAssetConsumptionResourceProxyProviderFunction.
+					apply(
+						(proxy, method, arguments) -> _invoke(
+							method, arguments, _checkPermissions,
+							_httpServletRequest, _httpServletResponse,
+							_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public PerformanceAssetConsumptionResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceAssetConsumptionResource.Builder
+				httpServletRequest(HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceAssetConsumptionResource.Builder
+				httpServletResponse(HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceAssetConsumptionResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceAssetConsumptionResource.Builder uriInfo(
+				UriInfo uriInfo) {
+
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceAssetConsumptionResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function
+		<InvocationHandler, PerformanceAssetConsumptionResource>
+			_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			PerformanceAssetConsumptionResource.class.getClassLoader(),
+			PerformanceAssetConsumptionResource.class);
+
+		try {
+			Constructor<PerformanceAssetConsumptionResource> constructor =
+				(Constructor<PerformanceAssetConsumptionResource>)
+					proxyClass.getConstructor(InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		PerformanceAssetConsumptionResource
+			performanceAssetConsumptionResource =
+				_componentServiceObjects.getService();
+
+		performanceAssetConsumptionResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		performanceAssetConsumptionResource.setContextCompany(company);
+
+		performanceAssetConsumptionResource.setContextHttpServletRequest(
+			httpServletRequest);
+		performanceAssetConsumptionResource.setContextHttpServletResponse(
+			httpServletResponse);
+		performanceAssetConsumptionResource.setContextUriInfo(uriInfo);
+		performanceAssetConsumptionResource.setContextUser(user);
+		performanceAssetConsumptionResource.setExpressionConvert(
+			_expressionConvert);
+		performanceAssetConsumptionResource.setFilterParserProvider(
+			_filterParserProvider);
+		performanceAssetConsumptionResource.setGroupLocalService(
+			_groupLocalService);
+		performanceAssetConsumptionResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		performanceAssetConsumptionResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		performanceAssetConsumptionResource.setRoleLocalService(
+			_roleLocalService);
+		performanceAssetConsumptionResource.setSortParserProvider(
+			_sortParserProvider);
+
+		try {
+			return method.invoke(
+				performanceAssetConsumptionResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(
+				performanceAssetConsumptionResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<PerformanceAssetConsumptionResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function
+			<InvocationHandler, PerformanceAssetConsumptionResource>
+				_performanceAssetConsumptionResourceProxyProviderFunction =
+					_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-2082599231

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/performance-asset-consumption.properties
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/performance-asset-consumption.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumption
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Analytics.CMS.REST)
+osgi.jaxrs.resource=true

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceAssetConsumptionResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceAssetConsumptionResourceTestCase.java
@@ -1,0 +1,902 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceAssetConsumption;
+import com.liferay.analytics.cms.rest.client.http.HttpInvoker;
+import com.liferay.analytics.cms.rest.client.pagination.Page;
+import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceAssetConsumptionResource;
+import com.liferay.analytics.cms.rest.client.serdes.v1_0.PerformanceAssetConsumptionSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public abstract class BasePerformanceAssetConsumptionResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_performanceAssetConsumptionResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		performanceAssetConsumptionResource =
+			PerformanceAssetConsumptionResource.builder(
+			).authentication(
+				_testCompanyAdminUser.getEmailAddress(),
+				PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		PerformanceAssetConsumption performanceAssetConsumption1 =
+			randomPerformanceAssetConsumption();
+
+		String json = objectMapper.writeValueAsString(
+			performanceAssetConsumption1);
+
+		PerformanceAssetConsumption performanceAssetConsumption2 =
+			PerformanceAssetConsumptionSerDes.toDTO(json);
+
+		Assert.assertTrue(
+			equals(performanceAssetConsumption1, performanceAssetConsumption2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		PerformanceAssetConsumption performanceAssetConsumption =
+			randomPerformanceAssetConsumption();
+
+		String json1 = objectMapper.writeValueAsString(
+			performanceAssetConsumption);
+		String json2 = PerformanceAssetConsumptionSerDes.toJSON(
+			performanceAssetConsumption);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		PerformanceAssetConsumption performanceAssetConsumption =
+			randomPerformanceAssetConsumption();
+
+		String json = PerformanceAssetConsumptionSerDes.toJSON(
+			performanceAssetConsumption);
+
+		Assert.assertFalse(json.contains(regex));
+
+		performanceAssetConsumption = PerformanceAssetConsumptionSerDes.toDTO(
+			json);
+	}
+
+	@Test
+	public void testGetPerformanceAssetConsumption() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	protected void assertContains(
+		PerformanceAssetConsumption performanceAssetConsumption,
+		List<PerformanceAssetConsumption> performanceAssetConsumptions) {
+
+		boolean contains = false;
+
+		for (PerformanceAssetConsumption item : performanceAssetConsumptions) {
+			if (equals(performanceAssetConsumption, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			performanceAssetConsumptions + " does not contain " +
+				performanceAssetConsumption,
+			contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		PerformanceAssetConsumption performanceAssetConsumption1,
+		PerformanceAssetConsumption performanceAssetConsumption2) {
+
+		Assert.assertTrue(
+			performanceAssetConsumption1 + " does not equal " +
+				performanceAssetConsumption2,
+			equals(performanceAssetConsumption1, performanceAssetConsumption2));
+	}
+
+	protected void assertEquals(
+		List<PerformanceAssetConsumption> performanceAssetConsumptions1,
+		List<PerformanceAssetConsumption> performanceAssetConsumptions2) {
+
+		Assert.assertEquals(
+			performanceAssetConsumptions1.size(),
+			performanceAssetConsumptions2.size());
+
+		for (int i = 0; i < performanceAssetConsumptions1.size(); i++) {
+			PerformanceAssetConsumption performanceAssetConsumption1 =
+				performanceAssetConsumptions1.get(i);
+			PerformanceAssetConsumption performanceAssetConsumption2 =
+				performanceAssetConsumptions2.get(i);
+
+			assertEquals(
+				performanceAssetConsumption1, performanceAssetConsumption2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<PerformanceAssetConsumption> performanceAssetConsumptions1,
+		List<PerformanceAssetConsumption> performanceAssetConsumptions2) {
+
+		Assert.assertEquals(
+			performanceAssetConsumptions1.size(),
+			performanceAssetConsumptions2.size());
+
+		for (PerformanceAssetConsumption performanceAssetConsumption1 :
+				performanceAssetConsumptions1) {
+
+			boolean contains = false;
+
+			for (PerformanceAssetConsumption performanceAssetConsumption2 :
+					performanceAssetConsumptions2) {
+
+				if (equals(
+						performanceAssetConsumption1,
+						performanceAssetConsumption2)) {
+
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				performanceAssetConsumptions2 + " does not contain " +
+					performanceAssetConsumption1,
+				contains);
+		}
+	}
+
+	protected void assertValid(
+			PerformanceAssetConsumption performanceAssetConsumption)
+		throws Exception {
+
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals(
+					"performanceAssetConsumptionItems",
+					additionalAssertFieldName)) {
+
+				if (performanceAssetConsumption.
+						getPerformanceAssetConsumptionItems() == null) {
+
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"performanceAssetConsumptionItemsCount",
+					additionalAssertFieldName)) {
+
+				if (performanceAssetConsumption.
+						getPerformanceAssetConsumptionItemsCount() == null) {
+
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("totalCount", additionalAssertFieldName)) {
+				if (performanceAssetConsumption.getTotalCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<PerformanceAssetConsumption> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<PerformanceAssetConsumption> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<PerformanceAssetConsumption>
+			performanceAssetConsumptions = page.getItems();
+
+		int size = performanceAssetConsumptions.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.analytics.cms.rest.dto.v1_0.
+						PerformanceAssetConsumption.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		PerformanceAssetConsumption performanceAssetConsumption1,
+		PerformanceAssetConsumption performanceAssetConsumption2) {
+
+		if (performanceAssetConsumption1 == performanceAssetConsumption2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals(
+					"performanceAssetConsumptionItems",
+					additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						performanceAssetConsumption1.
+							getPerformanceAssetConsumptionItems(),
+						performanceAssetConsumption2.
+							getPerformanceAssetConsumptionItems())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"performanceAssetConsumptionItemsCount",
+					additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						performanceAssetConsumption1.
+							getPerformanceAssetConsumptionItemsCount(),
+						performanceAssetConsumption2.
+							getPerformanceAssetConsumptionItemsCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("totalCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						performanceAssetConsumption1.getTotalCount(),
+						performanceAssetConsumption2.getTotalCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_performanceAssetConsumptionResource instanceof
+				EntityModelResource)) {
+
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_performanceAssetConsumptionResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		PerformanceAssetConsumption performanceAssetConsumption) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("performanceAssetConsumptionItems")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("performanceAssetConsumptionItemsCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("totalCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected PerformanceAssetConsumption randomPerformanceAssetConsumption()
+		throws Exception {
+
+		return new PerformanceAssetConsumption() {
+			{
+				performanceAssetConsumptionItemsCount =
+					RandomTestUtil.randomLong();
+				totalCount = RandomTestUtil.randomLong();
+			}
+		};
+	}
+
+	protected PerformanceAssetConsumption
+			randomIrrelevantPerformanceAssetConsumption()
+		throws Exception {
+
+		PerformanceAssetConsumption
+			randomIrrelevantPerformanceAssetConsumption =
+				randomPerformanceAssetConsumption();
+
+		return randomIrrelevantPerformanceAssetConsumption;
+	}
+
+	protected PerformanceAssetConsumption
+			randomPatchPerformanceAssetConsumption()
+		throws Exception {
+
+		return randomPerformanceAssetConsumption();
+	}
+
+	protected PerformanceAssetConsumptionResource
+		performanceAssetConsumptionResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(
+			BasePerformanceAssetConsumptionResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.analytics.cms.rest.resource.v1_0.
+		PerformanceAssetConsumptionResource
+			_performanceAssetConsumptionResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-2022165993

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ObjectEntryHistogramMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ObjectEntryHistogramMetricResourceTest.java
@@ -174,7 +174,8 @@ public class ObjectEntryHistogramMetricResourceTest
 			ObjectEntryHistogramMetric objectEntryHistogramMetric =
 				_objectEntryHistogramMetricResource.
 					getObjectEntryHistogramMetric(
-						"1", null, 7, new String[] {"downloadsMetric"});
+						"1", null, RandomTestUtil.nextInt(),
+						new String[] {"downloadsMetric"});
 
 			Histogram[] histograms = objectEntryHistogramMetric.getHistograms();
 

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ObjectEntryMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ObjectEntryMetricResourceTest.java
@@ -129,7 +129,7 @@ public class ObjectEntryMetricResourceTest
 
 			ObjectEntryMetric objectEntryMetric =
 				_objectEntryMetricResource.getObjectEntryMetric(
-					"1", null, 30,
+					"1", null, RandomTestUtil.nextInt(),
 					new String[] {"downloadsMetric", "viewsMetric"});
 
 			Assert.assertEquals(

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -31,6 +31,8 @@ import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
+import jakarta.ws.rs.BadRequestException;
+
 import java.io.IOException;
 
 import java.util.Arrays;
@@ -402,6 +404,19 @@ public class PerformanceAssetConsumptionResourceTest
 			ReflectionTestUtil.setFieldValue(
 				_performanceAssetConsumptionResource, "_http", _http);
 		}
+	}
+
+	@Test
+	public void testGetPerformanceAssetConsumptionWithInvalidGroupBy()
+		throws Exception {
+
+		Assert.assertThrows(
+			BadRequestException.class,
+			() ->
+				_performanceAssetConsumptionResource.
+					getPerformanceAssetConsumption(
+						null, null, RandomTestUtil.randomString(), 30, null,
+						null, null, Pagination.of(1, 10)));
 	}
 
 	private void _setUpMockHttp(String json) {

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rachael Koestartyo
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class PerformanceAssetConsumptionResourceTest
+	extends BasePerformanceAssetConsumptionResourceTestCase {
+}

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -10,18 +10,30 @@ import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumptionItem;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceAssetConsumptionResource;
 import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.MockHttp;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -35,6 +47,7 @@ import jakarta.ws.rs.BadRequestException;
 
 import java.io.IOException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -42,6 +55,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,6 +77,15 @@ public class PerformanceAssetConsumptionResourceTest
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_addDepotEntry();
+		_addDepotEntry();
+	}
 
 	@Override
 	@Test
@@ -87,14 +110,15 @@ public class PerformanceAssetConsumptionResourceTest
 
 			});
 
+		long dataSourceId = RandomTestUtil.nextLong();
+
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
 					new CompanyConfigurationTemporarySwapper(
 						testCompany.getCompanyId(),
 						AnalyticsConfiguration.class.getName(),
 						HashMapDictionaryBuilder.<String, Object>put(
-							"liferayAnalyticsDataSourceId",
-							RandomTestUtil.nextLong()
+							"liferayAnalyticsDataSourceId", dataSourceId
 						).put(
 							"liferayAnalyticsEnableAllGroupIds", true
 						).put(
@@ -105,109 +129,13 @@ public class PerformanceAssetConsumptionResourceTest
 							"http://" + RandomTestUtil.randomString()
 						).build())) {
 
-			_setUpMockHttp(
-				JSONUtil.put(
-					"metrics",
-					JSONUtil.putAll(
-						JSONUtil.put(
-							"key", "key1"
-						).put(
-							"title", "title1"
-						).put(
-							"value", 10
-						),
-						JSONUtil.put(
-							"key", "key2"
-						).put(
-							"title", "title2"
-						).put(
-							"value", 20
-						))
-				).put(
-					"total", 2
-				).put(
-					"totalCount", 30
-				).toString());
+			_assertGetPerformanceAssetConsumptionGroupByStructure();
 
-			for (String groupBy :
-					new String[] {"category", "tag", "vocabulary"}) {
+			_assertGetPerformanceAssetConsumptionResponse();
 
-				PerformanceAssetConsumption performanceAssetConsumption =
-					_performanceAssetConsumptionResource.
-						getPerformanceAssetConsumption(
-							null, null, groupBy, 30, null, null, null,
-							Pagination.of(1, 10));
+			_assertGetPerformanceAssetConsumptionURL(dataSourceId);
 
-				PerformanceAssetConsumptionItem[]
-					performanceAssetConsumptionItems =
-						performanceAssetConsumption.
-							getPerformanceAssetConsumptionItems();
-
-				Assert.assertEquals(
-					Arrays.toString(performanceAssetConsumptionItems), 2,
-					performanceAssetConsumptionItems.length);
-				Assert.assertEquals(
-					"key1", performanceAssetConsumptionItems[0].getKey());
-				Assert.assertEquals(
-					"title1", performanceAssetConsumptionItems[0].getTitle());
-				Assert.assertEquals(
-					"key2", performanceAssetConsumptionItems[1].getKey());
-				Assert.assertEquals(
-					"title2", performanceAssetConsumptionItems[1].getTitle());
-
-				Assert.assertEquals(
-					2L,
-					(long)
-						performanceAssetConsumption.
-							getPerformanceAssetConsumptionItemsCount());
-				Assert.assertEquals(
-					30L, (long)performanceAssetConsumption.getTotalCount());
-			}
-
-			CMSTestUtil.getOrAddGroup(
-				PerformanceAssetConsumptionResourceTest.class);
-
-			ObjectDefinition objectDefinition =
-				_objectDefinitionLocalService.
-					getObjectDefinitionByExternalReferenceCode(
-						"L_CMS_BASIC_WEB_CONTENT", testCompany.getCompanyId());
-
-			_setUpMockHttp(
-				JSONUtil.put(
-					"metrics",
-					JSONUtil.putAll(
-						JSONUtil.put(
-							"key", RandomTestUtil.randomString()
-						).put(
-							"title", objectDefinition.getName()
-						).put(
-							"value", 30
-						))
-				).put(
-					"total", 1
-				).put(
-					"totalCount", 30
-				).toString());
-
-			PerformanceAssetConsumption performanceAssetConsumption =
-				_performanceAssetConsumptionResource.
-					getPerformanceAssetConsumption(
-						null, null, "structure", 30, null, null, null,
-						Pagination.of(1, 10));
-
-			PerformanceAssetConsumptionItem[] performanceAssetConsumptionItems =
-				performanceAssetConsumption.
-					getPerformanceAssetConsumptionItems();
-
-			Assert.assertEquals(
-				Arrays.toString(performanceAssetConsumptionItems), 1,
-				performanceAssetConsumptionItems.length);
-			Assert.assertEquals(
-				objectDefinition.getExternalReferenceCode(),
-				performanceAssetConsumptionItems[0].getKey());
-			Assert.assertEquals(
-				objectDefinition.getLabel(LocaleUtil.getDefault()),
-				performanceAssetConsumptionItems[0].getTitle());
+			_assertGetPerformanceAssetConsumptionWithInvalidGroupBy();
 		}
 		finally {
 			ReflectionTestUtil.setFieldValue(
@@ -215,218 +143,246 @@ public class PerformanceAssetConsumptionResourceTest
 		}
 	}
 
-	@Test
-	public void testGetPerformanceAssetConsumptionGroupByStructure()
+	private DepotEntry _addDepotEntry() throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext(
+				testGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		_depotEntries.add(depotEntry);
+
+		return depotEntry;
+	}
+
+	private void _assertGetPerformanceAssetConsumptionGroupByStructure()
 		throws Exception {
 
-		_performanceAssetConsumptionResource.setContextAcceptLanguage(
-			new AcceptLanguage() {
+		CMSTestUtil.getOrAddGroup(
+			PerformanceAssetConsumptionResourceTest.class);
 
-				@Override
-				public List<Locale> getLocales() {
-					return Arrays.asList(LocaleUtil.getDefault());
-				}
+		ObjectDefinition basicWebContentObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BASIC_WEB_CONTENT", testCompany.getCompanyId());
+		ObjectDefinition blogObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BLOG", testCompany.getCompanyId());
 
-				@Override
-				public String getPreferredLanguageId() {
-					return LocaleUtil.toLanguageId(LocaleUtil.getDefault());
-				}
-
-				@Override
-				public Locale getPreferredLocale() {
-					return LocaleUtil.getDefault();
-				}
-
-			});
-
-		try (CompanyConfigurationTemporarySwapper
-				companyConfigurationTemporarySwapper =
-					new CompanyConfigurationTemporarySwapper(
-						testCompany.getCompanyId(),
-						AnalyticsConfiguration.class.getName(),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"liferayAnalyticsDataSourceId",
-							RandomTestUtil.nextLong()
-						).put(
-							"liferayAnalyticsEnableAllGroupIds", true
-						).put(
-							"liferayAnalyticsFaroBackendSecuritySignature",
-							RandomTestUtil.randomString()
-						).put(
-							"liferayAnalyticsFaroBackendURL",
-							"http://" + RandomTestUtil.randomString()
-						).build())) {
-
-			CMSTestUtil.getOrAddGroup(
-				PerformanceAssetConsumptionResourceTest.class);
-
-			ObjectDefinition basicWebContentObjectDefinition =
-				_objectDefinitionLocalService.
-					getObjectDefinitionByExternalReferenceCode(
-						"L_CMS_BASIC_WEB_CONTENT", testCompany.getCompanyId());
-			ObjectDefinition blogObjectDefinition =
-				_objectDefinitionLocalService.
-					getObjectDefinitionByExternalReferenceCode(
-						"L_CMS_BLOG", testCompany.getCompanyId());
-
-			_setUpMockHttp(
-				JSONUtil.put(
-					"metrics",
-					JSONUtil.putAll(
-						JSONUtil.put(
-							"key", RandomTestUtil.randomString()
-						).put(
-							"title", basicWebContentObjectDefinition.getName()
-						).put(
-							"value", 30
-						),
-						JSONUtil.put(
-							"key", RandomTestUtil.randomString()
-						).put(
-							"title", blogObjectDefinition.getName()
-						).put(
-							"value", 20
-						))
-				).put(
-					"total", 2
-				).put(
-					"totalCount", 50
-				).toString());
-
-			PerformanceAssetConsumption performanceAssetConsumption =
-				_performanceAssetConsumptionResource.
-					getPerformanceAssetConsumption(
-						null, null, "structure", 30, null, null, null,
-						Pagination.of(1, 10));
-
-			PerformanceAssetConsumptionItem[] performanceAssetConsumptionItems =
-				performanceAssetConsumption.
-					getPerformanceAssetConsumptionItems();
-
-			Assert.assertEquals(
-				Arrays.toString(performanceAssetConsumptionItems), 2,
-				performanceAssetConsumptionItems.length);
-			Assert.assertEquals(
-				basicWebContentObjectDefinition.getExternalReferenceCode(),
-				performanceAssetConsumptionItems[0].getKey());
-			Assert.assertEquals(
-				basicWebContentObjectDefinition.getLabel(
-					LocaleUtil.getDefault()),
-				performanceAssetConsumptionItems[0].getTitle());
-			Assert.assertEquals(
-				blogObjectDefinition.getExternalReferenceCode(),
-				performanceAssetConsumptionItems[1].getKey());
-			Assert.assertEquals(
-				blogObjectDefinition.getLabel(LocaleUtil.getDefault()),
-				performanceAssetConsumptionItems[1].getTitle());
-		}
-		finally {
-			ReflectionTestUtil.setFieldValue(
-				_performanceAssetConsumptionResource, "_http", _http);
-		}
-	}
-
-	@Test
-	public void testGetPerformanceAssetConsumptionURL() throws Exception {
-		_performanceAssetConsumptionResource.setContextAcceptLanguage(
-			new AcceptLanguage() {
-
-				@Override
-				public List<Locale> getLocales() {
-					return Arrays.asList(LocaleUtil.getDefault());
-				}
-
-				@Override
-				public String getPreferredLanguageId() {
-					return LocaleUtil.toLanguageId(LocaleUtil.getDefault());
-				}
-
-				@Override
-				public Locale getPreferredLocale() {
-					return LocaleUtil.getDefault();
-				}
-
-			});
-
-		try (CompanyConfigurationTemporarySwapper
-				companyConfigurationTemporarySwapper =
-					new CompanyConfigurationTemporarySwapper(
-						testCompany.getCompanyId(),
-						AnalyticsConfiguration.class.getName(),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"liferayAnalyticsDataSourceId", "12345"
-						).put(
-							"liferayAnalyticsEnableAllGroupIds", true
-						).put(
-							"liferayAnalyticsFaroBackendSecuritySignature",
-							RandomTestUtil.randomString()
-						).put(
-							"liferayAnalyticsFaroBackendURL",
-							"http://" + RandomTestUtil.randomString()
-						).build())) {
-
-			RecordingMockHttp recordingMockHttp = new RecordingMockHttp(
-				Collections.singletonMap(
-					"/api/1.0/asset-metric/objectEntry/asset-consumption",
-					() -> JSONUtil.put(
-						"metrics", JSONUtil.putAll()
+		_setUpMockHttp(
+			JSONUtil.put(
+				"metrics",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"count", 30
 					).put(
-						"total", 0
+						"key", RandomTestUtil.randomString()
 					).put(
-						"totalCount", 0
-					).toString()));
+						"title", basicWebContentObjectDefinition.getName()
+					),
+					JSONUtil.put(
+						"count", 20
+					).put(
+						"key", RandomTestUtil.randomString()
+					).put(
+						"title", blogObjectDefinition.getName()
+					))
+			).put(
+				"total", 2
+			).put(
+				"totalCount", 50
+			).toString());
 
-			ReflectionTestUtil.setFieldValue(
-				_performanceAssetConsumptionResource, "_http",
-				recordingMockHttp);
-
+		PerformanceAssetConsumption performanceAssetConsumption =
 			_performanceAssetConsumptionResource.getPerformanceAssetConsumption(
-				11111L, null, "tag", 30, null, 22222L, 33333L,
-				Pagination.of(2, 5));
+				null, null, "structure", RandomTestUtil.nextInt(), null, null,
+				null, Pagination.of(1, 10));
 
-			String location = recordingMockHttp._getLocation();
+		PerformanceAssetConsumptionItem[] performanceAssetConsumptionItems =
+			performanceAssetConsumption.getPerformanceAssetConsumptionItems();
 
-			Assert.assertTrue(location, location.contains("categoryId=11111"));
-			Assert.assertTrue(
-				location, location.contains("dataSourceId=12345"));
-			Assert.assertTrue(location, location.contains("groupBy=tag"));
-			Assert.assertTrue(
-				location,
-				location.contains("assetSummaryMetricTypeString=viewsMetric"));
-			Assert.assertTrue(location, location.contains("page=2"));
-			Assert.assertTrue(location, location.contains("rangeKey=30"));
-			Assert.assertTrue(location, location.contains("size=5"));
-			Assert.assertTrue(location, location.contains("tagId=22222"));
-			Assert.assertTrue(
-				location, location.contains("vocabularyId=33333"));
-		}
-		finally {
-			ReflectionTestUtil.setFieldValue(
-				_performanceAssetConsumptionResource, "_http", _http);
-		}
+		Assert.assertEquals(
+			Arrays.toString(performanceAssetConsumptionItems), 2,
+			performanceAssetConsumptionItems.length);
+		Assert.assertEquals(
+			30L, (long)performanceAssetConsumptionItems[0].getCount());
+		Assert.assertEquals(
+			basicWebContentObjectDefinition.getExternalReferenceCode(),
+			performanceAssetConsumptionItems[0].getKey());
+		Assert.assertEquals(
+			basicWebContentObjectDefinition.getLabel(LocaleUtil.getDefault()),
+			performanceAssetConsumptionItems[0].getTitle());
+		Assert.assertEquals(
+			20L, (long)performanceAssetConsumptionItems[1].getCount());
+		Assert.assertEquals(
+			blogObjectDefinition.getExternalReferenceCode(),
+			performanceAssetConsumptionItems[1].getKey());
+		Assert.assertEquals(
+			blogObjectDefinition.getLabel(LocaleUtil.getDefault()),
+			performanceAssetConsumptionItems[1].getTitle());
+
+		Assert.assertEquals(
+			2L,
+			(long)
+				performanceAssetConsumption.
+					getPerformanceAssetConsumptionItemsCount());
+		Assert.assertEquals(
+			50L, (long)performanceAssetConsumption.getTotalCount());
 	}
 
-	@Test
-	public void testGetPerformanceAssetConsumptionWithInvalidGroupBy()
+	private void _assertGetPerformanceAssetConsumptionResponse()
 		throws Exception {
 
+		String key1 = RandomTestUtil.randomString();
+		String key2 = RandomTestUtil.randomString();
+		String title1 = RandomTestUtil.randomString();
+		String title2 = RandomTestUtil.randomString();
+
+		_setUpMockHttp(
+			JSONUtil.put(
+				"metrics",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"count", 10
+					).put(
+						"key", key1
+					).put(
+						"title", title1
+					),
+					JSONUtil.put(
+						"count", 20
+					).put(
+						"key", key2
+					).put(
+						"title", title2
+					))
+			).put(
+				"total", 2
+			).put(
+				"totalCount", 30
+			).toString());
+
+		PerformanceAssetConsumption performanceAssetConsumption =
+			_performanceAssetConsumptionResource.getPerformanceAssetConsumption(
+				null, null, "category", RandomTestUtil.nextInt(), null, null,
+				null, Pagination.of(1, 10));
+
+		PerformanceAssetConsumptionItem[] performanceAssetConsumptionItems =
+			performanceAssetConsumption.getPerformanceAssetConsumptionItems();
+
+		Assert.assertEquals(
+			Arrays.toString(performanceAssetConsumptionItems), 2,
+			performanceAssetConsumptionItems.length);
+		Assert.assertEquals(
+			10L, (long)performanceAssetConsumptionItems[0].getCount());
+		Assert.assertEquals(key1, performanceAssetConsumptionItems[0].getKey());
+		Assert.assertEquals(
+			title1, performanceAssetConsumptionItems[0].getTitle());
+		Assert.assertEquals(
+			20L, (long)performanceAssetConsumptionItems[1].getCount());
+		Assert.assertEquals(key2, performanceAssetConsumptionItems[1].getKey());
+		Assert.assertEquals(
+			title2, performanceAssetConsumptionItems[1].getTitle());
+
+		Assert.assertEquals(
+			2L,
+			(long)
+				performanceAssetConsumption.
+					getPerformanceAssetConsumptionItemsCount());
+		Assert.assertEquals(
+			30L, (long)performanceAssetConsumption.getTotalCount());
+	}
+
+	private void _assertGetPerformanceAssetConsumptionURL(long dataSourceId)
+		throws Exception {
+
+		RecordingMockHttp recordingMockHttp = _setUpMockHttp("{}");
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_CMS_BLOG", testCompany.getCompanyId());
+
+		long categoryId = RandomTestUtil.nextLong();
+		int page = 2;
+		int rangeKey = RandomTestUtil.nextInt();
+		int size = 5;
+		long tagId = RandomTestUtil.nextLong();
+		long vocabularyId = RandomTestUtil.nextLong();
+
+		_performanceAssetConsumptionResource.getPerformanceAssetConsumption(
+			categoryId,
+			TransformUtil.transformToArray(
+				_depotEntries, DepotEntry::getDepotEntryId, Long.class),
+			"tag", rangeKey, objectDefinition.getObjectDefinitionId(), tagId,
+			vocabularyId, Pagination.of(page, size));
+
+		String location = recordingMockHttp.getLocation();
+
+		_assertParameter(
+			"viewsMetric", "assetSummaryMetricTypeString", location);
+		_assertParameter(String.valueOf(categoryId), "categoryId", location);
+		_assertParameter(
+			String.valueOf(dataSourceId), "dataSourceId", location);
+		_assertParameter("tag", "groupBy", location);
+		_assertParameter(
+			StringUtil.merge(
+				TransformUtil.transformToArray(
+					_depotEntries, DepotEntry::getGroupId, Long.class),
+				StringPool.COMMA),
+			"groupIds", location);
+		_assertParameter(objectDefinition.getName(), "objectType", location);
+		_assertParameter(String.valueOf(page), "page", location);
+		_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
+		_assertParameter(String.valueOf(size), "size", location);
+		_assertParameter(String.valueOf(tagId), "tagId", location);
+		_assertParameter(
+			String.valueOf(vocabularyId), "vocabularyId", location);
+	}
+
+	private void _assertGetPerformanceAssetConsumptionWithInvalidGroupBy() {
 		Assert.assertThrows(
 			BadRequestException.class,
 			() ->
 				_performanceAssetConsumptionResource.
 					getPerformanceAssetConsumption(
-						null, null, RandomTestUtil.randomString(), 30, null,
-						null, null, Pagination.of(1, 10)));
+						null, null, RandomTestUtil.randomString(),
+						RandomTestUtil.nextInt(), null, null, null,
+						Pagination.of(1, 10)));
 	}
 
-	private void _setUpMockHttp(String json) {
-		ReflectionTestUtil.setFieldValue(
-			_performanceAssetConsumptionResource, "_http",
-			new MockHttp(
-				Collections.singletonMap(
-					"/api/1.0/asset-metric/objectEntry/asset-consumption",
-					() -> json)));
+	private void _assertParameter(
+		String expectedValue, String name, String url) {
+
+		Assert.assertEquals(
+			expectedValue,
+			URLCodec.decodeURL(
+				HttpComponentsUtil.getParameter(url, name, false)));
 	}
+
+	private RecordingMockHttp _setUpMockHttp(String json) {
+		RecordingMockHttp recordingMockHttp = new RecordingMockHttp(
+			Collections.singletonMap(
+				"/api/1.0/asset-metric/objectEntry/asset-consumption",
+				() -> json));
+
+		ReflectionTestUtil.setFieldValue(
+			_performanceAssetConsumptionResource, "_http", recordingMockHttp);
+
+		return recordingMockHttp;
+	}
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Inject
 	private Http _http;
@@ -446,15 +402,15 @@ public class PerformanceAssetConsumptionResourceTest
 			super(unsafeSuppliers);
 		}
 
+		public String getLocation() {
+			return _location;
+		}
+
 		@Override
 		public String URLtoString(Http.Options options) throws IOException {
 			_location = options.getLocation();
 
 			return super.URLtoString(options);
-		}
-
-		private String _getLocation() {
-			return _location;
 		}
 
 		private String _location;

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -5,16 +5,445 @@
 
 package com.liferay.analytics.cms.rest.resource.v1_0.test;
 
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumption;
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumptionItem;
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceAssetConsumptionResource;
+import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.MockHttp;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
-import org.junit.Ignore;
+import java.io.IOException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Rachael Koestartyo
  */
-@Ignore
+@FeatureFlags(
+	featureFlags = {@FeatureFlag("LPD-17564"), @FeatureFlag("LPD-34594")}
+)
 @RunWith(Arquillian.class)
 public class PerformanceAssetConsumptionResourceTest
 	extends BasePerformanceAssetConsumptionResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	@Test
+	public void testGetPerformanceAssetConsumption() throws Exception {
+		_performanceAssetConsumptionResource.setContextAcceptLanguage(
+			new AcceptLanguage() {
+
+				@Override
+				public List<Locale> getLocales() {
+					return Arrays.asList(LocaleUtil.getDefault());
+				}
+
+				@Override
+				public String getPreferredLanguageId() {
+					return LocaleUtil.toLanguageId(LocaleUtil.getDefault());
+				}
+
+				@Override
+				public Locale getPreferredLocale() {
+					return LocaleUtil.getDefault();
+				}
+
+			});
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						AnalyticsConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsDataSourceId",
+							RandomTestUtil.nextLong()
+						).put(
+							"liferayAnalyticsEnableAllGroupIds", true
+						).put(
+							"liferayAnalyticsFaroBackendSecuritySignature",
+							RandomTestUtil.randomString()
+						).put(
+							"liferayAnalyticsFaroBackendURL",
+							"http://" + RandomTestUtil.randomString()
+						).build())) {
+
+			_setUpMockHttp(
+				JSONUtil.put(
+					"metrics",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"key", "key1"
+						).put(
+							"title", "title1"
+						).put(
+							"value", 10
+						),
+						JSONUtil.put(
+							"key", "key2"
+						).put(
+							"title", "title2"
+						).put(
+							"value", 20
+						))
+				).put(
+					"total", 2
+				).put(
+					"totalCount", 30
+				).toString());
+
+			for (String groupBy :
+					new String[] {"category", "tag", "vocabulary"}) {
+
+				PerformanceAssetConsumption performanceAssetConsumption =
+					_performanceAssetConsumptionResource.
+						getPerformanceAssetConsumption(
+							null, null, groupBy, 30, null, null, null,
+							Pagination.of(1, 10));
+
+				PerformanceAssetConsumptionItem[]
+					performanceAssetConsumptionItems =
+						performanceAssetConsumption.
+							getPerformanceAssetConsumptionItems();
+
+				Assert.assertEquals(
+					Arrays.toString(performanceAssetConsumptionItems), 2,
+					performanceAssetConsumptionItems.length);
+				Assert.assertEquals(
+					"key1", performanceAssetConsumptionItems[0].getKey());
+				Assert.assertEquals(
+					"title1", performanceAssetConsumptionItems[0].getTitle());
+				Assert.assertEquals(
+					"key2", performanceAssetConsumptionItems[1].getKey());
+				Assert.assertEquals(
+					"title2", performanceAssetConsumptionItems[1].getTitle());
+
+				Assert.assertEquals(
+					2L,
+					(long)
+						performanceAssetConsumption.
+							getPerformanceAssetConsumptionItemsCount());
+				Assert.assertEquals(
+					30L, (long)performanceAssetConsumption.getTotalCount());
+			}
+
+			CMSTestUtil.getOrAddGroup(
+				PerformanceAssetConsumptionResourceTest.class);
+
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.
+					getObjectDefinitionByExternalReferenceCode(
+						"L_CMS_BASIC_WEB_CONTENT", testCompany.getCompanyId());
+
+			_setUpMockHttp(
+				JSONUtil.put(
+					"metrics",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"key", RandomTestUtil.randomString()
+						).put(
+							"title", objectDefinition.getName()
+						).put(
+							"value", 30
+						))
+				).put(
+					"total", 1
+				).put(
+					"totalCount", 30
+				).toString());
+
+			PerformanceAssetConsumption performanceAssetConsumption =
+				_performanceAssetConsumptionResource.
+					getPerformanceAssetConsumption(
+						null, null, "structure", 30, null, null, null,
+						Pagination.of(1, 10));
+
+			PerformanceAssetConsumptionItem[] performanceAssetConsumptionItems =
+				performanceAssetConsumption.
+					getPerformanceAssetConsumptionItems();
+
+			Assert.assertEquals(
+				Arrays.toString(performanceAssetConsumptionItems), 1,
+				performanceAssetConsumptionItems.length);
+			Assert.assertEquals(
+				objectDefinition.getExternalReferenceCode(),
+				performanceAssetConsumptionItems[0].getKey());
+			Assert.assertEquals(
+				objectDefinition.getLabel(LocaleUtil.getDefault()),
+				performanceAssetConsumptionItems[0].getTitle());
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				_performanceAssetConsumptionResource, "_http", _http);
+		}
+	}
+
+	@Test
+	public void testGetPerformanceAssetConsumptionGroupByStructure()
+		throws Exception {
+
+		_performanceAssetConsumptionResource.setContextAcceptLanguage(
+			new AcceptLanguage() {
+
+				@Override
+				public List<Locale> getLocales() {
+					return Arrays.asList(LocaleUtil.getDefault());
+				}
+
+				@Override
+				public String getPreferredLanguageId() {
+					return LocaleUtil.toLanguageId(LocaleUtil.getDefault());
+				}
+
+				@Override
+				public Locale getPreferredLocale() {
+					return LocaleUtil.getDefault();
+				}
+
+			});
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						AnalyticsConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsDataSourceId",
+							RandomTestUtil.nextLong()
+						).put(
+							"liferayAnalyticsEnableAllGroupIds", true
+						).put(
+							"liferayAnalyticsFaroBackendSecuritySignature",
+							RandomTestUtil.randomString()
+						).put(
+							"liferayAnalyticsFaroBackendURL",
+							"http://" + RandomTestUtil.randomString()
+						).build())) {
+
+			CMSTestUtil.getOrAddGroup(
+				PerformanceAssetConsumptionResourceTest.class);
+
+			ObjectDefinition basicWebContentObjectDefinition =
+				_objectDefinitionLocalService.
+					getObjectDefinitionByExternalReferenceCode(
+						"L_CMS_BASIC_WEB_CONTENT", testCompany.getCompanyId());
+			ObjectDefinition blogObjectDefinition =
+				_objectDefinitionLocalService.
+					getObjectDefinitionByExternalReferenceCode(
+						"L_CMS_BLOG", testCompany.getCompanyId());
+
+			_setUpMockHttp(
+				JSONUtil.put(
+					"metrics",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"key", RandomTestUtil.randomString()
+						).put(
+							"title", basicWebContentObjectDefinition.getName()
+						).put(
+							"value", 30
+						),
+						JSONUtil.put(
+							"key", RandomTestUtil.randomString()
+						).put(
+							"title", blogObjectDefinition.getName()
+						).put(
+							"value", 20
+						))
+				).put(
+					"total", 2
+				).put(
+					"totalCount", 50
+				).toString());
+
+			PerformanceAssetConsumption performanceAssetConsumption =
+				_performanceAssetConsumptionResource.
+					getPerformanceAssetConsumption(
+						null, null, "structure", 30, null, null, null,
+						Pagination.of(1, 10));
+
+			PerformanceAssetConsumptionItem[] performanceAssetConsumptionItems =
+				performanceAssetConsumption.
+					getPerformanceAssetConsumptionItems();
+
+			Assert.assertEquals(
+				Arrays.toString(performanceAssetConsumptionItems), 2,
+				performanceAssetConsumptionItems.length);
+			Assert.assertEquals(
+				basicWebContentObjectDefinition.getExternalReferenceCode(),
+				performanceAssetConsumptionItems[0].getKey());
+			Assert.assertEquals(
+				basicWebContentObjectDefinition.getLabel(
+					LocaleUtil.getDefault()),
+				performanceAssetConsumptionItems[0].getTitle());
+			Assert.assertEquals(
+				blogObjectDefinition.getExternalReferenceCode(),
+				performanceAssetConsumptionItems[1].getKey());
+			Assert.assertEquals(
+				blogObjectDefinition.getLabel(LocaleUtil.getDefault()),
+				performanceAssetConsumptionItems[1].getTitle());
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				_performanceAssetConsumptionResource, "_http", _http);
+		}
+	}
+
+	@Test
+	public void testGetPerformanceAssetConsumptionURL() throws Exception {
+		_performanceAssetConsumptionResource.setContextAcceptLanguage(
+			new AcceptLanguage() {
+
+				@Override
+				public List<Locale> getLocales() {
+					return Arrays.asList(LocaleUtil.getDefault());
+				}
+
+				@Override
+				public String getPreferredLanguageId() {
+					return LocaleUtil.toLanguageId(LocaleUtil.getDefault());
+				}
+
+				@Override
+				public Locale getPreferredLocale() {
+					return LocaleUtil.getDefault();
+				}
+
+			});
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						AnalyticsConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsDataSourceId", "12345"
+						).put(
+							"liferayAnalyticsEnableAllGroupIds", true
+						).put(
+							"liferayAnalyticsFaroBackendSecuritySignature",
+							RandomTestUtil.randomString()
+						).put(
+							"liferayAnalyticsFaroBackendURL",
+							"http://" + RandomTestUtil.randomString()
+						).build())) {
+
+			RecordingMockHttp recordingMockHttp = new RecordingMockHttp(
+				Collections.singletonMap(
+					"/api/1.0/asset-metric/objectEntry/asset-consumption",
+					() -> JSONUtil.put(
+						"metrics", JSONUtil.putAll()
+					).put(
+						"total", 0
+					).put(
+						"totalCount", 0
+					).toString()));
+
+			ReflectionTestUtil.setFieldValue(
+				_performanceAssetConsumptionResource, "_http",
+				recordingMockHttp);
+
+			_performanceAssetConsumptionResource.getPerformanceAssetConsumption(
+				11111L, null, "tag", 30, null, 22222L, 33333L,
+				Pagination.of(2, 5));
+
+			String location = recordingMockHttp._getLocation();
+
+			Assert.assertTrue(location, location.contains("categoryId=11111"));
+			Assert.assertTrue(
+				location, location.contains("dataSourceId=12345"));
+			Assert.assertTrue(location, location.contains("groupBy=tag"));
+			Assert.assertTrue(
+				location,
+				location.contains("assetSummaryMetricTypeString=viewsMetric"));
+			Assert.assertTrue(location, location.contains("page=2"));
+			Assert.assertTrue(location, location.contains("rangeKey=30"));
+			Assert.assertTrue(location, location.contains("size=5"));
+			Assert.assertTrue(location, location.contains("tagId=22222"));
+			Assert.assertTrue(
+				location, location.contains("vocabularyId=33333"));
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				_performanceAssetConsumptionResource, "_http", _http);
+		}
+	}
+
+	private void _setUpMockHttp(String json) {
+		ReflectionTestUtil.setFieldValue(
+			_performanceAssetConsumptionResource, "_http",
+			new MockHttp(
+				Collections.singletonMap(
+					"/api/1.0/asset-metric/objectEntry/asset-consumption",
+					() -> json)));
+	}
+
+	@Inject
+	private Http _http;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private PerformanceAssetConsumptionResource
+		_performanceAssetConsumptionResource;
+
+	private static class RecordingMockHttp extends MockHttp {
+
+		public RecordingMockHttp(
+			Map<String, UnsafeSupplier<String, Exception>> unsafeSuppliers) {
+
+			super(unsafeSuppliers);
+		}
+
+		@Override
+		public String URLtoString(Http.Options options) throws IOException {
+			_location = options.getLocation();
+
+			return super.URLtoString(options);
+		}
+
+		private String _getLocation() {
+			return _location;
+		}
+
+		private String _location;
+
+	}
+
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
@@ -156,7 +156,8 @@ public class PerformanceOverviewMetricResourceTest
 
 			PerformanceOverviewMetric performanceOverviewMetric =
 				_performanceOverviewMetricResource.getPerformanceOverviewMetric(
-					new Long[] {_depotEntry.getDepotEntryId()}, 30);
+					new Long[] {_depotEntry.getDepotEntryId()},
+					RandomTestUtil.nextInt());
 
 			_assertMetric(
 				performanceOverviewMetric.getDownloadsMetric(),

--- a/modules/apps/analytics/source-formatter-suppressions.xml
+++ b/modules/apps/analytics/source-formatter-suppressions.xml
@@ -7,6 +7,7 @@
 		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ObjectEntryHistogramMetricResourceTest\.java" />
 		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ObjectEntryMetricResourceTest\.java" />
 		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ObjectEntryTopPagesResourceTest\.java" />
+		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest\.java" />
 		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest\.java" />
 	</checkstyle>
 </suppressions>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92417

## What Is Being Fixed

The analytics CMS REST API exposed metrics per object entry but had no endpoint for performance asset consumption — how assets are consumed aggregated by category, structure, tag, or vocabulary. Clients had no way to request this data.

## How It Is Being Fixed

A new `/performance-asset-consumption` GET endpoint is added to the analytics CMS REST API. The `rest-openapi.yaml` defines the operation and the `PerformanceAssetConsumption` and `PerformanceAssetConsumptionItem` schemas, with the API, client, and resource scaffolding regenerated through REST Builder. `PerformanceAssetConsumptionResourceImpl` validates the `groupBy` value against the allowed set (category, structure, tag, vocabulary), resolves depot entry group IDs, derives the object type from a structure's object definition, and delegates to `AnalyticsCloudClient`.

`AnalyticsCloudClient` gains a `getPerformanceAssetConsumption` method that constructs the Analytics Cloud request URL, parses the response, and — when grouping by structure — relabels each item with its object definition's external reference code and locale-specific label via a new constructor overload that injects `ObjectDefinitionLocalService`. To carry the new query parameters, the private `_getUrl` method was generalized to accept them; its original signature is retained as a delegating overload so the existing metric resources build identical URLs and are unaffected.

## PR Check

**pr-check: PASS** — tested on `efc3e7f079dd36f2606d7746371a28f9ca4ed6fb`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "efc3e7f079dd36f2606d7746371a28f9ca4ed6fb"} -->
