### PR TITLE
LPD-91393 Retry failed Analytics Cloud batch uploads

### DIFF
--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
@@ -100,7 +100,6 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.FileEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
@@ -195,40 +194,44 @@ public class AnalyticsBatchExportImportManagerImpl
 
 		StreamUtil.cleanUp(gzipOutputStream);
 
-		if (!skipUpload) {
-			_notify(
-				"Uploading resources " + resourceName,
-				notificationUnsafeConsumer);
+		try {
+			if (!skipUpload) {
+				_notify(
+					"Uploading resources " + resourceName,
+					notificationUnsafeConsumer);
 
-			_upload(
-				companyId, "gzip", tempFile, resourceLastModifiedDate,
-				resourceName);
+				_upload(
+					companyId, "gzip", tempFile, resourceLastModifiedDate,
+					resourceName);
 
-			_notify(
-				"Completed uploading resources " + resourceName,
-				notificationUnsafeConsumer);
-		}
-		else {
-			_notify(
-				"Skip uploading resource " + resourceName,
-				notificationUnsafeConsumer);
-		}
-
-		for (BatchEngineExportTask batchEngineExportTask :
-				batchEngineExportTasks) {
-
-			_batchEngineExportTaskLocalService.deleteBatchEngineExportTask(
-				batchEngineExportTask);
-		}
-
-		boolean deleted = tempFile.delete();
-
-		if (_log.isDebugEnabled()) {
-			if (deleted) {
-				_log.debug("Deleted temp file: " + tempFile.getName());
+				_notify(
+					"Completed uploading resources " + resourceName,
+					notificationUnsafeConsumer);
 			}
 			else {
-				_log.debug("Unable to delete temp file: " + tempFile.getName());
+				_notify(
+					"Skip uploading resource " + resourceName,
+					notificationUnsafeConsumer);
+			}
+
+			for (BatchEngineExportTask batchEngineExportTask :
+					batchEngineExportTasks) {
+
+				_batchEngineExportTaskLocalService.deleteBatchEngineExportTask(
+					batchEngineExportTask);
+			}
+		}
+		finally {
+			boolean deleted = tempFile.delete();
+
+			if (_log.isDebugEnabled()) {
+				if (deleted) {
+					_log.debug("Deleted temp file: " + tempFile.getName());
+				}
+				else {
+					_log.debug(
+						"Unable to delete temp file: " + tempFile.getName());
+				}
 			}
 		}
 	}
@@ -306,33 +309,39 @@ public class AnalyticsBatchExportImportManagerImpl
 
 			File tempFile = FileUtil.createTempFile();
 
-			try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(
-					new FileOutputStream(tempFile));
-				ZipInputStream zipInputStream = new ZipInputStream(
-					_batchEngineExportTaskLocalService.openContentInputStream(
-						batchEngineExportTask.getBatchEngineExportTaskId()))) {
+			try {
+				try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(
+						new FileOutputStream(tempFile));
+					ZipInputStream zipInputStream = new ZipInputStream(
+						_batchEngineExportTaskLocalService.
+							openContentInputStream(
+								batchEngineExportTask.
+									getBatchEngineExportTaskId()))) {
 
-				zipInputStream.getNextEntry();
+					zipInputStream.getNextEntry();
 
-				StreamUtil.transfer(zipInputStream, gzipOutputStream, false);
-			}
-
-			_upload(
-				companyId, "gzip", tempFile, resourceLastModifiedDate,
-				resourceName);
-
-			_batchEngineExportTaskLocalService.deleteBatchEngineExportTask(
-				batchEngineExportTask);
-
-			boolean deleted = tempFile.delete();
-
-			if (_log.isDebugEnabled()) {
-				if (deleted) {
-					_log.debug("Deleted temp file " + tempFile.getName());
+					StreamUtil.transfer(
+						zipInputStream, gzipOutputStream, false);
 				}
-				else {
-					_log.debug(
-						"Unable to delete temp file " + tempFile.getName());
+
+				_upload(
+					companyId, "gzip", tempFile, resourceLastModifiedDate,
+					resourceName);
+
+				_batchEngineExportTaskLocalService.deleteBatchEngineExportTask(
+					batchEngineExportTask);
+			}
+			finally {
+				boolean deleted = tempFile.delete();
+
+				if (_log.isDebugEnabled()) {
+					if (deleted) {
+						_log.debug("Deleted temp file " + tempFile.getName());
+					}
+					else {
+						_log.debug(
+							"Unable to delete temp file " + tempFile.getName());
+					}
 				}
 			}
 
@@ -492,9 +501,14 @@ public class AnalyticsBatchExportImportManagerImpl
 
 			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
 
-			header = "\r\n--" + boundary + "--\r\n";
+			header = StringBundler.concat("\r\n--", boundary, "--\r\n");
 
 			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
+		}
+		catch (Exception exception) {
+			tempFile.delete();
+
+			throw exception;
 		}
 
 		return tempFile;
@@ -820,16 +834,15 @@ public class AnalyticsBatchExportImportManagerImpl
 
 		httpClientBuilder.useSystemProperties();
 
-		RequestConfig.Builder requestConfig = RequestConfig.custom();
+		RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
 
-		requestConfig.setConnectTimeout(30_000);
-		requestConfig.setConnectionRequestTimeout(60_000);
-		requestConfig.setSocketTimeout(600_000);
+		requestConfigBuilder.setConnectionRequestTimeout(60000);
+		requestConfigBuilder.setConnectTimeout(30000);
+		requestConfigBuilder.setSocketTimeout(600000);
 
-		httpClientBuilder.setDefaultRequestConfig(requestConfig.build());
+		httpClientBuilder.setDefaultRequestConfig(requestConfigBuilder.build());
 
-		httpClientBuilder.setRetryHandler(
-			new DefaultHttpRequestRetryHandler(3, true));
+		httpClientBuilder.disableAutomaticRetries();
 
 		return httpClientBuilder.build();
 	}
