### PR TITLE
LPD-95358 LPD-95359 Set default sort to last activity date

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountIndividuals.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountIndividuals.tsx
@@ -77,14 +77,6 @@ const AccountIndividuals: React.FC<IAccountIndividualsProps> = ({
 						id={FDS_ID}
 						pagination={pagination}
 						showPagination
-						sorts={[
-							{
-								active: true,
-								direction: 'desc',
-								key: 'lastActivityDate',
-								label: Liferay.Language.get('last-active')
-							}
-						]}
 						views={[
 							{
 								contentRenderer: 'table',

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountIndividuals.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/AccountIndividuals.tsx
@@ -77,6 +77,14 @@ const AccountIndividuals: React.FC<IAccountIndividualsProps> = ({
 						id={FDS_ID}
 						pagination={pagination}
 						showPagination
+						sorts={[
+							{
+								active: true,
+								direction: 'desc',
+								key: 'lastActivityDate',
+								label: Liferay.Language.get('last-active')
+							}
+						]}
 						views={[
 							{
 								contentRenderer: 'table',

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsList.tsx
@@ -133,7 +133,7 @@ const IndividualsList: React.FC = () => {
 		initialFilterBy: Map({
 			activeUsers: Set([RangeKeyTimeRanges.Last30Days])
 		}) as FilterByType,
-		initialOrderIOMap: createOrderIOMap(NAME)
+		initialOrderIOMap: createOrderIOMap(LAST_ACTIVITY_DATE)
 	});
 
 	const {data: countriesData, loading: countriesLoading} = useRequest({

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -198,9 +198,9 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 				sorts={[
 					{
 						active: true,
-						direction: 'asc',
-						key: 'accountName',
-						label: Liferay.Language.get('account')
+						direction: 'desc',
+						key: 'lastActive',
+						label: Liferay.Language.get('last-active')
 					}
 				]}
 				views={[

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/BasePage.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/BasePage.tsx
@@ -96,10 +96,7 @@ export class WorkspacesBasePage extends React.Component<IWorkspacesBasePageProps
 					<DocumentTitle title={title} />
 
 					<div className='header-container'>
-						<ClayLink
-							href='https://liferay-portal.com'
-							target='_blank'
-						>
+						<ClayLink href='https://liferay.com' target='_blank'>
 							<ClayIcon
 								className='icon-root liferay-logo'
 								symbol='liferay_logo'


### PR DESCRIPTION
## Summary

- Set default sort to `LAST_ACTIVITY_DATE` in `IndividualsList`
- Set default sort to `lastActive` (desc) in `AccountsDataSet` (previously `accountName` asc)

## Cherry-pick conflict resolution

`BasePage.tsx` tinha um conflito no atributo `href` do `ClayLink`: a branch de destino continha `https://liferay-portal.com` (URL desatualizado), enquanto o commit cherry-pickado usava `https://liferay.com`. O conflito foi resolvido mantendo `https://liferay.com`, que é o URL correto conforme o commit `0c3f2de` (LPD-94517 "Uses right link").

🤖 Generated with [Claude Code](https://claude.com/claude-code)