### PR TITLE
LPD-94965 Mock new usage metric fields in the project usage report

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
@@ -1448,11 +1448,11 @@ public class ProjectFaroController extends BaseFaroController {
 
 				usageMetrics.add(
 					new UsageMetric(
-						GetterUtil.getString(objects[1]),
-						GetterUtil.getLong(objects[0]),
+						1000, 1000, 5, 5, GetterUtil.getString(objects[1]),
+						100000, GetterUtil.getLong(objects[0]),
 						GetterUtil.getLong(tuple.getObject(0)),
 						GetterUtil.getLong(objects[2]),
-						GetterUtil.getLong(tuple.getObject(1))));
+						GetterUtil.getLong(tuple.getObject(1)), 3));
 			}
 		}
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/UsageMetric.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/UsageMetric.java
@@ -11,21 +11,49 @@ package com.liferay.osb.faro.web.internal.model.display.contacts;
 public class UsageMetric {
 
 	public UsageMetric(
-		String dateString, long knownIndividualsCount,
+		long addonEventsCount, long apiRequestsCount, long batchSegmentsCount,
+		long connectedDataSourcesCount, String dateString, long eventsCount,
+		long knownIndividualsCount,
 		long knownIndividualsCountSinceLastAnniversary, long pageViewsCount,
-		long pageViewsCountSinceLastAnniversary) {
+		long pageViewsCountSinceLastAnniversary, long realTimeSegmentsCount) {
 
+		_addonEventsCount = addonEventsCount;
+		_apiRequestsCount = apiRequestsCount;
+		_batchSegmentsCount = batchSegmentsCount;
+		_connectedDataSourcesCount = connectedDataSourcesCount;
 		_dateString = dateString;
+		_eventsCount = eventsCount;
 		_knownIndividualsCount = knownIndividualsCount;
 		_knownIndividualsCountSinceLastAnniversary =
 			knownIndividualsCountSinceLastAnniversary;
 		_pageViewsCount = pageViewsCount;
 		_pageViewsCountSinceLastAnniversary =
 			pageViewsCountSinceLastAnniversary;
+		_realTimeSegmentsCount = realTimeSegmentsCount;
+	}
+
+	public long getAddonEventsCount() {
+		return _addonEventsCount;
+	}
+
+	public long getApiRequestsCount() {
+		return _apiRequestsCount;
+	}
+
+	public long getBatchSegmentsCount() {
+		return _batchSegmentsCount;
+	}
+
+	public long getConnectedDataSourcesCount() {
+		return _connectedDataSourcesCount;
 	}
 
 	public String getDateString() {
 		return _dateString;
+	}
+
+	public long getEventsCount() {
+		return _eventsCount;
 	}
 
 	public long getKnownIndividualsCount() {
@@ -44,10 +72,20 @@ public class UsageMetric {
 		return _pageViewsCountSinceLastAnniversary;
 	}
 
+	public long getRealTimeSegmentsCount() {
+		return _realTimeSegmentsCount;
+	}
+
+	private final long _addonEventsCount;
+	private final long _apiRequestsCount;
+	private final long _batchSegmentsCount;
+	private final long _connectedDataSourcesCount;
 	private final String _dateString;
+	private final long _eventsCount;
 	private final long _knownIndividualsCount;
 	private final long _knownIndividualsCountSinceLastAnniversary;
 	private final long _pageViewsCount;
 	private final long _pageViewsCountSinceLastAnniversary;
+	private final long _realTimeSegmentsCount;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94965

## What Is Being Fixed

The project usage report endpoint (GET /o/faro/main/project/usage), which
returns per-month usage metrics for every workspace, did not include the addon
events, API requests, batch segments, real-time segments, events, or connected
data sources counts the frontend needs.

## How It Is Being Fixed

Enriches the per-month `UsageMetric` (returned inside each workspace's
`usageMetrics` array by `getProjectUsageMetricDisplays`) with those six fields.
For now their values are mocked placeholders; the existing per-month known
individuals, page views, and date still come from real `FaroProjectUsage` data.
This is only the mock — a follow-up will replace the mocked fields with the real
asah feature-usage values.

## Why Are There No Tests?

This PR only adds mocked placeholder fields to the usage report so the frontend
can integrate against the contract. The actual data and its test coverage will
be added in the follow-up that sends the real values.

## PR Check

Pending re-run on the current head `99491172823a333359b356eb57344861be786192`. Source Format and module
compilation were verified clean on this commit; the full pr-check should be
re-run before merge.
