### PR TITLE
LPD-95807 Add audiences definition provider, criteria types, and cache

### DIFF
--- a/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/constants/AudiencesCriteriaKeys.java
+++ b/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/constants/AudiencesCriteriaKeys.java
@@ -10,6 +10,8 @@ package com.liferay.audiences.constants;
  */
 public class AudiencesCriteriaKeys {
 
+	public static final String AUTHENTICATION = "authentication";
+
 	public static final String BROWSER_NAME = "browser_name";
 
 	public static final String BROWSER_VERSION = "browser_version";

--- a/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/internal/criteria/AudiencesCriteriaProviderImpl.java
+++ b/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/internal/criteria/AudiencesCriteriaProviderImpl.java
@@ -60,36 +60,36 @@ public class AudiencesCriteriaProviderImpl
 		return new AudiencesCriteriaType(
 			Arrays.asList(
 				new AudiencesCriteria(
-					"desktop", AudiencesCriteriaKeys.BROWSER_NAME,
+					"text", AudiencesCriteriaKeys.BROWSER_NAME,
 					_language.get(locale, "browser-name"),
 					AudiencesCriteria.Type.STRING),
 				new AudiencesCriteria(
-					"desktop", AudiencesCriteriaKeys.BROWSER_VERSION,
+					"text", AudiencesCriteriaKeys.BROWSER_VERSION,
 					_language.get(locale, "browser-version"),
 					AudiencesCriteria.Type.STRING),
 				new AudiencesCriteria(
-					"password", AudiencesCriteriaKeys.COOKIES,
+					"fieldset", AudiencesCriteriaKeys.COOKIES,
 					_language.get(locale, "cookies"),
 					AudiencesCriteria.Type.COLLECTION),
 				new AudiencesCriteria(
-					"desktop", AudiencesCriteriaKeys.DEVICE_TYPE,
+					"text", AudiencesCriteriaKeys.DEVICE_TYPE,
 					_language.get(locale, "device-type"),
 					AudiencesCriteria.Type.STRING),
 				new AudiencesCriteria(
-					"globe", AudiencesCriteriaKeys.GEOLOCATION,
+					"text", AudiencesCriteriaKeys.GEOLOCATION,
 					_language.get(locale, "geolocation"),
 					AudiencesCriteria.Type.STRING),
 				new AudiencesCriteria(
-					"globe", AudiencesCriteriaKeys.HOSTNAME,
+					"text", AudiencesCriteriaKeys.HOSTNAME,
 					_language.get(locale, "hostname"),
 					AudiencesCriteria.Type.STRING),
 				new AudiencesCriteria(
-					"globe", AudiencesCriteriaKeys.LANGUAGE,
+					"text", AudiencesCriteriaKeys.LANGUAGE,
 					_language.get(locale, "language"),
 					_getLanguageOptions(locale),
 					AudiencesCriteria.Type.OPTIONS),
 				new AudiencesCriteria(
-					"calendar", AudiencesCriteriaKeys.LOCAL_DATE,
+					"date", AudiencesCriteriaKeys.LOCAL_DATE,
 					_language.get(locale, "local-date"),
 					AudiencesCriteria.Type.DATE),
 				new AudiencesCriteria(
@@ -97,27 +97,27 @@ public class AudiencesCriteriaProviderImpl
 					_language.get(locale, "local-hour"), _getLocalHourOptions(),
 					AudiencesCriteria.Type.NUMBER),
 				new AudiencesCriteria(
-					"link", AudiencesCriteriaKeys.PATHNAME,
+					"text", AudiencesCriteriaKeys.PATHNAME,
 					_language.get(locale, "pathname"),
 					AudiencesCriteria.Type.STRING),
 				new AudiencesCriteria(
-					"link", AudiencesCriteriaKeys.REFERRER,
+					"text", AudiencesCriteriaKeys.REFERRER,
 					_language.get(locale, "referrer-url"),
 					AudiencesCriteria.Type.STRING),
 				new AudiencesCriteria(
-					"code", AudiencesCriteriaKeys.REQUEST_PARAMETERS,
+					"fieldset", AudiencesCriteriaKeys.REQUEST_PARAMETERS,
 					_language.get(locale, "request-parameters"),
 					AudiencesCriteria.Type.COLLECTION),
 				new AudiencesCriteria(
-					"time", AudiencesCriteriaKeys.TIMEZONE,
+					"text", AudiencesCriteriaKeys.TIMEZONE,
 					_language.get(locale, "time-zone"),
 					AudiencesCriteria.Type.STRING),
 				new AudiencesCriteria(
-					"link", AudiencesCriteriaKeys.URL,
+					"text", AudiencesCriteriaKeys.URL,
 					_language.get(locale, "url"),
 					AudiencesCriteria.Type.STRING),
 				new AudiencesCriteria(
-					"desktop", AudiencesCriteriaKeys.USER_AGENT,
+					"text", AudiencesCriteriaKeys.USER_AGENT,
 					_language.get(locale, "user-agent"),
 					AudiencesCriteria.Type.STRING)),
 			_language.get(locale, "browser-attributes"));

--- a/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/internal/criteria/AudiencesCriteriaProviderImpl.java
+++ b/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/internal/criteria/AudiencesCriteriaProviderImpl.java
@@ -44,6 +44,9 @@ public class AudiencesCriteriaProviderImpl
 		audiencesCriteriaTypes.add(
 			_getBrowserAttributesAudiencesCriteriaType(locale));
 
+		audiencesCriteriaTypes.add(
+			_getGeneralAttributesAudiencesCriteriaType(locale));
+
 		AudiencesCriteriaType customAudiencesCriteriaType =
 			_getCustomAudiencesCriteriaType(companyId, locale);
 
@@ -151,6 +154,28 @@ public class AudiencesCriteriaProviderImpl
 
 			return null;
 		}
