### PR TITLE
LPD-95358 LPD-95359 Revert BasePage URL change

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/BasePage.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/BasePage.tsx
@@ -96,7 +96,10 @@ export class WorkspacesBasePage extends React.Component<IWorkspacesBasePageProps
 					<DocumentTitle title={title} />
 
 					<div className='header-container'>
-						<ClayLink href='https://liferay.com' target='_blank'>
+						<ClayLink
+							href='https://liferay-portal.com'
+							target='_blank'
+						>
 							<ClayIcon
 								className='icon-root liferay-logo'
 								symbol='liferay_logo'


### PR DESCRIPTION
## Summary

Reverts the `BasePage.tsx` URL change (`https://liferay-portal.com` → `https://liferay.com`) that foi incluída acidentalmente no commit LPD-95358/LPD-95359. Essa correção pertence ao LPD-94517, que ainda não foi portado para a `faro-v4.15.x`.