### PR TITLE
LPD-92420 Add CSV export endpoints to the Analytics CMS REST API

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/resource/v1_0/PerformanceMetricResource.java
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/resource/v1_0/PerformanceMetricResource.java
@@ -20,6 +20,7 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collections;
@@ -42,6 +43,11 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface PerformanceMetricResource {
 
 	public PerformanceMetric getPerformanceMetric(
+			Long[] depotEntryIds, String groupBy, String metricType,
+			Integer rangeKey)
+		throws Exception;
+
+	public Response getPerformanceMetricExport(
 			Long[] depotEntryIds, String groupBy, String metricType,
 			Integer rangeKey)
 		throws Exception;
@@ -134,4 +140,4 @@ public interface PerformanceMetricResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-10594854
+// LIFERAY-REST-BUILDER-HASH:-213412740

--- a/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/resource/v1_0/PerformanceTopAssetResource.java
+++ b/modules/apps/analytics/analytics-cms-rest-api/src/main/java/com/liferay/analytics/cms/rest/resource/v1_0/PerformanceTopAssetResource.java
@@ -21,6 +21,7 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collections;
@@ -43,8 +44,13 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface PerformanceTopAssetResource {
 
 	public PerformanceTopAsset getPerformanceTopAsset(
-			String assetFilter, Long[] depotEntryIds, Integer rangeKey,
+			String assetFilterString, Long[] depotEntryIds, Integer rangeKey,
 			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
+	public Response getPerformanceTopAssetExport(
+			String assetFilterString, Long[] depotEntryIds, Integer rangeKey,
 			com.liferay.portal.kernel.search.Sort[] sorts)
 		throws Exception;
 
@@ -136,4 +142,4 @@ public interface PerformanceTopAssetResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-853044339
+// LIFERAY-REST-BUILDER-HASH:476736702

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/resource/v1_0/PerformanceMetricResource.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/resource/v1_0/PerformanceMetricResource.java
@@ -42,6 +42,16 @@ public interface PerformanceMetricResource {
 			Integer rangeKey)
 		throws Exception;
 
+	public void getPerformanceMetricExport(
+			Long[] depotEntryIds, String groupBy, String metricType,
+			Integer rangeKey)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getPerformanceMetricExportHttpResponse(
+			Long[] depotEntryIds, String groupBy, String metricType,
+			Integer rangeKey)
+		throws Exception;
+
 	public static class Builder {
 
 		public Builder authentication(String login, String password) {
@@ -277,6 +287,121 @@ public interface PerformanceMetricResource {
 			return httpInvoker.invoke();
 		}
 
+		public void getPerformanceMetricExport(
+				Long[] depotEntryIds, String groupBy, String metricType,
+				Integer rangeKey)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getPerformanceMetricExportHttpResponse(
+					depotEntryIds, groupBy, metricType, rangeKey);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse getPerformanceMetricExportHttpResponse(
+				Long[] depotEntryIds, String groupBy, String metricType,
+				Integer rangeKey)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (depotEntryIds != null) {
+				for (int i = 0; i < depotEntryIds.length; i++) {
+					httpInvoker.parameter(
+						"depotEntryIds", String.valueOf(depotEntryIds[i]));
+				}
+			}
+
+			if (groupBy != null) {
+				httpInvoker.parameter("groupBy", String.valueOf(groupBy));
+			}
+
+			if (metricType != null) {
+				httpInvoker.parameter("metricType", String.valueOf(metricType));
+			}
+
+			if (rangeKey != null) {
+				httpInvoker.parameter("rangeKey", String.valueOf(rangeKey));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/analytics-cms-rest/v1.0/performance-metric/export");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		private PerformanceMetricResourceImpl(Builder builder) {
 			_builder = builder;
 		}
@@ -289,4 +414,4 @@ public interface PerformanceMetricResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1998125767
+// LIFERAY-REST-BUILDER-HASH:-1713701081

--- a/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/resource/v1_0/PerformanceTopAssetResource.java
+++ b/modules/apps/analytics/analytics-cms-rest-client/src/main/java/com/liferay/analytics/cms/rest/client/resource/v1_0/PerformanceTopAssetResource.java
@@ -34,13 +34,23 @@ public interface PerformanceTopAssetResource {
 	}
 
 	public PerformanceTopAsset getPerformanceTopAsset(
-			String assetFilter, Long[] depotEntryIds, Integer rangeKey,
+			String assetFilterString, Long[] depotEntryIds, Integer rangeKey,
 			Pagination pagination, String sortString)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse getPerformanceTopAssetHttpResponse(
-			String assetFilter, Long[] depotEntryIds, Integer rangeKey,
+			String assetFilterString, Long[] depotEntryIds, Integer rangeKey,
 			Pagination pagination, String sortString)
+		throws Exception;
+
+	public void getPerformanceTopAssetExport(
+			String assetFilterString, Long[] depotEntryIds, Integer rangeKey,
+			String sortString)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getPerformanceTopAssetExportHttpResponse(
+			String assetFilterString, Long[] depotEntryIds, Integer rangeKey,
+			String sortString)
 		throws Exception;
 
 	public static class Builder {
@@ -153,13 +163,13 @@ public interface PerformanceTopAssetResource {
 		implements PerformanceTopAssetResource {
 
 		public PerformanceTopAsset getPerformanceTopAsset(
-				String assetFilter, Long[] depotEntryIds, Integer rangeKey,
-				Pagination pagination, String sortString)
+				String assetFilterString, Long[] depotEntryIds,
+				Integer rangeKey, Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				getPerformanceTopAssetHttpResponse(
-					assetFilter, depotEntryIds, rangeKey, pagination,
+					assetFilterString, depotEntryIds, rangeKey, pagination,
 					sortString);
 
 			String content = httpResponse.getContent();
@@ -222,8 +232,8 @@ public interface PerformanceTopAssetResource {
 		}
 
 		public HttpInvoker.HttpResponse getPerformanceTopAssetHttpResponse(
-				String assetFilter, Long[] depotEntryIds, Integer rangeKey,
-				Pagination pagination, String sortString)
+				String assetFilterString, Long[] depotEntryIds,
+				Integer rangeKey, Pagination pagination, String sortString)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -247,9 +257,9 @@ public interface PerformanceTopAssetResource {
 
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
 
-			if (assetFilter != null) {
+			if (assetFilterString != null) {
 				httpInvoker.parameter(
-					"assetFilter", String.valueOf(assetFilter));
+					"assetFilterString", String.valueOf(assetFilterString));
 			}
 
 			if (depotEntryIds != null) {
@@ -287,6 +297,123 @@ public interface PerformanceTopAssetResource {
 			return httpInvoker.invoke();
 		}
 
+		public void getPerformanceTopAssetExport(
+				String assetFilterString, Long[] depotEntryIds,
+				Integer rangeKey, String sortString)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getPerformanceTopAssetExportHttpResponse(
+					assetFilterString, depotEntryIds, rangeKey, sortString);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getPerformanceTopAssetExportHttpResponse(
+					String assetFilterString, Long[] depotEntryIds,
+					Integer rangeKey, String sortString)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (assetFilterString != null) {
+				httpInvoker.parameter(
+					"assetFilterString", String.valueOf(assetFilterString));
+			}
+
+			if (depotEntryIds != null) {
+				for (int i = 0; i < depotEntryIds.length; i++) {
+					httpInvoker.parameter(
+						"depotEntryIds", String.valueOf(depotEntryIds[i]));
+				}
+			}
+
+			if (rangeKey != null) {
+				httpInvoker.parameter("rangeKey", String.valueOf(rangeKey));
+			}
+
+			if (sortString != null) {
+				httpInvoker.parameter("sort", sortString);
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/analytics-cms-rest/v1.0/performance-top-asset/export");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		private PerformanceTopAssetResourceImpl(Builder builder) {
 			_builder = builder;
 		}
@@ -299,4 +426,4 @@ public interface PerformanceTopAssetResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:466283231
+// LIFERAY-REST-BUILDER-HASH:-996216549

--- a/modules/apps/analytics/analytics-cms-rest-impl/build.gradle
+++ b/modules/apps/analytics/analytics-cms-rest-impl/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-sql-dsl-spi")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/analytics/analytics-cms-rest-impl/rest-openapi.yaml
+++ b/modules/apps/analytics/analytics-cms-rest-impl/rest-openapi.yaml
@@ -729,7 +729,7 @@ paths:
             operationId: getPerformanceTopAsset
             parameters:
                 -   in: query
-                    name: assetFilter
+                    name: assetFilterString
                     schema:
                         type: string
                 -   in: query
@@ -772,7 +772,7 @@ paths:
             operationId: getPerformanceTopAssetExport
             parameters:
                 -   in: query
-                    name: assetFilter
+                    name: assetFilterString
                     schema:
                         type: string
                 -   in: query

--- a/modules/apps/analytics/analytics-cms-rest-impl/rest-openapi.yaml
+++ b/modules/apps/analytics/analytics-cms-rest-impl/rest-openapi.yaml
@@ -664,6 +664,41 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/PerformanceMetric"
             tags: ["PerformanceMetric"]
+    "/performance-metric/export":
+        get:
+            operationId: getPerformanceMetricExport
+            parameters:
+                -   in: query
+                    name: depotEntryIds
+                    schema:
+                        items:
+                            format: int64
+                            type: integer
+                        type: array
+                -   in: query
+                    name: groupBy
+                    schema:
+                        type: string
+                -   in: query
+                    name: metricType
+                    schema:
+                        type: string
+                -   in: query
+                    name: rangeKey
+                    schema:
+                        type: integer
+            responses:
+                200:
+                    content:
+                        text/csv:
+                            schema:
+                                format: binary
+                                type: string
+                    headers:
+                        Content-Disposition:
+                            schema:
+                                type: string
+            tags: ["PerformanceMetric"]
     "/performance-overview-metric":
         get:
             operationId: getPerformanceOverviewMetric
@@ -731,4 +766,39 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/PerformanceTopAsset"
+            tags: ["PerformanceTopAsset"]
+    "/performance-top-asset/export":
+        get:
+            operationId: getPerformanceTopAssetExport
+            parameters:
+                -   in: query
+                    name: assetFilter
+                    schema:
+                        type: string
+                -   in: query
+                    name: depotEntryIds
+                    schema:
+                        items:
+                            format: int64
+                            type: integer
+                        type: array
+                -   in: query
+                    name: rangeKey
+                    schema:
+                        type: integer
+                -   in: query
+                    name: sort
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        text/csv:
+                            schema:
+                                format: binary
+                                type: string
+                    headers:
+                        Content-Disposition:
+                            schema:
+                                type: string
             tags: ["PerformanceTopAsset"]

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -659,7 +659,7 @@ public class AnalyticsCloudClient {
 
 		if (Validator.isNotNull(metricType)) {
 			url = HttpComponentsUtil.addParameter(
-				url, "assetSummaryMetricTypeString", metricType);
+				url, "assetSummaryMetricType", metricType);
 		}
 
 		if (Validator.isNotNull(objectType)) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -471,12 +471,24 @@ public class AnalyticsCloudClient {
 
 					performanceMetric.setMetricType(() -> metricType);
 
-					ObjectReader objectReader =
-						ObjectMapperHolder._objectMapper.readerFor(
-							Metric[].class);
+					Metric[] metrics;
 
-					performanceMetric.setMetrics(
-						() -> objectReader.readValue(jsonNode));
+					JsonNode metricsJsonNode = jsonNode.get("metrics");
+
+					if ((metricsJsonNode == null) ||
+						!metricsJsonNode.isArray()) {
+
+						metrics = new Metric[0];
+					}
+					else {
+						ObjectReader objectReader =
+							ObjectMapperHolder._objectMapper.readerFor(
+								Metric[].class);
+
+						metrics = objectReader.readValue(jsonNode);
+					}
+
+					performanceMetric.setMetrics(() -> metrics);
 				}
 
 				return performanceMetric;

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -45,6 +45,8 @@ import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.io.InputStream;
+
 import java.net.HttpURLConnection;
 
 import java.util.ArrayList;
@@ -68,6 +70,53 @@ public class AnalyticsCloudClient {
 
 		_http = http;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
+	}
+
+	public InputStream getInputStream(
+			AnalyticsConfiguration analyticsConfiguration, String filterString,
+			List<Long> groupIds, String metricType, String path,
+			Integer rangeKey, Sort[] sorts)
+		throws PortalException {
+
+		try {
+			Http.Options options = _getOptions(analyticsConfiguration);
+
+			options.addHeader("Accept", "application/octet-stream, */*");
+
+			options.setLocation(
+				_getLocation(
+					null, analyticsConfiguration.liferayAnalyticsDataSourceId(),
+					null, filterString, null, groupIds,
+					analyticsConfiguration.liferayAnalyticsFaroBackendURL(),
+					metricType, null, null, path, rangeKey, null, null, sorts,
+					null, null));
+
+			InputStream inputStream = _http.URLtoInputStream(options);
+
+			Http.Response response = options.getResponse();
+
+			if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
+				if (inputStream != null) {
+					inputStream.close();
+				}
+
+				if (_log.isDebugEnabled()) {
+					_log.debug("Response code " + response.getResponseCode());
+				}
+
+				throw new PortalException("Unable to get input stream " + path);
+			}
+
+			return inputStream;
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			throw new PortalException(
+				"Unable to get input stream " + path, exception);
+		}
 	}
 
 	public List<ObjectEntryAcquisitionChannel>

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/BasePerformanceMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/BasePerformanceMetricResourceImpl.java
@@ -27,6 +27,7 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collection;
@@ -92,6 +93,60 @@ public abstract class BasePerformanceMetricResourceImpl
 		throws Exception {
 
 		return new PerformanceMetric();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/analytics-cms-rest/v1.0/performance-metric/export'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "depotEntryIds"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "groupBy"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "metricType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "rangeKey"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "PerformanceMetric")
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/performance-metric/export")
+	@jakarta.ws.rs.Produces("text/csv")
+	@Override
+	public Response getPerformanceMetricExport(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("depotEntryIds")
+			Long[] depotEntryIds,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("groupBy")
+			String groupBy,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("metricType")
+			String metricType,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("rangeKey")
+			Integer rangeKey)
+		throws Exception {
+
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
@@ -539,4 +594,4 @@ public abstract class BasePerformanceMetricResourceImpl
 		LogFactoryUtil.getLog(BasePerformanceMetricResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:42315806
+// LIFERAY-REST-BUILDER-HASH:821872626

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/BasePerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/BasePerformanceTopAssetResourceImpl.java
@@ -31,6 +31,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collection;
@@ -55,7 +56,7 @@ public abstract class BasePerformanceTopAssetResourceImpl
 		value = {
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "assetFilter"
+				name = "assetFilterString"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -92,8 +93,8 @@ public abstract class BasePerformanceTopAssetResourceImpl
 	@Override
 	public PerformanceTopAsset getPerformanceTopAsset(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("assetFilter")
-			String assetFilter,
+			@jakarta.ws.rs.QueryParam("assetFilterString")
+			String assetFilterString,
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("depotEntryIds")
 			Long[] depotEntryIds,
@@ -106,6 +107,61 @@ public abstract class BasePerformanceTopAssetResourceImpl
 		throws Exception {
 
 		return new PerformanceTopAsset();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/analytics-cms-rest/v1.0/performance-top-asset/export'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "assetFilterString"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "depotEntryIds"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "rangeKey"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "sort"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "PerformanceTopAsset"
+			)
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/performance-top-asset/export")
+	@jakarta.ws.rs.Produces("text/csv")
+	@Override
+	public Response getPerformanceTopAssetExport(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("assetFilterString")
+			String assetFilterString,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("depotEntryIds")
+			Long[] depotEntryIds,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("rangeKey")
+			Integer rangeKey,
+			@jakarta.ws.rs.core.Context com.liferay.portal.kernel.search.Sort[]
+				sorts)
+		throws Exception {
+
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
 	}
 
 	@Override
@@ -560,4 +616,4 @@ public abstract class BasePerformanceTopAssetResourceImpl
 		LogFactoryUtil.getLog(BasePerformanceTopAssetResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1825283813
+// LIFERAY-REST-BUILDER-HASH:-976205030

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
@@ -10,11 +10,19 @@ import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceMetricResource;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.petra.io.StreamUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+
+import java.io.InputStream;
+
+import java.time.LocalDate;
 
 import java.util.Arrays;
 
@@ -53,6 +61,40 @@ public class PerformanceMetricResourceImpl
 			_analyticsSettingsManager.getAnalyticsConfiguration(
 				contextCompany.getCompanyId()),
 			Arrays.asList(groupIds), metricType, _getPath(groupBy), rangeKey);
+	}
+
+	@Override
+	public Response getPerformanceMetricExport(
+			Long[] depotEntryIds, String groupBy, String metricType,
+			Integer rangeKey)
+		throws Exception {
+
+		LicenseManagerUtil.checkFreeTier();
+
+		_validateMetricType(metricType);
+
+		Long[] groupIds = DepotEntryUtil.getGroupIds(
+			DepotEntryUtil.getDepotEntries(
+				contextCompany.getCompanyId(), depotEntryIds));
+
+		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
+			_http);
+
+		InputStream inputStream = analyticsCloudClient.getInputStream(
+			_analyticsSettingsManager.getAnalyticsConfiguration(
+				contextCompany.getCompanyId()),
+			null, Arrays.asList(groupIds), metricType,
+			_getPath(groupBy) + "/export", rangeKey, null);
+
+		return Response.ok(
+			(StreamingOutput)outputStream -> StreamUtil.transfer(
+				inputStream, outputStream)
+		).header(
+			"Content-Disposition",
+			StringBundler.concat(
+				"attachment; filename=performance-metric-",
+				StringUtil.toLowerCase(groupBy), "-", LocalDate.now(), ".csv")
+		).build();
 	}
 
 	private String _getPath(String groupBy) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
@@ -10,10 +10,19 @@ import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceTopAssetResource;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.petra.io.StreamUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.vulcan.pagination.Pagination;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+
+import java.io.InputStream;
+
+import java.time.LocalDate;
 
 import java.util.Arrays;
 
@@ -51,6 +60,37 @@ public class PerformanceTopAssetResourceImpl
 				contextCompany.getCompanyId()),
 			assetFilterString, Arrays.asList(groupIds), pagination.getPage(),
 			rangeKey, pagination.getPageSize(), sorts);
+	}
+
+	@Override
+	public Response getPerformanceTopAssetExport(
+			String assetFilterString, Long[] depotEntryIds, Integer rangeKey,
+			Sort[] sorts)
+		throws Exception {
+
+		LicenseManagerUtil.checkFreeTier();
+
+		Long[] groupIds = DepotEntryUtil.getGroupIds(
+			DepotEntryUtil.getDepotEntries(
+				contextCompany.getCompanyId(), depotEntryIds));
+
+		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
+			_http);
+
+		InputStream inputStream = analyticsCloudClient.getInputStream(
+			_analyticsSettingsManager.getAnalyticsConfiguration(
+				contextCompany.getCompanyId()),
+			assetFilterString, Arrays.asList(groupIds), null,
+			"/summaries/export", rangeKey, sorts);
+
+		return Response.ok(
+			(StreamingOutput)outputStream -> StreamUtil.transfer(
+				inputStream, outputStream)
+		).header(
+			"Content-Disposition",
+			StringBundler.concat(
+				"attachment; filename=top-assets-", LocalDate.now(), ".csv")
+		).build();
 	}
 
 	@Reference

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceMetricResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceMetricResourceTestCase.java
@@ -184,6 +184,11 @@ public abstract class BasePerformanceMetricResourceTestCase {
 		Assert.assertTrue(false);
 	}
 
+	@Test
+	public void testGetPerformanceMetricExport() throws Exception {
+		Assert.assertTrue(false);
+	}
+
 	protected void assertContains(
 		PerformanceMetric performanceMetric,
 		List<PerformanceMetric> performanceMetrics) {
@@ -864,4 +869,4 @@ public abstract class BasePerformanceMetricResourceTestCase {
 			_performanceMetricResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-548735459
+// LIFERAY-REST-BUILDER-HASH:-31028759

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceTopAssetResourceTestCase.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/BasePerformanceTopAssetResourceTestCase.java
@@ -180,6 +180,11 @@ public abstract class BasePerformanceTopAssetResourceTestCase {
 		Assert.assertTrue(false);
 	}
 
+	@Test
+	public void testGetPerformanceTopAssetExport() throws Exception {
+		Assert.assertTrue(false);
+	}
+
 	protected void assertContains(
 		PerformanceTopAsset performanceTopAsset,
 		List<PerformanceTopAsset> performanceTopAssets) {
@@ -902,4 +907,4 @@ public abstract class BasePerformanceTopAssetResourceTestCase {
 			_performanceTopAssetResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1098663781
+// LIFERAY-REST-BUILDER-HASH:-1344748680

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -338,8 +338,7 @@ public class PerformanceAssetConsumptionResourceTest
 
 		String location = recordingMockHttp.getLocation();
 
-		_assertParameter(
-			"viewsMetric", "assetSummaryMetricTypeString", location);
+		_assertParameter("viewsMetric", "assetSummaryMetricType", location);
 		_assertParameter(String.valueOf(categoryId), "categoryId", location);
 		_assertParameter(
 			String.valueOf(dataSourceId), "dataSourceId", location);

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
@@ -89,6 +89,7 @@ public class PerformanceMetricResourceTest
 			"location", "downloadsMetric",
 			"/api/1.0/asset-metric/objectEntry/geolocation");
 		_testGetPerformanceMetricWithInvalidMetricType();
+		_testGetPerformanceMetricWithNoData();
 	}
 
 	@Override
@@ -202,17 +203,21 @@ public class PerformanceMetricResourceTest
 
 		PerformanceMetric performanceMetric = _getPerformanceMetric(
 			dataSourceId,
-			JSONUtil.putAll(
-				JSONUtil.put(
-					"value", value1
-				).put(
-					"valueKey", valueKey1
-				),
-				JSONUtil.put(
-					"value", value2
-				).put(
-					"valueKey", valueKey2
-				)
+			JSONUtil.put(
+				"metricName", metricType
+			).put(
+				"metrics",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"value", value1
+					).put(
+						"valueKey", valueKey1
+					),
+					JSONUtil.put(
+						"value", value2
+					).put(
+						"valueKey", valueKey2
+					))
 			).toString(),
 			metricType, path, rangeKey,
 			depotEntryIds -> _performanceMetricResource.getPerformanceMetric(
@@ -322,6 +327,29 @@ public class PerformanceMetricResourceTest
 					_depotEntries, DepotEntry::getDepotEntryId, Long.class),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.nextInt()));
+	}
+
+	private void _testGetPerformanceMetricWithNoData() throws Exception {
+		String metricType = "viewsMetric";
+		int rangeKey = RandomTestUtil.nextInt();
+
+		PerformanceMetric performanceMetric = _getPerformanceMetric(
+			RandomTestUtil.nextLong(),
+			JSONUtil.put(
+				"metricName", metricType
+			).put(
+				"metrics", JSONUtil.putAll()
+			).toString(),
+			metricType, "/api/1.0/asset-metric/objectEntry/geolocation",
+			rangeKey,
+			depotEntryIds -> _performanceMetricResource.getPerformanceMetric(
+				depotEntryIds, "location", metricType, rangeKey));
+
+		Assert.assertEquals(metricType, performanceMetric.getMetricType());
+
+		Metric[] metrics = performanceMetric.getMetrics();
+
+		Assert.assertEquals(Arrays.toString(metrics), 0, metrics.length);
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
@@ -15,6 +15,7 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -36,6 +37,12 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+
+import java.io.ByteArrayOutputStream;
+
+import java.time.LocalDate;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,6 +89,18 @@ public class PerformanceMetricResourceTest
 			"location", "downloadsMetric",
 			"/api/1.0/asset-metric/objectEntry/geolocation");
 		_testGetPerformanceMetricWithInvalidMetricType();
+	}
+
+	@Override
+	@Test
+	public void testGetPerformanceMetricExport() throws Exception {
+		_testGetPerformanceMetricExport(
+			"categories", "viewsMetric",
+			"/api/1.0/asset-metric/objectEntry/categories/export");
+		_testGetPerformanceMetricExport(
+			"location", "downloadsMetric",
+			"/api/1.0/asset-metric/objectEntry/geolocation/export");
+		_testGetPerformanceMetricExportWithInvalidMetricType();
 	}
 
 	private DepotEntry _addDepotEntry() throws Exception {
@@ -207,6 +226,92 @@ public class PerformanceMetricResourceTest
 
 		_assertMetric(metrics[0], value1, valueKey1);
 		_assertMetric(metrics[1], value2, valueKey2);
+	}
+
+	private void _testGetPerformanceMetricExport(
+			String groupBy, String metricType, String path)
+		throws Exception {
+
+		long dataSourceId = RandomTestUtil.nextLong();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						AnalyticsConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsDataSourceId", dataSourceId
+						).put(
+							"liferayAnalyticsEnableAllGroupIds", true
+						).put(
+							"liferayAnalyticsFaroBackendSecuritySignature",
+							RandomTestUtil.randomString()
+						).put(
+							"liferayAnalyticsFaroBackendURL",
+							"http://" + RandomTestUtil.randomString()
+						).build())) {
+
+			String value = RandomTestUtil.randomString();
+
+			RecordingMockHttp recordingMockHttp = new RecordingMockHttp(
+				Collections.singletonMap(path, () -> value));
+
+			ReflectionTestUtil.setFieldValue(
+				_performanceMetricResource, "_http", recordingMockHttp);
+
+			int rangeKey = RandomTestUtil.nextInt();
+
+			Response response =
+				_performanceMetricResource.getPerformanceMetricExport(
+					TransformUtil.transformToArray(
+						_depotEntries, DepotEntry::getDepotEntryId, Long.class),
+					groupBy, metricType, rangeKey);
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					"attachment; filename=performance-metric-",
+					StringUtil.toLowerCase(groupBy), "-", LocalDate.now(),
+					".csv"),
+				response.getHeaderString("Content-Disposition"));
+
+			StreamingOutput streamingOutput =
+				(StreamingOutput)response.getEntity();
+
+			ByteArrayOutputStream byteArrayOutputStream =
+				new ByteArrayOutputStream();
+
+			streamingOutput.write(byteArrayOutputStream);
+
+			Assert.assertEquals(value, byteArrayOutputStream.toString());
+
+			String location = recordingMockHttp.getLocation();
+
+			_assertParameter(
+				metricType, "assetSummaryMetricTypeString", location);
+			_assertParameter(
+				String.valueOf(dataSourceId), "dataSourceId", location);
+			_assertParameter(
+				StringUtil.merge(
+					TransformUtil.transformToArray(
+						_depotEntries, DepotEntry::getGroupId, Long.class),
+					StringPool.COMMA),
+				"groupIds", location);
+			_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				_performanceMetricResource, "_http", _http);
+		}
+	}
+
+	private void _testGetPerformanceMetricExportWithInvalidMetricType() {
+		Assert.assertThrows(
+			BadRequestException.class,
+			() -> _performanceMetricResource.getPerformanceMetricExport(
+				TransformUtil.transformToArray(
+					_depotEntries, DepotEntry::getDepotEntryId, Long.class),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.nextInt()));
 	}
 
 	private void _testGetPerformanceMetricWithInvalidMetricType() {

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
@@ -170,8 +170,7 @@ public class PerformanceMetricResourceTest
 
 			String location = recordingMockHttp.getLocation();
 
-			_assertParameter(
-				metricType, "assetSummaryMetricTypeString", location);
+			_assertParameter(metricType, "assetSummaryMetricType", location);
 			_assertParameter(
 				String.valueOf(dataSourceId), "dataSourceId", location);
 			_assertParameter(
@@ -291,8 +290,7 @@ public class PerformanceMetricResourceTest
 
 			String location = recordingMockHttp.getLocation();
 
-			_assertParameter(
-				metricType, "assetSummaryMetricTypeString", location);
+			_assertParameter(metricType, "assetSummaryMetricType", location);
 			_assertParameter(
 				String.valueOf(dataSourceId), "dataSourceId", location);
 			_assertParameter(

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -28,6 +28,13 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+
+import java.io.ByteArrayOutputStream;
+
+import java.time.LocalDate;
+
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -82,6 +89,37 @@ public class PerformanceTopAssetResourceTest
 		}
 	}
 
+	@Override
+	@Test
+	public void testGetPerformanceTopAssetExport() throws Exception {
+		String dataSourceId = RandomTestUtil.randomString();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						AnalyticsConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsDataSourceId", dataSourceId
+						).put(
+							"liferayAnalyticsEnableAllGroupIds", true
+						).put(
+							"liferayAnalyticsFaroBackendSecuritySignature",
+							RandomTestUtil.randomString()
+						).put(
+							"liferayAnalyticsFaroBackendURL",
+							"http://" + RandomTestUtil.randomString()
+						).build())) {
+
+			_testGetPerformanceTopAssetExportResponse();
+			_testGetPerformanceTopAssetExportURL(dataSourceId);
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				_performanceTopAssetResource, "_http", _http);
+		}
+	}
+
 	private void _assertParameter(
 		String expectedValue, String name, String url) {
 
@@ -91,15 +129,79 @@ public class PerformanceTopAssetResourceTest
 				HttpComponentsUtil.getParameter(url, name, false)));
 	}
 
