### PR TITLE
LPD-95615 Add Marketo Campaign data source provider type

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/provider/MarketoCampaignProvider.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/provider/MarketoCampaignProvider.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.engine.client.model.provider;
+
+import com.liferay.osb.faro.engine.client.model.ChannelsConfiguration;
+import com.liferay.osb.faro.engine.client.model.Provider;
+
+/**
+ * @author Rachael Koestartyo
+ */
+public class MarketoCampaignProvider implements Provider {
+
+	public static final String TYPE = "MARKETO_CAMPAIGN";
+
+	public ChannelsConfiguration getChannelsConfiguration() {
+		return _channelsConfiguration;
+	}
+
+	@Override
+	public String getType() {
+		return TYPE;
+	}
+
+	public void setChannelsConfiguration(
+		ChannelsConfiguration channelsConfiguration) {
+
+		_channelsConfiguration = channelsConfiguration;
+	}
+
+	private ChannelsConfiguration _channelsConfiguration;
+
+}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
@@ -34,6 +34,7 @@ import com.liferay.osb.faro.engine.client.model.provider.CSVProvider;
 import com.liferay.osb.faro.engine.client.model.provider.DemandbaseProvider;
 import com.liferay.osb.faro.engine.client.model.provider.HubSpotProvider;
 import com.liferay.osb.faro.engine.client.model.provider.LiferayProvider;
+import com.liferay.osb.faro.engine.client.model.provider.MarketoCampaignProvider;
 import com.liferay.osb.faro.engine.client.model.provider.MarketoProvider;
 import com.liferay.osb.faro.engine.client.model.provider.SalesforceProvider;
 import com.liferay.osb.faro.engine.client.util.EngineServiceURLUtil;
@@ -301,6 +302,30 @@ public class DataSourceFaroController extends BaseFaroController {
 
 		return create(
 			groupId, credentials, marketoProvider, name, null, null, status);
+	}
+
+	@Path("/marketo-campaign")
+	@POST
+	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
+	public DataSourceDisplay createTypeMarketoCampaign(
+			@PathParam("groupId") long groupId,
+			@DefaultValue(StringPool.BLANK) @FormParam("channelsConfiguration")
+				FaroParam<ChannelsConfiguration> channelsConfigurationFaroParam,
+			@FormParam("credentials") Credentials credentials,
+			@FormParam("name") String name,
+			@DefaultValue("ACTIVE") @FormParam("status") String status,
+			@FormParam("url") String url)
+		throws Exception {
+
+		MarketoCampaignProvider marketoCampaignProvider =
+			new MarketoCampaignProvider();
+
+		marketoCampaignProvider.setChannelsConfiguration(
+			channelsConfigurationFaroParam.getValue());
+
+		return create(
+			groupId, credentials, marketoCampaignProvider, name, url, null,
+			status);
 	}
 
 	@Path("/salesforce")
@@ -1254,6 +1279,39 @@ public class DataSourceFaroController extends BaseFaroController {
 	}
 
 	@PATCH
+	@Path("/{id}/marketo-campaign")
+	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
+	public DataSourceDisplay patchTypeMarketoCampaign(
+			@PathParam("groupId") long groupId, @PathParam("id") String id,
+			@DefaultValue(StringPool.BLANK) @FormParam("channelsConfiguration")
+				FaroParam<ChannelsConfiguration> channelsConfigurationFaroParam,
+			@FormParam("credentials") Credentials credentials,
+			@FormParam("name") String name, @FormParam("status") String status,
+			@FormParam("url") String url)
+		throws Exception {
+
+		MarketoCampaignProvider marketoCampaignProvider = null;
+
+		ChannelsConfiguration channelsConfiguration =
+			channelsConfigurationFaroParam.getValue();
+
+		if (channelsConfiguration != null) {
+			DataSource dataSource = contactsEngineClient.getDataSource(
+				faroProjectLocalService.getFaroProjectByGroupId(groupId), id);
+
+			marketoCampaignProvider =
+				(MarketoCampaignProvider)dataSource.getProvider();
+
+			marketoCampaignProvider.setChannelsConfiguration(
+				channelsConfiguration);
+		}
+
+		return update(
+			groupId, id, credentials, null, null, 0, name, true,
+			marketoCampaignProvider, MarketoCampaignProvider.TYPE, status, url);
+	}
+
+	@PATCH
 	@Path("/{id}/salesforce")
 	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
 	public DataSourceDisplay patchTypeSalesforce(
@@ -1537,6 +1595,29 @@ public class DataSourceFaroController extends BaseFaroController {
 			marketoProvider, MarketoProvider.TYPE, status, null);
 	}
 
