### PR TITLE
LPD-96073 Fix page number and sort format in asset metric requests

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -484,7 +484,7 @@ public class AnalyticsCloudClient {
 							ObjectMapperHolder._objectMapper.readerFor(
 								Metric[].class);
 
-						metrics = objectReader.readValue(jsonNode);
+						metrics = objectReader.readValue(metricsJsonNode);
 					}
 
 					performanceMetric.setMetrics(() -> metrics);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -624,85 +624,94 @@ public class AnalyticsCloudClient {
 		String[] selectedMetrics, Integer size, Sort[] sorts, Long tagId,
 		Long vocabularyId) {
 
-		String url = String.join(
+		String location = String.join(
 			StringPool.BLANK, liferayAnalyticsFaroBackendURL,
 			"/api/1.0/asset-metric/objectEntry", path);
 
 		if (categoryId != null) {
-			url = HttpComponentsUtil.addParameter(
-				url, "categoryId", categoryId);
+			location = HttpComponentsUtil.addParameter(
+				location, "categoryId", categoryId);
 		}
 
 		if (Validator.isNotNull(dataSourceId)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "dataSourceId", dataSourceId);
+			location = HttpComponentsUtil.addParameter(
+				location, "dataSourceId", dataSourceId);
 		}
 
 		if (Validator.isNotNull(externalReferenceCode)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "externalReferenceCode", externalReferenceCode);
+			location = HttpComponentsUtil.addParameter(
+				location, "externalReferenceCode", externalReferenceCode);
 		}
 
 		if (Validator.isNotNull(filterString)) {
-			url = HttpComponentsUtil.addParameter(url, "filter", filterString);
+			location = HttpComponentsUtil.addParameter(
+				location, "filter", filterString);
 		}
 
 		if (Validator.isNotNull(groupBy)) {
-			url = HttpComponentsUtil.addParameter(url, "groupBy", groupBy);
+			location = HttpComponentsUtil.addParameter(
+				location, "groupBy", groupBy);
 		}
 
 		if (!groupIds.isEmpty()) {
-			url = HttpComponentsUtil.addParameter(
-				url, "groupIds", StringUtil.merge(groupIds, StringPool.COMMA));
+			location = HttpComponentsUtil.addParameter(
+				location, "groupIds",
+				StringUtil.merge(groupIds, StringPool.COMMA));
 		}
 
 		if (Validator.isNotNull(metricType)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "assetSummaryMetricType", metricType);
+			location = HttpComponentsUtil.addParameter(
+				location, "assetSummaryMetricType", metricType);
 		}
 
 		if (Validator.isNotNull(objectType)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "objectType", objectType);
+			location = HttpComponentsUtil.addParameter(
+				location, "objectType", objectType);
 		}
 
 		if (page != null) {
-			url = HttpComponentsUtil.addParameter(url, "page", page);
+			location = HttpComponentsUtil.addParameter(location, "page", page);
 		}
 
 		if (rangeKey != null) {
-			url = HttpComponentsUtil.addParameter(url, "rangeKey", rangeKey);
+			location = HttpComponentsUtil.addParameter(
+				location, "rangeKey", rangeKey);
 		}
 
 		if (ArrayUtil.isNotEmpty(selectedMetrics)) {
-			url = HttpComponentsUtil.addParameter(
-				url, "selectedMetrics",
+			location = HttpComponentsUtil.addParameter(
+				location, "selectedMetrics",
 				StringUtil.merge(selectedMetrics, StringPool.COMMA));
 		}
 
 		if (size != null) {
-			url = HttpComponentsUtil.addParameter(url, "size", size);
+			location = HttpComponentsUtil.addParameter(location, "size", size);
 		}
 
 		if (ArrayUtil.isNotEmpty(sorts)) {
+			List<String> sortStrings = new ArrayList<>();
+
 			for (Sort sort : sorts) {
-				url = HttpComponentsUtil.addParameter(
-					url, "sort", sort.getFieldName());
-				url = HttpComponentsUtil.addParameter(
-					url, "sort", sort.isReverse() ? "desc" : "asc");
+				sortStrings.add(sort.getFieldName());
+				sortStrings.add(sort.isReverse() ? "desc" : "asc");
 			}
+
+			location = HttpComponentsUtil.addParameter(
+				location, "sort",
+				StringUtil.merge(sortStrings, StringPool.COMMA));
 		}
 
 		if (tagId != null) {
-			url = HttpComponentsUtil.addParameter(url, "tagId", tagId);
+			location = HttpComponentsUtil.addParameter(
+				location, "tagId", tagId);
 		}
 
 		if (vocabularyId != null) {
-			url = HttpComponentsUtil.addParameter(
-				url, "vocabularyId", vocabularyId);
+			location = HttpComponentsUtil.addParameter(
+				location, "vocabularyId", vocabularyId);
 		}
 
-		return url;
+		return location;
 	}
 
 	private String _getLocation(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -32,7 +32,6 @@ import com.liferay.object.model.ObjectDefinitionTable;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -686,19 +685,12 @@ public class AnalyticsCloudClient {
 		}
 
 		if (ArrayUtil.isNotEmpty(sorts)) {
-			StringBundler sb = new StringBundler((sorts.length * 4) - 1);
-
-			for (int i = 0; i < sorts.length; i++) {
-				if (i > 0) {
-					sb.append(StringPool.COMMA);
-				}
-
-				sb.append(sorts[i].getFieldName());
-				sb.append(StringPool.COLON);
-				sb.append(sorts[i].isReverse() ? "desc" : "asc");
+			for (Sort sort : sorts) {
+				url = HttpComponentsUtil.addParameter(
+					url, "sort", sort.getFieldName());
+				url = HttpComponentsUtil.addParameter(
+					url, "sort", sort.isReverse() ? "desc" : "asc");
 			}
-
-			url = HttpComponentsUtil.addParameter(url, "sort", sb.toString());
 		}
 
 		if (tagId != null) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
@@ -71,7 +71,7 @@ public class PerformanceAssetConsumptionResourceImpl
 				contextCompany.getCompanyId()),
 			categoryId, groupBy, Arrays.asList(groupIds),
 			contextAcceptLanguage.getPreferredLocale(), "viewsMetric",
-			objectType, pagination.getPage(), rangeKey,
+			objectType, pagination.getPage() - 1, rangeKey,
 			pagination.getPageSize(), tagId, vocabularyId);
 	}
 

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
@@ -58,8 +58,9 @@ public class PerformanceTopAssetResourceImpl
 		return analyticsCloudClient.getPerformanceTopAsset(
 			_analyticsSettingsManager.getAnalyticsConfiguration(
 				contextCompany.getCompanyId()),
-			assetFilterString, Arrays.asList(groupIds), pagination.getPage(),
-			rangeKey, pagination.getPageSize(), sorts);
+			assetFilterString, Arrays.asList(groupIds),
+			pagination.getPage() - 1, rangeKey, pagination.getPageSize(),
+			sorts);
 	}
 
 	@Override

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -323,9 +323,9 @@ public class PerformanceAssetConsumptionResourceTest
 					"L_CMS_BLOG", testCompany.getCompanyId());
 
 		long categoryId = RandomTestUtil.nextLong();
