### PR TITLE
LPD-95251 Fix pagination on the Account Activity Stream

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
@@ -100,7 +100,6 @@ const ActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 		items: activityHistory,
 		loading,
 		refetch,
-		total: totalSessions,
 	} = mapListResultsToProps(metricResponse, ({eventMetric}) => ({
 		items: eventMetric.totalEventsMetric.histogram.metrics?.map(
 			({key, value}, index: number) => ({
@@ -112,7 +111,6 @@ const ActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 					].value,
 			})
 		),
-		total: eventMetric.totalSessionsMetric?.value,
 	}));
 
 	const trendResponse = useQuery<
@@ -224,10 +222,7 @@ const ActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 		? getDateRangeLabelFromDate(selectedIntervalInitDate, interval)
 		: getDateRangeLabel(activityHistory, interval, 'intervalInitDate');
 
-	const totalItems =
-		selectedPoint !== undefined
-			? activityHistory[selectedPoint]?.totalSessions ?? 0
-			: totalSessions ?? 0;
+	const totalItems = sessionsData?.totalEventsMetric?.value ?? 0;
 
 	return (
 		<WrapSafeResults

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamCard.tsx
@@ -71,6 +71,24 @@ describe('ActivityStreamCard', () => {
 		expect(getByText('Jane Doe')).toBeInTheDocument();
 	});
 
+	it('drives pagination from the activity stream event total, not the session count', async () => {
+		const {container} = render(
+			<Wrapper
+				mocks={[
+					mockAccountEventMetricsReq(),
+					mockAccountEventsTrendReq(),
+					mockAccountUserSessionsReq({totalEvents: 186}),
+				]}
+			/>
+		);
+
+		await waitForLoadingToBeRemoved(container);
+
+		expect(
+			container.querySelector('.pagination-results')
+		).toHaveTextContent('186');
+	});
+
 	it('renders the empty state when the histogram has no events', async () => {
 		const {container, getByText} = render(
 			<Wrapper


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95251

## What Is Being Fixed

The Account Activity Stream pagination collapsed to a single page even when an account had many activities. Scrolling to the bottom showed only one page, and raising the items-per-page count from 20 to 60 surfaced more events that the pagination had hidden.

## How It Is Being Fixed

The activity stream is paginated by events: the backend applies the page size as a limit on event rows and then groups them into sessions. The pagination total, however, was read from the event metrics query's session count, so the page count was computed against sessions while the list advanced through events. With fewer sessions than events, ceil(sessions / pageSize) produced too few pages and later events became unreachable.

The total is now taken from the event count already returned by the eventsByUserSessions query - the same source that paginates the list - so the page count stays consistent with what is shown. This restores the component's original event-based total; a prior change had switched it to the session count, which is what introduced the regression.

## PR Check

**pr-check: PASS** — tested on `ec0dc167694fa67d0f86351c5e22298f924460ed`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ec0dc167694fa67d0f86351c5e22298f924460ed"} -->
