### PR TITLE
LPD-97086 Fix account filtering on the account profile cards

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -272,9 +272,9 @@ public interface ContactsEngineClient {
 		String assetType, int cur, int delta, List<OrderByField> orderByFields);
 
 	public Results<AssetSummary> getAssetSummaries(
-		FaroProject faroProject, String accountId, long channelId,
-		String filterString, String keywords, String objectType, int rangeKey,
-		String selectedMetric, int cur, int delta, String sortString);
+		FaroProject faroProject, long channelId, String filterString,
+		String keywords, String objectType, int rangeKey, String selectedMetric,
+		int cur, int delta, String sortString);
 
 	public Results<AssetSummaryCategory> getAssetSummaryCategories(
 		FaroProject faroProject, String accountId, long channelId,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -1262,7 +1262,7 @@ public class ContactsEngineClientImpl
 			faroProject, cur, delta, null);
 
 		if (Validator.isNotNull(accountId)) {
-			uriVariables.put("accountId", accountId);
+			uriVariables.put("accountIds", Arrays.asList(accountId));
 		}
 
 		uriVariables.put("channelId", channelId);
@@ -1342,7 +1342,7 @@ public class ContactsEngineClientImpl
 			faroProject, cur, delta, null);
 
 		if (Validator.isNotNull(accountId)) {
-			uriVariables.put("accountId", accountId);
+			uriVariables.put("accountIds", Arrays.asList(accountId));
 		}
 
 		uriVariables.put("channelId", channelId);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -1210,16 +1210,12 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public Results<AssetSummary> getAssetSummaries(
-		FaroProject faroProject, String accountId, long channelId,
-		String filterString, String keywords, String objectType, int rangeKey,
-		String selectedMetric, int cur, int delta, String sortString) {
+		FaroProject faroProject, long channelId, String filterString,
+		String keywords, String objectType, int rangeKey, String selectedMetric,
+		int cur, int delta, String sortString) {
 
 		Map<String, Object> uriVariables = getUriVariables(
 			faroProject, cur, delta, null);
-
-		if (Validator.isNotNull(accountId)) {
-			uriVariables.put("accountId", accountId);
-		}
 
 		uriVariables.put("channelId", channelId);
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -518,13 +518,13 @@ public abstract class BaseMockContactsEngineClientImpl
 	}
 
 	public Results<AssetSummary> getAssetSummaries(
-		FaroProject faroProject, String accountId, long channelId,
-		String filterString, String keywords, String objectType, int rangeKey,
-		String selectedMetric, int cur, int delta, String sortString) {
+		FaroProject faroProject, long channelId, String filterString,
+		String keywords, String objectType, int rangeKey, String selectedMetric,
+		int cur, int delta, String sortString) {
 
 		return contactsEngineClient.getAssetSummaries(
-			faroProject, accountId, channelId, filterString, keywords,
-			objectType, rangeKey, selectedMetric, cur, delta, sortString);
+			faroProject, channelId, filterString, keywords, objectType,
+			rangeKey, selectedMetric, cur, delta, sortString);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryFaroController.java
@@ -33,7 +33,6 @@ public class AssetSummaryFaroController extends BaseFaroController {
 	public FaroFDSResultsDisplay<AssetSummary>
 			getAssetSummaryFaroFDSResultsDisplay(
 				@PathParam("groupId") long groupId,
-				@QueryParam("accountId") String accountId,
 				@QueryParam("channelId") long channelId,
 				@QueryParam("filter") String filterString,
 				@QueryParam("objectType") String objectType,
@@ -49,8 +48,8 @@ public class AssetSummaryFaroController extends BaseFaroController {
 		return new FaroFDSResultsDisplay<>(
 			contactsEngineClient.getAssetSummaries(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId),
-				accountId, channelId, filterString, search, objectType,
-				rangeKey, selectedMetric, page, pageSize, sortString),
+				channelId, filterString, search, objectType, rangeKey,
+				selectedMetric, page, pageSize, sortString),
 			AssetSummaryDisplay::new, page, pageSize);
 	}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/assets.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/assets.ts
@@ -37,8 +37,8 @@ export async function fetchAccountTopAssets({
 }: IFetchAccountTopAssets): Promise<{items: ITopAsset[]}> {
 	return sendRequest({
 		data: {
-			accountId,
 			channelId,
+			filter: `accountIds in ('${accountId}')`,
 			pageSize: 5,
 			selectedMetric,
 			sort: `${selectedMetric},desc`,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97086

## What Is Being Fixed

The account profile's Top Assets and Top Categories & Tags cards stopped filtering by account and silently showed data for the whole channel. After LPD-94753 renamed the asset-summary account parameter from the discrete `accountId` to the `accountIds` OData filter (to support multi-account filtering of the asset table), the portal side that feeds the profile cards was never updated — it kept sending `accountId`, which the backend no longer reads, so the account filter was dropped.

## How It Is Being Fixed

The Top Assets card now sends the account through the OData `filter` parameter (`accountIds in ('<id>')`), the same path the asset table already uses, and the now-unused discrete account parameter is removed from `getAssetSummaries` across the interface, implementation, mock, and controller. The Top Categories & Tags cards go through endpoints that do not support the OData filter, so their engine-client calls are fixed by sending the account under the correct `accountIds` name.

## Why Are There No Tests?

The behavior is covered by the osb-asah backend integration test (AssetSummaryRestControllerTest), which exercises the accountIds OData filter path and ships in its own repository and PR. On the portal side the change is a request-shape fix in the engine client plus a React data-source fetcher whose only consumer mocks the API, so there is no portal-level unit surface to assert against.

## PR Check

**pr-check: PASS** — tested on `1f69011785e1ae954f257179c3a52a2723084bf0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

Note: `osb-faro-web:compileTestJava` cannot resolve `com.liferay.portal.test:32.6.3-SNAPSHOT` from the local `.m2` — a known osb-faro workspace limitation that is verified in CI. Main sources compile across all three affected modules and the full osb-faro-web JS suite passes (661 suites, 3311 tests).

<!-- pr-check {"result": "success", "sha": "1f69011785e1ae954f257179c3a52a2723084bf0"} -->