@@ -856,16 +869,6 @@ public class AnalyticsBatchExportImportManagerImpl
 		}
 
 		return true;
-	}
-
-	private boolean _isRetryableStatus(int statusCode) {
-		if ((statusCode >= 500) || (statusCode == 400) || (statusCode == 408) ||
-			(statusCode == 429)) {
-
-			return true;
-		}
-
-		return false;
 	}
 
 	private void _notify(
@@ -986,18 +989,23 @@ public class AnalyticsBatchExportImportManagerImpl
 				companyId);
 
 		int lastStatusCode = -1;
+		int retryCount = 3;
+		long[] retryDelays = {5000, 15000};
 
-		for (int attempt = 0; attempt < _RETRY_COUNT; attempt++) {
+		for (int attempt = 0; attempt < retryCount; attempt++) {
 			if (attempt > 0) {
 				if (_log.isInfoEnabled()) {
 					_log.info(
 						StringBundler.concat(
 							"Retrying upload of ", resourceName, " (attempt ",
-							attempt + 1, "/", _RETRY_COUNT, ")"));
+							attempt + 1, "/", retryCount, ")"));
 				}
 
+				int retryDelayIndex = Math.min(
+					attempt - 1, retryDelays.length - 1);
+
 				try {
-					Thread.sleep(_RETRY_DELAYS[attempt]);
+					Thread.sleep(retryDelays[retryDelayIndex]);
 				}
 				catch (InterruptedException interruptedException) {
 					Thread thread = Thread.currentThread();
@@ -1025,6 +1033,13 @@ public class AnalyticsBatchExportImportManagerImpl
 						"/dxp-batch-entities");
 
 				httpPost.setHeader(
+					HttpHeaders.CONTENT_ENCODING, contentEncoding);
+				httpPost.setHeader(
+					HttpHeaders.CONTENT_TYPE,
+					StringBundler.concat(
+						ContentTypes.MULTIPART_FORM_DATA, "; boundary=",
+						boundary));
+				httpPost.setHeader(
 					"OSB-Asah-Data-Source-ID",
 					analyticsConfiguration.liferayAnalyticsDataSourceId());
 				httpPost.setHeader(
@@ -1034,12 +1049,6 @@ public class AnalyticsBatchExportImportManagerImpl
 				httpPost.setHeader(
 					"OSB-Asah-Project-ID",
 					analyticsConfiguration.liferayAnalyticsProjectId());
-				httpPost.setHeader(
-					HttpHeaders.CONTENT_ENCODING, contentEncoding);
-				httpPost.setHeader(
-					HttpHeaders.CONTENT_TYPE,
-					ContentTypes.MULTIPART_FORM_DATA + "; boundary=" +
-						boundary);
 
 				httpPost.setEntity(new FileEntity(multipartFile));
 
@@ -1103,7 +1112,9 @@ public class AnalyticsBatchExportImportManagerImpl
 								responseBody));
 					}
 
-					if (!_isRetryableStatus(statusCode)) {
+					if ((statusCode != 400) && (statusCode != 408) &&
+						(statusCode != 429) && (statusCode < 500)) {
+
 						throw new RuntimeException(
 							"Upload failed with HTTP response code: " +
 								statusCode);
@@ -1111,6 +1122,13 @@ public class AnalyticsBatchExportImportManagerImpl
 				}
 			}
 			catch (IOException ioException) {
+				if (attempt == (retryCount - 1)) {
+					throw new RuntimeException(
+						StringBundler.concat(
+							"Upload failed after ", retryCount, " attempts"),
+						ioException);
+				}
+
 				_log.error(
 					StringBundler.concat(
 						"Transport failure on upload attempt ", attempt + 1,
@@ -1131,13 +1149,9 @@ public class AnalyticsBatchExportImportManagerImpl
 
 		throw new RuntimeException(
 			StringBundler.concat(
-				"Upload failed after ", _RETRY_COUNT,
+				"Upload failed after ", retryCount,
 				" attempts with HTTP response code: ", lastStatusCode));
 	}
-
-	private static final int _RETRY_COUNT = 3;
-
-	private static final long[] _RETRY_DELAYS = {0, 5_000, 15_000};
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AnalyticsBatchExportImportManagerImpl.class);

--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
@@ -61,9 +61,10 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.zip.ZipReaderFactory;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Serializable;
 
 import java.net.HttpURLConnection;
@@ -85,17 +86,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipInputStream;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.FileEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 
@@ -195,13 +200,9 @@ public class AnalyticsBatchExportImportManagerImpl
 				"Uploading resources " + resourceName,
 				notificationUnsafeConsumer);
 
