### PR TITLE
LPD-95609 Forward Salesforce campaigns and opportunities to the engine

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/provider/SalesforceProvider.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/provider/SalesforceProvider.java
@@ -19,12 +19,20 @@ public class SalesforceProvider implements Provider {
 		return _accountsConfiguration;
 	}
 
+	public CampaignsConfiguration getCampaignsConfiguration() {
+		return _campaignsConfiguration;
+	}
+
 	public ChannelsConfiguration getChannelsConfiguration() {
 		return _channelsConfiguration;
 	}
 
 	public ContactsConfiguration getContactsConfiguration() {
 		return _contactsConfiguration;
+	}
+
+	public OpportunitiesConfiguration getOpportunitiesConfiguration() {
+		return _opportunitiesConfiguration;
 	}
 
 	@Override
@@ -36,6 +44,12 @@ public class SalesforceProvider implements Provider {
 		AccountsConfiguration accountsConfiguration) {
 
 		_accountsConfiguration = accountsConfiguration;
+	}
+
+	public void setCampaignsConfiguration(
+		CampaignsConfiguration campaignsConfiguration) {
+
+		_campaignsConfiguration = campaignsConfiguration;
 	}
 
 	public void setChannelsConfiguration(
@@ -50,6 +64,12 @@ public class SalesforceProvider implements Provider {
 		_contactsConfiguration = contactsConfiguration;
 	}
 
+	public void setOpportunitiesConfiguration(
+		OpportunitiesConfiguration opportunitiesConfiguration) {
+
+		_opportunitiesConfiguration = opportunitiesConfiguration;
+	}
+
 	public static class AccountsConfiguration {
 
 		public boolean isEnableAllAccounts() {
@@ -61,6 +81,20 @@ public class SalesforceProvider implements Provider {
 		}
 
 		private boolean _enableAllAccounts;
+
+	}
+
+	public static class CampaignsConfiguration {
+
+		public boolean isEnableAllCampaigns() {
+			return _enableAllCampaigns;
+		}
+
+		public void setEnableAllCampaigns(boolean enableAllCampaigns) {
+			_enableAllCampaigns = enableAllCampaigns;
+		}
+
+		private boolean _enableAllCampaigns;
 
 	}
 
@@ -87,8 +121,24 @@ public class SalesforceProvider implements Provider {
 
 	}
 
+	public static class OpportunitiesConfiguration {
+
+		public boolean isEnableAllOpportunities() {
+			return _enableAllOpportunities;
+		}
+
+		public void setEnableAllOpportunities(boolean enableAllOpportunities) {
+			_enableAllOpportunities = enableAllOpportunities;
+		}
+
+		private boolean _enableAllOpportunities;
+
+	}
+
 	private AccountsConfiguration _accountsConfiguration;
+	private CampaignsConfiguration _campaignsConfiguration;
 	private ChannelsConfiguration _channelsConfiguration;
 	private ContactsConfiguration _contactsConfiguration;
+	private OpportunitiesConfiguration _opportunitiesConfiguration;
 
 }

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-rest-test/build.gradle
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-rest-test/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	testIntegrationCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.test", version: "32.6.3-SNAPSHOT"
+	testIntegrationCompileOnly group: "com.liferay.portal", name: "com.liferay.portal.test", version: "32.6.2"
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.18.6"
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.18.6"
 	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.6"
@@ -8,7 +8,7 @@ dependencies {
 	testIntegrationImplementation group: "junit", name: "junit", version: "4.13.1"
 	testIntegrationImplementation project(":modules:osb-faro-rest-api")
 	testIntegrationImplementation project(":modules:osb-faro-rest-client")
-	testModules group: "com.liferay.portal", name: "com.liferay.portal.test", version: "32.6.3-SNAPSHOT"
+	testModules group: "com.liferay.portal", name: "com.liferay.portal.test", version: "32.6.2"
 }
 
 deploy {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-test/build.gradle
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-test/build.gradle
@@ -18,8 +18,8 @@ dependencies {
 	testIntegrationImplementation group: "org.apache.logging.log4j", name: "log4j-core", version: "2.19.0"
 	testIntegrationImplementation project(":modules:osb-faro-api")
 	testModules group: "com.liferay", name: "com.liferay.arquillian.extension.junit.bridge.connector", version: "1.0.1"
-	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.test", version: "32.6.3-SNAPSHOT"
-	testModules group: "com.liferay.portal", name: "com.liferay.portal.test", version: "32.6.3-SNAPSHOT"
+	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.test", version: "32.6.2"
+	testModules group: "com.liferay.portal", name: "com.liferay.portal.test", version: "32.6.2"
 }
 
 deploy {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/build.gradle
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	compileOnly project(":modules:osb-faro-contacts-api")
 	compileOnly project(":modules:osb-faro-engine-client")
 	compileOnly project(":modules:osb-faro-provisioning-client")
-	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.test", version: "32.6.3-SNAPSHOT"
+	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.test", version: "32.6.2"
 	testImplementation group: "com.liferay.portal", name: "release.dxp.api", version: "2026.q1.5"
 	testImplementation group: "junit", name: "junit", version: "4.13.1"
 	testImplementation group: "org.mockito", name: "mockito-core", version: "5.14.2"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
@@ -311,6 +311,9 @@ public class DataSourceFaroController extends BaseFaroController {
 			@DefaultValue(StringPool.BLANK) @FormParam("accountsConfiguration")
 				FaroParam<SalesforceProvider.AccountsConfiguration>
 					accountsConfigurationFaroParam,
+			@DefaultValue(StringPool.BLANK) @FormParam("campaignsConfiguration")
+				FaroParam<SalesforceProvider.CampaignsConfiguration>
+					campaignsConfigurationFaroParam,
 			@DefaultValue(StringPool.BLANK) @FormParam("channelsConfiguration")
 				FaroParam<ChannelsConfiguration> channelsConfigurationFaroParam,
 			@DefaultValue(StringPool.BLANK) @FormParam("contactsConfiguration")
@@ -318,6 +321,11 @@ public class DataSourceFaroController extends BaseFaroController {
 					contactsConfigurationFaroParam,
 			@FormParam("credentials") Credentials credentials,
 			@FormParam("name") String name,
+			@DefaultValue(StringPool.BLANK)
+			@FormParam("opportunitiesConfiguration")
+			FaroParam
+				<SalesforceProvider.OpportunitiesConfiguration>
+					opportunitiesConfigurationFaroParam,
 			@DefaultValue("INACTIVE") @FormParam("status") String status,
 			@FormParam("url") String url)
 		throws Exception {
@@ -326,10 +334,14 @@ public class DataSourceFaroController extends BaseFaroController {
 
 		salesforceProvider.setAccountsConfiguration(
 			accountsConfigurationFaroParam.getValue());
+		salesforceProvider.setCampaignsConfiguration(
+			campaignsConfigurationFaroParam.getValue());
 		salesforceProvider.setChannelsConfiguration(
 			channelsConfigurationFaroParam.getValue());
 		salesforceProvider.setContactsConfiguration(
 			contactsConfigurationFaroParam.getValue());
+		salesforceProvider.setOpportunitiesConfiguration(
+			opportunitiesConfigurationFaroParam.getValue());
 
 		return create(
 			groupId, credentials, salesforceProvider, name, url, null, status);
@@ -1261,38 +1273,59 @@ public class DataSourceFaroController extends BaseFaroController {
 			@DefaultValue(StringPool.BLANK) @FormParam("accountsConfiguration")
 				FaroParam<SalesforceProvider.AccountsConfiguration>
 					accountsConfigurationFaroParam,
+			@DefaultValue(StringPool.BLANK) @FormParam("campaignsConfiguration")
+				FaroParam<SalesforceProvider.CampaignsConfiguration>
+					campaignsConfigurationFaroParam,
 			@DefaultValue(StringPool.BLANK) @FormParam("channelsConfiguration")
 				FaroParam<ChannelsConfiguration> channelsConfigurationFaroParam,
 			@DefaultValue(StringPool.BLANK) @FormParam("contactsConfiguration")
 				FaroParam<SalesforceProvider.ContactsConfiguration>
 					contactsConfigurationFaroParam,
 			@FormParam("credentials") Credentials credentials,
-			@FormParam("name") String name, @FormParam("status") String status,
-			@FormParam("url") String url)
+			@FormParam("name") String name,
+			@DefaultValue(StringPool.BLANK)
+			@FormParam("opportunitiesConfiguration")
+			FaroParam
+				<SalesforceProvider.OpportunitiesConfiguration>
+					opportunitiesConfigurationFaroParam,
+			@FormParam("status") String status, @FormParam("url") String url)
 		throws Exception {
 
 		SalesforceProvider salesforceProvider = null;
 
 		SalesforceProvider.AccountsConfiguration accountsConfiguration =
 			accountsConfigurationFaroParam.getValue();
+		SalesforceProvider.CampaignsConfiguration campaignsConfiguration =
+			campaignsConfigurationFaroParam.getValue();
 		ChannelsConfiguration channelsConfiguration =
 			channelsConfigurationFaroParam.getValue();
 		SalesforceProvider.ContactsConfiguration contactsConfiguration =
 			contactsConfigurationFaroParam.getValue();
+		SalesforceProvider.OpportunitiesConfiguration
+			opportunitiesConfiguration =
+				opportunitiesConfigurationFaroParam.getValue();
 
 		if ((accountsConfiguration != null) &&
+			(campaignsConfiguration != null) &&
 			(channelsConfiguration != null) &&
-			(contactsConfiguration != null)) {
+			(contactsConfiguration != null) &&
+			(opportunitiesConfiguration != null)) {
 
 			salesforceProvider = new SalesforceProvider();
 
 			salesforceProvider.setAccountsConfiguration(accountsConfiguration);
+			salesforceProvider.setCampaignsConfiguration(
+				campaignsConfiguration);
 			salesforceProvider.setChannelsConfiguration(channelsConfiguration);
 			salesforceProvider.setContactsConfiguration(contactsConfiguration);
+			salesforceProvider.setOpportunitiesConfiguration(
+				opportunitiesConfiguration);
 		}
 		else if ((accountsConfiguration != null) ||
+				 (campaignsConfiguration != null) ||
 				 (channelsConfiguration != null) ||
-				 (contactsConfiguration != null)) {
+				 (contactsConfiguration != null) ||
+				 (opportunitiesConfiguration != null)) {
 
 			DataSource dataSource = contactsEngineClient.getDataSource(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId), id);
@@ -1304,6 +1337,11 @@ public class DataSourceFaroController extends BaseFaroController {
 					accountsConfiguration);
 			}
 
+			if (campaignsConfiguration != null) {
+				salesforceProvider.setCampaignsConfiguration(
+					campaignsConfiguration);
+			}
+
 			if (channelsConfiguration != null) {
 				salesforceProvider.setChannelsConfiguration(
 					channelsConfiguration);
@@ -1312,6 +1350,11 @@ public class DataSourceFaroController extends BaseFaroController {
 			if (contactsConfiguration != null) {
 				salesforceProvider.setContactsConfiguration(
 					contactsConfiguration);
+			}
+
+			if (opportunitiesConfiguration != null) {
+				salesforceProvider.setOpportunitiesConfiguration(
+					opportunitiesConfiguration);
 			}
 		}
 
@@ -1545,24 +1588,36 @@ public class DataSourceFaroController extends BaseFaroController {
 			@DefaultValue(StringPool.BLANK) @FormParam("accountsConfiguration")
 				FaroParam<SalesforceProvider.AccountsConfiguration>
 					accountsConfigurationFaroParam,
+			@DefaultValue(StringPool.BLANK) @FormParam("campaignsConfiguration")
+				FaroParam<SalesforceProvider.CampaignsConfiguration>
+					campaignsConfigurationFaroParam,
 			@DefaultValue(StringPool.BLANK) @FormParam("channelsConfiguration")
 				FaroParam<ChannelsConfiguration> channelsConfigurationFaroParam,
 			@DefaultValue(StringPool.BLANK) @FormParam("contactsConfiguration")
 				FaroParam<SalesforceProvider.ContactsConfiguration>
 					contactsConfigurationFaroParam,
 			@FormParam("credentials") Credentials credentials,
-			@FormParam("name") String name, @FormParam("status") String status,
-			@FormParam("url") String url)
+			@FormParam("name") String name,
+			@DefaultValue(StringPool.BLANK)
+			@FormParam("opportunitiesConfiguration")
+			FaroParam
+				<SalesforceProvider.OpportunitiesConfiguration>
+					opportunitiesConfigurationFaroParam,
+			@FormParam("status") String status, @FormParam("url") String url)
 		throws Exception {
 
 		SalesforceProvider salesforceProvider = new SalesforceProvider();
 
 		salesforceProvider.setAccountsConfiguration(
 			accountsConfigurationFaroParam.getValue());
+		salesforceProvider.setCampaignsConfiguration(
+			campaignsConfigurationFaroParam.getValue());
 		salesforceProvider.setChannelsConfiguration(
 			channelsConfigurationFaroParam.getValue());
 		salesforceProvider.setContactsConfiguration(
 			contactsConfigurationFaroParam.getValue());
+		salesforceProvider.setOpportunitiesConfiguration(
+			opportunitiesConfigurationFaroParam.getValue());
 
 		return update(
 			groupId, id, credentials, null, null, 0, name, false,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroControllerTest.java
@@ -7,14 +7,18 @@ package com.liferay.osb.faro.web.internal.controller.contacts;
 
 import com.liferay.osb.faro.engine.client.ContactsEngineClient;
 import com.liferay.osb.faro.engine.client.constants.FieldMappingConstants;
+import com.liferay.osb.faro.engine.client.model.DataSource;
 import com.liferay.osb.faro.engine.client.model.DataSourceField;
 import com.liferay.osb.faro.engine.client.model.Field;
 import com.liferay.osb.faro.engine.client.model.FieldMapping;
+import com.liferay.osb.faro.engine.client.model.Provider;
 import com.liferay.osb.faro.engine.client.model.Results;
+import com.liferay.osb.faro.engine.client.model.provider.SalesforceProvider;
 import com.liferay.osb.faro.model.FaroProject;
 import com.liferay.osb.faro.service.FaroProjectLocalService;
 import com.liferay.osb.faro.util.FaroPropsValues;
 import com.liferay.osb.faro.web.internal.model.display.contacts.DataSourceMappingDisplay;
+import com.liferay.osb.faro.web.internal.param.FaroParam;
 import com.liferay.osb.faro.web.internal.util.ContactsCSVHelper;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -45,6 +49,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.mockito.AdditionalAnswers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -188,6 +193,77 @@ public class DataSourceFaroControllerTest {
 	}
 
 	@Test
+	public void testCreateTypeSalesforce() throws Exception {
+		DataSource dataSource = Mockito.mock(DataSource.class);
+
+		Mockito.when(
+			dataSource.getProvider()
+		).thenReturn(
+			new SalesforceProvider()
+		);
+
+		Mockito.when(
+			_contactsEngineClient.addDataSource(
+				Mockito.eq(_faroProject), Mockito.isNull(), Mockito.anyLong(),
+				Mockito.eq("Salesforce"), Mockito.isNull(),
+				Mockito.any(Provider.class), Mockito.isNull(),
+				Mockito.eq("ACTIVE"))
+		).thenReturn(
+			dataSource
+		);
+
+		SalesforceProvider.CampaignsConfiguration campaignsConfiguration =
+			new SalesforceProvider.CampaignsConfiguration();
+
+		campaignsConfiguration.setEnableAllCampaigns(true);
+
+		SalesforceProvider.OpportunitiesConfiguration
+			opportunitiesConfiguration =
+				new SalesforceProvider.OpportunitiesConfiguration();
+
+		opportunitiesConfiguration.setEnableAllOpportunities(true);
+
+		try (MockedStatic<PermissionThreadLocal>
+				permissionThreadLocalMockedStatic = Mockito.mockStatic(
+					PermissionThreadLocal.class)) {
+
+			permissionThreadLocalMockedStatic.when(
+				PermissionThreadLocal::getPermissionChecker
+			).thenReturn(
+				Mockito.mock(PermissionChecker.class)
+			);
+
+			_dataSourceFaroController.createTypeSalesforce(
+				32719L, new FaroParam<>(),
+				new FaroParam<>(campaignsConfiguration), new FaroParam<>(),
+				new FaroParam<>(), null, "Salesforce",
+				new FaroParam<>(opportunitiesConfiguration), "ACTIVE", null);
+		}
+
+		ArgumentCaptor<Provider> providerArgumentCaptor =
+			ArgumentCaptor.forClass(Provider.class);
+
+		Mockito.verify(
+			_contactsEngineClient
+		).addDataSource(
+			Mockito.eq(_faroProject), Mockito.isNull(), Mockito.anyLong(),
+			Mockito.eq("Salesforce"), Mockito.isNull(),
+			providerArgumentCaptor.capture(), Mockito.isNull(),
+			Mockito.eq("ACTIVE")
+		);
+
+		SalesforceProvider salesforceProvider =
+			(SalesforceProvider)providerArgumentCaptor.getValue();
+
+		Assert.assertTrue(
+			salesforceProvider.getCampaignsConfiguration(
+			).isEnableAllCampaigns());
+		Assert.assertTrue(
+			salesforceProvider.getOpportunitiesConfiguration(
+			).isEnableAllOpportunities());
+	}
+
+	@Test
 	public void testGenerateDataSourceAccessToken() throws Exception {
 		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
 
@@ -262,6 +338,104 @@ public class DataSourceFaroControllerTest {
 		Assert.assertEquals(
 			dataSourceMappingDisplays.toString(), 13,
 			dataSourceMappingDisplays.size());
+	}
+
+	@Test
+	public void testPatchTypeSalesforce() throws Exception {
+		SalesforceProvider existingSalesforceProvider =
+			new SalesforceProvider();
+
+		SalesforceProvider.AccountsConfiguration accountsConfiguration =
+			new SalesforceProvider.AccountsConfiguration();
+
+		accountsConfiguration.setEnableAllAccounts(true);
+
+		existingSalesforceProvider.setAccountsConfiguration(
+			accountsConfiguration);
+
+		DataSource existingDataSource = Mockito.mock(DataSource.class);
+
+		Mockito.when(
+			existingDataSource.getProvider()
+		).thenReturn(
+			existingSalesforceProvider
+		);
+
+		Mockito.when(
+			_contactsEngineClient.getDataSource(_faroProject, "32720")
+		).thenReturn(
+			existingDataSource
+		);
+
+		DataSource dataSource = Mockito.mock(DataSource.class);
+
+		Mockito.when(
+			dataSource.getProvider()
+		).thenReturn(
+			new SalesforceProvider()
+		);
+
+		Mockito.when(
+			_contactsEngineClient.patchDataSource(
+				Mockito.eq(_faroProject), Mockito.eq("32720"), Mockito.isNull(),
+				Mockito.isNull(), Mockito.isNull(), Mockito.any(Provider.class),
+				Mockito.isNull(), Mockito.isNull(), Mockito.anyLong())
+		).thenReturn(
+			dataSource
+		);
+
+		SalesforceProvider.CampaignsConfiguration campaignsConfiguration =
+			new SalesforceProvider.CampaignsConfiguration();
+
+		campaignsConfiguration.setEnableAllCampaigns(true);
+
+		SalesforceProvider.OpportunitiesConfiguration
+			opportunitiesConfiguration =
+				new SalesforceProvider.OpportunitiesConfiguration();
+
+		opportunitiesConfiguration.setEnableAllOpportunities(true);
+
+		try (MockedStatic<PermissionThreadLocal>
+				permissionThreadLocalMockedStatic = Mockito.mockStatic(
+					PermissionThreadLocal.class)) {
+
+			permissionThreadLocalMockedStatic.when(
+				PermissionThreadLocal::getPermissionChecker
+			).thenReturn(
+				Mockito.mock(PermissionChecker.class)
+			);
+
+			_dataSourceFaroController.patchTypeSalesforce(
+				32719L, "32720", new FaroParam<>(),
+				new FaroParam<>(campaignsConfiguration), new FaroParam<>(),
+				new FaroParam<>(), null, null,
+				new FaroParam<>(opportunitiesConfiguration), null, null);
+		}
+
+		ArgumentCaptor<Provider> providerArgumentCaptor =
+			ArgumentCaptor.forClass(Provider.class);
+
+		Mockito.verify(
+			_contactsEngineClient
+		).patchDataSource(
+			Mockito.eq(_faroProject), Mockito.eq("32720"), Mockito.isNull(),
+			Mockito.isNull(), Mockito.isNull(),
+			providerArgumentCaptor.capture(), Mockito.isNull(),
+			Mockito.isNull(), Mockito.anyLong()
+		);
+
+		SalesforceProvider salesforceProvider =
+			(SalesforceProvider)providerArgumentCaptor.getValue();
+
+		Assert.assertTrue(
+			salesforceProvider.getAccountsConfiguration(
+			).isEnableAllAccounts());
+		Assert.assertTrue(
+			salesforceProvider.getCampaignsConfiguration(
+			).isEnableAllCampaigns());
+		Assert.assertTrue(
+			salesforceProvider.getOpportunitiesConfiguration(
+			).isEnableAllOpportunities());
 	}
 
 	private Field _createField(String name, String sourceName, String value) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95609
https://liferay.atlassian.net/browse/LPD-93151

## What Is Being Fixed

LPD-95609 extends Analytics Cloud so a Salesforce data source can sync Campaigns and Opportunities independently. The engine and the data-source DTO already understand the new enableAllCampaigns and enableAllOpportunities flags, but Faro's Java layer deserializes the Salesforce provider configuration into a typed SalesforceProvider, so the campaignsConfiguration and opportunitiesConfiguration objects the data-source UI will send were silently dropped before reaching the engine. Separately, the Faro test modules depended on an unresolvable com.liferay.portal.test 32.6.2-SNAPSHOT, so the tests could not compile (LPD-93151).

## How It Is Being Fixed

Add CampaignsConfiguration and OpportunitiesConfiguration to SalesforceProvider and wire both through the create, patch, and update Salesforce handlers in DataSourceFaroController, so enableAllCampaigns and enableAllOpportunities now round-trip to the engine on read and write. New controller tests capture the provider forwarded to the engine client for both the create path and the patch merge path, asserting the two flags survive and that a partial patch preserves the existing configuration. The com.liferay.portal.test dependency is pinned to the released 32.6.2 across the Faro test modules so the tests resolve and compile. This PR is the Java pass-through; the Faro frontend (checkboxes, submit mapping, validity) is a separate follow-up.

## PR Check

**pr-check: PASS** — tested on `fac3737c6d747f0219fb41c5922cd2e1296486af`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

Structural Smoke matched (build.gradle) but was trimmed: its ModulesStructureTest scans the main modules/ tree, not workspaces/, so it carries no signal for this change and would require a full install-portal-snapshots build. The Java unit tests are compiled by Workspace Build; the workspace disables the test task locally, so they execute in CI (the workspace JS suite ran green: 3310 passed).

<!-- pr-check {"result": "success", "sha": "fac3737c6d747f0219fb41c5922cd2e1296486af"} -->