+	}
+
+	private AudiencesCriteriaType _getGeneralAttributesAudiencesCriteriaType(
+		Locale locale) {
+
+		return new AudiencesCriteriaType(
+			Arrays.asList(
+				new AudiencesCriteria(
+					"text", AudiencesCriteriaKeys.AUTHENTICATION,
+					_language.get(locale, "authentication"),
+					Arrays.asList(
+						new AudiencesCriteria.Option(
+							_language.get(locale, "yes"), "yes"),
+						new AudiencesCriteria.Option(
+							_language.get(locale, "no"), "no")),
+					AudiencesCriteria.Type.OPTIONS),
+				new AudiencesCriteria(
+					"text", AudiencesCriteriaKeys.LANGUAGE,
+					_language.get(locale, "language"),
+					_getLanguageOptions(locale),
+					AudiencesCriteria.Type.OPTIONS)),
+			_language.get(locale, "general"));
 	}
 
 	private List<AudiencesCriteria.Option> _getLanguageOptions(Locale locale) {

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/criteria/test/AudiencesCriteriaProviderTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/criteria/test/AudiencesCriteriaProviderTest.java
@@ -79,7 +79,7 @@ public class AudiencesCriteriaProviderTest {
 				TestPropsValues.getCompanyId(), LocaleUtil.getDefault());
 
 		AudiencesCriteriaType audiencesCriteriaType =
-			audiencesCriteriaTypes.get(1);
+			audiencesCriteriaTypes.get(2);
 
 		List<AudiencesCriteria> audiencesCriterias =
 			audiencesCriteriaType.getAudiencesCriterias();
@@ -94,6 +94,51 @@ public class AudiencesCriteriaProviderTest {
 		Assert.assertEquals(name, audiencesCriteria.getLabel());
 		Assert.assertEquals(
 			AudiencesCriteria.Type.STRING, audiencesCriteria.getType());
+	}
+
+	@Test
+	public void testGetGeneralAttributesAudiencesCriteriaType()
+		throws Exception {
+
+		List<AudiencesCriteriaType> audiencesCriteriaTypes =
+			_audiencesCriteriaProvider.getAudiencesCriteriaTypes(
+				TestPropsValues.getCompanyId(), LocaleUtil.getDefault());
+
+		AudiencesCriteriaType audiencesCriteriaType =
+			audiencesCriteriaTypes.get(1);
+
+		List<AudiencesCriteria> audiencesCriterias =
+			audiencesCriteriaType.getAudiencesCriterias();
+
+		Assert.assertEquals(
+			audiencesCriterias.toString(), 2, audiencesCriterias.size());
+
+		AudiencesCriteria authenticationAudiencesCriteria =
+			_getAudiencesCriteria(audiencesCriterias, "authentication");
+
+		Assert.assertEquals(
+			AudiencesCriteria.Type.OPTIONS,
+			authenticationAudiencesCriteria.getType());
+
+		List<AudiencesCriteria.Option> options =
+			authenticationAudiencesCriteria.getOptions();
+
+		Assert.assertEquals(options.toString(), 2, options.size());
+
+		AudiencesCriteria.Option option1 = options.get(0);
+
+		Assert.assertEquals("yes", option1.getValue());
+
+		AudiencesCriteria.Option option2 = options.get(1);
+
+		Assert.assertEquals("no", option2.getValue());
+
+		AudiencesCriteria languageAudiencesCriteria = _getAudiencesCriteria(
+			audiencesCriterias, "language");
+
+		Assert.assertEquals(
+			AudiencesCriteria.Type.OPTIONS,
+			languageAudiencesCriteria.getType());
 	}
 
 	private ClientExtensionEntry _addClientExtensionEntry(String name)

--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/frontend/js/audiences/AudiencesDefinitionProviderImpl.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/frontend/js/audiences/AudiencesDefinitionProviderImpl.java
@@ -5,10 +5,21 @@
 
 package com.liferay.audiences.web.internal.frontend.js.audiences;
 
+import com.liferay.audiences.model.AudiencesEntry;
+import com.liferay.audiences.service.AudiencesEntryLocalService;
 import com.liferay.frontend.js.audiences.AudiencesDefinition;
 import com.liferay.frontend.js.audiences.AudiencesDefinitionProvider;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONUtil;
+
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -19,7 +30,31 @@ public class AudiencesDefinitionProviderImpl
 
 	@Override
 	public AudiencesDefinition getAudiencesDefinition(long companyId) {
-		return null;
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-93951")) {
+			return null;
+		}
+
+		JSONArray audiencesJSONArray = _jsonFactory.createJSONArray();
+
+		List<AudiencesEntry> audiencesEntries =
+			_audiencesEntryLocalService.getAudiencesEntries(
+				companyId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		for (AudiencesEntry audiencesEntry : audiencesEntries) {
+			audiencesJSONArray.put(audiencesEntry);
+		}
+
+		String json = JSONUtil.put(
+			"audiences", audiencesJSONArray
+		).toString();
+
+		return new AudiencesDefinition(HashedFilesUtil.computeHash(json), json);
 	}
+
+	@Reference
+	private AudiencesEntryLocalService _audiencesEntryLocalService;
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 }