-			try (FileInputStream fileInputStream = new FileInputStream(
-					tempFile)) {
-
-				_upload(
-					companyId, "gzip", fileInputStream,
-					resourceLastModifiedDate, resourceName);
-			}
+			_upload(
+				companyId, "gzip", tempFile, resourceLastModifiedDate,
+				resourceName);
 
 			_notify(
 				"Completed uploading resources " + resourceName,
@@ -316,13 +317,9 @@ public class AnalyticsBatchExportImportManagerImpl
 				StreamUtil.transfer(zipInputStream, gzipOutputStream, false);
 			}
 
-			try (FileInputStream fileInputStream = new FileInputStream(
-					tempFile)) {
-
-				_upload(
-					companyId, "gzip", fileInputStream,
-					resourceLastModifiedDate, resourceName);
-			}
+			_upload(
+				companyId, "gzip", tempFile, resourceLastModifiedDate,
+				resourceName);
 
 			_batchEngineExportTaskLocalService.deleteBatchEngineExportTask(
 				batchEngineExportTask);
@@ -470,6 +467,37 @@ public class AnalyticsBatchExportImportManagerImpl
 		}
 
 		return httpUriRequest;
+	}
+
+	private File _buildMultipartFile(
+			String boundary, File file, String resourceName, String uploadType)
+		throws Exception {
+
+		File tempFile = FileUtil.createTempFile();
+
+		try (OutputStream outputStream = new FileOutputStream(tempFile)) {
+			String header = StringBundler.concat(
+				"--", boundary, "\r\n",
+				"Content-Disposition: form-data; name=\"file\"; filename=\"",
+				resourceName, "\"\r\n", "Content-Type: ",
+				ContentTypes.MULTIPART_FORM_DATA, "\r\n\r\n");
+
+			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
+
+			Files.copy(file.toPath(), outputStream);
+
+			header = StringBundler.concat(
+				"\r\n--", boundary, "\r\n", "Content-Disposition: form-data; ",
+				"name=\"uploadType\"\r\n\r\n", uploadType);
+
+			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
+
+			header = "\r\n--" + boundary + "--\r\n";
+
+			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
+		}
+
+		return tempFile;
 	}
 
 	private void _checkCompany(long companyId) {
@@ -787,6 +815,25 @@ public class AnalyticsBatchExportImportManagerImpl
 		return options;
 	}
 
