### PR TITLE
LPD-94517 Uses right link

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/BasePage.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/BasePage.tsx
@@ -97,7 +97,7 @@ export class WorkspacesBasePage extends React.Component<IWorkspacesBasePageProps
 
 					<div className='header-container'>
 						<ClayLink
-							href='https://liferay-portal.com'
+							href='https://liferay.com'
 							target='_blank'
 						>
 							<ClayIcon

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/BasePage.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/shared/components/workspaces/BasePage.tsx
@@ -96,7 +96,10 @@ export class WorkspacesBasePage extends React.Component<IWorkspacesBasePageProps
 					<DocumentTitle title={title} />
 
 					<div className='header-container'>
-						<ClayLink href='https://liferay.com' target='_blank'>
+						<ClayLink
+							href='https://liferay-portal.com'
+							target='_blank'
+						>
 							<ClayIcon
 								className='icon-root liferay-logo'
 								symbol='liferay_logo'


### PR DESCRIPTION
## Summary

Backport do commit `0c3f2de` (LPD-94517) para a `faro-v4.15.x`: corrige o URL do link do logo Liferay de `https://liferay-portal.com` para `https://liferay.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)