### PR TITLE
LPD-96648 Populate trend classification for performance overview metric

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/client/AnalyticsCloudClient.java
@@ -535,6 +535,9 @@ public class AnalyticsCloudClient {
 					content);
 
 				if (jsonNode != null) {
+					_renameKey(
+						jsonNode, "classification", "trendClassification");
+
 					TypeFactory typeFactory = TypeFactory.defaultInstance();
 
 					ObjectReader objectReader =

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
@@ -103,9 +103,9 @@ public class PerformanceOverviewMetricResourceTest
 							).put(
 								"trend",
 								JSONUtil.put(
-									"classification", "POSITIVE"
-								).put(
 									"percentage", 50
+								).put(
+									"trendClassification", "POSITIVE"
 								)
 							).put(
 								"value", 6
@@ -117,9 +117,9 @@ public class PerformanceOverviewMetricResourceTest
 							).put(
 								"trend",
 								JSONUtil.put(
-									"classification", "NEGATIVE"
-								).put(
 									"percentage", 25
+								).put(
+									"trendClassification", "NEGATIVE"
 								)
 							).put(
 								"value", 3
@@ -131,9 +131,9 @@ public class PerformanceOverviewMetricResourceTest
 							).put(
 								"trend",
 								JSONUtil.put(
-									"classification", "NEUTRAL"
-								).put(
 									"percentage", 0
+								).put(
+									"trendClassification", "NEUTRAL"
 								)
 							).put(
 								"value", 5
@@ -145,9 +145,9 @@ public class PerformanceOverviewMetricResourceTest
 							).put(
 								"trend",
 								JSONUtil.put(
-									"classification", "POSITIVE"
-								).put(
 									"percentage", 100
+								).put(
+									"trendClassification", "POSITIVE"
 								)
 							).put(
 								"value", 2


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96648

## What Is Being Fixed

The performance overview metric endpoint returns each trend's classification under the JSON key "trendClassification", but AnalyticsCloudClient deserializes the response directly into the Metric DTO, whose field is "classification". Because the keys did not match, the trend classification was always dropped and returned as null for the performance overview metric.

## How It Is Being Fixed

AnalyticsCloudClient.getPerformanceOverviewMetric now renames "trendClassification" to "classification" before deserialization, matching the existing handling in getObjectEntryMetric. The integration test PerformanceOverviewMetricResourceTest previously mocked the backend response with the "classification" key that the client only produces after the rename, so it never exercised the conversion and passed even without the fix. It now mocks the real "trendClassification" key, like the sibling ObjectEntryMetricResourceTest, so the test fails without the production change and passes with it.

## PR Check

**pr-check: PASS** — tested on `0ab7c3ecc01730180ac948883d1e4fb733caa791`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "0ab7c3ecc01730180ac948883d1e4fb733caa791"} -->