+	private CloseableHttpClient _getUploadHttpClient() {
+		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+
+		httpClientBuilder.useSystemProperties();
+
+		RequestConfig.Builder requestConfig = RequestConfig.custom();
+
+		requestConfig.setConnectTimeout(30_000);
+		requestConfig.setConnectionRequestTimeout(60_000);
+		requestConfig.setSocketTimeout(600_000);
+
+		httpClientBuilder.setDefaultRequestConfig(requestConfig.build());
+
+		httpClientBuilder.setRetryHandler(
+			new DefaultHttpRequestRetryHandler(3, true));
+
+		return httpClientBuilder.build();
+	}
+
 	private boolean _isEnabled(long companyId) {
 		if (!_analyticsConfigurationRegistry.isActive()) {
 			if (_log.isDebugEnabled()) {
@@ -809,6 +856,16 @@ public class AnalyticsBatchExportImportManagerImpl
 		}
 
 		return true;
+	}
+
+	private boolean _isRetryableStatus(int statusCode) {
+		if ((statusCode >= 500) || (statusCode == 400) || (statusCode == 408) ||
+			(statusCode == 429)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private void _notify(
@@ -919,69 +976,168 @@ public class AnalyticsBatchExportImportManagerImpl
 	}
 
 	private void _upload(
-		long companyId, String contentEncoding, InputStream resourceInputStream,
+		long companyId, String contentEncoding, File file,
 		Date resourceLastModifiedDate, String resourceName) {
 
 		_checkCompany(companyId);
-
-		Http.Options options = _getOptions(companyId);
-
-		options.addHeader(HttpHeaders.CONTENT_ENCODING, contentEncoding);
-		options.addHeader(
-			HttpHeaders.CONTENT_TYPE,
-			ContentTypes.MULTIPART_FORM_DATA +
-				"; boundary=__MULTIPART_BOUNDARY__");
-		options.addInputStreamPart(
-			"file", resourceName, resourceInputStream,
-			ContentTypes.MULTIPART_FORM_DATA);
-		options.addPart(
-			"uploadType",
-			(resourceLastModifiedDate != null) ? "INCREMENTAL" : "FULL");
 
 		AnalyticsConfiguration analyticsConfiguration =
 			_analyticsConfigurationRegistry.getAnalyticsConfiguration(
 				companyId);
 
-		options.setLocation(
-			analyticsConfiguration.liferayAnalyticsEndpointURL() +
-				"/dxp-batch-entities");
+		int lastStatusCode = -1;
 
-		options.setPost(true);
+		for (int attempt = 0; attempt < _RETRY_COUNT; attempt++) {
+			if (attempt > 0) {
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"Retrying upload of ", resourceName, " (attempt ",
+							attempt + 1, "/", _RETRY_COUNT, ")"));
+				}
 
-		try (InputStream inputStream = _http.URLtoInputStream(options)) {
-			Http.Response response = options.getResponse();
+				try {
+					Thread.sleep(_RETRY_DELAYS[attempt]);
+				}
+				catch (InterruptedException interruptedException) {
+					Thread thread = Thread.currentThread();
 
-			if (response.getResponseCode() ==
-					HttpURLConnection.HTTP_FORBIDDEN) {
+					thread.interrupt();
 
-				JSONObject responseJSONObject = _jsonFactory.createJSONObject(
-					StringUtil.read(inputStream));
-
-				boolean disconnected = StringUtil.equals(
-					GetterUtil.getString(responseJSONObject.getString("state")),
-					"DISCONNECTED");
-
-				_processInvalidTokenMessage(
-					analyticsConfiguration, companyId, disconnected,
-					responseJSONObject.getString("message"));
+					throw new RuntimeException(
+						"Upload retry interrupted", interruptedException);
+				}
 			}
 
-			if ((response.getResponseCode() < 200) ||
-				(response.getResponseCode() >= 300)) {
+			File multipartFile = null;
 
-				throw new Exception(
-					"Upload failed with HTTP response code: " +
-						response.getResponseCode());
+			try {
+				String boundary = StringUtil.removeSubstring(
+					String.valueOf(UUID.randomUUID()), "-");
+
+				multipartFile = _buildMultipartFile(
+					boundary, file, resourceName,
+					(resourceLastModifiedDate != null) ? "INCREMENTAL" :
+						"FULL");
+
+				HttpPost httpPost = new HttpPost(
+					analyticsConfiguration.liferayAnalyticsEndpointURL() +
+						"/dxp-batch-entities");
+
+				httpPost.setHeader(
+					"OSB-Asah-Data-Source-ID",
+					analyticsConfiguration.liferayAnalyticsDataSourceId());
+				httpPost.setHeader(
+					"OSB-Asah-Faro-Backend-Security-Signature",
+					analyticsConfiguration.
+						liferayAnalyticsFaroBackendSecuritySignature());
+				httpPost.setHeader(
+					"OSB-Asah-Project-ID",
+					analyticsConfiguration.liferayAnalyticsProjectId());
+				httpPost.setHeader(
+					HttpHeaders.CONTENT_ENCODING, contentEncoding);
+				httpPost.setHeader(
+					HttpHeaders.CONTENT_TYPE,
+					ContentTypes.MULTIPART_FORM_DATA + "; boundary=" +
+						boundary);
+
+				httpPost.setEntity(new FileEntity(multipartFile));
+
+				try (CloseableHttpClient closeableHttpClient =
+						_getUploadHttpClient();
+
+					CloseableHttpResponse closeableHttpResponse =
+						closeableHttpClient.execute(httpPost)) {
+
+					StatusLine statusLine =
+						closeableHttpResponse.getStatusLine();
+
+					int statusCode = statusLine.getStatusCode();
+
+					String responseBody = StringPool.BLANK;
+
+					try {
+						responseBody = EntityUtils.toString(
+							closeableHttpResponse.getEntity(),
+							Charset.defaultCharset());
+					}
+					catch (Exception exception) {
+						_log.error(
+							StringBundler.concat(
+								"Unable to read upload response body for ",
+								resourceName, " (HTTP ", statusCode, ")"),
+							exception);
+					}
+
+					if (statusCode == HttpURLConnection.HTTP_FORBIDDEN) {
+						JSONObject responseJSONObject =
+							_jsonFactory.createJSONObject(responseBody);
+
+						boolean disconnected = StringUtil.equals(
+							GetterUtil.getString(
+								responseJSONObject.getString("state")),
+							"DISCONNECTED");
+
+						_processInvalidTokenMessage(
+							analyticsConfiguration, companyId, disconnected,
+							responseJSONObject.getString("message"));
+					}
+
+					if ((statusCode >= 200) && (statusCode < 300)) {
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								"Upload completed successfully on attempt " +
+									(attempt + 1));
+						}
+
+						return;
+					}
+
+					lastStatusCode = statusCode;
+
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Upload of ", resourceName, " returned HTTP ",
+								statusCode, " on attempt ", attempt + 1, ": ",
+								responseBody));
+					}
+
+					if (!_isRetryableStatus(statusCode)) {
+						throw new RuntimeException(
+							"Upload failed with HTTP response code: " +
+								statusCode);
+					}
+				}
 			}
-
-			if (_log.isDebugEnabled()) {
-				_log.debug("Upload completed successfully");
+			catch (IOException ioException) {
+				_log.error(
+					StringBundler.concat(
+						"Transport failure on upload attempt ", attempt + 1,
+						": ", ioException.getMessage()));
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+			finally {
+				if (multipartFile != null) {
+					multipartFile.delete();
+				}
 			}
 		}
-		catch (Exception exception) {
-			throw new RuntimeException(exception);
-		}
+
+		throw new RuntimeException(
+			StringBundler.concat(
+				"Upload failed after ", _RETRY_COUNT,
+				" attempts with HTTP response code: ", lastStatusCode));
 	}
