### PR TITLE
LPD-94970 Prevent activity chart crash on interval or range change

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/ActivitiesChart.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/ActivitiesChart.tsx
@@ -271,7 +271,7 @@ const ActivitiesChart: React.FC<
 					strokeWidth={1}
 					x={
 						selectedPoint !== undefined
-							? history[selectedPoint].intervalInitDate
+							? history[selectedPoint]?.intervalInitDate
 							: undefined
 					}
 				/>

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/__tests__/ActivitiesChart.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/components/__tests__/ActivitiesChart.tsx
@@ -1,0 +1,54 @@
+import ActivitiesChart from '../ActivitiesChart';
+import React from 'react';
+import {RangeKeyTimeRanges} from 'shared/util/constants';
+import {render} from '@testing-library/react';
+
+jest.unmock('react-dom');
+
+jest.mock('recharts', () => {
+	const OriginalModule = jest.requireActual('recharts');
+
+	return {
+		...OriginalModule,
+		ResponsiveContainer: ({children}: {children: React.ReactNode}) => (
+			<OriginalModule.ResponsiveContainer height={350} width={800}>
+				{children}
+			</OriginalModule.ResponsiveContainer>
+		)
+	};
+});
+
+const history = [
+	{intervalInitDate: 1717200000000, totalEvents: 3, totalSessions: 2},
+	{intervalInitDate: 1717286400000, totalEvents: 5, totalSessions: 4}
+];
+
+const renderChart = (selectedPoint?: number) =>
+	render(
+		<ActivitiesChart
+			alwaysShowSelectedTooltip={false}
+			history={history}
+			interval='D'
+			onPointSelect={() => {}}
+			rangeSelectors={{
+				rangeEnd: null,
+				rangeKey: RangeKeyTimeRanges.Last30Days,
+				rangeStart: null
+			}}
+			selectedPoint={selectedPoint}
+		/>
+	);
+
+describe('ActivitiesChart', () => {
+	it('does not crash when the selected point index is out of bounds for the current history', () => {
+		expect(() => renderChart(history.length + 5)).not.toThrow();
+	});
+
+	it('draws the reference line for an in-bounds selected point', () => {
+		const {container} = renderChart(1);
+
+		expect(
+			container.querySelector('.recharts-reference-line')
+		).toBeInTheDocument();
+	});
+});

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
@@ -73,9 +73,19 @@ const ActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 	const {delta, onDeltaChange, onPageChange, page, resetPage} =
 		useStatefulPagination();
 
-	useEffect(() => {
+	const handleChangeSelection = (index: number | null) => {
 		resetPage();
-	}, [rangeSelectors.rangeKey]);
+		onPointSelect(index ?? undefined);
+	};
+
+	useEffect(() => {
+		handleChangeSelection(null);
+	}, [
+		interval,
+		rangeSelectors.rangeEnd,
+		rangeSelectors.rangeKey,
+		rangeSelectors.rangeStart
+	]);
 
 	const safeRangeSelectors = getSafeRangeSelectors(rangeSelectors);
 
@@ -186,11 +196,6 @@ const ActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 
 	const sessionsData = sessionsResponse.data?.eventsByUserSessions;
 	const userSessions = sessionsData?.userSessions ?? [];
-
-	const handleChangeSelection = (index: number | null) => {
-		resetPage();
-		onPointSelect(index ?? undefined);
-	};
 
 	const handleQuerySubmit = (value: string) => {
 		setKeywords(value);


### PR DESCRIPTION
Selecting a bar in the account Activity Stream chart stored the point's index, but that index was never cleared when the chart interval or date range changed. After the chart refetched with a different number of buckets, the stale index pointed out of bounds and ActivitiesChart dereferenced an undefined entry, white-screening the card; an in-bounds stale index instead labeled the wrong date. The selected point is now cleared whenever the interval or range changes, and the reference line access is null-guarded as a safeguard.