### PR TITLE
LPD-96425 Align osb-faro workspace package.json with setUpYarn output

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/package.json
+++ b/workspaces/liferay-osbfaro-workspace/package.json
@@ -18,8 +18,8 @@
 			"**/osb-faro-web/@clayui/css/**"
 		],
 		"packages": [
-			"modules/osb-faro-theme",
-			"modules/osb-faro-web"
+			"modules/osb-faro-web",
+			"modules/osb-faro-theme"
 		]
 	}
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96425

## What Is Being Fixed

Running `./gradlew build` on the `liferay-osbfaro-workspace` triggers the workspace plugin's `setUpYarn` task, which regenerates the root `package.json`. The task rebuilds the `workspaces.packages` list by walking the directory tree, so the entry order it produces does not match the committed file, leaving the working tree dirty after every build.

## How It Is Being Fixed

Update the committed `package.json` so the `workspaces.packages` order matches what `setUpYarn` generates, so the workspace build no longer leaves the working tree dirty.

## Why Are There No Tests?

This change only reorders entries in the workspace `package.json`, a build-generated configuration file. There is no code or behavior to cover with a test.

## PR Check

**pr-check: SKIPPED** — Faro workspace PRs base on liferay-ac/master; pr-check's auto-rebase targets upstream/master (ahead of the base) and would bloat the diff. The only diff-triggered validation, Workspace Build, was verified manually: ./gradlew setUpYarn runs clean on a fresh liferay-ac/master checkout.

<!-- pr-check {"reason": "Faro workspace PRs base on liferay-ac/master; pr-check's auto-rebase targets upstream/master (ahead of the base) and would bloat the diff. The only diff-triggered validation, Workspace Build, was verified manually: ./gradlew setUpYarn runs clean on a fresh liferay-ac/master checkout.", "result": "skipped", "sha": "8cbacb0bf379dc09f78b655004e567fca0d26cda"} -->
