### PR TITLE
LPD-88820 Use space depot in CMS REST tests for domain validation

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ExpiredAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ExpiredAssetResourceTest.java
@@ -217,7 +217,7 @@ public class ExpiredAssetResourceTest extends BaseExpiredAssetResourceTestCase {
 		_depotEntry = _depotEntryLocalService.addDepotEntry(
 			Collections.singletonMap(
 				LocaleUtil.US, RandomTestUtil.randomString()),
-			null, DepotConstants.TYPE_ASSET_LIBRARY, _serviceContext);
+			null, DepotConstants.TYPE_SPACE, _serviceContext);
 
 		_themeDisplay = _getThemeDisplay();
 	}

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/InventoryAnalysisResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/InventoryAnalysisResourceTest.java
@@ -187,7 +187,7 @@ public class InventoryAnalysisResourceTest
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			DepotConstants.TYPE_ASSET_LIBRARY, _serviceContext);
+			DepotConstants.TYPE_SPACE, _serviceContext);
 
 		_webContentDefinition =
 			_objectDefinitionLocalService.

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
@@ -234,7 +234,7 @@ public class OverviewResourceTest extends BaseOverviewResourceTestCase {
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
-			DepotConstants.TYPE_ASSET_LIBRARY, _serviceContext);
+			DepotConstants.TYPE_SPACE, _serviceContext);
 	}
 
 	@DeleteAfterTestRun


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88820

## What Is Being Fixed

Three Analytics CMS REST integration tests began failing once the depot domain validation from this story landed on master: ExpiredAssetResourceTest, InventoryAnalysisResourceTest, and OverviewResourceTest. Each created its DepotEntry with DepotConstants.TYPE_ASSET_LIBRARY, whose depot role subtype is null, while the CMS object definitions (L_CMS_BASIC_WEB_CONTENT, L_CMS_BASIC_DOCUMENT, L_CMS_EXTERNAL_VIDEO) are tagged with the "space" domain. ObjectEntryLocalServiceImpl now rejects an object entry whose object definition domain does not match the depot subtype, so every addObjectEntry call threw ObjectEntryGroupIdException.InvalidGroupIdForDomain.

## How It Is Being Fixed

The tests now create the DepotEntry with DepotConstants.TYPE_SPACE, whose subtype resolves to "space" and matches the domain on the CMS object definitions. This aligns the test fixtures with the validation introduced in this story; no production code changes are needed.

## Why Are There No Tests?

This change only updates existing integration tests so they pass against the new depot domain validation. The affected tests are themselves the coverage.

## PR Check

**pr-check: PASS** — tested on `41fca542b5b83246c6d3de7da0485cfb87d8128a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "41fca542b5b83246c6d3de7da0485cfb87d8128a"} -->