### PR TITLE
LPD-95248 Truncate individual name and email to stop column overlap

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/MemberCell.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/MemberCell.tsx
@@ -26,7 +26,7 @@ const MemberCell: React.FC<IMemberCellProps> = ({className, data, routeFn}) => {
 
 	return (
 		<td className={getCN('name-cell-root', className)}>
-			<div className="text-dark">
+			<div className="text-dark text-truncate">
 				<Text size={3} weight="semi-bold">
 					{routeFn ? (
 						<Link className="text-dark" href={routeFn({data})}>
@@ -38,9 +38,11 @@ const MemberCell: React.FC<IMemberCellProps> = ({className, data, routeFn}) => {
 				</Text>
 			</div>
 			{!anonymous && (
-				<Text color="secondary" size={3}>
-					{resolvedEmail}
-				</Text>
+				<div className="text-truncate">
+					<Text color="secondary" size={3}>
+						{resolvedEmail}
+					</Text>
+				</div>
 			)}
 		</td>
 	);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/__tests__/MemberCell.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/__tests__/MemberCell.jsx
@@ -1,0 +1,73 @@
+import MemberCell from '../MemberCell';
+import React from 'react';
+import {render} from '@testing-library/react';
+
+jest.unmock('react-dom');
+
+const LONG_EMAIL = 'abderrahmane.boutitaou@tamarisoft.com';
+
+const FilledComponent = props => (
+	<table>
+		<tbody>
+			<tr>
+				<MemberCell
+					data={{
+						id: 'test',
+						name: 'foo',
+						properties: {email: LONG_EMAIL}
+					}}
+					{...props}
+				/>
+			</tr>
+		</tbody>
+	</table>
+);
+
+describe('MemberCell', () => {
+	it('should render the name and the email', () => {
+		const {getByText} = render(<FilledComponent />);
+
+		expect(getByText('foo')).toBeTruthy();
+		expect(getByText(LONG_EMAIL)).toBeTruthy();
+	});
+
+	it('should truncate the name and the email so they do not overlap the next column', () => {
+		const {getByText} = render(<FilledComponent />);
+
+		expect(getByText('foo').closest('.text-truncate')).toBeTruthy();
+		expect(getByText(LONG_EMAIL).closest('.text-truncate')).toBeTruthy();
+	});
+
+	it('should render the name as a link if a route is passed', () => {
+		const {container} = render(
+			<FilledComponent routeFn={({data: {id}}) => `/foo/${id}`} />
+		);
+
+		expect(container.querySelector('a')).toHaveAttribute(
+			'href',
+			'/foo/test'
+		);
+	});
+
+	it('should not render an email when the individual is anonymous', () => {
+		const {queryByText} = render(
+			<FilledComponent data={{id: 'test', name: 'foo', properties: {}}} />
+		);
+
+		expect(queryByText(LONG_EMAIL)).toBeFalsy();
+	});
+
+	it('should fall back to emailAddress when email is missing', () => {
+		const {getByText} = render(
+			<FilledComponent
+				data={{
+					id: 'test',
+					name: 'foo',
+					properties: {emailAddress: LONG_EMAIL}
+				}}
+			/>
+		);
+
+		expect(getByText(LONG_EMAIL)).toBeTruthy();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95248

## What Is Being Fixed

In the Individual Profiles table, a long email in the "Individual | Email" column overflowed its cell and overlapped the adjacent "Account Name" column.

## How It Is Being Fixed

The name and email cell (MemberCell) renders inside a `table-cell-expand` column of a `table-autofit` / `table-nowrap` table, where Clay fixes the cell width and the inner content must carry `text-truncate` to clip with an ellipsis. Every other column — and the canonical NameCell — already wraps its content in `text-truncate`, but MemberCell rendered the email in a bare element, so a long email spilled past the cell. The fix wraps both the name and the email in `text-truncate` containers, mirroring NameCell. Because the change lives in the shared MemberCell component, it also corrects the same name and email column in the Membership Changes table.

The accompanying test renders MemberCell with a long email and asserts that both the name and the email resolve to a `text-truncate` ancestor, capturing the regression.

## PR Check

**pr-check: PASS** — tested on `1c04f566ffb6e8641bfffad917af70bfd6ed7d78`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1c04f566ffb6e8641bfffad917af70bfd6ed7d78"} -->