+
+	private static final int _RETRY_COUNT = 3;
+
+	private static final long[] _RETRY_DELAYS = {0, 5_000, 15_000};
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AnalyticsBatchExportImportManagerImpl.class);

--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
@@ -478,42 +478,6 @@ public class AnalyticsBatchExportImportManagerImpl
 		return httpUriRequest;
 	}
 
-	private File _buildMultipartFile(
-			String boundary, File file, String resourceName, String uploadType)
-		throws Exception {
-
-		File tempFile = FileUtil.createTempFile();
-
-		try (OutputStream outputStream = new FileOutputStream(tempFile)) {
-			String header = StringBundler.concat(
-				"--", boundary, "\r\n",
-				"Content-Disposition: form-data; name=\"file\"; filename=\"",
-				resourceName, "\"\r\n", "Content-Type: ",
-				ContentTypes.MULTIPART_FORM_DATA, "\r\n\r\n");
-
-			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
-
-			Files.copy(file.toPath(), outputStream);
-
-			header = StringBundler.concat(
-				"\r\n--", boundary, "\r\n", "Content-Disposition: form-data; ",
-				"name=\"uploadType\"\r\n\r\n", uploadType);
-
-			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
-
-			header = StringBundler.concat("\r\n--", boundary, "--\r\n");
-
-			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
-		}
-		catch (Exception exception) {
-			tempFile.delete();
-
-			throw exception;
-		}
-
-		return tempFile;
-	}
-
 	private void _checkCompany(long companyId) {
 		if (_analyticsConfigurationRegistry.isActive()) {
 			return;
@@ -1020,7 +984,7 @@ public class AnalyticsBatchExportImportManagerImpl
 				String boundary = StringUtil.removeSubstring(
 					String.valueOf(UUID.randomUUID()), "-");
 
-				multipartFile = _buildMultipartFile(
+				multipartFile = _writeMultipartFile(
 					boundary, file, resourceName,
 					(resourceLastModifiedDate != null) ? "INCREMENTAL" :
 						"FULL");
@@ -1148,6 +1112,42 @@ public class AnalyticsBatchExportImportManagerImpl
 			StringBundler.concat(
 				"Upload failed after ", retryCount,
 				" attempts with HTTP response code: ", lastStatusCode));
+	}
+
+	private File _writeMultipartFile(
+			String boundary, File file, String resourceName, String uploadType)
+		throws Exception {
+
+		File tempFile = FileUtil.createTempFile();
+
+		try (OutputStream outputStream = new FileOutputStream(tempFile)) {
+			String header = StringBundler.concat(
+				"--", boundary, "\r\n",
+				"Content-Disposition: form-data; name=\"file\"; filename=\"",
+				resourceName, "\"\r\n", "Content-Type: ",
+				ContentTypes.MULTIPART_FORM_DATA, "\r\n\r\n");
+
+			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
+
+			Files.copy(file.toPath(), outputStream);
+
+			header = StringBundler.concat(
+				"\r\n--", boundary, "\r\n", "Content-Disposition: form-data; ",
+				"name=\"uploadType\"\r\n\r\n", uploadType);
+
+			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
+
+			header = StringBundler.concat("\r\n--", boundary, "--\r\n");
+
+			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
+		}
+		catch (Exception exception) {
+			tempFile.delete();
+
+			throw exception;
+		}
+
+		return tempFile;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
@@ -197,7 +197,7 @@ public class AnalyticsBatchExportImportManagerImpl
 		try {
 			if (!skipUpload) {
 				_notify(
-					"Uploading resources " + resourceName,
+					"Uploading resource " + resourceName,
 					notificationUnsafeConsumer);
 
 				_upload(
@@ -205,7 +205,7 @@ public class AnalyticsBatchExportImportManagerImpl
 					resourceName);
 
 				_notify(
-					"Completed uploading resources " + resourceName,
+					"Completed uploading resource " + resourceName,
 					notificationUnsafeConsumer);
 			}
 			else {
@@ -226,11 +226,11 @@ public class AnalyticsBatchExportImportManagerImpl
 
 			if (_log.isDebugEnabled()) {
 				if (deleted) {
-					_log.debug("Deleted temp file: " + tempFile.getName());
+					_log.debug("Deleted temp file " + tempFile.getName());
 				}
 				else {
 					_log.debug(
-						"Unable to delete temp file: " + tempFile.getName());
+						"Unable to delete temp file " + tempFile.getName());
 				}
 			}
 		}
@@ -729,9 +729,9 @@ public class AnalyticsBatchExportImportManagerImpl
 
 		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
 
-		httpClientBuilder.useSystemProperties();
-
 		if (disableAutomaticRetries) {
+			httpClientBuilder.disableAutomaticRetries();
+
 			RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
 
 			requestConfigBuilder.setConnectionRequestTimeout(60000);
@@ -740,9 +740,9 @@ public class AnalyticsBatchExportImportManagerImpl
 
 			httpClientBuilder.setDefaultRequestConfig(
 				requestConfigBuilder.build());
-
-			httpClientBuilder.disableAutomaticRetries();
 		}
+
+		httpClientBuilder.useSystemProperties();
 
 		return httpClientBuilder.build();
 	}
@@ -993,13 +993,14 @@ public class AnalyticsBatchExportImportManagerImpl
 					analyticsConfiguration.liferayAnalyticsEndpointURL() +
 						"/dxp-batch-entities");
 
