### PR TITLE
LPD-94821 Replace group-by dropdowns with pickers on account cards

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_account_profile.scss
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/css/_account_profile.scss
@@ -16,6 +16,8 @@
 
 .top-assets,
 .top-categories-and-tags {
+	overflow: hidden;
+
 	.tab-content,
 	.tab-pane.active {
 		display: flex;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopAssets.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopAssets.tsx
@@ -2,7 +2,6 @@ import * as API from 'shared/api';
 import Card from 'shared/components/Card';
 import classNames from 'classnames';
 import ClayButton from '@clayui/button';
-import ClayDropDown, {Align} from '@clayui/drop-down';
 import ClayEmptyState from '@clayui/empty-state';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
@@ -13,8 +12,8 @@ import React, {useState} from 'react';
 import StatesRenderer from 'shared/components/states-renderer/StatesRenderer';
 import {getMimeType} from 'assets/components/mime-type';
 import {ITopAsset, TopAssetMetric, TopAssetObjectType} from 'shared/api/assets';
+import {Option, Picker, Text} from '@clayui/core';
 import {Routes, toRoute} from 'shared/util/router';
-import {Text} from '@clayui/core';
 import {toThousands} from 'shared/util/numbers';
 import {useHistory, useParams} from 'react-router-dom';
 import {useRequest} from 'shared/hooks/useRequest';
@@ -62,6 +61,25 @@ const ASSET_ROUTE_MAP = {
 const getAssetRoute = (assetType?: string) =>
 	ASSET_ROUTE_MAP[assetType as keyof typeof ASSET_ROUTE_MAP] ??
 	Routes.ASSETS_OBJECT_ENTRY_OVERVIEW;
+
+const GroupByTrigger = React.forwardRef<
+	HTMLButtonElement,
+	React.ButtonHTMLAttributes<HTMLButtonElement> & {label?: string}
+>(({label, ...rest}, ref) => (
+	<ClayButton
+		{...rest}
+		className='rounded-lg'
+		displayType='secondary'
+		ref={ref}
+		size='sm'
+	>
+		{label}
+		<ClayIcon
+			className='inline-item inline-item-after'
+			symbol='caret-bottom'
+		/>
+	</ClayButton>
+));
 
 interface ITopAssetsTabContentProps {
 	assets: ITopAsset[];
@@ -120,48 +138,26 @@ const TopAssetsTabContent: React.FC<ITopAssetsTabContentProps> = ({
 				/>
 			</StatesRenderer.Empty>
 			<StatesRenderer.Success>
-				<ClayDropDown
-					alignmentPosition={Align.BottomRight}
-					closeOnClick
-					trigger={
-						<ClayButton
-							borderless
-							className='align-items-baseline d-inline-flex'
-							displayType='unstyled'
-							size='sm'
-						>
-							<div className='font-weight-semi-bold mr-3'>
-								<Text size={3}>
-									{Liferay.Language.get('group-by')}
-								</Text>
-							</div>
+				<div className='align-items-center d-flex'>
+					<div className='font-weight-semi-bold mr-2'>
+						<Text size={3}>{Liferay.Language.get('group-by')}</Text>
+					</div>
 
-							<div className='font-weight-semi-bold text-secondary'>
-								<Text size={3}>
-									{groupByLabel}
-									<ClayIcon
-										className='ml-1'
-										symbol='caret-bottom'
-									/>
-								</Text>
-							</div>
-						</ClayButton>
-					}
-				>
-					<ClayDropDown.ItemList>
-						{metrics.map(key => (
-							<ClayDropDown.Item
-								key={key}
-								onClick={() => setGroupBy(key)}
-								symbolRight={
-									groupBy === key ? 'check' : undefined
-								}
-							>
-								{groupByLabels[key]}
-							</ClayDropDown.Item>
-						))}
-					</ClayDropDown.ItemList>
-				</ClayDropDown>
+					<Picker
+						aria-label={Liferay.Language.get('group-by')}
+						as={GroupByTrigger}
+						items={metrics}
+						label={groupByLabel}
+						onSelectionChange={key =>
+							setGroupBy(key as GroupByMetric)
+						}
+						selectedKey={groupBy}
+					>
+						{(key: GroupByMetric) => (
+							<Option key={key}>{groupByLabels[key]}</Option>
+						)}
+					</Picker>
+				</div>
 
 				<ClayTable className='mt-3'>
 					<ClayTable.Head>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopCategoriesAndTags.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/TopCategoriesAndTags.tsx
@@ -2,14 +2,13 @@ import * as API from 'shared/api';
 import Card from 'shared/components/Card';
 import classNames from 'classnames';
 import ClayButton from '@clayui/button';
-import ClayDropDown, {Align} from '@clayui/drop-down';
 import ClayEmptyState from '@clayui/empty-state';
 import ClayIcon from '@clayui/icon';
 import ClayTable from '@clayui/table';
 import ClayTabs from '@clayui/tabs';
 import React, {useCallback, useState} from 'react';
 import StatesRenderer from 'shared/components/states-renderer/StatesRenderer';
-import {Text} from '@clayui/core';
+import {Option, Picker, Text} from '@clayui/core';
 import {toThousands} from 'shared/util/numbers';
 import {useParams} from 'react-router-dom';
 import {useRequest} from 'shared/hooks/useRequest';
@@ -54,6 +53,25 @@ const GROUP_BY_TO_METRIC: Record<GroupByMetric, TaxonomyMetric> = {
 };
 
 const TABS = ['category', 'tag'] as const;
+
+const GroupByTrigger = React.forwardRef<
+	HTMLButtonElement,
+	React.ButtonHTMLAttributes<HTMLButtonElement> & {label?: string}
+>(({label, ...rest}, ref) => (
+	<ClayButton
+		{...rest}
+		className='rounded-lg'
+		displayType='secondary'
+		ref={ref}
+		size='sm'
+	>
+		{label}
+		<ClayIcon
+			className='inline-item inline-item-after'
+			symbol='caret-bottom'
+		/>
+	</ClayButton>
+));
 
 type TaxonomyItem = ITopCategory | ITopTag;
 
@@ -108,50 +126,26 @@ const TabContent: React.FC<ITabContentProps> = ({
 				/>
 			</StatesRenderer.Empty>
 			<StatesRenderer.Success>
-				<ClayDropDown
-					alignmentPosition={Align.BottomRight}
-					closeOnClick
-					trigger={
-						<ClayButton
-							borderless
-							className='align-items-baseline d-inline-flex'
-							displayType='unstyled'
-							size='sm'
-						>
-							<div className='font-weight-semi-bold mr-3'>
-								<Text size={3}>
-									{Liferay.Language.get('group-by')}
-								</Text>
-							</div>
+				<div className='align-items-center d-flex'>
+					<div className='font-weight-semi-bold mr-2'>
+						<Text size={3}>{Liferay.Language.get('group-by')}</Text>
+					</div>
 
-							<div className='font-weight-semi-bold text-secondary'>
-								<Text size={3}>
-									{groupByLabel}
-									<ClayIcon
-										className='ml-1'
-										symbol='caret-bottom'
-									/>
-								</Text>
-							</div>
-						</ClayButton>
-					}
-				>
-					<ClayDropDown.ItemList>
-						{(Object.keys(groupByLabels) as GroupByMetric[]).map(
-							key => (
-								<ClayDropDown.Item
-									key={key}
-									onClick={() => setGroupBy(key)}
-									symbolRight={
-										groupBy === key ? 'check' : undefined
-									}
-								>
-									{groupByLabels[key]}
-								</ClayDropDown.Item>
-							)
+					<Picker
+						aria-label={Liferay.Language.get('group-by')}
+						as={GroupByTrigger}
+						items={Object.keys(groupByLabels) as GroupByMetric[]}
+						label={groupByLabel}
+						onSelectionChange={key =>
+							setGroupBy(key as GroupByMetric)
+						}
+						selectedKey={groupBy}
+					>
+						{(key: GroupByMetric) => (
+							<Option key={key}>{groupByLabels[key]}</Option>
 						)}
-					</ClayDropDown.ItemList>
-				</ClayDropDown>
+					</Picker>
+				</div>
 
 				<ClayTable className='mt-3'>
 					<ClayTable.Head>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopAssets.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopAssets.tsx
@@ -134,7 +134,7 @@ describe('TopAssets', () => {
 			).toBeInTheDocument();
 		});
 
-		it('should render the Group By dropdown with the default metric (Impressions)', () => {
+		it('should render the Group By picker with the default metric (Impressions)', () => {
 			render(<TopAssets />);
 
 			expect(screen.getAllByText('Group By').length).toBeGreaterThan(0);
@@ -230,17 +230,15 @@ describe('TopAssets', () => {
 		});
 	});
 
-	describe('group by dropdown', () => {
+	describe('group by picker', () => {
 		it('should refetch with viewsMetric when the user picks Views', () => {
 			render(<TopAssets />);
 
 			fireEvent.click(
-				screen.getAllByRole('button', {name: /Group By/})[0]
+				screen.getAllByRole('combobox', {name: 'Group By'})[0]
 			);
 
-			fireEvent.click(
-				screen.getAllByRole('menuitem', {name: 'Views'})[0]
-			);
+			fireEvent.click(screen.getAllByRole('option', {name: 'Views'})[0]);
 
 			const lastCall =
 				mockedUseRequest.mock.calls[
@@ -256,11 +254,11 @@ describe('TopAssets', () => {
 			fireEvent.click(screen.getByRole('tab', {name: 'Files'}));
 
 			fireEvent.click(
-				screen.getAllByRole('button', {name: /Group By/})[0]
+				screen.getAllByRole('combobox', {name: 'Group By'})[0]
 			);
 
 			fireEvent.click(
-				screen.getAllByRole('menuitem', {name: 'Downloads'})[0]
+				screen.getAllByRole('option', {name: 'Downloads'})[0]
 			);
 
 			const lastCall =
@@ -275,17 +273,17 @@ describe('TopAssets', () => {
 			render(<TopAssets />);
 
 			fireEvent.click(
-				screen.getAllByRole('button', {name: /Group By/})[0]
+				screen.getAllByRole('combobox', {name: 'Group By'})[0]
 			);
 
 			expect(
-				screen.queryByRole('menuitem', {name: 'Downloads'})
+				screen.queryByRole('option', {name: 'Downloads'})
 			).toBeNull();
 			expect(
-				screen.getAllByRole('menuitem', {name: 'Impressions'}).length
+				screen.getAllByRole('option', {name: 'Impressions'}).length
 			).toBeGreaterThan(0);
 			expect(
-				screen.getAllByRole('menuitem', {name: 'Views'}).length
+				screen.getAllByRole('option', {name: 'Views'}).length
 			).toBeGreaterThan(0);
 		});
 
@@ -295,11 +293,11 @@ describe('TopAssets', () => {
 			fireEvent.click(screen.getByRole('tab', {name: 'Files'}));
 
 			fireEvent.click(
-				screen.getAllByRole('button', {name: /Group By/})[0]
+				screen.getAllByRole('combobox', {name: 'Group By'})[0]
 			);
 
 			expect(
-				screen.getAllByRole('menuitem', {name: 'Downloads'}).length
+				screen.getAllByRole('option', {name: 'Downloads'}).length
 			).toBeGreaterThan(0);
 		});
 
@@ -309,11 +307,11 @@ describe('TopAssets', () => {
 			fireEvent.click(screen.getByRole('tab', {name: 'Files'}));
 
 			fireEvent.click(
-				screen.getAllByRole('button', {name: /Group By/})[0]
+				screen.getAllByRole('combobox', {name: 'Group By'})[0]
 			);
 
 			fireEvent.click(
-				screen.getAllByRole('menuitem', {name: 'Downloads'})[0]
+				screen.getAllByRole('option', {name: 'Downloads'})[0]
 			);
 
 			fireEvent.click(screen.getByRole('tab', {name: 'Content'}));

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopCategoriesAndTags.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopCategoriesAndTags.tsx
@@ -139,7 +139,7 @@ describe('TopCategoriesAndTags', () => {
 			expect(screen.getByRole('tab', {name: 'Tag'})).toBeInTheDocument();
 		});
 
-		it('should render the Group By dropdown with the default metric (Impressions)', () => {
+		it('should render the Group By picker with the default metric (Impressions)', () => {
 			render(<TopCategoriesAndTags />);
 
 			expect(screen.getAllByText('Group By').length).toBeGreaterThan(0);
@@ -233,17 +233,15 @@ describe('TopCategoriesAndTags', () => {
 		});
 	});
 
-	describe('group by dropdown', () => {
+	describe('group by picker', () => {
 		it('should refetch with viewsMetric when the user picks Views', () => {
 			render(<TopCategoriesAndTags />);
 
 			fireEvent.click(
-				screen.getAllByRole('button', {name: /Group By/})[0]
+				screen.getAllByRole('combobox', {name: 'Group By'})[0]
 			);
 
-			fireEvent.click(
-				screen.getAllByRole('menuitem', {name: 'Views'})[0]
-			);
+			fireEvent.click(screen.getAllByRole('option', {name: 'Views'})[0]);
 
 			const lastCall =
 				mockedUseRequest.mock.calls[
@@ -257,11 +255,11 @@ describe('TopCategoriesAndTags', () => {
 			render(<TopCategoriesAndTags />);
 
 			fireEvent.click(
-				screen.getAllByRole('button', {name: /Group By/})[0]
+				screen.getAllByRole('combobox', {name: 'Group By'})[0]
 			);
 
 			fireEvent.click(
-				screen.getAllByRole('menuitem', {name: 'Downloads'})[0]
+				screen.getAllByRole('option', {name: 'Downloads'})[0]
 			);
 
 			const lastCall =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94821

## What Is Being Fixed

On the account profile, the Top Assets and Top Asset Vocabularies and Categories cards used a dropdown for the group-by control. The cards also rendered with an "open" border at their bottom corners.

## How It Is Being Fixed

The group-by dropdown is replaced with a Picker that uses a secondary button trigger, keeping the "Group by" label outside the control so the trigger shows only the selected metric. The existing component tests were updated to drive the picker (combobox trigger and listbox options) instead of dropdown menu items.

The open corner came from the active tab pane: it has a white background and a smaller border radius than the card, and because the card was set to overflow visible, the pane painted over the card's border at the bottom corners. Clipping the cards with overflow hidden keeps the border closed; the picker menu is unaffected because it renders in a portal.

## PR Check

**pr-check: PASS** — tested on `8d68a60f714d88018b317c823e7ff75fffcff962`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8d68a60f714d88018b317c823e7ff75fffcff962"} -->
