### PR TITLE
[POC] LPD-96954 Add push-based subscription flow alongside Koroneiki

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-api/src/main/java/com/liferay/osb/faro/util/FaroPropsValues.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-api/src/main/java/com/liferay/osb/faro/util/FaroPropsValues.java
@@ -99,4 +99,10 @@ public class FaroPropsValues {
 		PropsUtil.get("osb.faro.clamav.timeout"),
 		GetterUtil.getInteger(System.getenv("OSB_FARO_CLAMAV_TIMEOUT")));
 
+	public static final boolean OSB_FARO_SUBSCRIPTION_PUSH_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get("osb.faro.subscription.push.enabled"),
+			GetterUtil.getBoolean(
+				System.getenv("OSB_FARO_SUBSCRIPTION_PUSH_ENABLED")));
+
 }

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-provisioning-client/src/main/java/com/liferay/osb/faro/provisioning/client/model/OSBAccountEntryBuilder.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-provisioning-client/src/main/java/com/liferay/osb/faro/provisioning/client/model/OSBAccountEntryBuilder.java
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.provisioning.client.model;
+
+import java.util.List;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class OSBAccountEntryBuilder {
+
+	public static AfterCorpEntryNameStep setCorpEntryName(
+		String corpEntryName) {
+
+		OSBAccountEntryStep osbAccountEntryStep = new OSBAccountEntryStep();
+
+		return osbAccountEntryStep.setCorpEntryName(corpEntryName);
+	}
+
+	public static class OSBAccountEntryStep
+		implements AfterCorpEntryNameStep, AfterCorpProjectUuidStep,
+				   AfterNameStep, AfterOfferingEntriesStep, BuildStep,
+				   CorpEntryNameStep, CorpProjectUuidStep, NameStep,
+				   OfferingEntriesStep {
+
+		@Override
+		public OSBAccountEntry build() {
+			return _osbAccountEntry;
+		}
+
+		@Override
+		public AfterCorpEntryNameStep setCorpEntryName(String corpEntryName) {
+			_osbAccountEntry.setCorpEntryName(corpEntryName);
+
+			return this;
+		}
+
+		@Override
+		public AfterCorpProjectUuidStep setCorpProjectUuid(
+			String corpProjectUuid) {
+
+			_osbAccountEntry.setCorpProjectUuid(corpProjectUuid);
+
+			return this;
+		}
+
+		@Override
+		public AfterNameStep setName(String name) {
+			_osbAccountEntry.setName(name);
+
+			return this;
+		}
+
+		@Override
+		public AfterOfferingEntriesStep setOfferingEntries(
+			List<OSBOfferingEntry> offeringEntries) {
+
+			_osbAccountEntry.setOfferingEntries(offeringEntries);
+
+			return this;
+		}
+
+		private final OSBAccountEntry _osbAccountEntry = new OSBAccountEntry();
+
+	}
+
+	public interface AfterCorpEntryNameStep extends CorpProjectUuidStep {
+	}
+
+	public interface AfterCorpProjectUuidStep extends NameStep {
+	}
+
+	public interface AfterNameStep extends OfferingEntriesStep {
+	}
+
+	public interface AfterOfferingEntriesStep extends BuildStep {
+	}
+
+	public interface BuildStep {
+
+		public OSBAccountEntry build();
+
+	}
+
+	public interface CorpEntryNameStep {
+
+		public AfterCorpEntryNameStep setCorpEntryName(String corpEntryName);
+
+	}
+
+	public interface CorpProjectUuidStep {
+
+		public AfterCorpProjectUuidStep setCorpProjectUuid(
+			String corpProjectUuid);
+
+	}
+
+	public interface NameStep {
+
+		public AfterNameStep setName(String name);
+
+	}
+
+	public interface OfferingEntriesStep {
+
+		public AfterOfferingEntriesStep setOfferingEntries(
+			List<OSBOfferingEntry> offeringEntries);
+
+	}
+
+}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
@@ -26,6 +26,7 @@ import com.liferay.osb.faro.provisioning.client.ProvisioningClient;
 import com.liferay.osb.faro.provisioning.client.constants.CorpProjectConstants;
 import com.liferay.osb.faro.provisioning.client.constants.ProductConstants;
 import com.liferay.osb.faro.provisioning.client.model.OSBAccountEntry;
