### PR TITLE
LPD-93568 Re-apply lifecycle stage filter on every chart click

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/LifecycleChart.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/LifecycleChart.tsx
@@ -202,7 +202,7 @@ interface ILifecycleChartProps {
 }
 
 const LifecycleChart = ({error, loading, stages}: ILifecycleChartProps) => {
-	const {updateFilters} = useLifecycle();
+	const {selectStage} = useLifecycle();
 
 	const isEmpty = error || !stages?.length;
 
@@ -213,7 +213,7 @@ const LifecycleChart = ({error, loading, stages}: ILifecycleChartProps) => {
 			)!;
 
 	const onFilterClick = (stageType: LifecycleStages) =>
-		updateFilters({lifecycleStageFilter: stageType});
+		selectStage(stageType);
 
 	const refPct = Math.max(
 		...resolvedStages.map((stage) => stage.percentage),

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/context/LifecycleContext.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/context/LifecycleContext.tsx
@@ -19,6 +19,8 @@ interface ILifecycleFilters extends ILifecycleFilterValues {
 interface ILifecycleContext {
 	filters: ILifecycleFilters;
 	lifecycleId: string;
+	selectStage: (stage: LifecycleStages) => void;
+	stageSelectionNonce: number;
 	updateFilters: (newFilters: Partial<ILifecycleFilterValues>) => void;
 	resetFilters: () => void;
 }
@@ -32,6 +34,8 @@ const LifecycleContext = createContext<ILifecycleContext>({
 	},
 	lifecycleId: '',
 	resetFilters: () => {},
+	selectStage: () => {},
+	stageSelectionNonce: 0,
 	updateFilters: () => {},
 });
 
@@ -56,6 +60,8 @@ export const LifecycleContextProvider = ({
 	const [filterValues, setFilterValues] =
 		useState<ILifecycleFilterValues>(initialValues);
 
+	const [stageSelectionNonce, setStageSelectionNonce] = useState(0);
+
 	const filters = useMemo<ILifecycleFilters>(
 		() => ({
 			...filterValues,
@@ -70,11 +76,30 @@ export const LifecycleContextProvider = ({
 		[]
 	);
 
+	const selectStage = useCallback((stage: LifecycleStages) => {
+		setFilterValues((prev) => ({...prev, lifecycleStageFilter: stage}));
+		setStageSelectionNonce((prev) => prev + 1);
+	}, []);
+
 	const resetFilters = useCallback(() => setFilterValues(initialValues), []);
 
 	const value = useMemo(
-		() => ({filters, lifecycleId, resetFilters, updateFilters}),
-		[filters, lifecycleId, resetFilters, updateFilters]
+		() => ({
+			filters,
+			lifecycleId,
+			resetFilters,
+			selectStage,
+			stageSelectionNonce,
+			updateFilters,
+		}),
+		[
+			filters,
+			lifecycleId,
+			resetFilters,
+			selectStage,
+			stageSelectionNonce,
+			updateFilters,
+		]
 	);
 
 	return (

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/context/__tests__/LifecycleContext.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/context/__tests__/LifecycleContext.tsx
@@ -80,4 +80,29 @@ describe('LifecycleContext', () => {
 			lifecycleStageFilter: LifecycleStages.AT_RISK,
 		});
 	});
+
+	it('should set the stage and bump stageSelectionNonce when selectStage is called', () => {
+		const {result} = renderHook(() => useLifecycle(), {wrapper});
+
+		expect(result.current.stageSelectionNonce).toBe(0);
+
+		act(() => result.current.selectStage(LifecycleStages.AWARE));
+
+		expect(result.current.filters.lifecycleStageFilter).toBe(
+			LifecycleStages.AWARE
+		);
+		expect(result.current.stageSelectionNonce).toBe(1);
+	});
+
+	it('should bump stageSelectionNonce even when selectStage is called with the same stage', () => {
+		const {result} = renderHook(() => useLifecycle(), {wrapper});
+
+		act(() => result.current.selectStage(LifecycleStages.AWARE));
+		act(() => result.current.selectStage(LifecycleStages.AWARE));
+
+		expect(result.current.filters.lifecycleStageFilter).toBe(
+			LifecycleStages.AWARE
+		);
+		expect(result.current.stageSelectionNonce).toBe(2);
+	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
@@ -127,7 +127,7 @@ const LifecycleStagesSection = () => {
 };
 
 const LifecycleAccounts = () => {
-	const {filters, lifecycleId} = useLifecycle();
+	const {filters, lifecycleId, stageSelectionNonce} = useLifecycle();
 
 	const {channelId, groupId} = useParams();
 
@@ -146,6 +146,7 @@ const LifecycleAccounts = () => {
 				groupId={groupId!}
 				industryFilter={filters.industryFilter}
 				lifecycleStageFilter={filters.lifecycleStageFilter}
+				stageSelectionNonce={stageSelectionNonce}
 			/>
 		</section>
 	);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -24,6 +24,7 @@ interface IAccountsDataSetProps {
 	groupId: string;
 	industryFilter?: string;
 	lifecycleStageFilter?: LifecycleStages;
+	stageSelectionNonce?: number;
 }
 
 interface ILifecycleStageFieldValue {
@@ -47,6 +48,7 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 	groupId,
 	industryFilter,
 	lifecycleStageFilter,
+	stageSelectionNonce,
 }) => {
 	const {data: lifecycleStageFieldValues} = useRequest({
 		dataSourceFn: API.accounts.fetchLifecycleStageFieldValues,
@@ -176,6 +178,7 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 					countryFilter,
 					industryFilter,
 					lifecycleStageFilter,
+					stageSelectionNonce,
 					lifecycleStages.length,
 				].join()}
 				pagination={pagination}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -52,6 +52,7 @@ type FakeCustomDataRenderers = {
 let lastApiURL: string | undefined;
 let lastCustomDataRenderers: FakeCustomDataRenderers | undefined;
 let lastFilters: FakeFilter[] | undefined;
+let mountCount = 0;
 
 jest.mock('@liferay/frontend-data-set-web', () => ({
 	...jest.requireActual('@liferay/frontend-data-set-web'),
@@ -70,6 +71,10 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 		lastCustomDataRenderers = customDataRenderers;
 		lastFilters = filters;
 
+		React.useEffect(() => {
+			mountCount += 1;
+		}, []);
+
 		return <div data-testid="fds-component" id={id} />;
 	},
 }));
@@ -81,6 +86,7 @@ describe('AccountsDataSet', () => {
 		lastApiURL = undefined;
 		lastCustomDataRenderers = undefined;
 		lastFilters = undefined;
+		mountCount = 0;
 	});
 
 	afterEach(cleanup);
@@ -281,5 +287,33 @@ describe('AccountsDataSet', () => {
 			'href',
 			'/workspace/23/123/contacts/accounts/abc'
 		);
+	});
+
+	it('should remount the FrontendDataSet when stageSelectionNonce changes even if lifecycleStageFilter is unchanged', () => {
+		const {rerender} = render(
+			<AccountsDataSet
+				accountLifecycleId="al-1"
+				apiURL="fake-url"
+				channelId="123"
+				groupId="23"
+				lifecycleStageFilter={LifecycleStages.AWARE}
+				stageSelectionNonce={0}
+			/>
+		);
+
+		expect(mountCount).toBe(1);
+
+		rerender(
+			<AccountsDataSet
+				accountLifecycleId="al-1"
+				apiURL="fake-url"
+				channelId="123"
+				groupId="23"
+				lifecycleStageFilter={LifecycleStages.AWARE}
+				stageSelectionNonce={1}
+			/>
+		);
+
+		expect(mountCount).toBe(2);
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93568

## What Is Being Fixed

In the Lifecycles dashboard, after removing the stage-filter chip from the
accounts list, clicking the same stage on the chart did nothing — the filter
button appeared broken. The stage filter reaches the accounts list only
through the FrontendDataSet remount key, and re-selecting the same stage
produced no change to that key (removing the chip mutates only the
FrontendDataSet's internal state, never the Lifecycles context), so the data
set never remounted — no chip, no request. Selecting a different stage
recovered because it changed the key.

## How It Is Being Fixed

A monotonic stage-selection nonce is added to the Lifecycles context, bumped
on every chart-stage selection through a dedicated selectStage action, and
threaded into the FrontendDataSet remount key. Because the nonce changes on
every click — even for the same stage — the data set always remounts and
re-applies the filter, regardless of whether its chip was previously removed.
This stays bundle-free: FrontendDataSet is not bundled and its state atom is
not shared, so it remains a runtime external.

## PR Check

**pr-check: PASS** — tested on `a027ce98c79c5255ac14a3d226f551c4da7c846b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "a027ce98c79c5255ac14a3d226f551c4da7c846b"} -->
