### PR TITLE
LPD-96995 Adjust connector status cards behavior

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorOverview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorOverview.tsx
@@ -661,7 +661,7 @@ describe('ConnectorOverview', () => {
 			});
 
 			expect(container.querySelectorAll('.list-group-item')).toHaveLength(
-				3
+				2
 			);
 			expect(getByText('Events')).toBeTruthy();
 			expect(getByText('Unconfigured')).toBeTruthy();

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/getConnectorStatusItems.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/getConnectorStatusItems.ts
@@ -9,12 +9,11 @@ describe('getInitialLogEntries', () => {
 		expect(entries[0].title).toBe('Token Generated');
 	});
 
-	it('seeds Listening and Token generated for Active with no data', () => {
+	it('falls back to a single Token generated entry for Active with no data (a state that should no longer occur)', () => {
 		const entries = getInitialLogEntries(ConnectorStatus.Active, 0);
 
-		expect(entries).toHaveLength(2);
-		expect(entries[0].title).toBe('Listening...');
-		expect(entries[1].title).toBe('Token Generated');
+		expect(entries).toHaveLength(1);
+		expect(entries[0].title).toBe('Token Generated');
 	});
 
 	it('seeds Data flow, Listening, Token generated for Active with data', () => {
@@ -37,14 +36,11 @@ describe('getInitialLogEntries', () => {
 		expect(entries[3].title).toBe('Token Generated');
 	});
 
-	it('seeds disconnected history for Disconnected status', () => {
+	it('shows only the Data source disconnected entry for Disconnected status', () => {
 		const entries = getInitialLogEntries(ConnectorStatus.Disconnected, 0);
 
-		expect(entries).toHaveLength(4);
+		expect(entries).toHaveLength(1);
 		expect(entries[0].title).toBe('Data Source Disconnected');
-		expect(entries[1].title).toBe('Inactive Data Flow');
-		expect(entries[2].title).toBe('Data Flow Established');
-		expect(entries[3].title).toBe('Listening...');
 	});
 });
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorStatusItems.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorStatusItems.ts
@@ -13,7 +13,7 @@ const DATA_FLOW_ACTIVE: ConnectorStatusItem = {
 	icon: 'plug',
 	iconDisplayType: 'success',
 	secondaryText: Liferay.Language.get('data-received-successfully'),
-	title: Liferay.Language.get('data-flow-established'),
+	title: Liferay.Language.get('data-flow-established')
 };
 
 const DATA_SOURCE_DISCONNECTED: ConnectorStatusItem = {
@@ -21,7 +21,7 @@ const DATA_SOURCE_DISCONNECTED: ConnectorStatusItem = {
 	icon: 'plug',
 	iconDisplayType: 'secondary',
 	secondaryText: Liferay.Language.get('token-revoked-successfully'),
-	title: Liferay.Language.get('data-source-disconnected'),
+	title: Liferay.Language.get('data-source-disconnected')
 };
 
 const INACTIVE_DATA_FLOW: ConnectorStatusItem = {
@@ -31,7 +31,7 @@ const INACTIVE_DATA_FLOW: ConnectorStatusItem = {
 	secondaryText: Liferay.Language.get(
 		'there-were-no-activities-in-the-past-90-days'
 	),
-	title: Liferay.Language.get('inactive-data-flow'),
+	title: Liferay.Language.get('inactive-data-flow')
 };
 
 const LISTENING: ConnectorStatusItem = {
@@ -41,7 +41,7 @@ const LISTENING: ConnectorStatusItem = {
 	secondaryText: Liferay.Language.get(
 		'waiting-for-first-data-to-arrive-this-may-take-some-time'
 	),
-	title: Liferay.Language.get('listening'),
+	title: Liferay.Language.get('listening')
 };
 
 const TOKEN_GENERATED: ConnectorStatusItem = {
@@ -51,7 +51,7 @@ const TOKEN_GENERATED: ConnectorStatusItem = {
 	secondaryText: Liferay.Language.get(
 		'liferay-data-platform-setup-completed'
 	),
-	title: Liferay.Language.get('token-generated'),
+	title: Liferay.Language.get('token-generated')
 };
 
 export function getInitialLogEntries(
@@ -59,20 +59,11 @@ export function getInitialLogEntries(
 	entityCount: number
 ): ConnectorStatusItem[] {
 	if (status === ConnectorStatus.Disconnected) {
-		return [
-			DATA_SOURCE_DISCONNECTED,
-			INACTIVE_DATA_FLOW,
-			DATA_FLOW_ACTIVE,
-			LISTENING,
-		];
+		return [DATA_SOURCE_DISCONNECTED];
 	}
 
-	if (status === ConnectorStatus.Active) {
-		if (entityCount > 0) {
-			return [DATA_FLOW_ACTIVE, LISTENING, TOKEN_GENERATED];
-		}
-
-		return [LISTENING, TOKEN_GENERATED];
+	if (status === ConnectorStatus.Active && entityCount > 0) {
+		return [DATA_FLOW_ACTIVE, LISTENING, TOKEN_GENERATED];
 	}
 
 	if (entityCount > 0) {
@@ -80,7 +71,7 @@ export function getInitialLogEntries(
 			INACTIVE_DATA_FLOW,
 			DATA_FLOW_ACTIVE,
 			LISTENING,
-			TOKEN_GENERATED,
+			TOKEN_GENERATED
 		];
 	}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorStatusItems.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorStatusItems.ts
@@ -13,7 +13,7 @@ const DATA_FLOW_ACTIVE: ConnectorStatusItem = {
 	icon: 'plug',
 	iconDisplayType: 'success',
 	secondaryText: Liferay.Language.get('data-received-successfully'),
-	title: Liferay.Language.get('data-flow-established')
+	title: Liferay.Language.get('data-flow-established'),
 };
 
 const DATA_SOURCE_DISCONNECTED: ConnectorStatusItem = {
@@ -21,7 +21,7 @@ const DATA_SOURCE_DISCONNECTED: ConnectorStatusItem = {
 	icon: 'plug',
 	iconDisplayType: 'secondary',
 	secondaryText: Liferay.Language.get('token-revoked-successfully'),
-	title: Liferay.Language.get('data-source-disconnected')
+	title: Liferay.Language.get('data-source-disconnected'),
 };
 
 const INACTIVE_DATA_FLOW: ConnectorStatusItem = {
@@ -31,7 +31,7 @@ const INACTIVE_DATA_FLOW: ConnectorStatusItem = {
 	secondaryText: Liferay.Language.get(
 		'there-were-no-activities-in-the-past-90-days'
 	),
-	title: Liferay.Language.get('inactive-data-flow')
+	title: Liferay.Language.get('inactive-data-flow'),
 };
 
 const LISTENING: ConnectorStatusItem = {
@@ -41,7 +41,7 @@ const LISTENING: ConnectorStatusItem = {
 	secondaryText: Liferay.Language.get(
 		'waiting-for-first-data-to-arrive-this-may-take-some-time'
 	),
-	title: Liferay.Language.get('listening')
+	title: Liferay.Language.get('listening'),
 };
 
 const TOKEN_GENERATED: ConnectorStatusItem = {
@@ -51,7 +51,7 @@ const TOKEN_GENERATED: ConnectorStatusItem = {
 	secondaryText: Liferay.Language.get(
 		'liferay-data-platform-setup-completed'
 	),
-	title: Liferay.Language.get('token-generated')
+	title: Liferay.Language.get('token-generated'),
 };
 
 export function getInitialLogEntries(
@@ -71,7 +71,7 @@ export function getInitialLogEntries(
 			INACTIVE_DATA_FLOW,
 			DATA_FLOW_ACTIVE,
 			LISTENING,
-			TOKEN_GENERATED
+			TOKEN_GENERATED,
 		];
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96995

## What Is Being Fixed

The connector overview status cards showed misleading log entries. A disconnected data source displayed a full history (disconnected, inactive data flow, data flow established, listening) instead of only its disconnected status, and an active data source with zero synced events rendered listening / data-flow entries — a "connected with no data" state that should no longer exist.

## How It Is Being Fixed

getInitialLogEntries was simplified. The Disconnected status now returns only the "Data Source Disconnected" entry. The "Active with no data" branch was removed and collapsed into a single condition, so Active yields the data-flow history only when synced data exists; any residual no-data case falls back to a single "Token Generated" entry. The existing unit tests were updated to assert the new output, and one dependent list-item-count assertion in the ConnectorOverview test was adjusted to match.

## Why Are There No Tests?

This changes an already unit-tested pure function (getInitialLogEntries); rather than adding new test files, the existing unit tests were updated to assert the new expected output, so coverage is maintained.

## PR Check

**pr-check: SKIPPED** — Workspace Build fails locally only due to a missing com.liferay.portal.test:32.6.3-SNAPSHOT (Java testIntegration classpath), unrelated to this frontend-only change; Source Format, the full JS unit suite, and TypeScript checks all pass. CI has the snapshot and runs the full build.

<!-- pr-check {"reason": "Workspace Build fails locally only due to a missing com.liferay.portal.test:32.6.3-SNAPSHOT (Java testIntegration classpath), unrelated to this frontend-only change; Source Format, JS unit suite, and TypeScript checks pass. CI has the snapshot.", "result": "skipped", "sha": "e1f6bb23af158b5895486c7a9199b0982d7dfee3"} -->