-	private RecordingMockHttp _setUpRecordingMockHttp(String json) {
+	private RecordingMockHttp _setUpRecordingMockHttp(
+		String json, String path) {
+
 		RecordingMockHttp recordingMockHttp = new RecordingMockHttp(
-			Collections.singletonMap(
-				"/api/1.0/asset-metric/objectEntry/summaries", () -> json));
+			Collections.singletonMap(path, () -> json));
 
 		ReflectionTestUtil.setFieldValue(
 			_performanceTopAssetResource, "_http", recordingMockHttp);
 
 		return recordingMockHttp;
+	}
+
+	private void _testGetPerformanceTopAssetExportResponse() throws Exception {
+		String value = RandomTestUtil.randomString();
+
+		_setUpRecordingMockHttp(
+			value, "/api/1.0/asset-metric/objectEntry/summaries/export");
+
+		Response response =
+			_performanceTopAssetResource.getPerformanceTopAssetExport(
+				RandomTestUtil.randomString(), null, RandomTestUtil.nextInt(),
+				null);
+
+		Assert.assertEquals(
+			"attachment; filename=top-assets-" + LocalDate.now() + ".csv",
+			response.getHeaderString("Content-Disposition"));
+
+		StreamingOutput streamingOutput = (StreamingOutput)response.getEntity();
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		streamingOutput.write(byteArrayOutputStream);
+
+		Assert.assertEquals(value, byteArrayOutputStream.toString());
+	}
+
+	private void _testGetPerformanceTopAssetExportURL(String dataSourceId)
+		throws Exception {
+
+		RecordingMockHttp recordingMockHttp = _setUpRecordingMockHttp(
+			RandomTestUtil.randomString(),
+			"/api/1.0/asset-metric/objectEntry/summaries/export");
+
+		String assetFilterString = RandomTestUtil.randomString();
+		int rangeKey = RandomTestUtil.nextInt();
+		Sort[] sorts = {
+			new Sort(RandomTestUtil.randomString(), true),
+			new Sort(RandomTestUtil.randomString(), false)
+		};
+
+		_performanceTopAssetResource.getPerformanceTopAssetExport(
+			assetFilterString, null, rangeKey, sorts);
+
+		String location = recordingMockHttp.getLocation();
+
+		_assertParameter(dataSourceId, "dataSourceId", location);
+		_assertParameter(assetFilterString, "filter", location);
+		_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
+
+		StringBundler sb = new StringBundler();
+
+		for (int i = 0; i < sorts.length; i++) {
+			if (i > 0) {
+				sb.append(StringPool.COMMA);
+			}
+
+			sb.append(sorts[i].getFieldName());
+			sb.append(StringPool.COLON);
+			sb.append(sorts[i].isReverse() ? "desc" : "asc");
+		}
+
+		_assertParameter(sb.toString(), "sort", location);
 	}
 
 	private void _testGetPerformanceTopAssetResponse() throws Exception {
@@ -156,7 +258,8 @@ public class PerformanceTopAssetResourceTest
 				).put(
 					"totalPages", lastPage
 				)
