### PR TITLE
LPD-94970 Prevent activity chart crash on interval or range change

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/.eslintrc.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/.eslintrc.js
@@ -19,7 +19,12 @@ module.exports = {
 		Liferay: true,
 		pendo: true,
 	},
-	parser: '@typescript-eslint/parser',
+	parser: require.resolve('@typescript-eslint/parser', {
+		paths: [
+			__dirname,
+			require('path').join(__dirname, '..', '..', '..', '..', 'modules'),
+		],
+	}),
 	parserOptions: {
 		ecmaFeatures: {
 			allowImportExportEverywhere: true,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/ActivitiesChart.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/ActivitiesChart.tsx
@@ -271,7 +271,7 @@ const ActivitiesChart: React.FC<
 					strokeWidth={1}
 					x={
 						selectedPoint !== undefined
-							? history[selectedPoint].intervalInitDate
+							? history[selectedPoint]?.intervalInitDate
 							: undefined
 					}
 				/>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/__tests__/ActivitiesChart.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/__tests__/ActivitiesChart.tsx
@@ -1,0 +1,54 @@
+import ActivitiesChart from '../ActivitiesChart';
+import React from 'react';
+import {RangeKeyTimeRanges} from 'shared/util/constants';
+import {render} from '@testing-library/react';
+
+jest.unmock('react-dom');
+
+jest.mock('recharts', () => {
+	const OriginalModule = jest.requireActual('recharts');
+
+	return {
+		...OriginalModule,
+		ResponsiveContainer: ({children}: {children: React.ReactNode}) => (
+			<OriginalModule.ResponsiveContainer height={350} width={800}>
+				{children}
+			</OriginalModule.ResponsiveContainer>
+		),
+	};
+});
+
+const history = [
+	{intervalInitDate: 1717200000000, totalEvents: 3, totalSessions: 2},
+	{intervalInitDate: 1717286400000, totalEvents: 5, totalSessions: 4},
+];
+
+const renderChart = (selectedPoint?: number) =>
+	render(
+		<ActivitiesChart
+			alwaysShowSelectedTooltip={false}
+			history={history}
+			interval="D"
+			onPointSelect={() => {}}
+			rangeSelectors={{
+				rangeEnd: null,
+				rangeKey: RangeKeyTimeRanges.Last30Days,
+				rangeStart: null,
+			}}
+			selectedPoint={selectedPoint}
+		/>
+	);
+
+describe('ActivitiesChart', () => {
+	it('does not crash when the selected point index is out of bounds for the current history', () => {
+		expect(() => renderChart(history.length + 5)).not.toThrow();
+	});
+
+	it('draws the reference line for an in-bounds selected point', () => {
+		const {container} = renderChart(1);
+
+		expect(
+			container.querySelector('.recharts-reference-line')
+		).toBeInTheDocument();
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
@@ -73,9 +73,19 @@ const ActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 	const {delta, onDeltaChange, onPageChange, page, resetPage} =
 		useStatefulPagination();
 
-	useEffect(() => {
+	const handleChangeSelection = (index: number | null) => {
 		resetPage();
-	}, [rangeSelectors.rangeKey]);
+		onPointSelect(index ?? undefined);
+	};
+
+	useEffect(() => {
+		handleChangeSelection(null);
+	}, [
+		interval,
+		rangeSelectors.rangeEnd,
+		rangeSelectors.rangeKey,
+		rangeSelectors.rangeStart,
+	]);
 
 	const safeRangeSelectors = getSafeRangeSelectors(rangeSelectors);
 
@@ -186,11 +196,6 @@ const ActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 
 	const sessionsData = sessionsResponse.data?.eventsByUserSessions;
 	const userSessions = sessionsData?.userSessions ?? [];
-
-	const handleChangeSelection = (index: number | null) => {
-		resetPage();
-		onPointSelect(index ?? undefined);
-	};
 
 	const handleQuerySubmit = (value: string) => {
 		setKeywords(value);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94970
https://liferay.atlassian.net/browse/LPD-96134

## What Is Being Fixed

The activity chart could crash when the interval or range changed.

## How It Is Being Fixed

Guards the activity chart rendering so it no longer crashes when the interval or range changes, and adds a regression test. This is the same change as liferay-ac PR #3573, reapplied to the new osb-faro-web location under workspaces/liferay-osbfaro-workspace after the module was migrated out of modules/dxp/apps/osb/osb-faro. It also carries the LPD-96134 ESLint parser-resolution fix so ci:test:sf can run on this workspace path.

## PR Check

**pr-check: PASS** — tested on `dd253824b13c9185ea84eb4c1d5f9c567a0a1364`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

Source Format: gw formatSource ran clean over the module; the LPD-96134 fix lets the global SF resolve the parser on CI. JavaScript Unit Tests did not fire (workspace-nested paths do not match ^modules/); the new contacts/components/__tests__/ActivitiesChart.tsx suite passes.

<!-- pr-check {"result": "success", "sha": "dd253824b13c9185ea84eb4c1d5f9c567a0a1364"} -->
