### PR TITLE
LPD-94515 Fix OAuth2 token 500 for non-omniadmin site administrators

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
@@ -166,8 +166,8 @@ public class OAuth2FaroController extends BaseFaroController {
 				"Unable to revoke OAuth2 authorization with token " + token);
 		}
 
-		_oAuth2AuthorizationService.revokeOAuth2Authorization(
-			oAuth2Authorization.getOAuth2AuthorizationId());
+		_oAuth2AuthorizationLocalService.deleteOAuth2Authorization(
+			oAuth2Authorization);
 	}
 
 	private boolean _filterOAuth2Authorization(
@@ -234,7 +234,7 @@ public class OAuth2FaroController extends BaseFaroController {
 		throws Exception {
 
 		return TransformUtil.transform(
-			_oAuth2AuthorizationService.getApplicationOAuth2Authorizations(
+			_oAuth2AuthorizationLocalService.getOAuth2Authorizations(
 				oAuth2ApplicationId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 				null),
 			oAuth2Authorization -> {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/request.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/request.js
@@ -203,6 +203,21 @@ describe('request', () => {
 		});
 	});
 
+	it('should reject with a generic error on a 500 with a non-JSON body', () => {
+		fetch.mockReturnValue(
+			Promise.resolve(
+				new Response('<html><body>500</body></html>', {
+					status: 500,
+				})
+			)
+		);
+
+		return request({}).catch((error) => {
+			expect(error instanceof SyntaxError).toBe(false);
+			expect(error.message).toBe('Request Error');
+		});
+	});
+
 	it('should call reloadPage on an xhr status equal to 401', () => {
 		fetch.mockReturnValue(
 			Promise.resolve(

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/request.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/request.js
@@ -109,7 +109,8 @@ export default (request) => {
 			return {};
 		}
 		else if (status === 400 || status === 500) {
-			const {field, localizedMessage, messageKey} = await response.json();
+			const {field, localizedMessage, messageKey} =
+				parseFromJSON(await response.text()) || {};
 
 			if (field) {
 				throw new ValidationError(field, localizedMessage);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
@@ -11,7 +11,6 @@ import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
-import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
 import com.liferay.osb.faro.web.internal.model.display.main.TokenDisplay;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -51,9 +50,6 @@ public class OAuth2FaroControllerTest {
 		ReflectionTestUtil.setFieldValue(
 			_oAuth2FaroController, "_oAuth2AuthorizationLocalService",
 			_oAuth2AuthorizationLocalService);
-		ReflectionTestUtil.setFieldValue(
-			_oAuth2FaroController, "_oAuth2AuthorizationService",
-			_oAuth2AuthorizationService);
 
 		_setUpPermissionChecker();
 	}
@@ -115,14 +111,6 @@ public class OAuth2FaroControllerTest {
 		OAuth2Authorization oAuth2Authorization = Mockito.mock(
 			OAuth2Authorization.class);
 
-		long oAuth2AuthorizationId = 123;
-
-		Mockito.when(
-			oAuth2Authorization.getOAuth2AuthorizationId()
-		).thenReturn(
-			oAuth2AuthorizationId
-		);
-
 		Mockito.when(
 			_oAuth2AuthorizationLocalService.
 				fetchOAuth2AuthorizationByAccessTokenContent("abc")
@@ -133,9 +121,9 @@ public class OAuth2FaroControllerTest {
 		_oAuth2FaroController.revokeToken(1, "abc");
 
 		Mockito.verify(
-			_oAuth2AuthorizationService
-		).revokeOAuth2Authorization(
-			oAuth2AuthorizationId
+			_oAuth2AuthorizationLocalService
+		).deleteOAuth2Authorization(
+			oAuth2Authorization
 		);
 	}
 
@@ -203,8 +191,6 @@ public class OAuth2FaroControllerTest {
 	private final OAuth2AuthorizationLocalService
 		_oAuth2AuthorizationLocalService = Mockito.mock(
 			OAuth2AuthorizationLocalService.class);
-	private final OAuth2AuthorizationService _oAuth2AuthorizationService =
-		Mockito.mock(OAuth2AuthorizationService.class);
 	private final OAuth2FaroController _oAuth2FaroController =
 		new OAuth2FaroController();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94515

## What Is Being Fixed

The OAuth2 token endpoint (`POST /o/faro/main/{groupId}/oauth2/tokens/new?type=...`) returned an HTTP 500 for any user who is a Site Administrator but not a DXP omniadmin, e.g. when opening a HubSpot/Marketo/Demandbase connector overview. The controller reads and revokes the company-scoped OAuth2Application authorizations through the permission-checked OAuth2AuthorizationService — getApplicationOAuth2Authorizations enforces VIEW and revokeOAuth2Authorization enforces REVOKE_TOKEN on that application — permissions a Site Administrator does not hold, so the check threw a PrincipalException that escaped as an HTML 500. The frontend then tried to JSON-parse that HTML page, showing a misleading "Unexpected token '<'" alert.

## How It Is Being Fixed

The controller already creates and manages this internal application through the permission-skipping OAuth2AuthorizationLocalService, so the matching reads and deletes now go through the same local service: getOAuth2Authorizations for the dedup lookup and deleteOAuth2Authorization for revoke. The endpoint stays gated by @RolesAllowed(SITE_ADMINISTRATOR). On the frontend, request.js no longer assumes 400/500 bodies are JSON; it reads the body as text and parses it defensively, so a non-JSON error page no longer produces a JSON parse alert.

This branch builds on LPD-92183 (its four commits are included here until that PR merges).

## PR Check

**pr-check: PASS** — tested on `2e18370a7da368b7ac8a08a7e5156259a253eae1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2e18370a7da368b7ac8a08a7e5156259a253eae1"} -->