+import com.liferay.osb.faro.provisioning.client.model.OSBAccountEntryBuilder;
 import com.liferay.osb.faro.provisioning.client.model.OSBOfferingEntry;
 import com.liferay.osb.faro.provisioning.client.model.display.main.FaroSubscriptionDisplay;
 import com.liferay.osb.faro.service.FaroNotificationLocalService;
@@ -48,6 +49,7 @@ import com.liferay.osb.faro.web.internal.model.display.contacts.TimeZoneDisplay;
 import com.liferay.osb.faro.web.internal.model.display.contacts.UsageMetric;
 import com.liferay.osb.faro.web.internal.param.FaroParam;
 import com.liferay.osb.faro.web.internal.util.JSONUtil;
+import com.liferay.osb.faro.web.internal.util.OSBAccountEntryUtil;
 import com.liferay.osb.faro.web.internal.util.TimeZoneUtil;
 import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -73,6 +75,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
@@ -284,6 +287,8 @@ public class ProjectFaroController extends BaseFaroController {
 	@POST
 	@RolesAllowed(StringPool.BLANK)
 	public ProjectDisplay createProvisioned(
+			@FormParam("corpEntryName") String corpEntryName,
+			@FormParam("corpProjectName") String corpProjectName,
 			@FormParam("corpProjectUuid") String corpProjectUuid,
 			@DefaultValue(JSONConstants.NULL_JSON_ARRAY)
 			@FormParam("emailAddressDomains")
@@ -297,6 +302,8 @@ public class ProjectFaroController extends BaseFaroController {
 			FaroParam
 				<List<String>> incidentReportEmailAddressesFaroParam,
 			@FormParam("name") String name,
+			@FormParam("offeringEntries") FaroParam<List<OSBOfferingEntry>>
+				offeringEntriesFaroParam,
 			@FormParam("ownerEmailAddress") String ownerEmailAddress,
 			@FormParam("serverLocation") String serverLocation,
 			@DefaultValue("UTC") @FormParam("timeZoneId") String timeZoneId)
@@ -305,10 +312,11 @@ public class ProjectFaroController extends BaseFaroController {
 		User user = getUser();
 
 		FaroProject faroProject = _create(
-			corpProjectUuid, name, emailAddressDomainsFaroParam.getValue(),
-			friendlyURL, incidentReportEmailAddressesFaroParam.getValue(),
-			serverLocation, FaroProjectConstants.STATE_UNCONFIGURED,
-			timeZoneId);
+			corpEntryName, corpProjectName, corpProjectUuid,
+			emailAddressDomainsFaroParam.getValue(), friendlyURL,
+			incidentReportEmailAddressesFaroParam.getValue(), name,
+			offeringEntriesFaroParam.getValue(), serverLocation,
+			FaroProjectConstants.STATE_UNCONFIGURED, timeZoneId);
 
 		Role role = _roleLocalService.getRole(
 			user.getCompanyId(), RoleConstants.SITE_OWNER);
@@ -974,6 +982,81 @@ public class ProjectFaroController extends BaseFaroController {
 			faroProjectLocalService.updateFaroProject(faroProject));
 	}
 
+	@Path("/corpProjectUuid/{corpProjectUuid}/subscription")
+	@PUT
+	@RolesAllowed(StringPool.BLANK)
+	public ProjectDisplay updateSubscription(
+			@FormParam("corpEntryName") String corpEntryName,
+			@FormParam("corpProjectName") String corpProjectName,
+			@PathParam("corpProjectUuid") String corpProjectUuid,
+			@FormParam("offeringEntries") FaroParam<List<OSBOfferingEntry>>
+				offeringEntriesFaroParam)
+		throws Exception {
+
+		if (!FaroPropsValues.OSB_FARO_SUBSCRIPTION_PUSH_ENABLED) {
+			throw new FaroException(
+				"Subscription push is not enabled",
+				Response.Status.NOT_IMPLEMENTED);
+		}
+
+		FaroProject faroProject =
+			_faroProjectLocalService.fetchFaroProjectByCorpProjectUuid(
+				corpProjectUuid);
+
+		if (faroProject == null) {
+			throw new FaroException(
+				"No project exists with the corp project UUID " +
+					corpProjectUuid,
+				Response.Status.NOT_FOUND);
+		}
+
+		_validateOfferingEntries(offeringEntriesFaroParam.getValue());
+
+		FaroSubscriptionDisplay faroSubscriptionDisplay =
+			new FaroSubscriptionDisplay(
+				OSBAccountEntryBuilder.setCorpEntryName(
+					corpEntryName
+				).setCorpProjectUuid(
+					corpProjectUuid
+				).setName(
+					corpProjectName
+				).setOfferingEntries(
+					offeringEntriesFaroParam.getValue()
+				).build());
+
+		if (_isSubscriptionPlanChanged(
+				faroProject, faroSubscriptionDisplay.getName())) {
+
+			faroProject.setSubscriptionModifiedTime(System.currentTimeMillis());
+		}
+
+		faroProject.setAccountName(corpEntryName);
+		faroProject.setCorpProjectName(corpProjectName);
+
+		try {
+			if (Objects.equals(
+					faroProject.getState(),
+					FaroProjectConstants.STATE_UNAVAILABLE)) {
+
+				faroProject.setState(FaroProjectConstants.STATE_READY);
+			}
+
+			faroSubscriptionDisplay.setCounts(
+				faroProject, _faroProjectUsageLocalService);
+
+			faroProject.setSubscription(
+				JSONUtil.writeValueAsString(faroSubscriptionDisplay));
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+
+			faroProject.setState(FaroProjectConstants.STATE_UNAVAILABLE);
+		}
+
+		return _getProjectDisplay(
+			_faroProjectLocalService.updateFaroProject(faroProject));
+	}
+
 	protected OSBAccountEntry createOSBAccountEntry(boolean trial) {
 		return new OSBAccountEntry() {
 			{
@@ -1018,6 +1101,10 @@ public class ProjectFaroController extends BaseFaroController {
 			};
 		}
 
+		if (FaroPropsValues.OSB_FARO_SUBSCRIPTION_PUSH_ENABLED) {
+			return OSBAccountEntryUtil.build(faroProject);
+		}
+
 		return _provisioningClient.getOSBAccountEntry(
 			faroProject.getCorpProjectUuid());
 	}
@@ -1033,17 +1120,35 @@ public class ProjectFaroController extends BaseFaroController {
 	}
 
 	private FaroProject _create(
-			String corpProjectUuid, String name,
-			List<String> emailAddressDomains, String friendlyURL,
-			List<String> incidentReportEmailAddresses, String serverLocation,
-			String state, String timeZoneId)
+			String corpEntryName, String corpProjectName,
+			String corpProjectUuid, List<String> emailAddressDomains,
+			String friendlyURL, List<String> incidentReportEmailAddresses,
+			String name, List<OSBOfferingEntry> offeringEntries,
+			String serverLocation, String state, String timeZoneId)
 		throws Exception {
 
 		_validateFriendlyURL(friendlyURL);
 		_validateIncidentReportEmailAddresses(incidentReportEmailAddresses);
 		_validateTimeZoneId(timeZoneId);
 
-		OSBAccountEntry osbAccountEntry = getOSBAccountEntry(corpProjectUuid);
+		OSBAccountEntry osbAccountEntry = null;
+
+		if (FaroPropsValues.OSB_FARO_SUBSCRIPTION_PUSH_ENABLED) {
+			_validateOfferingEntries(offeringEntries);
+
+			osbAccountEntry = OSBAccountEntryBuilder.setCorpEntryName(
+				corpEntryName
+			).setCorpProjectUuid(
+				corpProjectUuid
+			).setName(
+				corpProjectName
+			).setOfferingEntries(
+				offeringEntries
+			).build();
+		}
+		else {
+			osbAccountEntry = getOSBAccountEntry(corpProjectUuid);
+		}
 
 		FaroSubscriptionDisplay faroSubscriptionDisplay =
 			new FaroSubscriptionDisplay(osbAccountEntry);
@@ -1703,6 +1808,15 @@ public class ProjectFaroController extends BaseFaroController {
 		if (lastSeenDate.after(calendar.getTime())) {
 			throw new FaroValidationException(
 				"lastSeenDate", _getDeletionFailedErrorMessage(getUser()));
+		}
+	}
+
+	private void _validateOfferingEntries(
+		List<OSBOfferingEntry> offeringEntries) {
+
+		if (ListUtil.isEmpty(offeringEntries)) {
+			throw new FaroValidationException(
+				"offeringEntries", "Offering entries are required");
 		}
 	}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/messaging/UpdateFaroProjectSubscriptionsMessageListener.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/messaging/UpdateFaroProjectSubscriptionsMessageListener.java
@@ -19,9 +19,11 @@ import com.liferay.osb.faro.provisioning.client.model.display.main.FaroSubscript
 import com.liferay.osb.faro.service.FaroProjectLocalService;
 import com.liferay.osb.faro.service.FaroProjectUsageLocalService;
 import com.liferay.osb.faro.util.DateUtil;
+import com.liferay.osb.faro.util.FaroPropsValues;
 import com.liferay.osb.faro.web.internal.constants.FaroMessageDestinationNames;
 import com.liferay.osb.faro.web.internal.messaging.destination.creator.DestinationCreator;
 import com.liferay.osb.faro.web.internal.util.JSONUtil;
+import com.liferay.osb.faro.web.internal.util.OSBAccountEntryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -159,6 +161,9 @@ public class UpdateFaroProjectSubscriptionsMessageListener
 							Collections.singletonList(osbOfferingEntry));
 					}
 				};
