### PR TITLE
LPD-95807 Fix audiences definition content and hash parameter order

### DIFF
--- a/modules/apps/audiences/audiences-test/build.gradle
+++ b/modules/apps/audiences/audiences-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationImplementation project(":apps:audiences:audiences-api")
 	testIntegrationImplementation project(":apps:client-extension:client-extension-api")
+	testIntegrationImplementation project(":apps:frontend-js:frontend-js-audiences-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/frontend/js/audiences/test/AudiencesDefinitionProviderTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/frontend/js/audiences/test/AudiencesDefinitionProviderTest.java
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.audiences.frontend.js.audiences.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.audiences.model.AudiencesEntry;
+import com.liferay.audiences.service.AudiencesEntryLocalService;
+import com.liferay.frontend.js.audiences.AudiencesDefinition;
+import com.liferay.frontend.js.audiences.AudiencesDefinitionProvider;
+import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Eudaldo Alonso
+ */
+@RunWith(Arquillian.class)
+public class AudiencesDefinitionProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-93951"))
+	@Test
+	public void testGetAudiencesDefinition() throws Exception {
+		String name = RandomTestUtil.randomString();
+
+		_audiencesEntries.add(
+			_audiencesEntryLocalService.addAudiencesEntry(
+				null, "{\"conjunction\": \"AND\", \"rules\": []}", name,
+				ServiceContextTestUtil.getServiceContext(
+					TestPropsValues.getGroupId())));
+
+		AudiencesDefinition audiencesDefinition =
+			_audiencesDefinitionProvider.getAudiencesDefinition(
+				TestPropsValues.getCompanyId());
+
+		String content = audiencesDefinition.getContent();
+
+		Assert.assertTrue(content.contains(name));
+		Assert.assertEquals(
+			HashedFilesUtil.computeHash(content),
+			audiencesDefinition.getHash());
+	}
+
+	@Inject
+	private AudiencesDefinitionProvider _audiencesDefinitionProvider;
+
+	@DeleteAfterTestRun
+	private final List<AudiencesEntry> _audiencesEntries = new ArrayList<>();
+
+	@Inject
+	private AudiencesEntryLocalService _audiencesEntryLocalService;
+
+}

--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/frontend/js/audiences/AudiencesDefinitionProviderImpl.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/frontend/js/audiences/AudiencesDefinitionProviderImpl.java
@@ -59,7 +59,7 @@ public class AudiencesDefinitionProviderImpl
 		).toString();
 
 		audiencesDefinition = new AudiencesDefinition(
-			HashedFilesUtil.computeHash(json), json);
+			json, HashedFilesUtil.computeHash(json));
 
 		_portalCache.put(companyId, audiencesDefinition);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95807

## What Is Being Fixed

The audiences definition was built with its constructor arguments swapped: the content field received the hash and the hash field received the JSON content, so any consumer reading the definition got the hash where it expected the serialized audiences and vice versa.

## How It Is Being Fixed

Pass the JSON content and its computed hash to AudiencesDefinition in the order the constructor declares them. A new integration test, AudiencesDefinitionProviderTest, exercises AudiencesDefinitionProvider.getAudiencesDefinition and asserts that the returned content holds the serialized audiences and that the hash equals the hash of that content, so the argument order is now pinned.

## PR Check

**pr-check: PASS** — tested on `da8db484441e0668ee99343af462f9d31f3398d0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "da8db484441e0668ee99343af462f9d31f3398d0"} -->