+				httpPost.setEntity(new FileEntity(multipartFile));
+
 				httpPost.setHeader(
 					HttpHeaders.CONTENT_ENCODING, contentEncoding);
 				httpPost.setHeader(
 					HttpHeaders.CONTENT_TYPE,
-					StringBundler.concat(
-						ContentTypes.MULTIPART_FORM_DATA, "; boundary=",
-						boundary));
+					ContentTypes.MULTIPART_FORM_DATA + "; boundary=" +
+						boundary);
 				httpPost.setHeader(
 					"OSB-Asah-Data-Source-ID",
 					analyticsConfiguration.liferayAnalyticsDataSourceId());
@@ -1010,8 +1011,6 @@ public class AnalyticsBatchExportImportManagerImpl
 				httpPost.setHeader(
 					"OSB-Asah-Project-ID",
 					analyticsConfiguration.liferayAnalyticsProjectId());
-
-				httpPost.setEntity(new FileEntity(multipartFile));
 
 				try (CloseableHttpClient closeableHttpClient =
 						_getCloseableHttpClient(true);
@@ -1085,8 +1084,7 @@ public class AnalyticsBatchExportImportManagerImpl
 			catch (IOException ioException) {
 				if (attempt == (retryCount - 1)) {
 					throw new RuntimeException(
-						StringBundler.concat(
-							"Upload failed after ", retryCount, " attempts"),
+						"Upload failed after " + retryCount + " attempts",
 						ioException);
 				}
 
@@ -1121,25 +1119,28 @@ public class AnalyticsBatchExportImportManagerImpl
 		File tempFile = FileUtil.createTempFile();
 
 		try (OutputStream outputStream = new FileOutputStream(tempFile)) {
-			String header = StringBundler.concat(
+			String filePartHeader = StringBundler.concat(
 				"--", boundary, "\r\n",
 				"Content-Disposition: form-data; name=\"file\"; filename=\"",
 				resourceName, "\"\r\n", "Content-Type: ",
 				ContentTypes.MULTIPART_FORM_DATA, "\r\n\r\n");
 
-			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
+			outputStream.write(
+				filePartHeader.getBytes(StandardCharsets.US_ASCII));
 
 			Files.copy(file.toPath(), outputStream);
 
-			header = StringBundler.concat(
+			String uploadTypePart = StringBundler.concat(
 				"\r\n--", boundary, "\r\n", "Content-Disposition: form-data; ",
 				"name=\"uploadType\"\r\n\r\n", uploadType);
 
-			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
+			outputStream.write(
+				uploadTypePart.getBytes(StandardCharsets.US_ASCII));
 
-			header = StringBundler.concat("\r\n--", boundary, "--\r\n");
+			String closingBoundary = "\r\n--" + boundary + "--\r\n";
 
-			outputStream.write(header.getBytes(StandardCharsets.US_ASCII));
+			outputStream.write(
+				closingBoundary.getBytes(StandardCharsets.US_ASCII));
 		}
 		catch (Exception exception) {
 			tempFile.delete();

--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
@@ -200,7 +200,7 @@ public class AnalyticsBatchExportImportManagerImpl
 					"Uploading resource " + resourceName,
 					notificationUnsafeConsumer);
 
-				_upload(
+				_uploadWithRetry(
 					companyId, "gzip", tempFile, resourceLastModifiedDate,
 					resourceName);
 
@@ -324,7 +324,7 @@ public class AnalyticsBatchExportImportManagerImpl
 						zipInputStream, gzipOutputStream, false);
 				}
 
-				_upload(
+				_uploadWithRetry(
 					companyId, "gzip", tempFile, resourceLastModifiedDate,
 					resourceName);
 
@@ -939,7 +939,101 @@ public class AnalyticsBatchExportImportManagerImpl
 		}
 	}
 
-	private void _upload(
+	private int _upload(
+			AnalyticsConfiguration analyticsConfiguration, int attempt,
+			String boundary, long companyId, String contentEncoding,
+			File multipartFile, String resourceName)
+		throws Exception {
+
+		HttpPost httpPost = new HttpPost(
+			analyticsConfiguration.liferayAnalyticsEndpointURL() +
+				"/dxp-batch-entities");
+
+		httpPost.setEntity(new FileEntity(multipartFile));
+
+		httpPost.setHeader(HttpHeaders.CONTENT_ENCODING, contentEncoding);
+		httpPost.setHeader(
+			HttpHeaders.CONTENT_TYPE,
+			ContentTypes.MULTIPART_FORM_DATA + "; boundary=" + boundary);
+		httpPost.setHeader(
+			"OSB-Asah-Data-Source-ID",
+			analyticsConfiguration.liferayAnalyticsDataSourceId());
+		httpPost.setHeader(
+			"OSB-Asah-Faro-Backend-Security-Signature",
+			analyticsConfiguration.
+				liferayAnalyticsFaroBackendSecuritySignature());
+		httpPost.setHeader(
+			"OSB-Asah-Project-ID",
+			analyticsConfiguration.liferayAnalyticsProjectId());
+
+		try (CloseableHttpClient closeableHttpClient = _getCloseableHttpClient(
+				true);
+
+			CloseableHttpResponse closeableHttpResponse =
+				closeableHttpClient.execute(httpPost)) {
+
+			StatusLine statusLine = closeableHttpResponse.getStatusLine();
+
+			int statusCode = statusLine.getStatusCode();
+
+			String responseBody = StringPool.BLANK;
+
+			try {
+				responseBody = EntityUtils.toString(
+					closeableHttpResponse.getEntity(),
+					Charset.defaultCharset());
+			}
+			catch (Exception exception) {
+				_log.error(
+					StringBundler.concat(
+						"Unable to read upload response body for ",
+						resourceName, " (HTTP ", statusCode, ")"),
+					exception);
+			}
+
+			if (statusCode == HttpURLConnection.HTTP_FORBIDDEN) {
+				JSONObject responseJSONObject = _jsonFactory.createJSONObject(
+					responseBody);
+
+				boolean disconnected = StringUtil.equals(
+					GetterUtil.getString(responseJSONObject.getString("state")),
+					"DISCONNECTED");
+
+				_processInvalidTokenMessage(
+					analyticsConfiguration, companyId, disconnected,
+					responseJSONObject.getString("message"));
+			}
+
+			if ((statusCode >= 200) && (statusCode < 300)) {
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						"Upload completed successfully on attempt " +
+							(attempt + 1));
+				}
+
+				return statusCode;
+			}
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"Upload of ", resourceName, " returned HTTP ",
+						statusCode, " on attempt ", attempt + 1, ": ",
+						responseBody));
+			}
+
+			if ((statusCode != 400) && (statusCode != 408) &&
+				(statusCode != 429) && (statusCode < 500)) {
+
+				throw new RuntimeException(
+					"Upload failed with HTTP response code: " + statusCode);
+			}
+
+			return statusCode;
+		}
+	}
+
+	private void _uploadWithRetry(
 		long companyId, String contentEncoding, File file,
 		Date resourceLastModifiedDate, String resourceName) {
 
@@ -989,97 +1083,15 @@ public class AnalyticsBatchExportImportManagerImpl
 					(resourceLastModifiedDate != null) ? "INCREMENTAL" :
 						"FULL");
 