-			).toString());
+			).toString(),
+			"/api/1.0/asset-metric/objectEntry/summaries");
 
 		PerformanceTopAsset performanceTopAsset =
 			_performanceTopAssetResource.getPerformanceTopAsset(
@@ -201,7 +304,8 @@ public class PerformanceTopAssetResourceTest
 	private void _testGetPerformanceTopAssetURL(String dataSourceId)
 		throws Exception {
 
-		RecordingMockHttp recordingMockHttp = _setUpRecordingMockHttp("{}");
+		RecordingMockHttp recordingMockHttp = _setUpRecordingMockHttp(
+			"{}", "/api/1.0/asset-metric/objectEntry/summaries");
 
 		String assetFilterString = RandomTestUtil.randomString();
 		int page = RandomTestUtil.nextInt();

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/RecordingMockHttp.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/RecordingMockHttp.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.test.util.MockHttp;
 import com.liferay.portal.kernel.util.Http;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import java.util.Map;
 
@@ -26,6 +27,15 @@ public class RecordingMockHttp extends MockHttp {
 
 	public String getLocation() {
 		return _location;
+	}
+
+	@Override
+	public InputStream URLtoInputStream(Http.Options options)
+		throws IOException {
+
+		_location = options.getLocation();
+
+		return super.URLtoInputStream(options);
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92420

## What Is Being Fixed

The Analytics CMS REST API exposed performance metric and top-asset data only as paginated JSON. There was no way to download that data as a CSV file, so consumers that needed a spreadsheet-ready export of a performance report had no endpoint to call.

## How It Is Being Fixed

Two new operations, getPerformanceMetricExport and getPerformanceTopAssetExport, were added to the Analytics CMS rest-openapi.yaml. Each produces text/csv and sets a Content-Disposition attachment header so the response downloads as a dated CSV file. The resource implementations stream the CSV straight from the Analytics Cloud backend through a new AnalyticsCloudClient.getInputStream method, which issues the request with an octet-stream Accept header, validates the response code, and returns the raw response stream rather than parsing it as JSON. Along the way the change conforms a couple of parameter names to the values they carry (assetFilter becomes assetFilterString and the metric type parameter becomes assetSummaryMetricType) and fixes the performance metric mapping so an empty or non-array upstream response yields an empty result instead of failing. Integration tests cover both export endpoints with a recording mock HTTP client that captures the outbound request and asserts the streamed CSV payload and the response headers.

## PR Check

**pr-check: PASS** — tested on `ae18b4f50b57aa534746744d663383f57249b984`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "ae18b4f50b57aa534746744d663383f57249b984"} -->
