### PR TITLE
LPD-95615 Resolve MARKETO_CAMPAIGN as a Provider subtype

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Provider.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Provider.java
@@ -12,6 +12,7 @@ import com.liferay.osb.faro.engine.client.model.provider.CSVProvider;
 import com.liferay.osb.faro.engine.client.model.provider.DemandbaseProvider;
 import com.liferay.osb.faro.engine.client.model.provider.HubSpotProvider;
 import com.liferay.osb.faro.engine.client.model.provider.LiferayProvider;
+import com.liferay.osb.faro.engine.client.model.provider.MarketoCampaignProvider;
 import com.liferay.osb.faro.engine.client.model.provider.MarketoProvider;
 import com.liferay.osb.faro.engine.client.model.provider.SalesforceProvider;
 
@@ -29,6 +30,10 @@ import com.liferay.osb.faro.engine.client.model.provider.SalesforceProvider;
 		),
 		@JsonSubTypes.Type(
 			name = LiferayProvider.TYPE, value = LiferayProvider.class
+		),
+		@JsonSubTypes.Type(
+			name = MarketoCampaignProvider.TYPE,
+			value = MarketoCampaignProvider.class
 		),
 		@JsonSubTypes.Type(
 			name = MarketoProvider.TYPE, value = MarketoProvider.class


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95615

## What Is Being Fixed

Creating a Marketo Campaign data source failed with a 500. The engine client serializes a DataSource carrying a MarketoCampaignProvider, POSTs it, and deserializes the response back into Provider — but Jackson had no mapping for the "MARKETO_CAMPAIGN" type id (known ids were CSV, DEMANDBASE, HUBSPOT, LIFERAY, MARKETO, SALESFORCE), so it threw HttpMessageNotReadableException.

## How It Is Being Fixed

Register MarketoCampaignProvider in the @JsonSubTypes list on the Provider interface, mirroring the six existing provider types, so the "MARKETO_CAMPAIGN" type id resolves during deserialization.

## Why Are There No Tests?

The change is a single declarative @JsonSubTypes.Type entry on the Provider interface, registering MarketoCampaignProvider exactly as the existing provider types are registered; it adds no branching or logic to unit-test in isolation. The deserialization path it fixes is exercised by the Marketo Campaign connect flow (delivered separately on the frontend) and compiled by the workspace build. A standalone serialization test was judged disproportionate for a one-line annotation registration that mirrors established siblings.

## PR Check

**pr-check: PASS** — tested on `7172e4a8935ca448290d5540fe376bfffd55fa7b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "7172e4a8935ca448290d5540fe376bfffd55fa7b"} -->