--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/frontend/js/audiences/AudiencesDefinitionProviderImpl.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/frontend/js/audiences/AudiencesDefinitionProviderImpl.java
@@ -38,8 +38,7 @@ public class AudiencesDefinitionProviderImpl
 			return null;
 		}
 
-		AudiencesDefinition audiencesDefinition = _portalCache.get(
-			companyId);
+		AudiencesDefinition audiencesDefinition = _portalCache.get(companyId);
 
 		if (audiencesDefinition != null) {
 			return audiencesDefinition;

--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/frontend/js/audiences/AudiencesDefinitionProviderImpl.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/frontend/js/audiences/AudiencesDefinitionProviderImpl.java
@@ -9,6 +9,8 @@ import com.liferay.audiences.model.AudiencesEntry;
 import com.liferay.audiences.service.AudiencesEntryLocalService;
 import com.liferay.frontend.js.audiences.AudiencesDefinition;
 import com.liferay.frontend.js.audiences.AudiencesDefinitionProvider;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
@@ -18,7 +20,9 @@ import com.liferay.portal.kernel.json.JSONUtil;
 
 import java.util.List;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -32,6 +36,13 @@ public class AudiencesDefinitionProviderImpl
 	public AudiencesDefinition getAudiencesDefinition(long companyId) {
 		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-93951")) {
 			return null;
+		}
+
+		AudiencesDefinition audiencesDefinition = _portalCache.get(
+			companyId);
+
+		if (audiencesDefinition != null) {
+			return audiencesDefinition;
 		}
 
 		JSONArray audiencesJSONArray = _jsonFactory.createJSONArray();
@@ -48,7 +59,24 @@ public class AudiencesDefinitionProviderImpl
 			"audiences", audiencesJSONArray
 		).toString();
 
