### PR TITLE
#2 LPD-94264 Redirect to the asset table filtered by the account

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
@@ -392,6 +392,36 @@ describe('List', () => {
 		it('should set itemLabel to "accountName" in the account filter', () => {
 			expect(getAccountFilter().itemLabel).toBe('accountName');
 		});
+
+		it('should not preload the account filter when no accountId is in the URL', () => {
+			expect(getAccountFilter().preloadedData).toBeUndefined();
+		});
+
+		it('should preload the account filter from the accountId URL param', () => {
+			renderList({queryString: '?accountId=acc-1'});
+
+			const accountFilter = getFilters().find(
+				(filter: {id: string}) => filter.id === 'accountIds'
+			);
+
+			expect(accountFilter.preloadedData).toEqual({
+				selectedItems: [{label: 'acc-1', value: 'acc-1'}],
+			});
+		});
+
+		it('should use the accountName from the URL as the preloaded label', () => {
+			renderList({
+				queryString: '?accountId=acc-1&accountName=Acme%20Corp',
+			});
+
+			const accountFilter = getFilters().find(
+				(filter: {id: string}) => filter.id === 'accountIds'
+			);
+
+			expect(accountFilter.preloadedData).toEqual({
+				selectedItems: [{label: 'Acme Corp', value: 'acc-1'}],
+			});
+		});
 	});
 
 	describe('initial range selector state', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
@@ -21,7 +21,7 @@ import {
 } from 'shared/util/router';
 import {toThousands} from 'shared/util/numbers';
 import {useChannelContext} from 'shared/context/channel';
-import {useHistory, useParams} from 'react-router-dom';
+import {useHistory, useLocation, useParams} from 'react-router-dom';
 import {useQueryRangeSelectors} from 'shared/hooks/useQueryRangeSelectors';
 
 const {cur: DEFAULT_CUR} = FaroConstants.pagination;
@@ -136,9 +136,14 @@ const assetsEmptyStateDescription = (
 
 const List = () => {
 	const history = useHistory();
+	const {search} = useLocation();
 	const {selectedChannel} = useChannelContext();
 	const {channelId, groupId} = useParams();
 	const initialRangeSelectors = useQueryRangeSelectors();
+
+	const searchParams = new URLSearchParams(search);
+	const accountId = searchParams.get('accountId');
+	const accountName = searchParams.get('accountName');
 
 	const [rangeSelectors, setRangeSelectors] = useState<RangeSelectors>(
 		initialRangeSelectors
@@ -166,6 +171,13 @@ const List = () => {
 				itemLabel: 'accountName',
 				label: Liferay.Language.get('account'),
 				multiple: true,
+				...(accountId && {
+					preloadedData: {
+						selectedItems: [
+							{label: accountName || accountId, value: accountId},
+						],
+					},
+				}),
 				searchable: true,
 				type: 'selection',
 			},
@@ -214,7 +226,7 @@ const List = () => {
 				type: 'selection',
 			},
 		],
-		[groupId, rangeSelectorParams]
+		[accountId, accountName, groupId, rangeSelectorParams]
 	);
 
 	return (

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/Profile.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/Profile.tsx
@@ -22,7 +22,7 @@ const Profile: React.FC<IProfileProps> = ({account, loading}) => (
 			<LifecycleStatus />
 			<AccountInfo account={account} loading={loading} />
 			<TopAssets account={account} />
-			<TopCategoriesAndTags />
+			<TopCategoriesAndTags account={account} />
 		</div>
 
 		<AccountIndividuals />

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/Profile.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/Profile.tsx
@@ -21,9 +21,10 @@ const Profile: React.FC<IProfileProps> = ({account, loading}) => (
 		<div className="account-profile-cards mb-3">
 			<LifecycleStatus />
 			<AccountInfo account={account} loading={loading} />
-			<TopAssets />
+			<TopAssets account={account} />
 			<TopCategoriesAndTags />
 		</div>
+
 		<AccountIndividuals />
 	</section>
 );

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/AccountInfo.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/AccountInfo.tsx
@@ -20,6 +20,7 @@ export interface IAccount {
 		name: string;
 		value?: string;
 	}>;
+	id?: string;
 	industry?: string;
 	numberOfEmployees?: number;
 	website?: string;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/TopAssets.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/TopAssets.tsx
@@ -11,14 +11,16 @@ import ClayTabs from '@clayui/tabs';
 import React, {useState} from 'react';
 import StatesRenderer from 'shared/components/states-renderer/StatesRenderer';
 import {getMimeType} from 'assets/components/mime-type';
+import {IAccount} from './AccountInfo';
 import {ITopAsset, TopAssetMetric, TopAssetObjectType} from 'shared/api/assets';
 import {Option, Picker, Text} from '@clayui/core';
-import {Routes, toRoute} from 'shared/util/router';
+import {Routes, setUriQueryValues, toRoute} from 'shared/util/router';
 import {toThousands} from 'shared/util/numbers';
 import {useHistory, useParams} from 'react-router-dom';
 import {useRequest} from 'shared/hooks/useRequest';
 
 interface ITopAssetsProps {
+	account?: IAccount;
 	className?: string;
 }
 
@@ -237,17 +239,15 @@ const TopAssetsTabContent: React.FC<ITopAssetsTabContentProps> = ({
 	);
 };
 
-const TopAssets: React.FC<ITopAssetsProps> = ({className}) => {
+const TopAssets: React.FC<ITopAssetsProps> = ({account, className}) => {
 	const history = useHistory();
-	const {
-		channelId,
-		groupId,
-		id: accountId,
-	} = useParams<{
+	const {channelId, groupId} = useParams<{
 		channelId: string;
 		groupId: string;
-		id: string;
 	}>();
+
+	const accountId = account?.id;
+	const accountName = account?.accountName;
 
 	const [activeTab, setActiveTab] = useState(0);
 	const [groupBy, setGroupBy] = useState<GroupByMetric>(
@@ -271,8 +271,9 @@ const TopAssets: React.FC<ITopAssetsProps> = ({className}) => {
 		{items: ITopAsset[]}
 	>({
 		dataSourceFn: API.assets.fetchAccountTopAssets,
+		skipRequest: !accountId,
 		variables: {
-			accountId,
+			accountId: accountId!,
 			channelId,
 			groupId,
 			objectType: TAB_OBJECT_TYPES[TABS[activeTab]],
@@ -329,7 +330,16 @@ const TopAssets: React.FC<ITopAssetsProps> = ({className}) => {
 							className="ml-auto rounded-lg"
 							onClick={() =>
 								history.push(
-									toRoute(Routes.ASSETS, {channelId, groupId})
+									setUriQueryValues(
+										{
+											accountId,
+											...(accountName && {accountName}),
+										},
+										toRoute(Routes.ASSETS, {
+											channelId,
+											groupId,
+										})
+									)
 								)
 							}
 							size="sm"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/TopCategoriesAndTags.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/TopCategoriesAndTags.tsx
@@ -8,6 +8,7 @@ import ClayTable from '@clayui/table';
 import ClayTabs from '@clayui/tabs';
 import React, {useCallback, useState} from 'react';
 import StatesRenderer from 'shared/components/states-renderer/StatesRenderer';
+import {IAccount} from './AccountInfo';
 import {Option, Picker, Text} from '@clayui/core';
 import {toThousands} from 'shared/util/numbers';
 import {useParams} from 'react-router-dom';
@@ -37,6 +38,7 @@ export interface ITopTag {
 }
 
 interface ITopCategoriesAndTagsProps {
+	account?: IAccount;
 	className?: string;
 }
 
@@ -196,17 +198,15 @@ const TabContent: React.FC<ITabContentProps> = ({
 };
 
 const TopCategoriesAndTags: React.FC<ITopCategoriesAndTagsProps> = ({
+	account,
 	className,
 }) => {
-	const {
-		channelId,
-		groupId,
-		id: accountId,
-	} = useParams<{
+	const {channelId, groupId} = useParams<{
 		channelId: string;
 		groupId: string;
-		id: string;
 	}>();
+
+	const accountId = account?.id;
 
 	const [activeTab, setActiveTab] = useState(0);
 	const [groupBy, setGroupBy] = useState<GroupByMetric>(
@@ -245,7 +245,14 @@ const TopCategoriesAndTags: React.FC<ITopCategoriesAndTagsProps> = ({
 		{items: TaxonomyItem[]}
 	>({
 		dataSourceFn,
-		variables: {accountId, channelId, groupId, isCategory, selectedMetric},
+		skipRequest: !accountId,
+		variables: {
+			accountId: accountId!,
+			channelId,
+			groupId,
+			isCategory,
+			selectedMetric,
+		},
 	});
 
 	const items = data?.items ?? [];

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopAssets.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopAssets.tsx
@@ -32,6 +32,8 @@ jest.mock('react-router-dom', () => ({
 
 const mockedUseRequest = useRequest as jest.Mock;
 
+const ACCOUNT = {accountName: 'Acme', id: 'acc-1'};
+
 const buildAsset = (overrides: Partial<ITopAsset> = {}): ITopAsset => ({
 	assetTitle: 'Asset 1',
 	assetType: 'webContent',
@@ -110,13 +112,13 @@ describe('TopAssets', () => {
 
 	describe('rendering', () => {
 		it('should render the card title', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(screen.getByText('TOP ASSETS')).toBeInTheDocument();
 		});
 
 		it('should render both tab labels', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(
 				screen.getByRole('tab', {name: 'Content'})
@@ -127,7 +129,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should render the View All button', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(
 				screen.getByRole('button', {name: 'View All'})
@@ -135,7 +137,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should render the Group By picker with the default metric (Impressions)', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(screen.getAllByText('Group By').length).toBeGreaterThan(0);
 			expect(screen.getAllByText('Impressions').length).toBeGreaterThan(
@@ -146,7 +148,7 @@ describe('TopAssets', () => {
 
 	describe('data rendering', () => {
 		it('should render an asset link for every item returned', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(
 				screen.getAllByRole('link', {name: 'Web Content One'})[0]
@@ -166,7 +168,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should render the metric values for the default Impressions metric', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(screen.getAllByText('100').length).toBeGreaterThan(0);
 			expect(screen.getAllByText('80').length).toBeGreaterThan(0);
@@ -176,7 +178,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should route blog assets through the Blogs overview path', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			const link = screen.getAllByRole('link', {
 				name: 'Blog Post',
@@ -186,7 +188,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should route document assets through the Documents and Media path', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			const link = screen.getAllByRole('link', {
 				name: 'Brochure PDF',
@@ -198,7 +200,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should route form assets through the Forms path', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			const link = screen.getAllByRole('link', {
 				name: 'Lead Form',
@@ -208,7 +210,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should route web content assets through the Web Content path', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			const link = screen.getAllByRole('link', {
 				name: 'Web Content One',
@@ -218,7 +220,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should route unknown asset types through the Object Entry path', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			const link = screen.getAllByRole('link', {
 				name: 'Custom Entry',
@@ -232,7 +234,7 @@ describe('TopAssets', () => {
 
 	describe('group by picker', () => {
 		it('should refetch with viewsMetric when the user picks Views', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			fireEvent.click(
 				screen.getAllByRole('combobox', {name: 'Group By'})[0]
@@ -249,7 +251,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should refetch with downloadsMetric when the user picks Downloads on the Files tab', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			fireEvent.click(screen.getByRole('tab', {name: 'Files'}));
 
@@ -270,7 +272,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should not offer the Downloads metric on the Content tab', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			fireEvent.click(
 				screen.getAllByRole('combobox', {name: 'Group By'})[0]
@@ -288,7 +290,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should offer the Downloads metric on the Files tab', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			fireEvent.click(screen.getByRole('tab', {name: 'Files'}));
 
@@ -302,7 +304,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should reset to impressionsMetric when switching to Content while Downloads is selected', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			fireEvent.click(screen.getByRole('tab', {name: 'Files'}));
 
@@ -328,7 +330,7 @@ describe('TopAssets', () => {
 
 	describe('tab switching', () => {
 		it('should request the Content objectType on initial render', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			const firstCall = mockedUseRequest.mock.calls[0][0];
 
@@ -336,7 +338,7 @@ describe('TopAssets', () => {
 		});
 
 		it('should request the File objectType after clicking the Files tab', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			fireEvent.click(screen.getByRole('tab', {name: 'Files'}));
 
@@ -351,7 +353,7 @@ describe('TopAssets', () => {
 
 	describe('request shape', () => {
 		it('should forward accountId, channelId, and groupId to the data source', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			const firstCall = mockedUseRequest.mock.calls[0][0];
 
@@ -363,12 +365,17 @@ describe('TopAssets', () => {
 
 	describe('view all', () => {
 		it('should navigate to the asset list when the View All button is clicked', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			fireEvent.click(screen.getByRole('button', {name: 'View All'}));
 
 			expect(mockPush).toHaveBeenCalledTimes(1);
-			expect(mockPush.mock.calls[0][0]).toContain('/assets');
+
+			const pushedURL = mockPush.mock.calls[0][0];
+
+			expect(pushedURL).toContain('/assets');
+			expect(pushedURL).toContain('accountId=acc-1');
+			expect(pushedURL).toContain('accountName=Acme');
 		});
 	});
 
@@ -376,7 +383,7 @@ describe('TopAssets', () => {
 		it('should render the loading indicator while the request is in flight', () => {
 			mockUseRequestWith({loading: true});
 
-			const {container} = render(<TopAssets />);
+			const {container} = render(<TopAssets account={ACCOUNT} />);
 
 			expect(
 				container.querySelector('.loading-root')
@@ -386,7 +393,7 @@ describe('TopAssets', () => {
 		it('should not render asset rows while loading', () => {
 			mockUseRequestWith({loading: true});
 
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(
 				screen.queryByRole('link', {name: 'Web Content One'})
@@ -396,7 +403,7 @@ describe('TopAssets', () => {
 		it('should not render the View All button while loading', () => {
 			mockUseRequestWith({loading: true});
 
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(screen.queryByRole('button', {name: 'View All'})).toBeNull();
 		});
@@ -406,13 +413,13 @@ describe('TopAssets', () => {
 		it('should not render the View All button when there are no assets', () => {
 			mockUseRequestWith({data: {items: []}});
 
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(screen.queryByRole('button', {name: 'View All'})).toBeNull();
 		});
 
 		it('should render the View All button when assets are returned', () => {
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(
 				screen.getByRole('button', {name: 'View All'})
@@ -424,7 +431,7 @@ describe('TopAssets', () => {
 		it('should render the Content empty state when no assets are returned on the Content tab', () => {
 			mockUseRequestWith({data: {items: []}});
 
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(
 				screen.getAllByText('No Assets Available').length
@@ -434,7 +441,7 @@ describe('TopAssets', () => {
 		it('should render the Files empty state when no assets are returned on the Files tab', () => {
 			mockUseRequestWith({data: {items: []}});
 
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			fireEvent.click(screen.getByRole('tab', {name: 'Files'}));
 
@@ -446,7 +453,7 @@ describe('TopAssets', () => {
 		it('should not render asset rows when no assets are returned', () => {
 			mockUseRequestWith({data: {items: []}});
 
-			render(<TopAssets />);
+			render(<TopAssets account={ACCOUNT} />);
 
 			expect(
 				screen.queryByRole('link', {name: 'Web Content One'})
@@ -470,7 +477,7 @@ describe('TopAssets', () => {
 				},
 			});
 
-			const {container} = render(<TopAssets />);
+			const {container} = render(<TopAssets account={ACCOUNT} />);
 
 			const tabPanel = container.querySelector(
 				'.tab-pane'

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopCategoriesAndTags.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopCategoriesAndTags.tsx
@@ -34,6 +34,8 @@ jest.mock('react-router-dom', () => ({
 
 const mockedUseRequest = useRequest as jest.Mock;
 
+const ACCOUNT = {accountName: 'Acme', id: 'acc-1'};
+
 const buildCategory = (
 	overrides: Partial<ITopCategory> = {}
 ): ITopCategory => ({
@@ -123,7 +125,7 @@ describe('TopCategoriesAndTags', () => {
 
 	describe('rendering', () => {
 		it('should render the card title', () => {
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			expect(
 				screen.getByText('TOP ASSET VOCABULARIES AND CATEGORIES')
@@ -131,7 +133,7 @@ describe('TopCategoriesAndTags', () => {
 		});
 
 		it('should render both tab labels', () => {
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			expect(
 				screen.getByRole('tab', {name: 'Category'})
@@ -140,7 +142,7 @@ describe('TopCategoriesAndTags', () => {
 		});
 
 		it('should render the Group By picker with the default metric (Impressions)', () => {
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			expect(screen.getAllByText('Group By').length).toBeGreaterThan(0);
 			expect(screen.getAllByText('Impressions').length).toBeGreaterThan(
@@ -151,7 +153,7 @@ describe('TopCategoriesAndTags', () => {
 
 	describe('data rendering', () => {
 		it('should render the name of every item returned', () => {
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			expect(
 				screen.getAllByText('Department Names').length
@@ -171,7 +173,7 @@ describe('TopCategoriesAndTags', () => {
 		});
 
 		it('should render the metric values for the default Impressions metric', () => {
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			expect(screen.getAllByText('12K').length).toBeGreaterThan(0);
 			expect(screen.getAllByText('9.5K').length).toBeGreaterThan(0);
@@ -181,7 +183,9 @@ describe('TopCategoriesAndTags', () => {
 		});
 
 		it('should render the Category Name and Vocabulary column headers on the Category tab', () => {
-			const {container} = render(<TopCategoriesAndTags />);
+			const {container} = render(
+				<TopCategoriesAndTags account={ACCOUNT} />
+			);
 
 			const tabPanel = container.querySelector(
 				'.tab-pane'
@@ -196,7 +200,7 @@ describe('TopCategoriesAndTags', () => {
 		});
 
 		it('should render the vocabulary name of every category returned', () => {
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			expect(screen.getAllByText('Department').length).toBeGreaterThan(0);
 			expect(screen.getAllByText('Document Type').length).toBeGreaterThan(
@@ -208,7 +212,9 @@ describe('TopCategoriesAndTags', () => {
 		});
 
 		it('should use the Tag Name header and omit the Vocabulary column on the Tag tab', () => {
-			const {container} = render(<TopCategoriesAndTags />);
+			const {container} = render(
+				<TopCategoriesAndTags account={ACCOUNT} />
+			);
 
 			mockUseRequestWith({
 				data: {
@@ -235,7 +241,7 @@ describe('TopCategoriesAndTags', () => {
 
 	describe('group by picker', () => {
 		it('should refetch with viewsMetric when the user picks Views', () => {
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			fireEvent.click(
 				screen.getAllByRole('combobox', {name: 'Group By'})[0]
@@ -252,7 +258,7 @@ describe('TopCategoriesAndTags', () => {
 		});
 
 		it('should refetch with downloadsMetric when the user picks Downloads', () => {
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			fireEvent.click(
 				screen.getAllByRole('combobox', {name: 'Group By'})[0]
@@ -275,7 +281,7 @@ describe('TopCategoriesAndTags', () => {
 		it('should query the categories data source on initial render', () => {
 			const API = jest.requireMock('shared/api');
 
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			const firstCall = mockedUseRequest.mock.calls[0][0];
 
@@ -290,7 +296,7 @@ describe('TopCategoriesAndTags', () => {
 		it('should query the tags data source when the Tag tab is clicked', () => {
 			const API = jest.requireMock('shared/api');
 
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			fireEvent.click(screen.getByRole('tab', {name: 'Tag'}));
 
@@ -310,7 +316,7 @@ describe('TopCategoriesAndTags', () => {
 		});
 
 		it('should change the request variables when switching tabs so the request refetches', () => {
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			const categoryVariables =
 				mockedUseRequest.mock.calls[0][0].variables;
@@ -328,7 +334,7 @@ describe('TopCategoriesAndTags', () => {
 		});
 
 		it('should render tag items after switching to the Tag tab', () => {
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			mockUseRequestWith({
 				data: {
@@ -350,7 +356,7 @@ describe('TopCategoriesAndTags', () => {
 
 	describe('request shape', () => {
 		it('should forward accountId, channelId, and groupId to the data source', () => {
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			const firstCall = mockedUseRequest.mock.calls[0][0];
 
@@ -364,7 +370,9 @@ describe('TopCategoriesAndTags', () => {
 		it('should render the loading indicator while the request is in flight', () => {
 			mockUseRequestWith({loading: true});
 
-			const {container} = render(<TopCategoriesAndTags />);
+			const {container} = render(
+				<TopCategoriesAndTags account={ACCOUNT} />
+			);
 
 			expect(
 				container.querySelector('.loading-root')
@@ -374,7 +382,7 @@ describe('TopCategoriesAndTags', () => {
 		it('should not render rows while loading', () => {
 			mockUseRequestWith({loading: true});
 
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			expect(screen.queryByText('Department Names')).toBeNull();
 		});
@@ -384,7 +392,7 @@ describe('TopCategoriesAndTags', () => {
 		it('should render the categories empty message on the Category tab when no items are returned', () => {
 			mockUseRequestWith({data: {items: []}});
 
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			expect(
 				screen.getAllByText('No Categories Available').length
@@ -399,7 +407,7 @@ describe('TopCategoriesAndTags', () => {
 		it('should render the tags empty message on the Tag tab when no items are returned', () => {
 			mockUseRequestWith({data: {items: []}});
 
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			fireEvent.click(screen.getByRole('tab', {name: 'Tag'}));
 
@@ -415,7 +423,7 @@ describe('TopCategoriesAndTags', () => {
 		it('should keep tabs visible in the empty state', () => {
 			mockUseRequestWith({data: {items: []}});
 
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			expect(
 				screen.getByRole('tab', {name: 'Category'})
@@ -426,7 +434,7 @@ describe('TopCategoriesAndTags', () => {
 		it('should not render rows when no items are returned', () => {
 			mockUseRequestWith({data: {items: []}});
 
-			render(<TopCategoriesAndTags />);
+			render(<TopCategoriesAndTags account={ACCOUNT} />);
 
 			expect(screen.queryByText('Department Names')).toBeNull();
 		});
@@ -448,7 +456,9 @@ describe('TopCategoriesAndTags', () => {
 				},
 			});
 
-			const {container} = render(<TopCategoriesAndTags />);
+			const {container} = render(
+				<TopCategoriesAndTags account={ACCOUNT} />
+			);
 
 			const tabPanel = container.querySelector(
 				'.tab-pane'

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/FrontendDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/FrontendDataSet.tsx
@@ -130,8 +130,9 @@ export function useSnapshots(fdsName: string, enabled = true) {
 		Liferay.FeatureFlags['LPS-164563'];
 
 	const [snapshots, setSnapshots] = useState<Array<{
-		headerVisible: boolean;
-		items: any[];
+		configuration: string;
+		erc: string;
+		label: string;
 	}> | null>(fetchSnapshots ? null : []);
 
 	useEffect(() => {
@@ -157,11 +158,7 @@ export function useSnapshots(fdsName: string, enabled = true) {
 					})
 				);
 
-				setSnapshots(
-					formattedSnapshots.length
-						? [{headerVisible: false, items: formattedSnapshots}]
-						: []
-				);
+				setSnapshots(formattedSnapshots);
 			})
 			.catch((error) => {
 
@@ -203,7 +200,9 @@ const FrontendDataSet = ({
 		<BaseFrontendDataSet
 			{...props}
 			configInURLBehavior={configInURLBehavior}
-			snapshots={snapshots}
+			snapshots={
+				snapshots as unknown as IBaseFrontendDataSetProps['snapshots']
+			}
 			snapshotsEnabled={snapshotsEnabled}
 		/>
 	);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/FrontendDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/FrontendDataSet.tsx
@@ -111,7 +111,7 @@ describe('useSnapshots', () => {
 		expect(result.current).toBeNull();
 	});
 
-	it('should wrap saved views in a single headerless group', async () => {
+	it('should return saved views as a flat list of snapshots', async () => {
 		mockFetch([
 			{
 				externalReferenceCode: 'erc-1',
@@ -127,14 +127,9 @@ describe('useSnapshots', () => {
 		await waitFor(() =>
 			expect(result.current).toEqual([
 				{
-					headerVisible: false,
-					items: [
-						{
-							configuration: '{"filters":[]}',
-							erc: 'erc-1',
-							label: 'My View',
-						},
-					],
+					configuration: '{"filters":[]}',
+					erc: 'erc-1',
+					label: 'My View',
 				},
 			])
 		);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94264
https://liferay.atlassian.net/browse/LPD-94262

## What Is Being Fixed

There was no way to navigate from an account's profile cards to the asset table pre-filtered by that account, and the data set could crash when restoring saved-view snapshots. This also carries the account filter from LPD-94262 (included as the base this work builds on), which the assets table previously lacked.

## How It Is Being Fixed

On top of Rafaella's LPD-94262 account filter, the profile cards are standardized to take the account via props and link to the asset table filtered by that account, the FrontendDataSet snapshot handling is flattened to prevent the crash, and unit tests are added and updated. This is the same change as liferay-ac PR #3542, reapplied to the new osb-faro-web location under workspaces/liferay-osbfaro-workspace after the module was migrated out of modules/dxp/apps/osb/osb-faro.

## PR Check

**pr-check: PASS** — tested on `ac402b85be938beeb46175420990697bdba2cf2b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

JavaScript Unit Tests did not fire (its Match regex is anchored to `^modules/`, while this module lives under `workspaces/.../modules/`); the touched suites (assets List, TopAssets, TopCategoriesAndTags, FrontendDataSet) were run manually and pass 112/112.

<!-- pr-check {"result": "success", "sha": "ac402b85be938beeb46175420990697bdba2cf2b"} -->
