### PR TITLE
LPD-55870 Fix unusable date-of-birth segment left at default date

### DIFF
--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/utils/utils.ts
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/utils/utils.ts
@@ -184,14 +184,5 @@ export function jsDatetoYYYYMMDD(dateJsObject: string | Date) {
 		dateJsObject = new Date(dateJsObject as string);
 	}
 
-	const intl = new Intl.DateTimeFormat(
-		Liferay.ThemeDisplay.getBCP47LanguageId(),
-		{
-			day: '2-digit',
-			month: '2-digit',
-			year: 'numeric',
-		}
-	);
-
-	return intl.format(dateJsObject as Date);
+	return dateUtils.format(dateJsObject as Date, 'yyyy-MM-dd');
 }

--- a/modules/apps/segments/segments-web/test/js/utils/utils.es.js
+++ b/modules/apps/segments/segments-web/test/js/utils/utils.es.js
@@ -79,6 +79,20 @@ describe('utils', () => {
 		});
 	});
 
+	describe('jsDatetoYYYYMMDD', () => {
+		it('formats a Date object as a yyyy-MM-dd string', () => {
+			expect(
+				Utils.jsDatetoYYYYMMDD(new Date('2026-01-05T12:00:00.000Z'))
+			).toEqual('2026-01-05');
+		});
+
+		it('formats a date string as a yyyy-MM-dd string', () => {
+			expect(Utils.jsDatetoYYYYMMDD('2026-01-05T12:00:00.000Z')).toEqual(
+				'2026-01-05'
+			);
+		});
+	});
+
 	describe('objectToFormData', () => {
 		it('takes an object of key value pairs and return a form data object with the same values', () => {
 			const testData = {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-55870

## What Is Being Fixed

A segment with a date property (such as Date of Birth) becomes unusable when the date is left at its default value. The condition matches zero members, and after saving, reopening the segment fails with "The segment is no longer available." Setting the date to any explicit past value works around it.

## How It Is Being Fixed

The default value for a date criterion is produced by jsDatetoYYYYMMDD. Since LPD-45592 swapped date-fns for Intl.DateTimeFormat, the function returned a locale-formatted string (for example 06/23/2026) instead of a yyyy-MM-dd date literal, which is not valid OData. The malformed filter both matched no members and could not be parsed back when reopening the segment. The function now formats with dateUtils.format(date, 'yyyy-MM-dd'), restoring the valid literal it returned before that migration without reintroducing date-fns. The localized display is unaffected, as it is handled separately by dateToInternationalHuman.

## PR Check

**pr-check: PASS** — tested on `853635b3d98d7348c811c505317447a3253549a5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "853635b3d98d7348c811c505317447a3253549a5"} -->