-		return new AudiencesDefinition(HashedFilesUtil.computeHash(json), json);
+		audiencesDefinition = new AudiencesDefinition(
+			HashedFilesUtil.computeHash(json), json);
+
+		_portalCache.put(companyId, audiencesDefinition);
+
+		return audiencesDefinition;
+	}
+
+	@Activate
+	protected void activate() {
+		_portalCache =
+			(PortalCache<Long, AudiencesDefinition>)_multiVMPool.getPortalCache(
+				AudiencesEntry.class.getName());
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_multiVMPool.removePortalCache(AudiencesEntry.class.getName());
 	}
 
 	@Reference
@@ -56,5 +84,10 @@ public class AudiencesDefinitionProviderImpl
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private MultiVMPool _multiVMPool;
+
+	private PortalCache<Long, AudiencesDefinition> _portalCache;
 
 }

--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/model/listener/AudiencesEntryModelListener.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/model/listener/AudiencesEntryModelListener.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.audiences.web.internal.model.listener;
+
+import com.liferay.audiences.model.AudiencesEntry;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.util.KeyValuePair;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@Component(service = ModelListener.class)
+public class AudiencesEntryModelListener
+	extends BaseModelListener<AudiencesEntry> {
+
+	@Override
+	public void onAfterCreate(AudiencesEntry audiencesEntry) {
+		_portalCache.remove(audiencesEntry.getCompanyId());
+	}
+
+	@Override
+	public void onAfterRemove(AudiencesEntry audiencesEntry) {
+		_portalCache.remove(audiencesEntry.getCompanyId());
+	}
+
+	@Override
+	public void onAfterUpdate(
+		AudiencesEntry originalAudiencesEntry, AudiencesEntry audiencesEntry) {
+
+		_portalCache.remove(audiencesEntry.getCompanyId());
+	}
+
+	@Activate
+	protected void activate() {
+		_portalCache =
+			(PortalCache<Long, KeyValuePair>)_multiVMPool.getPortalCache(
+				AudiencesEntry.class.getName());
+	}
+
+	@Reference
+	private MultiVMPool _multiVMPool;
+
+	private PortalCache<Long, KeyValuePair> _portalCache;
+
+}

--- a/modules/apps/frontend-js/frontend-js-audiences-api/src/main/java/com/liferay/frontend/js/audiences/AudiencesDefinition.java
+++ b/modules/apps/frontend-js/frontend-js-audiences-api/src/main/java/com/liferay/frontend/js/audiences/AudiencesDefinition.java
@@ -5,10 +5,12 @@
 
 package com.liferay.frontend.js.audiences;
 
+import java.io.Serializable;
+
 /**
  * @author Iván Zaera Avellón
  */
-public class AudiencesDefinition {
+public class AudiencesDefinition implements Serializable {
 
 	public AudiencesDefinition(String content, String hash) {
 		_content = content;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95807

## What Is Being Fixed

The audiences app did not expose its audience criteria definitions to the
frontend, and there was no provider supplying the available criteria types or
serving the audiences definition JSON. The definition also had to be served
efficiently across a cluster rather than recomputed on every request.

## How It Is Being Fixed

Adds an AudiencesDefinitionProvider implementation that builds the audiences
JSON and caches it in a clustered MultiVMPool keyed by company, with an
AudiencesEntryModelListener invalidating the cache when entries change. Adds an
AudiencesCriteriaProvider exposing the browser-attributes, general-attributes
(authentication and language), and custom client-extension criteria types,
along with their icons. AudiencesDefinition is made serializable so it can be
stored in the multi-VM cache. Integration tests cover the criteria provider,
including the new general-attributes type.

## PR Check

**pr-check: PASS** — tested on `94644089ccf7a77dbd9b139bad98c96567dca128`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "94644089ccf7a77dbd9b139bad98c96567dca128"} -->
