### PR TITLE
LPD-92419 Add performance top asset REST endpoint

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/dto/v1_0/PerformanceTopAsset.java
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/dto/v1_0/PerformanceTopAsset.java
@@ -1,0 +1,459 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+@GraphQLName("PerformanceTopAsset")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "PerformanceTopAsset")
+public class PerformanceTopAsset implements Serializable {
+
+	public static PerformanceTopAsset toDTO(String json) {
+		return ObjectMapperUtil.readValue(PerformanceTopAsset.class, json);
+	}
+
+	public static PerformanceTopAsset unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			PerformanceTopAsset.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getLastPage() {
+		if (_lastPageSupplier != null) {
+			lastPage = _lastPageSupplier.get();
+
+			_lastPageSupplier = null;
+		}
+
+		return lastPage;
+	}
+
+	public void setLastPage(Long lastPage) {
+		this.lastPage = lastPage;
+
+		_lastPageSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLastPage(
+		UnsafeSupplier<Long, Exception> lastPageUnsafeSupplier) {
+
+		_lastPageSupplier = () -> {
+			try {
+				return lastPageUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long lastPage;
+
+	@JsonIgnore
+	private Supplier<Long> _lastPageSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getPage() {
+		if (_pageSupplier != null) {
+			page = _pageSupplier.get();
+
+			_pageSupplier = null;
+		}
+
+		return page;
+	}
+
+	public void setPage(Long page) {
+		this.page = page;
+
+		_pageSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPage(UnsafeSupplier<Long, Exception> pageUnsafeSupplier) {
+		_pageSupplier = () -> {
+			try {
+				return pageUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long page;
+
+	@JsonIgnore
+	private Supplier<Long> _pageSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getPageSize() {
+		if (_pageSizeSupplier != null) {
+			pageSize = _pageSizeSupplier.get();
+
+			_pageSizeSupplier = null;
+		}
+
+		return pageSize;
+	}
+
+	public void setPageSize(Long pageSize) {
+		this.pageSize = pageSize;
+
+		_pageSizeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPageSize(
+		UnsafeSupplier<Long, Exception> pageSizeUnsafeSupplier) {
+
+		_pageSizeSupplier = () -> {
+			try {
+				return pageSizeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long pageSize;
+
+	@JsonIgnore
+	private Supplier<Long> _pageSizeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public PerformanceTopAssetItem[] getPerformanceTopAssetItems() {
+		if (_performanceTopAssetItemsSupplier != null) {
+			performanceTopAssetItems = _performanceTopAssetItemsSupplier.get();
+
+			_performanceTopAssetItemsSupplier = null;
+		}
+
+		return performanceTopAssetItems;
+	}
+
+	public void setPerformanceTopAssetItems(
+		PerformanceTopAssetItem[] performanceTopAssetItems) {
+
+		this.performanceTopAssetItems = performanceTopAssetItems;
+
+		_performanceTopAssetItemsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setPerformanceTopAssetItems(
+		UnsafeSupplier<PerformanceTopAssetItem[], Exception>
+			performanceTopAssetItemsUnsafeSupplier) {
+
+		_performanceTopAssetItemsSupplier = () -> {
+			try {
+				return performanceTopAssetItemsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected PerformanceTopAssetItem[] performanceTopAssetItems;
+
+	@JsonIgnore
+	private Supplier<PerformanceTopAssetItem[]>
+		_performanceTopAssetItemsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getTotalCount() {
+		if (_totalCountSupplier != null) {
+			totalCount = _totalCountSupplier.get();
+
+			_totalCountSupplier = null;
+		}
+
+		return totalCount;
+	}
+
+	public void setTotalCount(Long totalCount) {
+		this.totalCount = totalCount;
+
+		_totalCountSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTotalCount(
+		UnsafeSupplier<Long, Exception> totalCountUnsafeSupplier) {
+
+		_totalCountSupplier = () -> {
+			try {
+				return totalCountUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long totalCount;
+
+	@JsonIgnore
+	private Supplier<Long> _totalCountSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PerformanceTopAsset)) {
+			return false;
+		}
+
+		PerformanceTopAsset performanceTopAsset = (PerformanceTopAsset)object;
+
+		return Objects.equals(toString(), performanceTopAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		Long lastPage = getLastPage();
+
+		if (lastPage != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"lastPage\": ");
+
+			sb.append(lastPage);
+		}
+
+		Long page = getPage();
+
+		if (page != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"page\": ");
+
+			sb.append(page);
+		}
+
+		Long pageSize = getPageSize();
+
+		if (pageSize != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"pageSize\": ");
+
+			sb.append(pageSize);
+		}
+
+		PerformanceTopAssetItem[] performanceTopAssetItems =
+			getPerformanceTopAssetItems();
+
+		if (performanceTopAssetItems != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"performanceTopAssetItems\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < performanceTopAssetItems.length; i++) {
+				sb.append(String.valueOf(performanceTopAssetItems[i]));
+
+				if ((i + 1) < performanceTopAssetItems.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		Long totalCount = getTotalCount();
+
+		if (totalCount != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalCount\": ");
+
+			sb.append(totalCount);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.analytics.cms.rest.dto.v1_0.PerformanceTopAsset",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:1001946798

--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/dto/v1_0/PerformanceTopAssetItem.java
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/dto/v1_0/PerformanceTopAssetItem.java
@@ -1,0 +1,559 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+@GraphQLName("PerformanceTopAssetItem")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "PerformanceTopAssetItem")
+public class PerformanceTopAssetItem implements Serializable {
+
+	public static PerformanceTopAssetItem toDTO(String json) {
+		return ObjectMapperUtil.readValue(PerformanceTopAssetItem.class, json);
+	}
+
+	public static PerformanceTopAssetItem unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			PerformanceTopAssetItem.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Double getDownloads() {
+		if (_downloadsSupplier != null) {
+			downloads = _downloadsSupplier.get();
+
+			_downloadsSupplier = null;
+		}
+
+		return downloads;
+	}
+
+	public void setDownloads(Double downloads) {
+		this.downloads = downloads;
+
+		_downloadsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDownloads(
+		UnsafeSupplier<Double, Exception> downloadsUnsafeSupplier) {
+
+		_downloadsSupplier = () -> {
+			try {
+				return downloadsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Double downloads;
+
+	@JsonIgnore
+	private Supplier<Double> _downloadsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Double getEngagement() {
+		if (_engagementSupplier != null) {
+			engagement = _engagementSupplier.get();
+
+			_engagementSupplier = null;
+		}
+
+		return engagement;
+	}
+
+	public void setEngagement(Double engagement) {
+		this.engagement = engagement;
+
+		_engagementSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setEngagement(
+		UnsafeSupplier<Double, Exception> engagementUnsafeSupplier) {
+
+		_engagementSupplier = () -> {
+			try {
+				return engagementUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Double engagement;
+
+	@JsonIgnore
+	private Supplier<Double> _engagementSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Double getImpressions() {
+		if (_impressionsSupplier != null) {
+			impressions = _impressionsSupplier.get();
+
+			_impressionsSupplier = null;
+		}
+
+		return impressions;
+	}
+
+	public void setImpressions(Double impressions) {
+		this.impressions = impressions;
+
+		_impressionsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setImpressions(
+		UnsafeSupplier<Double, Exception> impressionsUnsafeSupplier) {
+
+		_impressionsSupplier = () -> {
+			try {
+				return impressionsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Double impressions;
+
+	@JsonIgnore
+	private Supplier<Double> _impressionsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getMimeType() {
+		if (_mimeTypeSupplier != null) {
+			mimeType = _mimeTypeSupplier.get();
+
+			_mimeTypeSupplier = null;
+		}
+
+		return mimeType;
+	}
+
+	public void setMimeType(String mimeType) {
+		this.mimeType = mimeType;
+
+		_mimeTypeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setMimeType(
+		UnsafeSupplier<String, Exception> mimeTypeUnsafeSupplier) {
+
+		_mimeTypeSupplier = () -> {
+			try {
+				return mimeTypeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String mimeType;
+
+	@JsonIgnore
+	private Supplier<String> _mimeTypeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getTitle() {
+		if (_titleSupplier != null) {
+			title = _titleSupplier.get();
+
+			_titleSupplier = null;
+		}
+
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+
+		_titleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		_titleSupplier = () -> {
+			try {
+				return titleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String title;
+
+	@JsonIgnore
+	private Supplier<String> _titleSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Trend getTrend() {
+		if (_trendSupplier != null) {
+			trend = _trendSupplier.get();
+
+			_trendSupplier = null;
+		}
+
+		return trend;
+	}
+
+	public void setTrend(Trend trend) {
+		this.trend = trend;
+
+		_trendSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setTrend(UnsafeSupplier<Trend, Exception> trendUnsafeSupplier) {
+		_trendSupplier = () -> {
+			try {
+				return trendUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Trend trend;
+
+	@JsonIgnore
+	private Supplier<Trend> _trendSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Double getViews() {
+		if (_viewsSupplier != null) {
+			views = _viewsSupplier.get();
+
+			_viewsSupplier = null;
+		}
+
+		return views;
+	}
+
+	public void setViews(Double views) {
+		this.views = views;
+
+		_viewsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setViews(
+		UnsafeSupplier<Double, Exception> viewsUnsafeSupplier) {
+
+		_viewsSupplier = () -> {
+			try {
+				return viewsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Double views;
+
+	@JsonIgnore
+	private Supplier<Double> _viewsSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PerformanceTopAssetItem)) {
+			return false;
+		}
+
+		PerformanceTopAssetItem performanceTopAssetItem =
+			(PerformanceTopAssetItem)object;
+
+		return Objects.equals(toString(), performanceTopAssetItem.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		Double downloads = getDownloads();
+
+		if (downloads != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"downloads\": ");
+
+			sb.append(downloads);
+		}
+
+		Double engagement = getEngagement();
+
+		if (engagement != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"engagement\": ");
+
+			sb.append(engagement);
+		}
+
+		Double impressions = getImpressions();
+
+		if (impressions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"impressions\": ");
+
+			sb.append(impressions);
+		}
+
+		String mimeType = getMimeType();
+
+		if (mimeType != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"mimeType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(mimeType));
+
+			sb.append("\"");
+		}
+
+		String title = getTitle();
+
+		if (title != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(title));
+
+			sb.append("\"");
+		}
+
+		Trend trend = getTrend();
+
+		if (trend != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"trend\": ");
+
+			sb.append(String.valueOf(trend));
+		}
+
+		Double views = getViews();
+
+		if (views != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"views\": ");
+
+			sb.append(views);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.analytics.cms.rest.dto.v1_0.PerformanceTopAssetItem",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1390459475

--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/resource/v1_0/PerformanceTopAssetResource.java
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/resource/v1_0/PerformanceTopAssetResource.java
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceTopAsset;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/analytics-cms-rest/v1.0
+ *
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface PerformanceTopAssetResource {
+
+	public PerformanceTopAsset getPerformanceTopAsset(
+			String assetFilter, Long[] depotEntryIds, Integer rangeKey,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public PerformanceTopAssetResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-853044339

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/dto/v1_0/PerformanceTopAsset.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/dto/v1_0/PerformanceTopAsset.java
@@ -1,0 +1,167 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.dto.v1_0;
+
+import com.liferay.analytics.cms.rest.client.function.UnsafeSupplier;
+import com.liferay.analytics.cms.rest.client.serdes.v1_0.PerformanceTopAssetSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public class PerformanceTopAsset implements Cloneable, Serializable {
+
+	public static PerformanceTopAsset toDTO(String json) {
+		return PerformanceTopAssetSerDes.toDTO(json);
+	}
+
+	public Long getLastPage() {
+		return lastPage;
+	}
+
+	public void setLastPage(Long lastPage) {
+		this.lastPage = lastPage;
+	}
+
+	public void setLastPage(
+		UnsafeSupplier<Long, Exception> lastPageUnsafeSupplier) {
+
+		try {
+			lastPage = lastPageUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long lastPage;
+
+	public Long getPage() {
+		return page;
+	}
+
+	public void setPage(Long page) {
+		this.page = page;
+	}
+
+	public void setPage(UnsafeSupplier<Long, Exception> pageUnsafeSupplier) {
+		try {
+			page = pageUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long page;
+
+	public Long getPageSize() {
+		return pageSize;
+	}
+
+	public void setPageSize(Long pageSize) {
+		this.pageSize = pageSize;
+	}
+
+	public void setPageSize(
+		UnsafeSupplier<Long, Exception> pageSizeUnsafeSupplier) {
+
+		try {
+			pageSize = pageSizeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long pageSize;
+
+	public PerformanceTopAssetItem[] getPerformanceTopAssetItems() {
+		return performanceTopAssetItems;
+	}
+
+	public void setPerformanceTopAssetItems(
+		PerformanceTopAssetItem[] performanceTopAssetItems) {
+
+		this.performanceTopAssetItems = performanceTopAssetItems;
+	}
+
+	public void setPerformanceTopAssetItems(
+		UnsafeSupplier<PerformanceTopAssetItem[], Exception>
+			performanceTopAssetItemsUnsafeSupplier) {
+
+		try {
+			performanceTopAssetItems =
+				performanceTopAssetItemsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected PerformanceTopAssetItem[] performanceTopAssetItems;
+
+	public Long getTotalCount() {
+		return totalCount;
+	}
+
+	public void setTotalCount(Long totalCount) {
+		this.totalCount = totalCount;
+	}
+
+	public void setTotalCount(
+		UnsafeSupplier<Long, Exception> totalCountUnsafeSupplier) {
+
+		try {
+			totalCount = totalCountUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long totalCount;
+
+	@Override
+	public PerformanceTopAsset clone() throws CloneNotSupportedException {
+		return (PerformanceTopAsset)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PerformanceTopAsset)) {
+			return false;
+		}
+
+		PerformanceTopAsset performanceTopAsset = (PerformanceTopAsset)object;
+
+		return Objects.equals(toString(), performanceTopAsset.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return PerformanceTopAssetSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:2054094997

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/dto/v1_0/PerformanceTopAssetItem.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/dto/v1_0/PerformanceTopAssetItem.java
@@ -1,0 +1,206 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.dto.v1_0;
+
+import com.liferay.analytics.cms.rest.client.function.UnsafeSupplier;
+import com.liferay.analytics.cms.rest.client.serdes.v1_0.PerformanceTopAssetItemSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public class PerformanceTopAssetItem implements Cloneable, Serializable {
+
+	public static PerformanceTopAssetItem toDTO(String json) {
+		return PerformanceTopAssetItemSerDes.toDTO(json);
+	}
+
+	public Double getDownloads() {
+		return downloads;
+	}
+
+	public void setDownloads(Double downloads) {
+		this.downloads = downloads;
+	}
+
+	public void setDownloads(
+		UnsafeSupplier<Double, Exception> downloadsUnsafeSupplier) {
+
+		try {
+			downloads = downloadsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Double downloads;
+
+	public Double getEngagement() {
+		return engagement;
+	}
+
+	public void setEngagement(Double engagement) {
+		this.engagement = engagement;
+	}
+
+	public void setEngagement(
+		UnsafeSupplier<Double, Exception> engagementUnsafeSupplier) {
+
+		try {
+			engagement = engagementUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Double engagement;
+
+	public Double getImpressions() {
+		return impressions;
+	}
+
+	public void setImpressions(Double impressions) {
+		this.impressions = impressions;
+	}
+
+	public void setImpressions(
+		UnsafeSupplier<Double, Exception> impressionsUnsafeSupplier) {
+
+		try {
+			impressions = impressionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Double impressions;
+
+	public String getMimeType() {
+		return mimeType;
+	}
+
+	public void setMimeType(String mimeType) {
+		this.mimeType = mimeType;
+	}
+
+	public void setMimeType(
+		UnsafeSupplier<String, Exception> mimeTypeUnsafeSupplier) {
+
+		try {
+			mimeType = mimeTypeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String mimeType;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<String, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String title;
+
+	public Trend getTrend() {
+		return trend;
+	}
+
+	public void setTrend(Trend trend) {
+		this.trend = trend;
+	}
+
+	public void setTrend(UnsafeSupplier<Trend, Exception> trendUnsafeSupplier) {
+		try {
+			trend = trendUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Trend trend;
+
+	public Double getViews() {
+		return views;
+	}
+
+	public void setViews(Double views) {
+		this.views = views;
+	}
+
+	public void setViews(
+		UnsafeSupplier<Double, Exception> viewsUnsafeSupplier) {
+
+		try {
+			views = viewsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Double views;
+
+	@Override
+	public PerformanceTopAssetItem clone() throws CloneNotSupportedException {
+		return (PerformanceTopAssetItem)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PerformanceTopAssetItem)) {
+			return false;
+		}
+
+		PerformanceTopAssetItem performanceTopAssetItem =
+			(PerformanceTopAssetItem)object;
+
+		return Objects.equals(toString(), performanceTopAssetItem.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return PerformanceTopAssetItemSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:867979568

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/resource/v1_0/PerformanceTopAssetResource.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/resource/v1_0/PerformanceTopAssetResource.java
@@ -1,0 +1,302 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceTopAsset;
+import com.liferay.analytics.cms.rest.client.http.HttpInvoker;
+import com.liferay.analytics.cms.rest.client.pagination.Pagination;
+import com.liferay.analytics.cms.rest.client.problem.Problem;
+import com.liferay.analytics.cms.rest.client.serdes.v1_0.PerformanceTopAssetSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public interface PerformanceTopAssetResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public PerformanceTopAsset getPerformanceTopAsset(
+			String assetFilter, Long[] depotEntryIds, Integer rangeKey,
+			Pagination pagination, String sortString)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getPerformanceTopAssetHttpResponse(
+			String assetFilter, Long[] depotEntryIds, Integer rangeKey,
+			Pagination pagination, String sortString)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public PerformanceTopAssetResource build() {
+			return new PerformanceTopAssetResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class PerformanceTopAssetResourceImpl
+		implements PerformanceTopAssetResource {
+
+		public PerformanceTopAsset getPerformanceTopAsset(
+				String assetFilter, Long[] depotEntryIds, Integer rangeKey,
+				Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getPerformanceTopAssetHttpResponse(
+					assetFilter, depotEntryIds, rangeKey, pagination,
+					sortString);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return PerformanceTopAssetSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getPerformanceTopAssetHttpResponse(
+				String assetFilter, Long[] depotEntryIds, Integer rangeKey,
+				Pagination pagination, String sortString)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (assetFilter != null) {
+				httpInvoker.parameter(
+					"assetFilter", String.valueOf(assetFilter));
+			}
+
+			if (depotEntryIds != null) {
+				for (int i = 0; i < depotEntryIds.length; i++) {
+					httpInvoker.parameter(
+						"depotEntryIds", String.valueOf(depotEntryIds[i]));
+				}
+			}
+
+			if (rangeKey != null) {
+				httpInvoker.parameter("rangeKey", String.valueOf(rangeKey));
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/analytics-cms-rest/v1.0/performance-top-asset");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private PerformanceTopAssetResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			PerformanceTopAssetResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:466283231

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/serdes/v1_0/PerformanceTopAssetItemSerDes.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/serdes/v1_0/PerformanceTopAssetItemSerDes.java
@@ -1,0 +1,381 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.serdes.v1_0;
+
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceTopAssetItem;
+import com.liferay.analytics.cms.rest.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public class PerformanceTopAssetItemSerDes {
+
+	public static PerformanceTopAssetItem toDTO(String json) {
+		PerformanceTopAssetItemJSONParser performanceTopAssetItemJSONParser =
+			new PerformanceTopAssetItemJSONParser();
+
+		return performanceTopAssetItemJSONParser.parseToDTO(json);
+	}
+
+	public static PerformanceTopAssetItem[] toDTOs(String json) {
+		PerformanceTopAssetItemJSONParser performanceTopAssetItemJSONParser =
+			new PerformanceTopAssetItemJSONParser();
+
+		return performanceTopAssetItemJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(
+		PerformanceTopAssetItem performanceTopAssetItem) {
+
+		if (performanceTopAssetItem == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (performanceTopAssetItem.getDownloads() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"downloads\": ");
+
+			sb.append(performanceTopAssetItem.getDownloads());
+		}
+
+		if (performanceTopAssetItem.getEngagement() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"engagement\": ");
+
+			sb.append(performanceTopAssetItem.getEngagement());
+		}
+
+		if (performanceTopAssetItem.getImpressions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"impressions\": ");
+
+			sb.append(performanceTopAssetItem.getImpressions());
+		}
+
+		if (performanceTopAssetItem.getMimeType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"mimeType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(performanceTopAssetItem.getMimeType()));
+
+			sb.append("\"");
+		}
+
+		if (performanceTopAssetItem.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(performanceTopAssetItem.getTitle()));
+
+			sb.append("\"");
+		}
+
+		if (performanceTopAssetItem.getTrend() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"trend\": ");
+
+			sb.append(String.valueOf(performanceTopAssetItem.getTrend()));
+		}
+
+		if (performanceTopAssetItem.getViews() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"views\": ");
+
+			sb.append(performanceTopAssetItem.getViews());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		PerformanceTopAssetItemJSONParser performanceTopAssetItemJSONParser =
+			new PerformanceTopAssetItemJSONParser();
+
+		return performanceTopAssetItemJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		PerformanceTopAssetItem performanceTopAssetItem) {
+
+		if (performanceTopAssetItem == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (performanceTopAssetItem.getDownloads() == null) {
+			map.put("downloads", null);
+		}
+		else {
+			map.put(
+				"downloads",
+				String.valueOf(performanceTopAssetItem.getDownloads()));
+		}
+
+		if (performanceTopAssetItem.getEngagement() == null) {
+			map.put("engagement", null);
+		}
+		else {
+			map.put(
+				"engagement",
+				String.valueOf(performanceTopAssetItem.getEngagement()));
+		}
+
+		if (performanceTopAssetItem.getImpressions() == null) {
+			map.put("impressions", null);
+		}
+		else {
+			map.put(
+				"impressions",
+				String.valueOf(performanceTopAssetItem.getImpressions()));
+		}
+
+		if (performanceTopAssetItem.getMimeType() == null) {
+			map.put("mimeType", null);
+		}
+		else {
+			map.put(
+				"mimeType",
+				String.valueOf(performanceTopAssetItem.getMimeType()));
+		}
+
+		if (performanceTopAssetItem.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put(
+				"title", String.valueOf(performanceTopAssetItem.getTitle()));
+		}
+
+		if (performanceTopAssetItem.getTrend() == null) {
+			map.put("trend", null);
+		}
+		else {
+			map.put(
+				"trend", String.valueOf(performanceTopAssetItem.getTrend()));
+		}
+
+		if (performanceTopAssetItem.getViews() == null) {
+			map.put("views", null);
+		}
+		else {
+			map.put(
+				"views", String.valueOf(performanceTopAssetItem.getViews()));
+		}
+
+		return map;
+	}
+
+	public static class PerformanceTopAssetItemJSONParser
+		extends BaseJSONParser<PerformanceTopAssetItem> {
+
+		@Override
+		protected PerformanceTopAssetItem createDTO() {
+			return new PerformanceTopAssetItem();
+		}
+
+		@Override
+		protected PerformanceTopAssetItem[] createDTOArray(int size) {
+			return new PerformanceTopAssetItem[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "downloads")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "engagement")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "impressions")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "mimeType")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "trend")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "views")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			PerformanceTopAssetItem performanceTopAssetItem,
+			String jsonParserFieldName, Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "downloads")) {
+				if (jsonParserFieldValue != null) {
+					performanceTopAssetItem.setDownloads(
+						Double.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "engagement")) {
+				if (jsonParserFieldValue != null) {
+					performanceTopAssetItem.setEngagement(
+						Double.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "impressions")) {
+				if (jsonParserFieldValue != null) {
+					performanceTopAssetItem.setImpressions(
+						Double.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "mimeType")) {
+				if (jsonParserFieldValue != null) {
+					performanceTopAssetItem.setMimeType(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					performanceTopAssetItem.setTitle(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "trend")) {
+				if (jsonParserFieldValue != null) {
+					performanceTopAssetItem.setTrend(
+						TrendSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "views")) {
+				if (jsonParserFieldValue != null) {
+					performanceTopAssetItem.setViews(
+						Double.valueOf((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-303417879

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/serdes/v1_0/PerformanceTopAssetSerDes.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/serdes/v1_0/PerformanceTopAssetSerDes.java
@@ -1,0 +1,353 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.client.serdes.v1_0;
+
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceTopAsset;
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceTopAssetItem;
+import com.liferay.analytics.cms.rest.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public class PerformanceTopAssetSerDes {
+
+	public static PerformanceTopAsset toDTO(String json) {
+		PerformanceTopAssetJSONParser performanceTopAssetJSONParser =
+			new PerformanceTopAssetJSONParser();
+
+		return performanceTopAssetJSONParser.parseToDTO(json);
+	}
+
+	public static PerformanceTopAsset[] toDTOs(String json) {
+		PerformanceTopAssetJSONParser performanceTopAssetJSONParser =
+			new PerformanceTopAssetJSONParser();
+
+		return performanceTopAssetJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(PerformanceTopAsset performanceTopAsset) {
+		if (performanceTopAsset == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (performanceTopAsset.getLastPage() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"lastPage\": ");
+
+			sb.append(performanceTopAsset.getLastPage());
+		}
+
+		if (performanceTopAsset.getPage() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"page\": ");
+
+			sb.append(performanceTopAsset.getPage());
+		}
+
+		if (performanceTopAsset.getPageSize() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"pageSize\": ");
+
+			sb.append(performanceTopAsset.getPageSize());
+		}
+
+		if (performanceTopAsset.getPerformanceTopAssetItems() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"performanceTopAssetItems\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < performanceTopAsset.getPerformanceTopAssetItems().length;
+				 i++) {
+
+				sb.append(
+					String.valueOf(
+						performanceTopAsset.getPerformanceTopAssetItems()[i]));
+
+				if ((i + 1) <
+						performanceTopAsset.
+							getPerformanceTopAssetItems().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (performanceTopAsset.getTotalCount() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"totalCount\": ");
+
+			sb.append(performanceTopAsset.getTotalCount());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		PerformanceTopAssetJSONParser performanceTopAssetJSONParser =
+			new PerformanceTopAssetJSONParser();
+
+		return performanceTopAssetJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		PerformanceTopAsset performanceTopAsset) {
+
+		if (performanceTopAsset == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (performanceTopAsset.getLastPage() == null) {
+			map.put("lastPage", null);
+		}
+		else {
+			map.put(
+				"lastPage", String.valueOf(performanceTopAsset.getLastPage()));
+		}
+
+		if (performanceTopAsset.getPage() == null) {
+			map.put("page", null);
+		}
+		else {
+			map.put("page", String.valueOf(performanceTopAsset.getPage()));
+		}
+
+		if (performanceTopAsset.getPageSize() == null) {
+			map.put("pageSize", null);
+		}
+		else {
+			map.put(
+				"pageSize", String.valueOf(performanceTopAsset.getPageSize()));
+		}
+
+		if (performanceTopAsset.getPerformanceTopAssetItems() == null) {
+			map.put("performanceTopAssetItems", null);
+		}
+		else {
+			map.put(
+				"performanceTopAssetItems",
+				String.valueOf(
+					performanceTopAsset.getPerformanceTopAssetItems()));
+		}
+
+		if (performanceTopAsset.getTotalCount() == null) {
+			map.put("totalCount", null);
+		}
+		else {
+			map.put(
+				"totalCount",
+				String.valueOf(performanceTopAsset.getTotalCount()));
+		}
+
+		return map;
+	}
+
+	public static class PerformanceTopAssetJSONParser
+		extends BaseJSONParser<PerformanceTopAsset> {
+
+		@Override
+		protected PerformanceTopAsset createDTO() {
+			return new PerformanceTopAsset();
+		}
+
+		@Override
+		protected PerformanceTopAsset[] createDTOArray(int size) {
+			return new PerformanceTopAsset[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "lastPage")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "page")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "pageSize")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "performanceTopAssetItems")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			PerformanceTopAsset performanceTopAsset, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "lastPage")) {
+				if (jsonParserFieldValue != null) {
+					performanceTopAsset.setLastPage(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "page")) {
+				if (jsonParserFieldValue != null) {
+					performanceTopAsset.setPage(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "pageSize")) {
+				if (jsonParserFieldValue != null) {
+					performanceTopAsset.setPageSize(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "performanceTopAssetItems")) {
+
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					PerformanceTopAssetItem[] performanceTopAssetItemsArray =
+						new PerformanceTopAssetItem
+							[jsonParserFieldValues.length];
+
+					for (int i = 0; i < performanceTopAssetItemsArray.length;
+						 i++) {
+
+						performanceTopAssetItemsArray[i] =
+							PerformanceTopAssetItemSerDes.toDTO(
+								(String)jsonParserFieldValues[i]);
+					}
+
+					performanceTopAsset.setPerformanceTopAssetItems(
+						performanceTopAssetItemsArray);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "totalCount")) {
+				if (jsonParserFieldValue != null) {
+					performanceTopAsset.setTotalCount(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1444694026

--- a/modules/apps/analytics/analytics-cms-rest-impl/rest-openapi.yaml
+++ b/modules/apps/analytics/analytics-cms-rest-impl/rest-openapi.yaml
@@ -168,6 +168,44 @@ components:
                     $ref: "#/components/schemas/Metric"
                 viewsMetric:
                     $ref: "#/components/schemas/Metric"
+        PerformanceTopAsset:
+            properties:
+                lastPage:
+                    format: int64
+                    type: integer
+                page:
+                    format: int64
+                    type: integer
+                pageSize:
+                    format: int64
+                    type: integer
+                performanceTopAssetItems:
+                    items:
+                        $ref: "#/components/schemas/PerformanceTopAssetItem"
+                    type: array
+                totalCount:
+                    format: int64
+                    type: integer
+        PerformanceTopAssetItem:
+            properties:
+                downloads:
+                    format: double
+                    type: number
+                engagement:
+                    format: double
+                    type: number
+                impressions:
+                    format: double
+                    type: number
+                mimeType:
+                    type: string
+                title:
+                    type: string
+                trend:
+                    $ref: "#/components/schemas/Trend"
+                views:
+                    format: double
+                    type: number
         TopPage:
             properties:
                 canonicalUrl:
@@ -651,3 +689,46 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/PerformanceOverviewMetric"
             tags: ["PerformanceOverviewMetric"]
+    "/performance-top-asset":
+        get:
+            operationId: getPerformanceTopAsset
+            parameters:
+                -   in: query
+                    name: assetFilter
+                    schema:
+                        type: string
+                -   in: query
+                    name: depotEntryIds
+                    schema:
+                        items:
+                            format: int64
+                            type: integer
+                        type: array
+                -   in: query
+                    name: page
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: rangeKey
+                    schema:
+                        type: integer
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PerformanceTopAsset"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/PerformanceTopAsset"
+            tags: ["PerformanceTopAsset"]

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -23,16 +23,21 @@ import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumption;
 import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumptionItem;
 import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceMetric;
 import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceOverviewMetric;
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceTopAsset;
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceTopAssetItem;
+import com.liferay.analytics.cms.rest.dto.v1_0.Trend;
 import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectDefinitionTable;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
@@ -331,10 +336,10 @@ public class AnalyticsCloudClient {
 				_getLocation(
 					categoryId,
 					analyticsConfiguration.liferayAnalyticsDataSourceId(), null,
-					groupBy, groupIds,
+					null, groupBy, groupIds,
 					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
 					metricType, objectType, page, "/asset-consumption",
-					rangeKey, null, size, tagId, vocabularyId));
+					rangeKey, null, size, null, tagId, vocabularyId));
 
 			String content = _http.URLtoString(options);
 
@@ -501,12 +506,63 @@ public class AnalyticsCloudClient {
 		}
 	}
 
+	public PerformanceTopAsset getPerformanceTopAsset(
+			AnalyticsConfiguration analyticsConfiguration, String filterString,
+			List<Long> groupIds, int page, Integer rangeKey, int size,
+			Sort[] sorts)
+		throws Exception {
+
+		try {
+			Http.Options options = _getOptions(analyticsConfiguration);
+
+			options.setLocation(
+				_getLocation(
+					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
+					null, filterString, null, groupIds,
+					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
+					null, null, page, "/summaries", rangeKey, null, size, sorts,
+					null, null));
+
+			String content = _http.URLtoString(options);
+
+			Http.Response response = options.getResponse();
+
+			if (response.getResponseCode() == HttpURLConnection.HTTP_OK) {
+				PerformanceTopAsset performanceTopAsset = null;
+
+				JsonNode jsonNode = ObjectMapperHolder._objectMapper.readTree(
+					content);
+
+				if (jsonNode != null) {
+					performanceTopAsset = _getPerformanceTopAsset(jsonNode);
+				}
+
+				return performanceTopAsset;
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug("Response code " + response.getResponseCode());
+			}
+
+			throw new PortalException("Unable to get performance top asset");
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			throw new PortalException(
+				"Unable to get performance top asset", exception);
+		}
+	}
+
 	private String _getLocation(
 		Long categoryId, String dataSourceId, String externalReferenceCode,
-		String groupBy, List<Long> groupIds,
+		String filterString, String groupBy, List<Long> groupIds,
 		String liferayAnalyticsFaroBackendURL, String metricType,
 		String objectType, Integer page, String path, Integer rangeKey,
-		String[] selectedMetrics, Integer size, Long tagId, Long vocabularyId) {
+		String[] selectedMetrics, Integer size, Sort[] sorts, Long tagId,
+		Long vocabularyId) {
 
 		String url = String.join(
 			StringPool.BLANK, liferayAnalyticsFaroBackendURL,
@@ -525,6 +581,10 @@ public class AnalyticsCloudClient {
 		if (Validator.isNotNull(externalReferenceCode)) {
 			url = HttpComponentsUtil.addParameter(
 				url, "externalReferenceCode", externalReferenceCode);
+		}
+
+		if (Validator.isNotNull(filterString)) {
+			url = HttpComponentsUtil.addParameter(url, "filter", filterString);
 		}
 
 		if (Validator.isNotNull(groupBy)) {
@@ -564,6 +624,22 @@ public class AnalyticsCloudClient {
 			url = HttpComponentsUtil.addParameter(url, "size", size);
 		}
 
+		if (ArrayUtil.isNotEmpty(sorts)) {
+			StringBundler sb = new StringBundler((sorts.length * 4) - 1);
+
+			for (int i = 0; i < sorts.length; i++) {
+				if (i > 0) {
+					sb.append(StringPool.COMMA);
+				}
+
+				sb.append(sorts[i].getFieldName());
+				sb.append(StringPool.COLON);
+				sb.append(sorts[i].isReverse() ? "desc" : "asc");
+			}
+
+			url = HttpComponentsUtil.addParameter(url, "sort", sb.toString());
+		}
+
 		if (tagId != null) {
 			url = HttpComponentsUtil.addParameter(url, "tagId", tagId);
 		}
@@ -582,9 +658,9 @@ public class AnalyticsCloudClient {
 		Integer rangeKey) {
 
 		return _getLocation(
-			null, dataSourceId, null, null, groupIds,
+			null, dataSourceId, null, null, null, groupIds,
 			liferayAnalyticsFaroBackendURL, metricType, null, null, path,
-			rangeKey, null, null, null, null);
+			rangeKey, null, null, null, null, null);
 	}
 
 	private String _getLocation(
@@ -593,9 +669,25 @@ public class AnalyticsCloudClient {
 		String[] selectedMetrics) {
 
 		return _getLocation(
-			null, dataSourceId, externalReferenceCode, null, groupIds,
+			null, dataSourceId, externalReferenceCode, null, null, groupIds,
 			liferayAnalyticsFaroBackendURL, null, null, null, path, rangeKey,
-			selectedMetrics, null, null, null);
+			selectedMetrics, null, null, null, null);
+	}
+
+	private Double _getMetricValue(JsonNode jsonNode, String metricName) {
+		JsonNode metricJsonNode = jsonNode.get(metricName);
+
+		if (metricJsonNode == null) {
+			return null;
+		}
+
+		JsonNode valueJsonNode = metricJsonNode.get("value");
+
+		if (valueJsonNode == null) {
+			return null;
+		}
+
+		return valueJsonNode.asDouble();
 	}
 
 	private Http.Options _getOptions(
@@ -639,6 +731,128 @@ public class AnalyticsCloudClient {
 		}
 
 		return performanceOverviewMetric;
+	}
+
+	private PerformanceTopAsset _getPerformanceTopAsset(JsonNode jsonNode) {
+		PerformanceTopAsset performanceTopAsset = new PerformanceTopAsset();
+
+		JsonNode pageJsonNode = jsonNode.get("page");
+
+		if (pageJsonNode != null) {
+			JsonNode pageNumberJsonNode = pageJsonNode.get("number");
+
+			if (pageNumberJsonNode != null) {
+				performanceTopAsset.setPage(pageNumberJsonNode::asLong);
+			}
+
+			JsonNode pageSizeJsonNode = pageJsonNode.get("size");
+
+			if (pageSizeJsonNode != null) {
+				performanceTopAsset.setPageSize(pageSizeJsonNode::asLong);
+			}
+
+			JsonNode totalElementsJsonNode = pageJsonNode.get("totalElements");
+
+			if (totalElementsJsonNode != null) {
+				performanceTopAsset.setTotalCount(
+					totalElementsJsonNode::asLong);
+			}
+
+			JsonNode totalPagesJsonNode = pageJsonNode.get("totalPages");
+
+			if (totalPagesJsonNode != null) {
+				performanceTopAsset.setLastPage(totalPagesJsonNode::asLong);
+			}
+		}
+
+		List<PerformanceTopAssetItem> performanceTopAssetItems =
+			new ArrayList<>();
+
+		JsonNode embeddedJsonNode = jsonNode.get("_embedded");
+
+		if (embeddedJsonNode != null) {
+			JsonNode assetSummaryMetricsJsonNode = embeddedJsonNode.get(
+				"assetSummaryMetrics");
+
+			if (assetSummaryMetricsJsonNode != null) {
+				for (JsonNode assetSummaryMetricJsonNode :
+						assetSummaryMetricsJsonNode) {
+
+					performanceTopAssetItems.add(
+						_getPerformanceTopAssetItem(
+							assetSummaryMetricJsonNode));
+				}
+			}
+		}
+
+		performanceTopAsset.setPerformanceTopAssetItems(
+			() -> performanceTopAssetItems.toArray(
+				new PerformanceTopAssetItem[0]));
+
+		return performanceTopAsset;
+	}
+
+	private PerformanceTopAssetItem _getPerformanceTopAssetItem(
+		JsonNode jsonNode) {
+
+		PerformanceTopAssetItem performanceTopAssetItem =
+			new PerformanceTopAssetItem();
+
+		performanceTopAssetItem.setDownloads(
+			() -> _getMetricValue(jsonNode, "downloadsMetric"));
+		performanceTopAssetItem.setEngagement(
+			() -> _getMetricValue(jsonNode, "engagementMetric"));
+		performanceTopAssetItem.setImpressions(
+			() -> _getMetricValue(jsonNode, "impressionsMetric"));
+
+		JsonNode assetTypeJsonNode = jsonNode.get("assetType");
+
+		if (assetTypeJsonNode != null) {
+			performanceTopAssetItem.setMimeType(assetTypeJsonNode::asText);
+		}
+
+		JsonNode assetTitleJsonNode = jsonNode.get("assetTitle");
+
+		if (assetTitleJsonNode != null) {
+			performanceTopAssetItem.setTitle(assetTitleJsonNode::asText);
+		}
+
+		JsonNode engagementMetricJsonNode = jsonNode.get("engagementMetric");
+
+		if (engagementMetricJsonNode != null) {
+			JsonNode trendJsonNode = engagementMetricJsonNode.get("trend");
+
+			if (trendJsonNode != null) {
+				performanceTopAssetItem.setTrend(
+					() -> _getTrend(trendJsonNode));
+			}
+		}
+
+		performanceTopAssetItem.setViews(
+			() -> _getMetricValue(jsonNode, "viewsMetric"));
+
+		return performanceTopAssetItem;
+	}
+
+	private Trend _getTrend(JsonNode jsonNode) {
+		Trend trend = new Trend();
+
+		JsonNode percentageJsonNode = jsonNode.get("percentage");
+
+		if (percentageJsonNode != null) {
+			trend.setPercentage(percentageJsonNode::asDouble);
+		}
+
+		JsonNode trendClassificationJsonNode = jsonNode.get(
+			"trendClassification");
+
+		if (trendClassificationJsonNode != null) {
+			trend.setClassification(
+				() -> Trend.Classification.create(
+					trendClassificationJsonNode.asText()));
+		}
+
+		return trend;
 	}
 
 	private void _renameKey(JsonNode jsonNode, String newKey, String oldKey) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -739,6 +739,12 @@ public class AnalyticsCloudClient {
 		JsonNode pageJsonNode = jsonNode.get("page");
 
 		if (pageJsonNode != null) {
+			JsonNode totalPagesJsonNode = pageJsonNode.get("totalPages");
+
+			if (totalPagesJsonNode != null) {
+				performanceTopAsset.setLastPage(totalPagesJsonNode::asLong);
+			}
+
 			JsonNode pageNumberJsonNode = pageJsonNode.get("number");
 
 			if (pageNumberJsonNode != null) {
@@ -756,12 +762,6 @@ public class AnalyticsCloudClient {
 			if (totalElementsJsonNode != null) {
 				performanceTopAsset.setTotalCount(
 					totalElementsJsonNode::asLong);
-			}
-
-			JsonNode totalPagesJsonNode = pageJsonNode.get("totalPages");
-
-			if (totalPagesJsonNode != null) {
-				performanceTopAsset.setLastPage(totalPagesJsonNode::asLong);
 			}
 		}
 
@@ -837,12 +837,6 @@ public class AnalyticsCloudClient {
 	private Trend _getTrend(JsonNode jsonNode) {
 		Trend trend = new Trend();
 
-		JsonNode percentageJsonNode = jsonNode.get("percentage");
-
-		if (percentageJsonNode != null) {
-			trend.setPercentage(percentageJsonNode::asDouble);
-		}
-
 		JsonNode trendClassificationJsonNode = jsonNode.get(
 			"trendClassification");
 
@@ -850,6 +844,12 @@ public class AnalyticsCloudClient {
 			trend.setClassification(
 				() -> Trend.Classification.create(
 					trendClassificationJsonNode.asText()));
+		}
+
+		JsonNode percentageJsonNode = jsonNode.get("percentage");
+
+		if (percentageJsonNode != null) {
+			trend.setPercentage(percentageJsonNode::asDouble);
 		}
 
 		return trend;

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -739,10 +739,10 @@ public class AnalyticsCloudClient {
 		JsonNode pageJsonNode = jsonNode.get("page");
 
 		if (pageJsonNode != null) {
-			JsonNode totalPagesJsonNode = pageJsonNode.get("totalPages");
+			JsonNode lastPageJsonNode = pageJsonNode.get("totalPages");
 
-			if (totalPagesJsonNode != null) {
-				performanceTopAsset.setLastPage(totalPagesJsonNode::asLong);
+			if (lastPageJsonNode != null) {
+				performanceTopAsset.setLastPage(lastPageJsonNode::asLong);
 			}
 
 			JsonNode pageNumberJsonNode = pageJsonNode.get("number");
@@ -757,11 +757,10 @@ public class AnalyticsCloudClient {
 				performanceTopAsset.setPageSize(pageSizeJsonNode::asLong);
 			}
 
-			JsonNode totalElementsJsonNode = pageJsonNode.get("totalElements");
+			JsonNode totalCountJsonNode = pageJsonNode.get("totalElements");
 
-			if (totalElementsJsonNode != null) {
-				performanceTopAsset.setTotalCount(
-					totalElementsJsonNode::asLong);
+			if (totalCountJsonNode != null) {
+				performanceTopAsset.setTotalCount(totalCountJsonNode::asLong);
 			}
 		}
 
@@ -805,16 +804,16 @@ public class AnalyticsCloudClient {
 		performanceTopAssetItem.setImpressions(
 			() -> _getMetricValue(jsonNode, "impressionsMetric"));
 
-		JsonNode assetTypeJsonNode = jsonNode.get("assetType");
+		JsonNode mimeTypeJsonNode = jsonNode.get("assetType");
 
-		if (assetTypeJsonNode != null) {
-			performanceTopAssetItem.setMimeType(assetTypeJsonNode::asText);
+		if (mimeTypeJsonNode != null) {
+			performanceTopAssetItem.setMimeType(mimeTypeJsonNode::asText);
 		}
 
-		JsonNode assetTitleJsonNode = jsonNode.get("assetTitle");
+		JsonNode titleJsonNode = jsonNode.get("assetTitle");
 
-		if (assetTitleJsonNode != null) {
-			performanceTopAssetItem.setTitle(assetTitleJsonNode::asText);
+		if (titleJsonNode != null) {
+			performanceTopAssetItem.setTitle(titleJsonNode::asText);
 		}
 
 		JsonNode engagementMetricJsonNode = jsonNode.get("engagementMetric");

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/BasePerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/BasePerformanceTopAssetResourceImpl.java
@@ -1,0 +1,563 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.internal.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceTopAsset;
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceTopAssetResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BasePerformanceTopAssetResourceImpl
+	implements EntityModelResource, PerformanceTopAssetResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/analytics-cms-rest/v1.0/performance-top-asset'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "assetFilter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "depotEntryIds"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "rangeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "PerformanceTopAsset"
+			)
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/performance-top-asset")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public PerformanceTopAsset getPerformanceTopAsset(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("assetFilter")
+			String assetFilter,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("depotEntryIds")
+			Long[] depotEntryIds,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("rangeKey")
+			Integer rangeKey,
+			@jakarta.ws.rs.core.Context Pagination pagination,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
+		throws Exception {
+
+		return new PerformanceTopAsset();
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "analytics-cms-rest";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BasePerformanceTopAssetResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1825283813

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -109,9 +109,11 @@ public class OpenAPIResourceImpl {
 
 			add(PerformanceOverviewMetricResourceImpl.class);
 
+			add(PerformanceTopAssetResourceImpl.class);
+
 			add(OpenAPIResourceImpl.class);
 		}
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:312172984
+// LIFERAY-REST-BUILDER-HASH:-749743319

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
@@ -5,9 +5,20 @@
 
 package com.liferay.analytics.cms.rest.internal.resource.v1_0;
 
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceTopAsset;
+import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
+import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceTopAssetResource;
+import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.Arrays;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -19,4 +30,33 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 public class PerformanceTopAssetResourceImpl
 	extends BasePerformanceTopAssetResourceImpl {
+
+	@Override
+	public PerformanceTopAsset getPerformanceTopAsset(
+			String assetFilter, Long[] depotEntryIds, Integer rangeKey,
+			Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		LicenseManagerUtil.checkFreeTier();
+
+		Long[] groupIds = DepotEntryUtil.getGroupIds(
+			DepotEntryUtil.getDepotEntries(
+				contextCompany.getCompanyId(), depotEntryIds));
+
+		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
+			_http);
+
+		return analyticsCloudClient.getPerformanceTopAsset(
+			_analyticsSettingsManager.getAnalyticsConfiguration(
+				contextCompany.getCompanyId()),
+			assetFilter, Arrays.asList(groupIds), pagination.getPage(),
+			rangeKey, pagination.getPageSize(), sorts);
+	}
+
+	@Reference
+	private AnalyticsSettingsManager _analyticsSettingsManager;
+
+	@Reference
+	private Http _http;
+
 }

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.internal.resource.v1_0;
+
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceTopAssetResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Rachael Koestartyo
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/performance-top-asset.properties",
+	scope = ServiceScope.PROTOTYPE, service = PerformanceTopAssetResource.class
+)
+public class PerformanceTopAssetResourceImpl
+	extends BasePerformanceTopAssetResourceImpl {
+}

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/factory/PerformanceTopAssetResourceFactoryImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/factory/PerformanceTopAssetResourceFactoryImpl.java
@@ -1,0 +1,338 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.internal.resource.v1_0.factory;
+
+import com.liferay.analytics.cms.rest.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceTopAssetResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/analytics-cms-rest/v1.0/PerformanceTopAsset",
+	service = PerformanceTopAssetResource.Factory.class
+)
+@Generated("")
+public class PerformanceTopAssetResourceFactoryImpl
+	implements PerformanceTopAssetResource.Factory {
+
+	@Override
+	public PerformanceTopAssetResource.Builder create() {
+		return new PerformanceTopAssetResource.Builder() {
+
+			@Override
+			public PerformanceTopAssetResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, PerformanceTopAssetResource>
+					performanceTopAssetResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_performanceTopAssetResourceProxyProviderFunction;
+
+				return performanceTopAssetResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public PerformanceTopAssetResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceTopAssetResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceTopAssetResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceTopAssetResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceTopAssetResource.Builder uriInfo(
+				UriInfo uriInfo) {
+
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public PerformanceTopAssetResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, PerformanceTopAssetResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			PerformanceTopAssetResource.class.getClassLoader(),
+			PerformanceTopAssetResource.class);
+
+		try {
+			Constructor<PerformanceTopAssetResource> constructor =
+				(Constructor<PerformanceTopAssetResource>)
+					proxyClass.getConstructor(InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		PerformanceTopAssetResource performanceTopAssetResource =
+			_componentServiceObjects.getService();
+
+		performanceTopAssetResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		performanceTopAssetResource.setContextCompany(company);
+
+		performanceTopAssetResource.setContextHttpServletRequest(
+			httpServletRequest);
+		performanceTopAssetResource.setContextHttpServletResponse(
+			httpServletResponse);
+		performanceTopAssetResource.setContextUriInfo(uriInfo);
+		performanceTopAssetResource.setContextUser(user);
+		performanceTopAssetResource.setExpressionConvert(_expressionConvert);
+		performanceTopAssetResource.setFilterParserProvider(
+			_filterParserProvider);
+		performanceTopAssetResource.setGroupLocalService(_groupLocalService);
+		performanceTopAssetResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		performanceTopAssetResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		performanceTopAssetResource.setRoleLocalService(_roleLocalService);
+		performanceTopAssetResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(performanceTopAssetResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(performanceTopAssetResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<PerformanceTopAssetResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function
+			<InvocationHandler, PerformanceTopAssetResource>
+				_performanceTopAssetResourceProxyProviderFunction =
+					_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1250273519

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/performance-top-asset.properties
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/performance-top-asset.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.analytics.cms.rest.dto.v1_0.PerformanceTopAsset
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Analytics.CMS.REST)
+osgi.jaxrs.resource=true

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceTopAssetResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceTopAssetResourceTestCase.java
@@ -1,0 +1,905 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceTopAsset;
+import com.liferay.analytics.cms.rest.client.http.HttpInvoker;
+import com.liferay.analytics.cms.rest.client.pagination.Page;
+import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceTopAssetResource;
+import com.liferay.analytics.cms.rest.client.serdes.v1_0.PerformanceTopAssetSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Rachael Koestartyo
+ * @generated
+ */
+@Generated("")
+public abstract class BasePerformanceTopAssetResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_performanceTopAssetResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		performanceTopAssetResource = PerformanceTopAssetResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		PerformanceTopAsset performanceTopAsset1 = randomPerformanceTopAsset();
+
+		String json = objectMapper.writeValueAsString(performanceTopAsset1);
+
+		PerformanceTopAsset performanceTopAsset2 =
+			PerformanceTopAssetSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(performanceTopAsset1, performanceTopAsset2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		PerformanceTopAsset performanceTopAsset = randomPerformanceTopAsset();
+
+		String json1 = objectMapper.writeValueAsString(performanceTopAsset);
+		String json2 = PerformanceTopAssetSerDes.toJSON(performanceTopAsset);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		PerformanceTopAsset performanceTopAsset = randomPerformanceTopAsset();
+
+		String json = PerformanceTopAssetSerDes.toJSON(performanceTopAsset);
+
+		Assert.assertFalse(json.contains(regex));
+
+		performanceTopAsset = PerformanceTopAssetSerDes.toDTO(json);
+	}
+
+	@Test
+	public void testGetPerformanceTopAsset() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	protected void assertContains(
+		PerformanceTopAsset performanceTopAsset,
+		List<PerformanceTopAsset> performanceTopAssets) {
+
+		boolean contains = false;
+
+		for (PerformanceTopAsset item : performanceTopAssets) {
+			if (equals(performanceTopAsset, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			performanceTopAssets + " does not contain " + performanceTopAsset,
+			contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		PerformanceTopAsset performanceTopAsset1,
+		PerformanceTopAsset performanceTopAsset2) {
+
+		Assert.assertTrue(
+			performanceTopAsset1 + " does not equal " + performanceTopAsset2,
+			equals(performanceTopAsset1, performanceTopAsset2));
+	}
+
+	protected void assertEquals(
+		List<PerformanceTopAsset> performanceTopAssets1,
+		List<PerformanceTopAsset> performanceTopAssets2) {
+
+		Assert.assertEquals(
+			performanceTopAssets1.size(), performanceTopAssets2.size());
+
+		for (int i = 0; i < performanceTopAssets1.size(); i++) {
+			PerformanceTopAsset performanceTopAsset1 =
+				performanceTopAssets1.get(i);
+			PerformanceTopAsset performanceTopAsset2 =
+				performanceTopAssets2.get(i);
+
+			assertEquals(performanceTopAsset1, performanceTopAsset2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<PerformanceTopAsset> performanceTopAssets1,
+		List<PerformanceTopAsset> performanceTopAssets2) {
+
+		Assert.assertEquals(
+			performanceTopAssets1.size(), performanceTopAssets2.size());
+
+		for (PerformanceTopAsset performanceTopAsset1 : performanceTopAssets1) {
+			boolean contains = false;
+
+			for (PerformanceTopAsset performanceTopAsset2 :
+					performanceTopAssets2) {
+
+				if (equals(performanceTopAsset1, performanceTopAsset2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				performanceTopAssets2 + " does not contain " +
+					performanceTopAsset1,
+				contains);
+		}
+	}
+
+	protected void assertValid(PerformanceTopAsset performanceTopAsset)
+		throws Exception {
+
+		boolean valid = true;
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("lastPage", additionalAssertFieldName)) {
+				if (performanceTopAsset.getLastPage() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("page", additionalAssertFieldName)) {
+				if (performanceTopAsset.getPage() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("pageSize", additionalAssertFieldName)) {
+				if (performanceTopAsset.getPageSize() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"performanceTopAssetItems", additionalAssertFieldName)) {
+
+				if (performanceTopAsset.getPerformanceTopAssetItems() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("totalCount", additionalAssertFieldName)) {
+				if (performanceTopAsset.getTotalCount() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<PerformanceTopAsset> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<PerformanceTopAsset> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<PerformanceTopAsset> performanceTopAssets =
+			page.getItems();
+
+		int size = performanceTopAssets.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.analytics.cms.rest.dto.v1_0.PerformanceTopAsset.
+						class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		PerformanceTopAsset performanceTopAsset1,
+		PerformanceTopAsset performanceTopAsset2) {
+
+		if (performanceTopAsset1 == performanceTopAsset2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("lastPage", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						performanceTopAsset1.getLastPage(),
+						performanceTopAsset2.getLastPage())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("page", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						performanceTopAsset1.getPage(),
+						performanceTopAsset2.getPage())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("pageSize", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						performanceTopAsset1.getPageSize(),
+						performanceTopAsset2.getPageSize())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"performanceTopAssetItems", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						performanceTopAsset1.getPerformanceTopAssetItems(),
+						performanceTopAsset2.getPerformanceTopAssetItems())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("totalCount", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						performanceTopAsset1.getTotalCount(),
+						performanceTopAsset2.getTotalCount())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_performanceTopAssetResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_performanceTopAssetResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		PerformanceTopAsset performanceTopAsset) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("lastPage")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("page")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("pageSize")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("performanceTopAssetItems")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("totalCount")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected PerformanceTopAsset randomPerformanceTopAsset() throws Exception {
+		return new PerformanceTopAsset() {
+			{
+				lastPage = RandomTestUtil.randomLong();
+				page = RandomTestUtil.randomLong();
+				pageSize = RandomTestUtil.randomLong();
+				totalCount = RandomTestUtil.randomLong();
+			}
+		};
+	}
+
+	protected PerformanceTopAsset randomIrrelevantPerformanceTopAsset()
+		throws Exception {
+
+		PerformanceTopAsset randomIrrelevantPerformanceTopAsset =
+			randomPerformanceTopAsset();
+
+		return randomIrrelevantPerformanceTopAsset;
+	}
+
+	protected PerformanceTopAsset randomPatchPerformanceTopAsset()
+		throws Exception {
+
+		return randomPerformanceTopAsset();
+	}
+
+	protected PerformanceTopAssetResource performanceTopAssetResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BasePerformanceTopAssetResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private
+		com.liferay.analytics.cms.rest.resource.v1_0.PerformanceTopAssetResource
+			_performanceTopAssetResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1098663781

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -15,7 +15,6 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
@@ -23,7 +22,6 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.MockHttp;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -45,14 +43,11 @@ import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import jakarta.ws.rs.BadRequestException;
 
-import java.io.IOException;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -390,28 +385,5 @@ public class PerformanceAssetConsumptionResourceTest
 	@Inject
 	private PerformanceAssetConsumptionResource
 		_performanceAssetConsumptionResource;
-
-	private static class RecordingMockHttp extends MockHttp {
-
-		public RecordingMockHttp(
-			Map<String, UnsafeSupplier<String, Exception>> unsafeSuppliers) {
-
-			super(unsafeSuppliers);
-		}
-
-		public String getLocation() {
-			return _location;
-		}
-
-		@Override
-		public String URLtoString(Http.Options options) throws IOException {
-			_location = options.getLocation();
-
-			return super.URLtoString(options);
-		}
-
-		private String _location;
-
-	}
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
@@ -14,7 +14,6 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.petra.function.UnsafeFunction;
-import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
@@ -22,7 +21,6 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.MockHttp;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -39,13 +37,10 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.ws.rs.BadRequestException;
 
-import java.io.IOException;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -235,28 +230,5 @@ public class PerformanceMetricResourceTest
 
 	@Inject
 	private PerformanceMetricResource _performanceMetricResource;
-
-	private static class RecordingMockHttp extends MockHttp {
-
-		public RecordingMockHttp(
-			Map<String, UnsafeSupplier<String, Exception>> unsafeSuppliersMap) {
-
-			super(unsafeSuppliersMap);
-		}
-
-		public String getLocation() {
-			return _location;
-		}
-
-		@Override
-		public String URLtoString(Http.Options options) throws IOException {
-			_location = options.getLocation();
-
-			return super.URLtoString(options);
-		}
-
-		private String _location;
-
-	}
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -11,7 +11,6 @@ import com.liferay.analytics.cms.rest.dto.v1_0.Trend;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceTopAssetResource;
 import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
@@ -19,7 +18,6 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.util.MockHttp;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
@@ -30,11 +28,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
-import java.io.IOException;
-
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -249,28 +244,5 @@ public class PerformanceTopAssetResourceTest
 
 	@Inject
 	private PerformanceTopAssetResource _performanceTopAssetResource;
-
-	private static class RecordingMockHttp extends MockHttp {
-
-		public RecordingMockHttp(
-			Map<String, UnsafeSupplier<String, Exception>> unsafeSuppliers) {
-
-			super(unsafeSuppliers);
-		}
-
-		public String getLocation() {
-			return _location;
-		}
-
-		@Override
-		public String URLtoString(Http.Options options) throws IOException {
-			_location = options.getLocation();
-
-			return super.URLtoString(options);
-		}
-
-		private String _location;
-
-	}
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rachael Koestartyo
+ */
+@Ignore
+@RunWith(Arquillian.class)
+public class PerformanceTopAssetResourceTest
+	extends BasePerformanceTopAssetResourceTestCase {
+}

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -5,16 +5,272 @@
 
 package com.liferay.analytics.cms.rest.resource.v1_0.test;
 
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceTopAsset;
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceTopAssetItem;
+import com.liferay.analytics.cms.rest.dto.v1_0.Trend;
+import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceTopAssetResource;
+import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.MockHttp;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.URLCodec;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
-import org.junit.Ignore;
+import java.io.IOException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Rachael Koestartyo
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class PerformanceTopAssetResourceTest
 	extends BasePerformanceTopAssetResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Override
+	@Test
+	public void testGetPerformanceTopAsset() throws Exception {
+		String dataSourceId = RandomTestUtil.randomString();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						AnalyticsConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsDataSourceId", dataSourceId
+						).put(
+							"liferayAnalyticsEnableAllGroupIds", true
+						).put(
+							"liferayAnalyticsFaroBackendSecuritySignature",
+							RandomTestUtil.randomString()
+						).put(
+							"liferayAnalyticsFaroBackendURL",
+							"http://" + RandomTestUtil.randomString()
+						).build())) {
+
+			_testGetPerformanceTopAssetResponse();
+			_testGetPerformanceTopAssetURL(dataSourceId);
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				_performanceTopAssetResource, "_http", _http);
+		}
+	}
+
+	private void _assertParameter(
+		String expectedValue, String name, String url) {
+
+		Assert.assertEquals(
+			expectedValue,
+			URLCodec.decodeURL(
+				HttpComponentsUtil.getParameter(url, name, false)));
+	}
+
+	private RecordingMockHttp _setUpRecordingMockHttp(String json) {
+		RecordingMockHttp recordingMockHttp = new RecordingMockHttp(
+			Collections.singletonMap(
+				"/api/1.0/asset-metric/objectEntry/summaries", () -> json));
+
+		ReflectionTestUtil.setFieldValue(
+			_performanceTopAssetResource, "_http", recordingMockHttp);
+
+		return recordingMockHttp;
+	}
+
+	private void _testGetPerformanceTopAssetResponse() throws Exception {
+		String assetTitle = RandomTestUtil.randomString();
+		String assetType = RandomTestUtil.randomString();
+		int downloads = RandomTestUtil.nextInt();
+		double engagement = RandomTestUtil.nextDouble();
+		double engagementTrend = RandomTestUtil.nextDouble();
+		int impressions = RandomTestUtil.nextInt();
+		int lastPage = RandomTestUtil.nextInt();
+		int page = RandomTestUtil.nextInt();
+		int pageSize = RandomTestUtil.nextInt();
+		int totalCount = RandomTestUtil.nextInt();
+		int views = RandomTestUtil.nextInt();
+
+		_setUpRecordingMockHttp(
+			JSONUtil.put(
+				"_embedded",
+				JSONUtil.put(
+					"assetSummaryMetrics",
+					JSONUtil.putAll(
+						JSONUtil.put(
+							"assetTitle", assetTitle
+						).put(
+							"assetType", assetType
+						).put(
+							"downloadsMetric", JSONUtil.put("value", downloads)
+						).put(
+							"engagementMetric",
+							JSONUtil.put(
+								"trend",
+								JSONUtil.put(
+									"percentage", engagementTrend
+								).put(
+									"trendClassification", "POSITIVE"
+								)
+							).put(
+								"value", engagement
+							)
+						).put(
+							"impressionsMetric",
+							JSONUtil.put("value", impressions)
+						).put(
+							"viewsMetric", JSONUtil.put("value", views)
+						)))
+			).put(
+				"page",
+				JSONUtil.put(
+					"number", page
+				).put(
+					"size", pageSize
+				).put(
+					"totalElements", totalCount
+				).put(
+					"totalPages", lastPage
+				)
+			).toString());
+
+		PerformanceTopAsset performanceTopAsset =
+			_performanceTopAssetResource.getPerformanceTopAsset(
+				RandomTestUtil.randomString(), null, RandomTestUtil.nextInt(),
+				Pagination.of(page, pageSize), null);
+
+		Assert.assertEquals(lastPage, (long)performanceTopAsset.getLastPage());
+		Assert.assertEquals(page, (long)performanceTopAsset.getPage());
+		Assert.assertEquals(pageSize, (long)performanceTopAsset.getPageSize());
+		Assert.assertEquals(
+			totalCount, (long)performanceTopAsset.getTotalCount());
+
+		PerformanceTopAssetItem[] performanceTopAssetItems =
+			performanceTopAsset.getPerformanceTopAssetItems();
+
+		Assert.assertEquals(
+			Arrays.toString(performanceTopAssetItems), 1,
+			performanceTopAssetItems.length);
+
+		PerformanceTopAssetItem performanceTopAssetItem =
+			performanceTopAssetItems[0];
+
+		Assert.assertEquals(
+			downloads, performanceTopAssetItem.getDownloads(), 0);
+		Assert.assertEquals(
+			engagement, performanceTopAssetItem.getEngagement(), 0);
+		Assert.assertEquals(
+			impressions, performanceTopAssetItem.getImpressions(), 0);
+		Assert.assertEquals(assetType, performanceTopAssetItem.getMimeType());
+		Assert.assertEquals(assetTitle, performanceTopAssetItem.getTitle());
+
+		Trend trend = performanceTopAssetItem.getTrend();
+
+		Assert.assertEquals(
+			Trend.Classification.POSITIVE.toString(),
+			String.valueOf(trend.getClassification()));
+		Assert.assertEquals(engagementTrend, trend.getPercentage(), 0);
+
+		Assert.assertEquals(views, performanceTopAssetItem.getViews(), 0);
+	}
+
+	private void _testGetPerformanceTopAssetURL(String dataSourceId)
+		throws Exception {
+
+		RecordingMockHttp recordingMockHttp = _setUpRecordingMockHttp("{}");
+
+		String assetFilter = RandomTestUtil.randomString();
+		int page = RandomTestUtil.nextInt();
+		int pageSize = RandomTestUtil.nextInt();
+		int rangeKey = RandomTestUtil.nextInt();
+
+		Sort[] sorts = {
+			new Sort(RandomTestUtil.randomString(), true),
+			new Sort(RandomTestUtil.randomString(), false)
+		};
+
+		_performanceTopAssetResource.getPerformanceTopAsset(
+			assetFilter, null, rangeKey, Pagination.of(page, pageSize), sorts);
+
+		String location = recordingMockHttp.getLocation();
+
+		_assertParameter(dataSourceId, "dataSourceId", location);
+		_assertParameter(assetFilter, "filter", location);
+		_assertParameter(String.valueOf(page), "page", location);
+		_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
+		_assertParameter(String.valueOf(pageSize), "size", location);
+
+		StringBundler sb = new StringBundler();
+
+		for (int i = 0; i < sorts.length; i++) {
+			if (i > 0) {
+				sb.append(StringPool.COMMA);
+			}
+
+			sb.append(sorts[i].getFieldName());
+			sb.append(StringPool.COLON);
+			sb.append(sorts[i].isReverse() ? "desc" : "asc");
+		}
+
+		_assertParameter(sb.toString(), "sort", location);
+	}
+
+	@Inject
+	private Http _http;
+
+	@Inject
+	private PerformanceTopAssetResource _performanceTopAssetResource;
+
+	private static class RecordingMockHttp extends MockHttp {
+
+		public RecordingMockHttp(
+			Map<String, UnsafeSupplier<String, Exception>> unsafeSuppliers) {
+
+			super(unsafeSuppliers);
+		}
+
+		public String getLocation() {
+			return _location;
+		}
+
+		@Override
+		public String URLtoString(Http.Options options) throws IOException {
+			_location = options.getLocation();
+
+			return super.URLtoString(options);
+		}
+
+		private String _location;
+
+	}
+
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/RecordingMockHttp.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/RecordingMockHttp.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.resource.v1_0.test;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.portal.kernel.test.util.MockHttp;
+import com.liferay.portal.kernel.util.Http;
+
+import java.io.IOException;
+
+import java.util.Map;
+
+/**
+ * @author Rachael Koestartyo
+ */
+public class RecordingMockHttp extends MockHttp {
+
+	public RecordingMockHttp(
+		Map<String, UnsafeSupplier<String, Exception>> unsafeSuppliers) {
+
+		super(unsafeSuppliers);
+	}
+
+	public String getLocation() {
+		return _location;
+	}
+
+	@Override
+	public String URLtoString(Http.Options options) throws IOException {
+		_location = options.getLocation();
+
+		return super.URLtoString(options);
+	}
+
+	private String _location;
+
+}

--- a/modules/apps/analytics/source-formatter-suppressions.xml
+++ b/modules/apps/analytics/source-formatter-suppressions.xml
@@ -10,5 +10,6 @@
 		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest\.java" />
 		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest\.java" />
 		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest\.java" />
+		<suppress checks="ResourceTestInjectionCheck" files="analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest\.java" />
 	</checkstyle>
 </suppressions>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92419

## What Is Being Fixed

The Analytics CMS REST API had no endpoint for retrieving the top performing assets, so the content performance top assets card had no backend to source its data from.

## How It Is Being Fixed

This adds a new `/performance-top-asset` GET operation to the Analytics CMS REST API, defined in `rest-openapi.yaml` along with the `PerformanceTopAsset` and `PerformanceTopAssetItem` schemas, and regenerates the API, client, and test scaffolding with REST Builder.

The resource is backed by `AnalyticsCloudClient.getPerformanceTopAsset`, which calls the Analytics Cloud (Faro) backend `/summaries` endpoint with the asset filter, group IDs, pagination, range key, and sort parameters. It maps the backend HAL response into the `PerformanceTopAsset` DTO: the paging fields come from the `page` object, and the list of `PerformanceTopAssetItem` (downloads, engagement, impressions, MIME type, title, trend, and views) comes from `_embedded`, with each item engagement trend mapped to a classification and percentage. `PerformanceTopAssetResourceImpl` resolves the depot entries to group IDs, enforces the free tier license check, and forwards pagination and sorts to the client. The integration tests share a single `RecordingMockHttp` helper for asserting the outgoing request URLs.

## PR Check

**pr-check: PASS** — tested on `aaa7d829262351348daca36c1ba7b36564ffc5d6`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "aaa7d829262351348daca36c1ba7b36564ffc5d6"} -->
