### PR TITLE
LPD-95102 Show empty states instead of a hardcoded lifecycle fallback

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/context/LifecycleContext.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/context/LifecycleContext.tsx
@@ -46,12 +46,12 @@ const initialValues: ILifecycleFilterValues = {
 
 interface ILifecycleContextProviderProps {
 	children: ReactNode;
-	lifecycleId: string;
+	lifecycleId?: string;
 }
 
 export const LifecycleContextProvider = ({
 	children,
-	lifecycleId,
+	lifecycleId = '',
 }: ILifecycleContextProviderProps) => {
 	const [filterValues, setFilterValues] =
 		useState<ILifecycleFilterValues>(initialValues);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
@@ -183,7 +183,11 @@ const BaseLifecycle = () => {
 	const loading = dataSourcesLoading || lifecyclesLoading || !lifecycleId;
 
 	const hasContent =
-		!loading && !noDataSources && !accountMetricsLoading && !!totalAccounts;
+		!loading &&
+		!noDataSources &&
+		!accountMetricsLoading &&
+		!!totalAccounts &&
+		!!lifecycleId;
 
 	const renderBody = () => {
 		if (loading) {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
@@ -165,7 +165,7 @@ const BaseLifecycle = () => {
 		variables: {groupId: groupId!},
 	});
 
-	const lifecycleId = lifecycles?.[0]?.id ?? '1';
+	const lifecycleId = lifecycles?.[0]?.id;
 
 	const {data: accountMetrics, loading: accountMetricsLoading} = useRequest({
 		dataSourceFn: API.accounts.fetchMetrics,
@@ -180,7 +180,7 @@ const BaseLifecycle = () => {
 
 	const authorized = currentUser.isAdmin();
 
-	const loading = dataSourcesLoading || lifecyclesLoading || !lifecycleId;
+	const loading = dataSourcesLoading || lifecyclesLoading;
 
 	const hasContent =
 		!loading &&
@@ -217,7 +217,7 @@ const BaseLifecycle = () => {
 			return <Loading />;
 		}
 
-		if (!totalAccounts) {
+		if (!totalAccounts || !lifecycleId) {
 			return (
 				<LifecycleEmptyState
 					authorized={authorized}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/BaseLifecycle.tsx
@@ -75,9 +75,14 @@ const buildAccountMetrics = (totalCount: number) =>
 
 const useRequestImpl =
 	({
+		lifecycles = [{id: '1'}],
 		metricsLoading = false,
 		totalCount = 1,
-	}: {metricsLoading?: boolean; totalCount?: number} = {}) =>
+	}: {
+		lifecycles?: {id: string}[];
+		metricsLoading?: boolean;
+		totalCount?: number;
+	} = {}) =>
 	({variables}: {variables?: {[key: string]: any}} = {}) =>
 		variables?.channelId !== undefined
 			? {
@@ -85,7 +90,7 @@ const useRequestImpl =
 					error: false,
 					loading: metricsLoading,
 				}
-			: {data: [{id: '1'}], error: false, loading: false};
+			: {data: lifecycles, error: false, loading: false};
 
 const store = mockStore();
 
@@ -239,5 +244,19 @@ describe('BaseLifecycle', () => {
 		expect(screen.getByTestId('accounts-dataset')).toBeInTheDocument();
 		expect(screen.getByTestId('global-filters')).toBeInTheDocument();
 		expect(screen.queryByText('No Account Data Available')).toBeNull();
+	});
+
+	it('renders the empty state and hides the filters when no lifecycle exists', () => {
+		mockedUseRequest.mockImplementation(
+			useRequestImpl({lifecycles: [], totalCount: 5})
+		);
+
+		renderPage();
+
+		expect(
+			screen.getByText('No Account Data Available')
+		).toBeInTheDocument();
+		expect(screen.queryByTestId('overview-section')).toBeNull();
+		expect(screen.queryByTestId('global-filters')).toBeNull();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95102

## What Is Being Fixed

The lifecycle page fell back to requesting a hardcoded lifecycle id (`1`)
whenever the account-lifecycle response held no lifecycle. That masked the
real "no lifecycle" state: the page issued requests against a lifecycle that
may not exist, and the global filters rendered even when there was no
lifecycle data to filter.

## How It Is Being Fixed

The `?? '1'` fallback is removed so the lifecycle id is undefined when no
lifecycle exists. The content branch is gated on a resolved lifecycle so the
page shows the existing empty state instead of firing requests against an
undefined id, and the `!lifecycleId` term is dropped from the loading flag so
the empty state can render rather than spinning forever. The global-filters
sub-header is gated on the same resolved lifecycle so it stays hidden in the
empty state, and the context provider's lifecycle id prop is made optional to
reflect that it may be absent. A unit test covers the new no-lifecycle path.

## PR Check

**pr-check: PASS** — tested on `bb15375f006b46be6421ea1bba03244b30901815`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "bb15375f006b46be6421ea1bba03244b30901815"} -->