-				HttpPost httpPost = new HttpPost(
-					analyticsConfiguration.liferayAnalyticsEndpointURL() +
-						"/dxp-batch-entities");
+				int statusCode = _upload(
+					analyticsConfiguration, attempt, boundary, companyId,
+					contentEncoding, multipartFile, resourceName);
 
-				httpPost.setEntity(new FileEntity(multipartFile));
-
-				httpPost.setHeader(
-					HttpHeaders.CONTENT_ENCODING, contentEncoding);
-				httpPost.setHeader(
-					HttpHeaders.CONTENT_TYPE,
-					ContentTypes.MULTIPART_FORM_DATA + "; boundary=" +
-						boundary);
-				httpPost.setHeader(
-					"OSB-Asah-Data-Source-ID",
-					analyticsConfiguration.liferayAnalyticsDataSourceId());
-				httpPost.setHeader(
-					"OSB-Asah-Faro-Backend-Security-Signature",
-					analyticsConfiguration.
-						liferayAnalyticsFaroBackendSecuritySignature());
-				httpPost.setHeader(
-					"OSB-Asah-Project-ID",
-					analyticsConfiguration.liferayAnalyticsProjectId());
-
-				try (CloseableHttpClient closeableHttpClient =
-						_getCloseableHttpClient(true);
-
-					CloseableHttpResponse closeableHttpResponse =
-						closeableHttpClient.execute(httpPost)) {
-
-					StatusLine statusLine =
-						closeableHttpResponse.getStatusLine();
-
-					int statusCode = statusLine.getStatusCode();
-
-					String responseBody = StringPool.BLANK;
-
-					try {
-						responseBody = EntityUtils.toString(
-							closeableHttpResponse.getEntity(),
-							Charset.defaultCharset());
-					}
-					catch (Exception exception) {
-						_log.error(
-							StringBundler.concat(
-								"Unable to read upload response body for ",
-								resourceName, " (HTTP ", statusCode, ")"),
-							exception);
-					}
-
-					if (statusCode == HttpURLConnection.HTTP_FORBIDDEN) {
-						JSONObject responseJSONObject =
-							_jsonFactory.createJSONObject(responseBody);
-
-						boolean disconnected = StringUtil.equals(
-							GetterUtil.getString(
-								responseJSONObject.getString("state")),
-							"DISCONNECTED");
-
-						_processInvalidTokenMessage(
-							analyticsConfiguration, companyId, disconnected,
-							responseJSONObject.getString("message"));
-					}
-
-					if ((statusCode >= 200) && (statusCode < 300)) {
-						if (_log.isInfoEnabled()) {
-							_log.info(
-								"Upload completed successfully on attempt " +
-									(attempt + 1));
-						}
-
-						return;
-					}
-
-					lastStatusCode = statusCode;
-
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							StringBundler.concat(
-								"Upload of ", resourceName, " returned HTTP ",
-								statusCode, " on attempt ", attempt + 1, ": ",
-								responseBody));
-					}
-
-					if ((statusCode != 400) && (statusCode != 408) &&
-						(statusCode != 429) && (statusCode < 500)) {
-
-						throw new RuntimeException(
-							"Upload failed with HTTP response code: " +
-								statusCode);
-					}
+				if ((statusCode >= 200) && (statusCode < 300)) {
+					return;
 				}
