### PR TITLE
[On hold] LPD-94753 Forward multiple account ids to the asset summary endpoints

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -272,12 +272,12 @@ public interface ContactsEngineClient {
 		String assetType, int cur, int delta, List<OrderByField> orderByFields);
 
 	public Results<AssetSummary> getAssetSummaries(
-		FaroProject faroProject, String accountId, long channelId,
+		FaroProject faroProject, List<String> accountIds, long channelId,
 		String filterString, String keywords, String objectType, int rangeKey,
 		String selectedMetric, int cur, int delta, String sortString);
 
 	public Results<AssetSummaryCategory> getAssetSummaryCategories(
-		FaroProject faroProject, String accountId, long channelId,
+		FaroProject faroProject, List<String> accountIds, long channelId,
 		String keywords, String rangeEnd, int rangeKey, String rangeStart,
 		String selectedMetric, String sort, String vocabularyId, int cur,
 		int delta);
@@ -287,7 +287,7 @@ public interface ContactsEngineClient {
 		String rangeStart, int cur, int delta);
 
 	public Results<AssetSummaryTag> getAssetSummaryTags(
-		FaroProject faroProject, String accountId, long channelId,
+		FaroProject faroProject, List<String> accountIds, long channelId,
 		String keywords, String rangeEnd, int rangeKey, String rangeStart,
 		String selectedMetric, String sort, int cur, int delta);
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -1210,15 +1210,15 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public Results<AssetSummary> getAssetSummaries(
-		FaroProject faroProject, String accountId, long channelId,
+		FaroProject faroProject, List<String> accountIds, long channelId,
 		String filterString, String keywords, String objectType, int rangeKey,
 		String selectedMetric, int cur, int delta, String sortString) {
 
 		Map<String, Object> uriVariables = getUriVariables(
 			faroProject, cur, delta, null);
 
-		if (Validator.isNotNull(accountId)) {
-			uriVariables.put("accountId", accountId);
+		if ((accountIds != null) && !accountIds.isEmpty()) {
+			uriVariables.put("accountIds", accountIds);
 		}
 
 		uriVariables.put("channelId", channelId);
@@ -1257,7 +1257,7 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public Results<AssetSummaryCategory> getAssetSummaryCategories(
-		FaroProject faroProject, String accountId, long channelId,
+		FaroProject faroProject, List<String> accountIds, long channelId,
 		String keywords, String rangeEnd, int rangeKey, String rangeStart,
 		String selectedMetric, String sort, String vocabularyId, int cur,
 		int delta) {
@@ -1265,8 +1265,8 @@ public class ContactsEngineClientImpl
 		Map<String, Object> uriVariables = getUriVariables(
 			faroProject, cur, delta, null);
 
-		if (Validator.isNotNull(accountId)) {
-			uriVariables.put("accountId", accountId);
+		if ((accountIds != null) && !accountIds.isEmpty()) {
+			uriVariables.put("accountIds", accountIds);
 		}
 
 		uriVariables.put("channelId", channelId);
@@ -1338,15 +1338,15 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public Results<AssetSummaryTag> getAssetSummaryTags(
-		FaroProject faroProject, String accountId, long channelId,
+		FaroProject faroProject, List<String> accountIds, long channelId,
 		String keywords, String rangeEnd, int rangeKey, String rangeStart,
 		String selectedMetric, String sort, int cur, int delta) {
 
 		Map<String, Object> uriVariables = getUriVariables(
 			faroProject, cur, delta, null);
 
-		if (Validator.isNotNull(accountId)) {
-			uriVariables.put("accountId", accountId);
+		if ((accountIds != null) && !accountIds.isEmpty()) {
+			uriVariables.put("accountIds", accountIds);
 		}
 
 		uriVariables.put("channelId", channelId);

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -518,24 +518,24 @@ public abstract class BaseMockContactsEngineClientImpl
 	}
 
 	public Results<AssetSummary> getAssetSummaries(
-		FaroProject faroProject, String accountId, long channelId,
+		FaroProject faroProject, List<String> accountIds, long channelId,
 		String filterString, String keywords, String objectType, int rangeKey,
 		String selectedMetric, int cur, int delta, String sortString) {
 
 		return contactsEngineClient.getAssetSummaries(
-			faroProject, accountId, channelId, filterString, keywords,
+			faroProject, accountIds, channelId, filterString, keywords,
 			objectType, rangeKey, selectedMetric, cur, delta, sortString);
 	}
 
 	@Override
 	public Results<AssetSummaryCategory> getAssetSummaryCategories(
-		FaroProject faroProject, String accountId, long channelId,
+		FaroProject faroProject, List<String> accountIds, long channelId,
 		String keywords, String rangeEnd, int rangeKey, String rangeStart,
 		String selectedMetric, String sort, String vocabularyId, int cur,
 		int delta) {
 
 		return contactsEngineClient.getAssetSummaryCategories(
-			faroProject, accountId, channelId, keywords, rangeEnd, rangeKey,
+			faroProject, accountIds, channelId, keywords, rangeEnd, rangeKey,
 			rangeStart, selectedMetric, sort, vocabularyId, cur, delta);
 	}
 
@@ -550,12 +550,12 @@ public abstract class BaseMockContactsEngineClientImpl
 
 	@Override
 	public Results<AssetSummaryTag> getAssetSummaryTags(
-		FaroProject faroProject, String accountId, long channelId,
+		FaroProject faroProject, List<String> accountIds, long channelId,
 		String keywords, String rangeEnd, int rangeKey, String rangeStart,
 		String selectedMetric, String sort, int cur, int delta) {
 
 		return contactsEngineClient.getAssetSummaryTags(
-			faroProject, accountId, channelId, keywords, rangeEnd, rangeKey,
+			faroProject, accountIds, channelId, keywords, rangeEnd, rangeKey,
 			rangeStart, selectedMetric, sort, cur, delta);
 	}
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryCategoryFaroController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryCategoryFaroController.java
@@ -19,6 +19,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
+import java.util.List;
+
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -33,7 +35,7 @@ public class AssetSummaryCategoryFaroController extends BaseFaroController {
 	public FaroFDSResultsDisplay<AssetSummaryCategory>
 			getAssetSummaryCategoriesFaroFDSResultsDisplay(
 				@PathParam("groupId") long groupId,
-				@QueryParam("accountId") String accountId,
+				@QueryParam("accountIds") List<String> accountIds,
 				@QueryParam("channelId") long channelId,
 				@QueryParam("keywords") String keywords,
 				@QueryParam("page") int page,
@@ -50,7 +52,7 @@ public class AssetSummaryCategoryFaroController extends BaseFaroController {
 		return new FaroFDSResultsDisplay<>(
 			contactsEngineClient.getAssetSummaryCategories(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId),
-				accountId, channelId, keywords, rangeEnd, rangeKey, rangeStart,
+				accountIds, channelId, keywords, rangeEnd, rangeKey, rangeStart,
 				selectedMetric, sortString, vocabularyId, page, pageSize),
 			AssetSummaryCategoryDisplay::new, page, pageSize);
 	}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryFaroController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryFaroController.java
@@ -19,6 +19,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
+import java.util.List;
+
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -33,7 +35,7 @@ public class AssetSummaryFaroController extends BaseFaroController {
 	public FaroFDSResultsDisplay<AssetSummary>
 			getAssetSummaryFaroFDSResultsDisplay(
 				@PathParam("groupId") long groupId,
-				@QueryParam("accountId") String accountId,
+				@QueryParam("accountIds") List<String> accountIds,
 				@QueryParam("channelId") long channelId,
 				@QueryParam("filter") String filterString,
 				@QueryParam("objectType") String objectType,
@@ -49,7 +51,7 @@ public class AssetSummaryFaroController extends BaseFaroController {
 		return new FaroFDSResultsDisplay<>(
 			contactsEngineClient.getAssetSummaries(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId),
-				accountId, channelId, filterString, search, objectType,
+				accountIds, channelId, filterString, search, objectType,
 				rangeKey, selectedMetric, page, pageSize, sortString),
 			AssetSummaryDisplay::new, page, pageSize);
 	}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryTagFaroController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryTagFaroController.java
@@ -19,6 +19,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
+import java.util.List;
+
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -33,7 +35,7 @@ public class AssetSummaryTagFaroController extends BaseFaroController {
 	public FaroFDSResultsDisplay<AssetSummaryTag>
 			getAssetSummaryTagsFaroFDSResultsDisplay(
 				@PathParam("groupId") long groupId,
-				@QueryParam("accountId") String accountId,
+				@QueryParam("accountIds") List<String> accountIds,
 				@QueryParam("channelId") long channelId,
 				@QueryParam("keywords") String keywords,
 				@QueryParam("page") int page,
@@ -49,7 +51,7 @@ public class AssetSummaryTagFaroController extends BaseFaroController {
 		return new FaroFDSResultsDisplay<>(
 			contactsEngineClient.getAssetSummaryTags(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId),
-				accountId, channelId, keywords, rangeEnd, rangeKey, rangeStart,
+				accountIds, channelId, keywords, rangeEnd, rangeKey, rangeStart,
 				selectedMetric, sortString, page, pageSize),
 			AssetSummaryTagDisplay::new, page, pageSize);
 	}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/assets.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/assets.ts
@@ -36,7 +36,7 @@ export async function fetchAccountTopAssets({
 }: IFetchAccountTopAssets): Promise<{items: ITopAsset[]}> {
 	return sendRequest({
 		data: {
-			accountId,
+			accountIds: accountId,
 			channelId,
 			pageSize: 5,
 			selectedMetric,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/categories.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/categories.js
@@ -23,7 +23,7 @@ export function fetchAccountTopCategories({
 }) {
 	return sendRequest({
 		data: {
-			accountId,
+			accountIds: accountId,
 			channelId,
 			pageSize: 5,
 			selectedMetric,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/tags.js
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/api/tags.js
@@ -22,7 +22,7 @@ export function fetchAccountTopTags({
 }) {
 	return sendRequest({
 		data: {
-			accountId,
+			accountIds: accountId,
 			channelId,
 			pageSize: 5,
 			selectedMetric,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94753

## What Is Being Fixed

The Analytics Cloud asset table (and its category and tag facets) could only be scoped to a single account. To support filtering by one or more accounts, the osb-asah backend endpoints were changed to take a list of account ids instead of a single one, so the portal proxy that forwards those requests has to match the new contract.

## How It Is Being Fixed

The Faro proxy controllers and the contacts engine client now accept and forward `accountIds` as a list, and the frontend request helpers send the account id under the `accountIds` parameter. This keeps the existing single-account callers working (a single id travels as a one-element list) while enabling multi-account filtering once the frontend offers a multi-select. The shared SearchQueryContext is untouched, so the other features that rely on its single-account field are unaffected.

## Why Are There No Tests?

This is the portal proxy and parameter-forwarding layer for the Analytics Cloud asset summary endpoints; it renames the account filter parameter to a list and forwards it to the osb-asah backend. The filtering logic and its coverage live in the backend, where integration tests for filtering by multiple accounts were added (LPD-94753 in com-liferay-osb-asah-private). The proxy controllers, engine client, and frontend request helpers contain no independent logic to unit-test.

## PR Check

**pr-check: PASS** — tested on `676c506f40d733002eb663792def31b350098179`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "676c506f40d733002eb663792def31b350098179"} -->