### PR TITLE
LPD-33985 Fix blank segment page for special characters in criteria

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/__tests__/odata.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/__tests__/odata.js
@@ -648,6 +648,36 @@ describe('odata', () => {
 
 			testConversionToAndFrom(testQuery);
 		});
+
+		it('should be able to translate a query string with a backtick in the value to map and back to string', () => {
+			const testQuery = "(givenName eq '`test`')";
+
+			testConversionToAndFrom(testQuery);
+		});
+
+		it('should be able to translate a query string with a caret in the value to map and back to string', () => {
+			const testQuery = "(givenName eq 'te^st')";
+
+			testConversionToAndFrom(testQuery);
+		});
+
+		it('should be able to translate a query string with braces in the value to map and back to string', () => {
+			const testQuery = "(givenName eq '{test}')";
+
+			testConversionToAndFrom(testQuery);
+		});
+
+		it('should be able to translate a query string with a pipe in the value to map and back to string', () => {
+			const testQuery = "(givenName eq 'te|st')";
+
+			testConversionToAndFrom(testQuery);
+		});
+
+		it('should be able to translate a query string with a single quote in the value to map and back to string', () => {
+			const testQuery = "(givenName eq 'O''Brien')";
+
+			testConversionToAndFrom(testQuery);
+		});
 	});
 
 	describe('vocabularies.filterByCount', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/odata.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/odata.ts
@@ -97,6 +97,18 @@ const FARO_SPECIAL_CHARS = {
 		encoded: '_FARO_AT_',
 		raw: '@',
 	},
+	backtick: {
+		encoded: '_FARO_BACKTICK_',
+		raw: '`',
+	},
+	braceLeft: {
+		encoded: '_FARO_LEFT_BRACE_',
+		raw: '{',
+	},
+	braceRight: {
+		encoded: '_FARO_RIGHT_BRACE_',
+		raw: '}',
+	},
 	bracketLeft: {
 		encoded: '_FARO_LEFT_BRACKET_',
 		raw: '[',
@@ -104,6 +116,10 @@ const FARO_SPECIAL_CHARS = {
 	bracketRight: {
 		encoded: '_FARO_RIGHT_BRACKET_',
 		raw: ']',
+	},
+	caret: {
+		encoded: '_FARO_CARET_',
+		raw: '^',
 	},
 	dash: {
 		encoded: '_FARO_DASH_',
@@ -128,6 +144,10 @@ const FARO_SPECIAL_CHARS = {
 	percent: {
 		encoded: '_FARO_PERCENT_',
 		raw: '%',
+	},
+	pipe: {
+		encoded: '_FARO_PIPE_',
+		raw: '|',
 	},
 	plus: {
 		encoded: '_FARO_PLUS_',
@@ -429,7 +449,7 @@ const encodeQuotes = (text: string): string => text.replace(/'/g, '%27');
  * Encode certain special characters with our own encoding.
  */
 const encodeSpecialCharacters = (queryString: string): string => {
-	const charsNeedEscaped = ['+', '?', '$', '[', ']'];
+	const charsNeedEscaped = ['+', '?', '$', '[', ']', '^', '{', '}', '|'];
 	const specialCharactersArr = Object.values(FARO_SPECIAL_CHARS);
 
 	const specialCharsPattern = specialCharactersArr


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-33985
https://liferay.atlassian.net/browse/LPD-33897

## What Is Being Fixed

Creating a segment whose criteria value contains a backtick (`) left the segment page blank: the saved criteria could no longer be displayed or edited. The same crash happened for a caret (^), braces ({ }), or a pipe (|) in the value (LPD-33985). A related report tracked single quotes being dropped from the criteria (LPD-33897).

## How It Is Being Fixed

When a saved segment's criteria string is translated back into the criteria builder it is fed to the OData parser, which rejects several characters inside a string literal. The code already works around this by pre-encoding those characters through FARO_SPECIAL_CHARS before parsing and decoding them afterwards, but the backtick, caret, braces, and pipe were missing from that map, so parsing threw, translateQueryToCriteria returned null, and the criteria card rendered nothing. These characters are added to the encoding map, and the regex-reserved ones to the escape list. The backslash and double quote are intentionally left out: they are not valid unescaped inside a JSON string and would break the JSON.parse step the decoding relies on, and the double quote already has its own %22-based handling. Single quotes (LPD-33897) already round-trip correctly on master through the existing '' escaping; this change adds regression coverage for them alongside the new characters.

## PR Check

**pr-check: PASS** — tested on `f41ce81fba259d4bbf86ee64976006b25c223a6f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f41ce81fba259d4bbf86ee64976006b25c223a6f"} -->