+	@Path("/{id}/marketo-campaign")
+	@PUT
+	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
+	public DataSourceDisplay updateTypeMarketoCampaign(
+			@PathParam("groupId") long groupId, @PathParam("id") String id,
+			@DefaultValue(StringPool.BLANK) @FormParam("channelsConfiguration")
+				FaroParam<ChannelsConfiguration> channelsConfigurationFaroParam,
+			@FormParam("credentials") Credentials credentials,
+			@FormParam("name") String name, @FormParam("status") String status,
+			@FormParam("url") String url)
+		throws Exception {
+
+		MarketoCampaignProvider marketoCampaignProvider =
+			new MarketoCampaignProvider();
+
+		marketoCampaignProvider.setChannelsConfiguration(
+			channelsConfigurationFaroParam.getValue());
+
+		return update(
+			groupId, id, credentials, null, null, 0, name, false,
+			marketoCampaignProvider, MarketoCampaignProvider.TYPE, status, url);
+	}
+
 	@Path("/{id}/salesforce")
 	@PUT
 	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
@@ -1706,6 +1787,13 @@ public class DataSourceFaroController extends BaseFaroController {
 		else if (type.equals(OAuth2Credentials.TYPE)) {
 			OAuth2Credentials oAuth2Credentials =
 				(OAuth2Credentials)credentials;
+
+			if (providerType.equals(MarketoCampaignProvider.TYPE)) {
+				return OAuthUtil.getOAuth20Credentials(
+					"CLIENT_CREDENTIALS", StringPool.BLANK, StringPool.BLANK,
+					StringPool.BLANK, oAuth2Credentials.getOAuthClientId(),
+					oAuth2Credentials.getOAuthClientSecret(), providerType);
+			}
 
 			return OAuthUtil.getOAuth20Credentials(
 				"REFRESH_TOKEN", url, oAuth2Credentials.getOAuthCode(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95615

## What Is Being Fixed

OSB Faro (Analytics Cloud) supported several data source provider types — Liferay, Salesforce, HubSpot, Marketo, Demandbase, CSV — but had no way to connect a Marketo Campaign data source. There was no provider model for it and no endpoints to create, update, or patch one.

## How It Is Being Fixed

A new MarketoCampaignProvider model is added to osb-faro-engine-client, carrying a channels configuration alongside the standard provider type. DataSourceFaroController gains the matching create (POST), update (PUT), and patch (PATCH) endpoints under /marketo-campaign, following the same shape as the existing Marketo and Salesforce endpoints. Credential resolution is extended so the Marketo Campaign provider authenticates through the OAuth 2.0 client-credentials grant rather than the refresh-token flow used by the other OAuth providers.

## Why Are There No Tests?

The new provider and its endpoints replicate the established provider patterns (Marketo, Salesforce) already present in DataSourceFaroController and introduce no new branching logic beyond selecting the client-credentials OAuth grant.

## PR Check

**pr-check: PASS** — tested on `0b36ed4b0ba5054d274db483d5393a0b331c15f6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "0b36ed4b0ba5054d274db483d5393a0b331c15f6"} -->
