### PR TITLE
LPD-96131 Fix broken Playwright tests

### DIFF
--- a/modules/test/playwright/tests/analytics-client-js/main/blog-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/blog-events.spec.ts
@@ -22,6 +22,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/analytics-client-js/main/comment-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/comment-events.spec.ts
@@ -23,6 +23,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/analytics-client-js/main/document-events.spec.ts
+++ b/modules/test/playwright/tests/analytics-client-js/main/document-events.spec.ts
@@ -24,6 +24,7 @@ const test = mergeTests(
 	apiHelpersTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/osb-faro-web/main/apis.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/apis.spec.ts
@@ -47,7 +47,7 @@ test('Generate a new token after expired', async ({
 			const rowToken = page.getByTestId(`row-token-${tokenId}`);
 
 			expect(await rowToken.textContent()).toBe(
-				`Token ending in${tokenId}Expired`
+				`Token Ending In${tokenId}Expired`
 			);
 		});
 

--- a/modules/test/playwright/tests/osb-faro-web/main/blog-ratings.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/main/blog-ratings.spec.ts
@@ -24,6 +24,7 @@ import {closeSessions} from './utils/sessions';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
+		'LPD-76864': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedChannelTest,

--- a/modules/test/playwright/tests/segments-web/main/pages/SegmentsPage.ts
+++ b/modules/test/playwright/tests/segments-web/main/pages/SegmentsPage.ts
@@ -143,7 +143,7 @@ export class SegmentsPage {
 
 	async clickDuplicateButton() {
 		const duplicateButton = this.page.getByRole('button', {
-			name: 'Duplicate Segment Property',
+			name: 'Duplicate Property',
 		});
 		await duplicateButton.click();
 	}
@@ -253,7 +253,9 @@ export class SegmentsPage {
 			exact: true,
 			name: tabName,
 		});
-		const propertyLocator = this.page.getByText(propertyName);
+		const propertyLocator = this.page.getByText(propertyName, {
+			exact: true,
+		});
 		const isPropertyVisible = await propertyLocator.isVisible();
 
 		if (!isPropertyVisible) {

--- a/modules/test/playwright/tests/segments-web/main/segmentation.spec.ts
+++ b/modules/test/playwright/tests/segments-web/main/segmentation.spec.ts
@@ -32,6 +32,7 @@ export const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-78863': {enabled: true, system: true},
+		'LPS-178052': {enabled: true},
 	}),
 	instanceSettingsPagesTest,
 	pageEditorPagesTest,
@@ -295,9 +296,11 @@ test(
 
 		// Create an organization, a user, and assign the user to the organization
 
+		const organizationName = getRandomString();
+
 		const organization =
 			await apiHelpers.headlessAdminUser.postOrganization({
-				name: getRandomString(),
+				name: organizationName,
 			});
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount({
@@ -318,7 +321,9 @@ test(
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: page.getByRole('menuitem', {name: 'Edit'}),
-			trigger: page.getByRole('button', {name: 'Show Actions'}),
+			trigger: page
+				.locator('tr', {hasText: organizationName})
+				.getByRole('button', {name: 'Show Actions'}),
 		});
 
 		await clickAndExpectToBeVisible({
@@ -1802,7 +1807,7 @@ test(
 			await editUserPage.lastNameInput.fill('userln');
 			await editUserPage.screenNameInput.fill('usersn');
 
-			const tagInputFied = page.getByLabel('Tags', {exact: true});
+			const tagInputFied = page.getByRole('combobox', {name: 'Tags'});
 			await tagInputFied.fill('tagName');
 			await tagInputFied.press('Enter');
 			await page.locator('body').click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96131

## What Is Being Fixed

Several Playwright tests for segments and analytics broke against the current portal: the segment editor renamed "Duplicate Segment Property" to "Duplicate Property", a new "Device Type" property collided with a non-exact "Type" locator, the Edit User "Tags" label now matches two elements, the organizations list can show more than one "Show Actions" button, the API token row text changed casing, and several specs create widget pages without enabling the widget pages feature flag.

## How It Is Being Fixed

The SegmentsPage page object targets the renamed "Duplicate Property" action and matches "Type" exactly. The segmentation spec selects the Tags combobox by role, scopes "Show Actions" to the created organization's row, and enables the LPS-178052 site pages flag for the back-button test. The apis spec expects the updated "Token Ending In" casing. The widget-page specs (blog, comment, document events and blog ratings) enable the LPD-76864 flag so widget pages can be created.

## Why Are There No Tests?

This change only updates existing Playwright tests (locators, expected text, and feature flags) to match the current portal UI and feature-flag state. There is no production code change, so no new coverage applies.

## PR Check

**pr-check: PASS** — tested on `12a5ae62e7fbd92b1333e0c9193b0a0b529d01c7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile (TypeScript) | PASS |

JavaScript Unit Tests matched the diff but does not apply: the changed files are Playwright end-to-end specs (out of pr-check scope) and the module declares no Jest unit specs.

<!-- pr-check {"result": "success", "sha": "12a5ae62e7fbd92b1333e0c9193b0a0b529d01c7"} -->
