### PR TITLE
LPD-92546 Hide anonymous individuals on known-only segment membership

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/Growth.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/Growth.tsx
@@ -46,6 +46,7 @@ import {INDIVIDUALS} from 'shared/util/router';
 import {OrderByDirections, RangeKeyTimeRanges} from 'shared/util/constants';
 import {OrderedMap} from 'immutable';
 import {OrderParams} from 'shared/util/records';
+import {ProfileTypes} from 'segment/segment-editor/dynamic/utils/constants';
 import {sub} from 'shared/util/lang';
 import {useStatefulPagination} from 'shared/hooks/useStatefulPagination';
 
@@ -65,6 +66,7 @@ type Data = {
 	modifiedDate: string;
 	orderIOMap: string;
 	page: number;
+	profileTypes?: string[];
 	query: string;
 };
 
@@ -78,7 +80,16 @@ interface CHANGES_AGGREGATION_SHAPE {
 }
 
 const getAllMembers = (data: Data) => {
-	const {channelId, delta, groupId, id, orderIOMap, page, query} = data;
+	const {
+		channelId,
+		delta,
+		groupId,
+		id,
+		orderIOMap,
+		page,
+		profileTypes,
+		query,
+	} = data;
 
 	return API.individuals.search({
 		channelId,
@@ -87,6 +98,7 @@ const getAllMembers = (data: Data) => {
 		individualSegmentId: id,
 		orderIOMap,
 		page,
+		profileTypes,
 		query,
 	});
 };
@@ -110,6 +122,7 @@ interface ISegmentGrowthChartProps {
 	data: Array<any>;
 	hasSelectedPoint: boolean;
 	height?: number;
+	includeAnonymousUsers?: boolean;
 	individualCounts?: {anonymousCount: number; knownCount: number};
 	selectedPoint?: number;
 	onSelectedPointChange?: (selectedPoint: number) => void;
@@ -124,6 +137,7 @@ export const SegmentGrowthChart: React.FC<ISegmentGrowthChartProps> = ({
 	data,
 	hasSelectedPoint,
 	height = 360,
+	includeAnonymousUsers = true,
 	individualCounts = {
 		anonymousCount: 0,
 		knownCount: 0,
@@ -202,24 +216,31 @@ export const SegmentGrowthChart: React.FC<ISegmentGrowthChartProps> = ({
 									</span>
 								),
 							},
-							{
-								className: 'pb-0',
-								label: () => (
-									<span className="text-secondary">
-										{sub(
-											Liferay.Language.get(
-												'x-anonymous-members'
+							...(includeAnonymousUsers
+								? [
+										{
+											className: 'pb-0',
+											label: () => (
+												<span className="text-secondary">
+													{sub(
+														Liferay.Language.get(
+															'x-anonymous-members'
+														),
+														[
+															<b
+																className="mr-1"
+																key="VALUE"
+															>
+																{anonymousCount.toLocaleString()}
+															</b>,
+														],
+														false
+													)}
+												</span>
 											),
-											[
-												<b className="mr-1" key="VALUE">
-													{anonymousCount.toLocaleString()}
-												</b>,
-											],
-											false
-										)}
-									</span>
-								),
-							},
+										},
+									]
+								: []),
 							{
 								label: () => (
 									<span className="text-secondary">
@@ -431,15 +452,19 @@ export const SegmentGrowthChart: React.FC<ISegmentGrowthChartProps> = ({
 								type: 'circle',
 								value: Liferay.Language.get('known-members'),
 							},
-							{
-								color: CHART_ORANGE,
-								count: anonymousCount,
-								dataKey: 'anonymousCount',
-								type: 'circle',
-								value: Liferay.Language.get(
-									'anonymous-members'
-								),
-							},
+							...(includeAnonymousUsers
+								? [
+										{
+											color: CHART_ORANGE,
+											count: anonymousCount,
+											dataKey: 'anonymousCount',
+											type: 'circle',
+											value: Liferay.Language.get(
+												'anonymous-members'
+											),
+										},
+									]
+								: []),
 							{
 								color: CHART_BLACK,
 								count: anonymousCount + knownCount,
@@ -499,24 +524,28 @@ export const SegmentGrowthChart: React.FC<ISegmentGrowthChartProps> = ({
 						}
 					/>
 
-					<ReferenceDot
-						fill={CHART_ORANGE}
-						fillOpacity={legendHoverItem === 'knownCount' ? 0.1 : 1}
-						isFront
-						r={4}
-						stroke="none"
-						x={
-							hasSelectedPoint
-								? data[selectedPoint].modifiedDate
-								: null
-						}
-						y={
-							hasSelectedPoint
-								? data[selectedPoint].knownCount +
-									data[selectedPoint].anonymousCount
-								: null
-						}
-					/>
+					{includeAnonymousUsers && (
+						<ReferenceDot
+							fill={CHART_ORANGE}
+							fillOpacity={
+								legendHoverItem === 'knownCount' ? 0.1 : 1
+							}
+							isFront
+							r={4}
+							stroke="none"
+							x={
+								hasSelectedPoint
+									? data[selectedPoint].modifiedDate
+									: null
+							}
+							y={
+								hasSelectedPoint
+									? data[selectedPoint].knownCount +
+										data[selectedPoint].anonymousCount
+									: null
+							}
+						/>
+					)}
 
 					<Area
 						{...commonAreaChartStyles}
@@ -534,21 +563,23 @@ export const SegmentGrowthChart: React.FC<ISegmentGrowthChartProps> = ({
 						}
 					/>
 
-					<Area
-						{...commonAreaChartStyles}
-						activeDot={{r: 4, stroke: CHART_ORANGE}}
-						dataKey="anonymousCount"
-						fill={CHART_ORANGE}
-						fillOpacity={
-							legendHoverItem === 'knownCount' ? 0.1 : 0.2
-						}
-						isAnimationActive={false}
-						name={Liferay.Language.get('anonymous-members')}
-						stroke={CHART_ORANGE}
-						strokeOpacity={
-							legendHoverItem === 'knownCount' ? 0.2 : 1
-						}
-					/>
+					{includeAnonymousUsers && (
+						<Area
+							{...commonAreaChartStyles}
+							activeDot={{r: 4, stroke: CHART_ORANGE}}
+							dataKey="anonymousCount"
+							fill={CHART_ORANGE}
+							fillOpacity={
+								legendHoverItem === 'knownCount' ? 0.1 : 0.2
+							}
+							isAnimationActive={false}
+							name={Liferay.Language.get('anonymous-members')}
+							stroke={CHART_ORANGE}
+							strokeOpacity={
+								legendHoverItem === 'knownCount' ? 0.2 : 1
+							}
+						/>
+					)}
 				</AreaChart>
 			</ResponsiveContainer>
 		</ComposedChartWithEmptyState>
@@ -568,6 +599,7 @@ interface ISegmentGrowthWithList {
 	groupId: string;
 	hasSelectedPoint: boolean;
 	id: string;
+	includeAnonymousUsers?: boolean;
 	individualCounts?: {anonymousCount: number; knownCount: number};
 	selectedPoint: number;
 	timeZoneId: string;
@@ -580,6 +612,7 @@ const SegmentGrowthWithList: React.FC<ISegmentGrowthWithList> = ({
 	groupId,
 	hasSelectedPoint,
 	id,
+	includeAnonymousUsers,
 	individualCounts,
 	selectedPoint,
 	timeZoneId,
@@ -651,6 +684,7 @@ const SegmentGrowthWithList: React.FC<ISegmentGrowthWithList> = ({
 					data={data}
 					hasSelectedPoint={hasSelectedPoint}
 					height={360}
+					includeAnonymousUsers={includeAnonymousUsers}
 					individualCounts={individualCounts}
 					selectedPoint={selectedPoint}
 				/>
@@ -668,6 +702,9 @@ const SegmentGrowthWithList: React.FC<ISegmentGrowthWithList> = ({
 							groupId,
 							id,
 							modifiedDate,
+							...(includeAnonymousUsers === false
+								? {profileTypes: [ProfileTypes.KNOWN]}
+								: {}),
 						}}
 						entityType={INDIVIDUALS}
 						noResultsRenderer={() => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/ProfileCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/ProfileCard.tsx
@@ -29,7 +29,11 @@ const SegmentProfileCard: React.FC<ISegmentProfileCardProps> = ({
 	channelId,
 	groupId,
 	id,
-	segment: {anonymousIndividualCount, knownIndividualCount},
+	segment: {
+		anonymousIndividualCount,
+		includeAnonymousUsers,
+		knownIndividualCount,
+	},
 }) => (
 	<Card
 		className="segment-profile-card-root"
@@ -49,6 +53,7 @@ const SegmentProfileCard: React.FC<ISegmentProfileCardProps> = ({
 				channelId={channelId}
 				groupId={groupId}
 				id={id}
+				includeAnonymousUsers={includeAnonymousUsers}
 				individualCounts={{
 					anonymousCount: anonymousIndividualCount,
 					knownCount: knownIndividualCount,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/__tests__/Growth.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/__tests__/Growth.jsx
@@ -1,3 +1,4 @@
+import * as API from 'shared/api';
 import * as data from 'test/data';
 import React from 'react';
 import SegmentGrowthWithList, {
@@ -42,6 +43,41 @@ describe('SegmentGrowthWithList', () => {
 		await waitForLoadingToBeRemoved(container);
 
 		expect(screen.getByText('Known Members')).toBeInTheDocument();
+	});
+
+	it('requests only known members when the segment excludes anonymous users', async () => {
+		const {container} = render(
+			<MemoryRouter
+				initialEntries={[
+					'/workspace/23/123123/contacts/segments/321321/membership'
+				]}
+			>
+				<Route path={Routes.CONTACTS_SEGMENT_MEMBERSHIP}>
+					<SegmentGrowthWithList
+						channelId='123'
+						data={[
+							{
+								added: 1,
+								modifiedDate: data.getTimestamp(),
+								removed: 3
+							}
+						]}
+						groupId='23'
+						id='3'
+						includeAnonymousUsers={false}
+						onPointSelect={jest.fn()}
+					/>
+				</Route>
+			</MemoryRouter>
+		);
+
+		jest.runAllTimers();
+
+		await waitForLoadingToBeRemoved(container);
+
+		expect(API.individuals.search).toHaveBeenCalledWith(
+			expect.objectContaining({profileTypes: ['KNOWN']})
+		);
 	});
 });
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/Membership.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/Membership.jsx
@@ -24,6 +24,7 @@ export const MembershipChart = withRequest(
 			data: PropTypes.array,
 			groupId: PropTypes.string.isRequired,
 			id: PropTypes.string.isRequired,
+			includeAnonymousUsers: PropTypes.bool,
 			individualCounts: PropTypes.shape({
 				anonymousCount: PropTypes.number,
 				knownCount: PropTypes.number
@@ -38,6 +39,7 @@ export const MembershipChart = withRequest(
 				data,
 				groupId,
 				id,
+				includeAnonymousUsers,
 				individualCounts,
 				segmentType,
 				timeZoneId
@@ -49,6 +51,7 @@ export const MembershipChart = withRequest(
 					data={data}
 					groupId={groupId}
 					id={id}
+					includeAnonymousUsers={includeAnonymousUsers}
 					individualCounts={individualCounts}
 					shouldShowMembershipList={
 						segmentType !== SegmentTypes.RealTime
@@ -83,6 +86,7 @@ export default class Membership extends React.Component {
 			segment: {
 				anonymousIndividualCount,
 				id,
+				includeAnonymousUsers,
 				knownIndividualCount,
 				segmentType
 			},
@@ -108,6 +112,7 @@ export default class Membership extends React.Component {
 					channelId={channelId}
 					groupId={groupId}
 					id={id}
+					includeAnonymousUsers={includeAnonymousUsers}
 					individualCounts={{
 						anonymousCount: anonymousIndividualCount,
 						knownCount: knownIndividualCount


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92546

## What Is Being Fixed

On the segment membership trend chart — shown both on the segment Overview card and on the Membership tab — anonymous individuals appeared even for segments configured to exclude them ("Include anonymous" toggle off). They were counted under an "Anonymous Members" legend and listed in the members table, so the chart and table disagreed with the segment's own definition.

## How It Is Being Fixed

The membership-trend chart and the members list now receive the segment's includeAnonymousUsers flag. The frontend was calling the individual search endpoint without honoring that setting; the endpoint already supports filtering by profile type, so the fix is to call it correctly. When the segment excludes anonymous users, the members list requests only known individuals (profileTypes: ["KNOWN"]) and the chart hides the anonymous series, its legend entry, and its tooltip row. The flag is threaded through Membership.jsx, Growth.tsx (SegmentGrowthWithList and SegmentGrowthChart), and ProfileCard.tsx; real-time segments are left unchanged since the toggle is batch-only.

## PR Check

**pr-check: PASS** — tested on `244c50deb1b3f9880a2e2e7a1d151e53b3289ad9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "244c50deb1b3f9880a2e2e7a1d151e53b3289ad9"} -->