+			}
+			else if (FaroPropsValues.OSB_FARO_SUBSCRIPTION_PUSH_ENABLED) {
+				osbAccountEntry = OSBAccountEntryUtil.build(faroProject);
 			}
 			else {
 				osbAccountEntry = _provisioningClient.getOSBAccountEntry(

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/OSBAccountEntryUtil.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/OSBAccountEntryUtil.java
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.web.internal.util;
+
+import com.liferay.osb.faro.model.FaroProject;
+import com.liferay.osb.faro.provisioning.client.constants.ProductConstants;
+import com.liferay.osb.faro.provisioning.client.model.OSBAccountEntry;
+import com.liferay.osb.faro.provisioning.client.model.OSBAccountEntryBuilder;
+import com.liferay.osb.faro.provisioning.client.model.OSBOfferingEntry;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class OSBAccountEntryUtil {
+
+	public static OSBAccountEntry build(FaroProject faroProject)
+		throws Exception {
+
+		JSONObject subscriptionJSONObject = JSONFactoryUtil.createJSONObject(
+			faroProject.getSubscription());
+
+		List<OSBOfferingEntry> offeringEntries = new ArrayList<>();
+
+		int status = ProductConstants.OSB_OFFERING_ENTRY_STATUS_ACTIVE;
+
+		if (!subscriptionJSONObject.getBoolean("active")) {
+			status = 0;
+		}
+
+		OSBOfferingEntry osbOfferingEntry = new OSBOfferingEntry();
+
+		osbOfferingEntry.setProductEntryId(
+			_getProductEntryId(subscriptionJSONObject.getString("name")));
+		osbOfferingEntry.setQuantity(1);
+		osbOfferingEntry.setStatus(status);
+
+		long startDate = subscriptionJSONObject.getLong("startDate");
+
+		if (startDate > 0) {
+			osbOfferingEntry.setStartDate(new Date(startDate));
+		}
+
+		long endDate = subscriptionJSONObject.getLong("endDate");
+
+		if (endDate > 0) {
+			osbOfferingEntry.setSupportEndDate(new Date(endDate));
+		}
+
+		offeringEntries.add(osbOfferingEntry);
+
+		JSONArray addOnsJSONArray = subscriptionJSONObject.getJSONArray(
+			"addOns");
+
+		if (addOnsJSONArray != null) {
+			for (int i = 0; i < addOnsJSONArray.length(); i++) {
+				OSBOfferingEntry curOSBOfferingEntry = new OSBOfferingEntry();
+
+				JSONObject addOnJSONObject = addOnsJSONArray.getJSONObject(i);
+
+				curOSBOfferingEntry.setProductEntryId(
+					ProductConstants.getProductEntryId(
+						addOnJSONObject.getString("name")));
+				curOSBOfferingEntry.setQuantity(
+					addOnJSONObject.getInt("quantity"));
+
+				curOSBOfferingEntry.setStatus(status);
+
+				offeringEntries.add(curOSBOfferingEntry);
+			}
+		}
+
+		return OSBAccountEntryBuilder.setCorpEntryName(
+			faroProject.getAccountName()
+		).setCorpProjectUuid(
+			faroProject.getCorpProjectUuid()
+		).setName(
+			faroProject.getCorpProjectName()
+		).setOfferingEntries(
+			offeringEntries
+		).build();
+	}
+
+	private static String _getProductEntryId(String name) {
+		String productEntryId = ProductConstants.getProductEntryId(name);
+
+		if (productEntryId == null) {
+			return ProductConstants.BASIC_PRODUCT_ENTRY_ID;
+		}
+
+		return productEntryId;
+	}
+
+}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/util/OSBAccountEntryUtilTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/util/OSBAccountEntryUtilTest.java
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.web.internal.util;
+
+import com.liferay.osb.faro.model.FaroProject;
+import com.liferay.osb.faro.provisioning.client.constants.ProductConstants;
+import com.liferay.osb.faro.provisioning.client.model.OSBAccountEntry;
+import com.liferay.osb.faro.provisioning.client.model.OSBAccountEntryBuilder;
+import com.liferay.osb.faro.provisioning.client.model.OSBOfferingEntry;
+import com.liferay.osb.faro.provisioning.client.model.display.main.FaroSubscriptionDisplay;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class OSBAccountEntryUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testBuildFromPayload() {
+		OSBOfferingEntry osbOfferingEntry = new OSBOfferingEntry();
+
+		osbOfferingEntry.setProductEntryId(
+			ProductConstants.ENTERPRISE_PRODUCT_ENTRY_ID);
+		osbOfferingEntry.setQuantity(1);
+
+		OSBAccountEntry osbAccountEntry =
+			OSBAccountEntryBuilder.setCorpEntryName(
+				"Corp Entry Name"
+			).setCorpProjectUuid(
+				"corp-project-uuid"
+			).setName(
+				"Corp Project Name"
+			).setOfferingEntries(
+				Collections.singletonList(osbOfferingEntry)
+			).build();
+
+		Assert.assertEquals(
+			"Corp Entry Name", osbAccountEntry.getCorpEntryName());
+		Assert.assertEquals(
+			"corp-project-uuid", osbAccountEntry.getCorpProjectUuid());
+		Assert.assertEquals("Corp Project Name", osbAccountEntry.getName());
+
+		List<OSBOfferingEntry> offeringEntries =
+			osbAccountEntry.getOfferingEntries();
+
+		Assert.assertEquals(
+			offeringEntries.toString(), 1, offeringEntries.size());
+		Assert.assertEquals(
+			ProductConstants.ENTERPRISE_PRODUCT_ENTRY_ID,
+			offeringEntries.get(
+				0
+			).getProductEntryId());
+	}
+
+	@Test
+	public void testBuildFromStoredSubscription() throws Exception {
+		OSBOfferingEntry osbOfferingEntry = new OSBOfferingEntry();
+
+		osbOfferingEntry.setProductEntryId(
+			ProductConstants.ENTERPRISE_PRODUCT_ENTRY_ID);
+		osbOfferingEntry.setQuantity(1);
+		osbOfferingEntry.setStartDate(new Date());
+		osbOfferingEntry.setStatus(
+			ProductConstants.OSB_OFFERING_ENTRY_STATUS_ACTIVE);
+
+		OSBAccountEntry pushedOSBAccountEntry =
+			OSBAccountEntryBuilder.setCorpEntryName(
+				"Corp Entry Name"
+			).setCorpProjectUuid(
+				"corp-project-uuid"
+			).setName(
+				"Corp Project Name"
+			).setOfferingEntries(
+				Collections.singletonList(osbOfferingEntry)
+			).build();
+
+		FaroProject faroProject = Mockito.mock(FaroProject.class);
+
+		Mockito.when(
+			faroProject.getAccountName()
+		).thenReturn(
+			"Corp Entry Name"
+		);
+
+		Mockito.when(
+			faroProject.getCorpProjectName()
+		).thenReturn(
+			"Corp Project Name"
+		);
+
+		Mockito.when(
+			faroProject.getCorpProjectUuid()
+		).thenReturn(
+			"corp-project-uuid"
+		);
+
+		Mockito.when(
+			faroProject.getSubscription()
+		).thenReturn(
+			JSONUtil.writeValueAsString(
+				new FaroSubscriptionDisplay(pushedOSBAccountEntry))
+		);
+
+		OSBAccountEntry osbAccountEntry = OSBAccountEntryUtil.build(
+			faroProject);
+
+		Assert.assertEquals(
+			"Corp Entry Name", osbAccountEntry.getCorpEntryName());
+		Assert.assertEquals(
+			"corp-project-uuid", osbAccountEntry.getCorpProjectUuid());
+		Assert.assertEquals("Corp Project Name", osbAccountEntry.getName());
+
+		List<OSBOfferingEntry> offeringEntries =
+			osbAccountEntry.getOfferingEntries();
+
+		Assert.assertEquals(
+			offeringEntries.toString(), 1, offeringEntries.size());
+
+		OSBOfferingEntry rebuiltOSBOfferingEntry = offeringEntries.get(0);
+
+		Assert.assertEquals(
+			ProductConstants.ENTERPRISE_PRODUCT_ENTRY_ID,
+			rebuiltOSBOfferingEntry.getProductEntryId());
+		Assert.assertEquals(1, rebuiltOSBOfferingEntry.getQuantity());
+		Assert.assertEquals(
+			ProductConstants.OSB_OFFERING_ENTRY_STATUS_ACTIVE,
+			rebuiltOSBOfferingEntry.getStatus());
+		Assert.assertNotNull(rebuiltOSBOfferingEntry.getStartDate());
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96954

## What Is Being Fixed

Koroneiki is being retired in favor of one.liferay, but the cutover cannot happen all at once. Faro needs to accept subscription data (corp project name, account name, offering/product info, dates, quantity, status) pushed directly in the request, running alongside today's Koroneiki pull rather than replacing it, so Faro keeps working exactly as it does today until the org is ready to switch.

## How It Is Being Fixed

A new deployment-wide flag, OSB_FARO_SUBSCRIPTION_PUSH_ENABLED (default false), selects the source of subscription data. With the flag off, everything behaves exactly as before. With it on, POST /project/provisioned builds the initial subscription from the new corpProjectName, corpEntryName, and offeringEntries parameters instead of fetching from Koroneiki, and a new PUT /project/corpProjectUuid/{corpProjectUuid}/subscription endpoint pushes renewals and plan changes into an already-provisioned project, resetting subscriptionModifiedTime on a plan change and recomputing usage-limit status; it returns 501 when the flag is off. The forceUpdate GET path and the 6-hour UpdateFaroProjectSubscriptionsMessageListener job rebuild the subscription from what is already stored instead of calling Koroneiki, since nothing new is pulled in push mode. A shared OSBAccountEntryBuilder constructs the OSBAccountEntry from either the pushed payload or the stored subscription. Koroneiki-backed consumption tracking, seat/role sync, and the cross-tenant authorization check are intentionally left unconditional (flagged as a known follow-up in the ticket).

## PR Check

**pr-check: PASS** — tested on `6b5f97f0794cf3a239782162384d0b79e8640bb6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "6b5f97f0794cf3a239782162384d0b79e8640bb6"} -->