-		int page = 2;
+		int page = RandomTestUtil.nextInt();
 		int rangeKey = RandomTestUtil.nextInt();
-		int size = 5;
+		int size = RandomTestUtil.nextInt();
 		long tagId = RandomTestUtil.nextLong();
 		long vocabularyId = RandomTestUtil.nextLong();
 

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -350,7 +350,7 @@ public class PerformanceAssetConsumptionResourceTest
 				StringPool.COMMA),
 			"groupIds", location);
 		_assertParameter(objectDefinition.getName(), "objectType", location);
-		_assertParameter(String.valueOf(page), "page", location);
+		_assertParameter(String.valueOf(page - 1), "page", location);
 		_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
 		_assertParameter(String.valueOf(size), "size", location);
 		_assertParameter(String.valueOf(tagId), "tagId", location);

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -197,7 +197,7 @@ public class PerformanceTopAssetResourceTest
 			}
 
 			sb.append(sorts[i].getFieldName());
-			sb.append(StringPool.COLON);
+			sb.append(StringPool.COMMA);
 			sb.append(sorts[i].isReverse() ? "desc" : "asc");
 		}
 
@@ -325,7 +325,7 @@ public class PerformanceTopAssetResourceTest
 
 		_assertParameter(dataSourceId, "dataSourceId", location);
 		_assertParameter(assetFilterString, "filter", location);
-		_assertParameter(String.valueOf(page), "page", location);
+		_assertParameter(String.valueOf(page - 1), "page", location);
 		_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
 		_assertParameter(String.valueOf(pageSize), "size", location);
 
@@ -337,7 +337,7 @@ public class PerformanceTopAssetResourceTest
 			}
 
 			sb.append(sorts[i].getFieldName());
-			sb.append(StringPool.COLON);
+			sb.append(StringPool.COMMA);
 			sb.append(sorts[i].isReverse() ? "desc" : "asc");
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96073

## What Is Being Fixed

The CMS performance analytics endpoints sent incorrect requests to the Analytics Cloud (Faro) backend and mis-parsed one response. The page number was sent one-based, but the backend expects a zero-based page, so every paged request was off by one — the sibling `ChannelResourceImpl` already decremented, but the CMS resources did not. The sort parameter was serialized as `field:direction` pairs, while the backend expects a flat comma-separated `field,direction` list. Finally, `getPerformanceMetric` deserialized the whole response body instead of its `metrics` array node.

## How It Is Being Fixed

`PerformanceTopAssetResourceImpl` and `PerformanceAssetConsumptionResourceImpl` now pass `pagination.getPage() - 1` to the client, matching the existing `ChannelResourceImpl` convention. In `AnalyticsCloudClient`, the sort parameter is built with a `List<String>` joined by `StringUtil.merge(..., StringPool.COMMA)`, producing the flat comma-separated format and matching how `groupIds` and `selectedMetrics` are already built in the same method. `getPerformanceMetric` now deserializes `metricsJsonNode` rather than the root node. Supporting cleanups rename the local `url` to `location` to match the `_getLocation` method and `setLocation` consumer, and the integration tests are updated and randomized to assert the corrected page value and sort format in line with sibling test classes.

## PR Check

**pr-check: PASS** — tested on `a990b0c309a227a7ff39eff6412fbb03d75fe679`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "a990b0c309a227a7ff39eff6412fbb03d75fe679"} -->
