### PR TITLE
LPD-92183 Fix 500 when generating a data source OAuth2 token

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
@@ -1,18 +1,18 @@
 /**
- * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package com.liferay.osb.faro.web.internal.controller.main;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.oauth.client.LocalOAuthClient;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
-import com.liferay.osb.faro.util.FaroPropsValues;
 import com.liferay.osb.faro.web.internal.application.ApiApplication;
 import com.liferay.osb.faro.web.internal.controller.BaseFaroController;
 import com.liferay.osb.faro.web.internal.controller.FaroController;
@@ -57,16 +57,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.apache.http.HttpStatus;
-import org.apache.http.StatusLine;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -115,34 +105,39 @@ public class OAuth2FaroController extends BaseFaroController {
 			}
 		}
 
-		synchronized (this) {
-			try {
-				if (expiresIn == null) {
-					expiresIn = 3153600000L;
-				}
-
-				AccessTokenExpiresInUtil.setExpiresIn(expiresIn);
-
-				JSONObject jsonObject = _jsonFactory.createJSONObject(
-					_invokeOAuth2Endpoint(
-						oAuth2Application.getClientId(),
-						oAuth2Application.getClientSecret()));
-
-				OAuth2Authorization oAuth2Authorization =
-					_fetchUserOAuth2AuthorizationByAccessToken(
-						jsonObject.getString("access_token"));
-
-				_setOAuth2AuthorizationGroupId(groupId, oAuth2Authorization);
-
-				if (Validator.isNotNull(type)) {
-					_setOAuth2AuthorizationType(oAuth2Authorization, type);
-				}
-
-				return _mapTokenDisplay(oAuth2Authorization);
+		try {
+			if (expiresIn == null) {
+				expiresIn = 3153600000L;
 			}
-			finally {
-				AccessTokenExpiresInUtil.removeExpiresIn();
+
+			AccessTokenExpiresInUtil.setExpiresIn(expiresIn);
+
+			String tokensJSON = _localOAuthClient.requestTokens(
+				oAuth2Application,
+				oAuth2Application.getClientCredentialUserId());
+
+			if (tokensJSON == null) {
+				throw new PortalException(
+					"Unable to create access token for OAuth2 application " +
+						oAuth2Application.getOAuth2ApplicationId());
 			}
+
+			JSONObject jsonObject = _jsonFactory.createJSONObject(tokensJSON);
+
+			OAuth2Authorization oAuth2Authorization =
+				_fetchUserOAuth2AuthorizationByAccessToken(
+					jsonObject.getString("access_token"));
+
+			_setOAuth2AuthorizationGroupId(groupId, oAuth2Authorization);
+
+			if (Validator.isNotNull(type)) {
+				_setOAuth2AuthorizationType(oAuth2Authorization, type);
+			}
+
+			return _mapTokenDisplay(oAuth2Authorization);
+		}
+		finally {
+			AccessTokenExpiresInUtil.removeExpiresIn();
 		}
 	}
 
@@ -325,41 +320,6 @@ public class OAuth2FaroController extends BaseFaroController {
 			});
 	}
 
-	private String _invokeOAuth2Endpoint(String clientId, String clientSecret)
-		throws Exception {
-
-		HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
-
-		try (CloseableHttpClient closeableHttpClient =
-				httpClientBuilder.build()) {
-
-			HttpPost httpPost = new HttpPost(
-				String.format(
-					_O_AUTH2_ENDPOINT_TEMPLATE, FaroPropsValues.FARO_URL));
-
-			httpPost.setEntity(
-				new UrlEncodedFormEntity(
-					Arrays.asList(
-						new BasicNameValuePair(
-							"grant_type", "client_credentials"),
-						new BasicNameValuePair("client_id", clientId),
-						new BasicNameValuePair(
-							"client_secret", clientSecret))));
-
-			CloseableHttpResponse closeableHttpResponse =
-				closeableHttpClient.execute(httpPost);
-
-			StatusLine statusLine = closeableHttpResponse.getStatusLine();
-
-			if (statusLine.getStatusCode() != HttpStatus.SC_OK) {
-				throw new PortalException(
-					"HTTP response status code: " + statusLine.getStatusCode());
-			}
-
-			return EntityUtils.toString(closeableHttpResponse.getEntity());
-		}
-	}
-
 	private TokenDisplay _mapTokenDisplay(
 		OAuth2Authorization oAuth2Authorization) {
 
@@ -392,14 +352,14 @@ public class OAuth2FaroController extends BaseFaroController {
 		expandoBridge.setAttribute("type", type, false);
 	}
 
-	private static final String _O_AUTH2_ENDPOINT_TEMPLATE =
-		"%s/o/oauth2/token";
-
 	private static final Pattern _baseIdPattern = Pattern.compile(
 		"(.{8})(.{4})(.{4})(.{4})(.*)");
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private LocalOAuthClient _localOAuthClient;
 
 	@Reference
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -12,6 +12,7 @@ import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
 import com.liferay.osb.faro.web.internal.application.ApiApplication;
 import com.liferay.osb.faro.web.internal.controller.BaseFaroController;
@@ -125,8 +126,14 @@ public class OAuth2FaroController extends BaseFaroController {
 			JSONObject jsonObject = _jsonFactory.createJSONObject(tokensJSON);
 
 			OAuth2Authorization oAuth2Authorization =
-				_fetchUserOAuth2AuthorizationByAccessToken(
+				_fetchOAuth2AuthorizationByAccessToken(
 					jsonObject.getString("access_token"));
+
+			if (oAuth2Authorization == null) {
+				throw new PortalException(
+					"Unable to find OAuth2 authorization for the created " +
+						"access token");
+			}
 
 			_setOAuth2AuthorizationGroupId(groupId, oAuth2Authorization);
 
@@ -150,7 +157,7 @@ public class OAuth2FaroController extends BaseFaroController {
 		throws Exception {
 
 		OAuth2Authorization oAuth2Authorization =
-			_fetchUserOAuth2AuthorizationByAccessToken(token);
+			_fetchOAuth2AuthorizationByAccessToken(token);
 
 		if (oAuth2Authorization == null) {
 			throw new IllegalArgumentException(
@@ -161,26 +168,11 @@ public class OAuth2FaroController extends BaseFaroController {
 			oAuth2Authorization.getOAuth2AuthorizationId());
 	}
 
-	private OAuth2Authorization _fetchUserOAuth2AuthorizationByAccessToken(
-			String accessToken)
-		throws Exception {
+	private OAuth2Authorization _fetchOAuth2AuthorizationByAccessToken(
+		String accessToken) {
 
-		List<OAuth2Authorization> userOAuth2Authorizations =
-			_oAuth2AuthorizationService.getUserOAuth2Authorizations(
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
-
-		for (OAuth2Authorization userOAuth2Authorization :
-				userOAuth2Authorizations) {
-
-			if (Objects.equals(
-					userOAuth2Authorization.getAccessTokenContent(),
-					accessToken)) {
-
-				return userOAuth2Authorization;
-			}
-		}
-
-		return null;
+		return _oAuth2AuthorizationLocalService.
+			fetchOAuth2AuthorizationByAccessTokenContent(accessToken);
 	}
 
 	private boolean _filterOAuth2Authorization(
@@ -363,6 +355,9 @@ public class OAuth2FaroController extends BaseFaroController {
 
 	@Reference
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	@Reference
+	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
 
 	@Reference
 	private OAuth2AuthorizationService _oAuth2AuthorizationService;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
@@ -126,8 +126,9 @@ public class OAuth2FaroController extends BaseFaroController {
 			JSONObject jsonObject = _jsonFactory.createJSONObject(tokensJSON);
 
 			OAuth2Authorization oAuth2Authorization =
-				_fetchOAuth2AuthorizationByAccessToken(
-					jsonObject.getString("access_token"));
+				_oAuth2AuthorizationLocalService.
+					fetchOAuth2AuthorizationByAccessTokenContent(
+						jsonObject.getString("access_token"));
 
 			if (oAuth2Authorization == null) {
 				throw new PortalException(
@@ -157,7 +158,8 @@ public class OAuth2FaroController extends BaseFaroController {
 		throws Exception {
 
 		OAuth2Authorization oAuth2Authorization =
-			_fetchOAuth2AuthorizationByAccessToken(token);
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent(token);
 
 		if (oAuth2Authorization == null) {
 			throw new IllegalArgumentException(
@@ -166,13 +168,6 @@ public class OAuth2FaroController extends BaseFaroController {
 
 		_oAuth2AuthorizationService.revokeOAuth2Authorization(
 			oAuth2Authorization.getOAuth2AuthorizationId());
-	}
-
-	private OAuth2Authorization _fetchOAuth2AuthorizationByAccessToken(
-		String accessToken) {
-
-		return _oAuth2AuthorizationLocalService.
-			fetchOAuth2AuthorizationByAccessTokenContent(accessToken);
 	}
 
 	private boolean _filterOAuth2Authorization(

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroController.java
@@ -132,7 +132,7 @@ public class OAuth2FaroController extends BaseFaroController {
 
 			if (oAuth2Authorization == null) {
 				throw new PortalException(
-					"Unable to find OAuth2 authorization for the created " +
+					"Unable to get OAuth2 authorization for the created " +
 						"access token");
 			}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/AccessTokenExpiresInUtil.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/AccessTokenExpiresInUtil.java
@@ -11,17 +11,23 @@ package com.liferay.osb.faro.web.internal.util;
 public class AccessTokenExpiresInUtil {
 
 	public static long getExpiresIn() {
-		return _expiresIn;
+		Long expiresIn = _expiresIn.get();
+
+		if (expiresIn == null) {
+			return 0;
+		}
+
+		return expiresIn;
 	}
 
 	public static void removeExpiresIn() {
-		_expiresIn = 0;
+		_expiresIn.remove();
 	}
 
 	public static void setExpiresIn(long expiresIn) {
-		_expiresIn = expiresIn;
+		_expiresIn.set(expiresIn);
 	}
 
-	private static long _expiresIn;
+	private static final ThreadLocal<Long> _expiresIn = new ThreadLocal<>();
 
 }

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
@@ -6,12 +6,10 @@
 package com.liferay.osb.faro.web.internal.controller.main;
 
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -19,8 +17,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.mockito.Mockito;
-
-import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Eudaldo Alonso
@@ -34,7 +30,10 @@ public class OAuth2FaroControllerTest {
 
 	@Before
 	public void setUp() {
-		ReflectionTestUtils.setField(
+		ReflectionTestUtil.setFieldValue(
+			_oAuth2FaroController, "_oAuth2AuthorizationLocalService",
+			_oAuth2AuthorizationLocalService);
+		ReflectionTestUtil.setFieldValue(
 			_oAuth2FaroController, "_oAuth2AuthorizationService",
 			_oAuth2AuthorizationService);
 	}
@@ -43,14 +42,6 @@ public class OAuth2FaroControllerTest {
 	public void testRevokeToken() throws Exception {
 		OAuth2Authorization oAuth2Authorization = Mockito.mock(
 			OAuth2Authorization.class);
-
-		String accessToken = "abc";
-
-		Mockito.when(
-			oAuth2Authorization.getAccessTokenContent()
-		).thenReturn(
-			accessToken
-		);
 
 		long oAuth2AuthorizationId = 123;
 
@@ -61,13 +52,13 @@ public class OAuth2FaroControllerTest {
 		);
 
 		Mockito.when(
-			_oAuth2AuthorizationService.getUserOAuth2Authorizations(
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("abc")
 		).thenReturn(
-			Arrays.asList(oAuth2Authorization)
+			oAuth2Authorization
 		);
 
-		_oAuth2FaroController.revokeToken(1, accessToken);
+		_oAuth2FaroController.revokeToken(1, "abc");
 
 		Mockito.verify(
 			_oAuth2AuthorizationService
@@ -78,16 +69,12 @@ public class OAuth2FaroControllerTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testRevokeTokenWhenTokenIsNotFound() throws Exception {
-		Mockito.when(
-			_oAuth2AuthorizationService.getUserOAuth2Authorizations(
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)
-		).thenReturn(
-			Collections.emptyList()
-		);
-
 		_oAuth2FaroController.revokeToken(1, "nonexistent");
 	}
 
+	private final OAuth2AuthorizationLocalService
+		_oAuth2AuthorizationLocalService = Mockito.mock(
+			OAuth2AuthorizationLocalService.class);
 	private final OAuth2AuthorizationService _oAuth2AuthorizationService =
 		Mockito.mock(OAuth2AuthorizationService.class);
 	private final OAuth2FaroController _oAuth2FaroController =

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2FaroControllerTest.java
@@ -5,12 +5,23 @@
 
 package com.liferay.osb.faro.web.internal.controller.main;
 
+import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.oauth.client.LocalOAuthClient;
+import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationService;
+import com.liferay.osb.faro.web.internal.model.display.main.TokenDisplay;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -31,11 +42,72 @@ public class OAuth2FaroControllerTest {
 	@Before
 	public void setUp() {
 		ReflectionTestUtil.setFieldValue(
+			_oAuth2FaroController, "_jsonFactory", new JSONFactoryImpl());
+		ReflectionTestUtil.setFieldValue(
+			_oAuth2FaroController, "_localOAuthClient", _localOAuthClient);
+		ReflectionTestUtil.setFieldValue(
+			_oAuth2FaroController, "_oAuth2ApplicationLocalService",
+			_oAuth2ApplicationLocalService);
+		ReflectionTestUtil.setFieldValue(
 			_oAuth2FaroController, "_oAuth2AuthorizationLocalService",
 			_oAuth2AuthorizationLocalService);
 		ReflectionTestUtil.setFieldValue(
 			_oAuth2FaroController, "_oAuth2AuthorizationService",
 			_oAuth2AuthorizationService);
+
+		_setUpPermissionChecker();
+	}
+
+	@Test
+	public void testNewToken() throws Exception {
+		Mockito.when(
+			_localOAuthClient.requestTokens(_mockOAuth2Application(), 100L)
+		).thenReturn(
+			"{\"access_token\": \"abc\"}"
+		);
+
+		Mockito.when(
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("abc")
+		).thenReturn(
+			_mockOAuth2Authorization("abc")
+		);
+
+		TokenDisplay tokenDisplay = _oAuth2FaroController.newToken(
+			1, null, "demandbase", null);
+
+		Assert.assertEquals("abc", tokenDisplay.getToken());
+	}
+
+	@Test(expected = PortalException.class)
+	public void testNewTokenWhenAccessTokenIsNotCreated() throws Exception {
+		Mockito.when(
+			_localOAuthClient.requestTokens(_mockOAuth2Application(), 100L)
+		).thenReturn(
+			null
+		);
+
+		_oAuth2FaroController.newToken(1, null, "demandbase", null);
+	}
+
+	@Test(expected = PortalException.class)
+	public void testNewTokenWhenOAuth2AuthorizationIsNotFound()
+		throws Exception {
+
+		Mockito.when(
+			_localOAuthClient.requestTokens(_mockOAuth2Application(), 100L)
+		).thenReturn(
+			"{\"access_token\": \"abc\"}"
+		);
+
+		Mockito.when(
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("abc")
+		).thenReturn(
+			null
+		);
+
+		_oAuth2FaroController.newToken(1, null, "demandbase", null);
 	}
 
 	@Test
@@ -72,6 +144,62 @@ public class OAuth2FaroControllerTest {
 		_oAuth2FaroController.revokeToken(1, "nonexistent");
 	}
 
+	private OAuth2Application _mockOAuth2Application() {
+		OAuth2Application oAuth2Application = Mockito.mock(
+			OAuth2Application.class);
+
+		Mockito.when(
+			_oAuth2ApplicationLocalService.fetchOAuth2Application(
+				Mockito.anyLong(), Mockito.eq("DEMANDBASE"))
+		).thenReturn(
+			oAuth2Application
+		);
+
+		Mockito.when(
+			oAuth2Application.getClientCredentialUserId()
+		).thenReturn(
+			100L
+		);
+
+		return oAuth2Application;
+	}
+
+	private OAuth2Authorization _mockOAuth2Authorization(String accessToken) {
+		OAuth2Authorization oAuth2Authorization = Mockito.mock(
+			OAuth2Authorization.class);
+
+		Mockito.when(
+			oAuth2Authorization.getAccessTokenContent()
+		).thenReturn(
+			accessToken
+		);
+
+		Mockito.when(
+			oAuth2Authorization.getExpandoBridge()
+		).thenReturn(
+			Mockito.mock(ExpandoBridge.class)
+		);
+
+		return oAuth2Authorization;
+	}
+
+	private void _setUpPermissionChecker() {
+		PermissionChecker permissionChecker = Mockito.mock(
+			PermissionChecker.class);
+
+		Mockito.when(
+			permissionChecker.getUser()
+		).thenReturn(
+			Mockito.mock(User.class)
+		);
+
+		PermissionThreadLocal.setPermissionChecker(permissionChecker);
+	}
+
+	private final LocalOAuthClient _localOAuthClient = Mockito.mock(
+		LocalOAuthClient.class);
+	private final OAuth2ApplicationLocalService _oAuth2ApplicationLocalService =
+		Mockito.mock(OAuth2ApplicationLocalService.class);
 	private final OAuth2AuthorizationLocalService
 		_oAuth2AuthorizationLocalService = Mockito.mock(
 			OAuth2AuthorizationLocalService.class);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92183

## What Is Being Fixed

Generating the OAuth2 token for a data source returned a 500, leaving the webhook connector in an inconsistent state. Token generation looked up the freshly created authorization through getUserOAuth2Authorizations, which is scoped to the current user; a client_credentials token belongs to the application's clientCredentialUserId, so when the OAuth2 application already existed (created by another user) the lookup returned nothing and the request failed with a NullPointerException surfaced as a 500. This reproduced consistently in staging but not locally, where the same user created the application and requested the token. The token was also minted through a self HTTP call to the portal's own OAuth2 endpoint, which in a cluster could be routed to a different node where the in-JVM expiresIn channel was never set, producing tokens that were born expired.

## How It Is Being Fixed

The token is now minted in process via LocalOAuthClient.requestTokens, which calls the same OAuth2 data provider as the HTTP endpoint but on the request thread, so no self HTTP call leaves the node and the expiresIn value carried through AccessTokenExpiresInUtil (now a thread local) is visible when the token is created. The freshly created authorization is resolved directly by its access token content, which does not depend on the current user, and a missing authorization now fails with a clear PortalException instead of a NullPointerException. Unit tests cover the new token minting and the error paths.

## PR Check

**pr-check: PASS** — tested on `26e78fbb6052fbd7f586cb4bafa1f5996125fed3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "26e78fbb6052fbd7f586cb4bafa1f5996125fed3"} -->