+
+				lastStatusCode = statusCode;
 			}
 			catch (IOException ioException) {
 				if (attempt == (retryCount - 1)) {

--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
@@ -549,8 +549,8 @@ public class AnalyticsBatchExportImportManagerImpl
 			analyticsConfiguration.liferayAnalyticsURL() + "/endpoints/" +
 				analyticsConfiguration.liferayAnalyticsProjectId());
 
-		try (CloseableHttpClient closeableHttpClient =
-				_getCloseableHttpClient()) {
+		try (CloseableHttpClient closeableHttpClient = _getCloseableHttpClient(
+				false)) {
 
 			CloseableHttpResponse closeableHttpResponse =
 				closeableHttpClient.execute(httpGet);
@@ -724,8 +724,8 @@ public class AnalyticsBatchExportImportManagerImpl
 			HttpUriRequest httpUriRequest)
 		throws Exception {
 
-		try (CloseableHttpClient closeableHttpClient =
-				_getCloseableHttpClient()) {
+		try (CloseableHttpClient closeableHttpClient = _getCloseableHttpClient(
+				false)) {
 
 			CloseableHttpResponse closeableHttpResponse =
 				closeableHttpClient.execute(httpUriRequest);
@@ -760,10 +760,25 @@ public class AnalyticsBatchExportImportManagerImpl
 		}
 	}
 
-	private CloseableHttpClient _getCloseableHttpClient() {
+	private CloseableHttpClient _getCloseableHttpClient(
+		boolean disableAutomaticRetries) {
+
 		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
 
 		httpClientBuilder.useSystemProperties();
+
+		if (disableAutomaticRetries) {
+			RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+
+			requestConfigBuilder.setConnectionRequestTimeout(60000);
+			requestConfigBuilder.setConnectTimeout(30000);
+			requestConfigBuilder.setSocketTimeout(600000);
+
+			httpClientBuilder.setDefaultRequestConfig(
+				requestConfigBuilder.build());
+
+			httpClientBuilder.disableAutomaticRetries();
+		}
 
 		return httpClientBuilder.build();
 	}
@@ -827,24 +842,6 @@ public class AnalyticsBatchExportImportManagerImpl
 			analyticsConfiguration.liferayAnalyticsProjectId());
 
 		return options;
-	}
-
-	private CloseableHttpClient _getUploadHttpClient() {
-		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-
-		httpClientBuilder.useSystemProperties();
-
-		RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
-
-		requestConfigBuilder.setConnectionRequestTimeout(60000);
-		requestConfigBuilder.setConnectTimeout(30000);
-		requestConfigBuilder.setSocketTimeout(600000);
-
-		httpClientBuilder.setDefaultRequestConfig(requestConfigBuilder.build());
-
-		httpClientBuilder.disableAutomaticRetries();
-
-		return httpClientBuilder.build();
 	}
 
 	private boolean _isEnabled(long companyId) {
@@ -1053,7 +1050,7 @@ public class AnalyticsBatchExportImportManagerImpl
 				httpPost.setEntity(new FileEntity(multipartFile));
 
 				try (CloseableHttpClient closeableHttpClient =
-						_getUploadHttpClient();
+						_getCloseableHttpClient(true);
 
 					CloseableHttpResponse closeableHttpResponse =
 						closeableHttpClient.execute(httpPost)) {


### PR DESCRIPTION
﻿https://liferay.atlassian.net/browse/LPD-91393

## What Is Being Fixed

Uploads to Analytics Cloud could fail with a transient connection reset, which previously aborted the entire dispatch run. Because the export trigger runs on a schedule and a failed run does not advance the incremental watermark, intermittent resets surfaced as scheduled runs that alternated between successful and failed.

## How It Is Being Fixed

The upload path uses Apache HttpClient directly with a client configured for connection, connection-request, and socket timeouts. The multipart body is written to a temporary file and posted inside a bounded retry loop with a short backoff between attempts. Transient outcomes — connection resets and the retryable HTTP statuses 400, 408, 429, and 5xx — are retried, while permanent statuses fail fast, and an invalid-token 403 is processed once. Automatic client-level retries are disabled so the loop is the single retry mechanism, the transport exception is chained as the cause when the final attempt fails, and both the multipart and source temporary files are deleted even when the upload throws.

## Why Are There No Tests?

AnalyticsBatchExportImportManagerImpl has no existing unit test harness, and the retry path exercises Apache HttpClient against a remote Analytics Cloud endpoint. It cannot be meaningfully covered without a live endpoint or heavy HTTP-layer mocking, so the behavior is verified manually rather than with an automated test.

## PR Check

**pr-check: PASS** — tested on `84a88f9c6e40750ea94c9cb7f20c1d2c306e8b60`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "84a88f9c6e40750ea94c9cb7f20c1d2c306e8b60"} -->