### PR TITLE
LPD-96134 Resolve osb-faro-web ESLint parser from modules on CI

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/.eslintrc.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/.eslintrc.js
@@ -19,7 +19,12 @@ module.exports = {
 		Liferay: true,
 		pendo: true,
 	},
-	parser: '@typescript-eslint/parser',
+	parser: require.resolve('@typescript-eslint/parser', {
+		paths: [
+			__dirname,
+			require('path').join(__dirname, '..', '..', '..', '..', 'modules'),
+		],
+	}),
 	parserOptions: {
 		ecmaFeatures: {
 			allowImportExportEverywhere: true,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96134

## What Is Being Fixed

After osb-faro-web moved to workspaces/liferay-osbfaro-workspace/modules/osb-faro-web, ci:test:sf (the portal Source Format check) fails on any PR that touches its .ts/.tsx files. The global SF (node-scripts, run from modules/) loads osb-faro-web/.eslintrc.js, which declares parser: '@typescript-eslint/parser'. ESLint resolves the parser relative to the workspace config, but CI only installs modules/node_modules (not the workspace's), so it cannot find the parser and fails with "Failed to load parser '@typescript-eslint/parser'". It passes locally only because the workspace node_modules is installed (false negative).

## How It Is Being Fixed

Resolve the parser explicitly in osb-faro-web/.eslintrc.js so it is found in modules/node_modules on CI, with a fallback to the workspace's own parser for the local workspace formatter. The declared plugins already resolve from modules/ via resolvePluginsRelativeTo, so only the parser needed this.

## Why Are There No Tests?

This is an ESLint configuration-resolution fix for the portal Source Format CI check; it changes no runtime behavior, so there is nothing unit-testable. It is verified by running Source Format (ci:test:sf) against the change, including under a simulated CI environment where the workspace node_modules is absent.

## PR Check

**pr-check: PASS** — tested on `edbe499a28a3b9796a7859efb9d70d9045fc6ace`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

Source Format was verified by running the global SF (node-scripts) on the changed .eslintrc.js both normally and with the workspace node_modules hidden (CI condition) — both pass. JavaScript Unit Tests did not fire (config-only change; path under workspaces/ does not match the validation's ^modules/ pattern).

<!-- pr-check {"result": "success", "sha": "edbe499a28a3b9796a7859efb9d70d9045fc6ace"} -->
