### PR TITLE
LPD-97380 Hide the experience filter dropdown for non-LDP workspaces

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/pages/TouchpointRoutes.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/pages/TouchpointRoutes.jsx
@@ -21,6 +21,7 @@ import {removeUriQueryParam, setUriQueryValues} from 'shared/util/router';
 import {Switch, useHistory} from 'react-router-dom';
 import {useChannelContext} from 'shared/context/channel';
 import {useDataSources} from 'shared/context/dataSources';
+import {useLDPEnabled} from 'shared/hooks/useLDPEnabled';
 import {useQueryRangeSelectors} from 'shared/hooks/useQueryRangeSelectors';
 
 const KnownIndividuals = lazy(() =>
@@ -74,6 +75,7 @@ function TouchpointRoutes({className, router}) {
 	const [selectedSegment, setSelectedSegment] = useState({});
 	const [experienceId, setExperienceId] = useState(experienceIdfromURL);
 	const history = useHistory();
+	const LDPEnabled = useLDPEnabled({groupId});
 
 	useEffect(() => {
 		setPathRangeSelectors(rangeSelectors);
@@ -124,14 +126,16 @@ function TouchpointRoutes({className, router}) {
 
 			{matchedRoute === Routes.SITES_TOUCHPOINTS_OVERVIEW && (
 				<BasePage.SubHeader>
-					<ExperienceDropdown
-						groupId={groupId}
-						onChange={experienceId => {
-							history.push(setUriQueryValues({experienceId}));
+					{LDPEnabled && (
+						<ExperienceDropdown
+							groupId={groupId}
+							onChange={experienceId => {
+								history.push(setUriQueryValues({experienceId}));
 
-							setExperienceId(experienceId);
-						}}
-					/>
+								setExperienceId(experienceId);
+							}}
+						/>
+					)}
 
 					<div className='d-flex justify-content-end w-100'>
 						<DropdownRangeKey

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/pages/__tests__/TouchpointRoutes.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/pages/__tests__/TouchpointRoutes.jsx
@@ -3,7 +3,9 @@ import React from 'react';
 import TouchpointRoutes from '../TouchpointRoutes';
 import {MemoryRouter} from 'react-router-dom';
 import {Provider} from 'react-redux';
+import {getMatchedRoute, Routes} from 'shared/util/router';
 import {render, screen} from '@testing-library/react';
+import {useLDPEnabled} from 'shared/hooks/useLDPEnabled';
 
 jest.unmock('react-dom');
 
@@ -40,7 +42,7 @@ jest.mock('route-middleware/BundleRouter', () => ({
 
 jest.mock('../../components/ExperienceDropdown', () => ({
 	__esModule: true,
-	default: () => null
+	default: () => <div data-testid='experience-dropdown' />
 }));
 
 jest.mock('../../components/FilterBySegment', () => ({
@@ -60,6 +62,10 @@ jest.mock('shared/hooks/useQueryRangeSelectors', () => ({
 	useQueryRangeSelectors: () => ({rangeKey: '30'})
 }));
 
+jest.mock('shared/hooks/useLDPEnabled', () => ({
+	useLDPEnabled: jest.fn()
+}));
+
 jest.mock('shared/util/router', () => {
 	const actual = jest.requireActual('shared/util/router');
 
@@ -72,6 +78,13 @@ jest.mock('shared/util/router', () => {
 });
 
 describe('TouchpointRoutes', () => {
+	beforeEach(() => {
+		getMatchedRoute.mockReturnValue(
+			Routes.SITES_TOUCHPOINTS_KNOWN_INDIVIDUALS
+		);
+		useLDPEnabled.mockReturnValue(false);
+	});
+
 	it('forwards a percent-encoded touchpoint as assetId for the Known Individuals CSV download', () => {
 		const router = {
 			params: {
@@ -98,5 +111,55 @@ describe('TouchpointRoutes', () => {
 		).toBe(
 			'http://example.com/web/site/%E4%BA%BA%E4%BA%8B%E7%99%BA%E5%91%8A'
 		);
+	});
+
+	it('shows the experience filter dropdown on the overview route for LDP workspaces', () => {
+		getMatchedRoute.mockReturnValue(Routes.SITES_TOUCHPOINTS_OVERVIEW);
+		useLDPEnabled.mockReturnValue(true);
+
+		const router = {
+			params: {
+				channelId: '1',
+				experienceId: '',
+				groupId: '2',
+				title: 'page',
+				touchpoint: 'http://example.com/web/site/home'
+			}
+		};
+
+		render(
+			<Provider store={mockStore()}>
+				<MemoryRouter>
+					<TouchpointRoutes router={router} />
+				</MemoryRouter>
+			</Provider>
+		);
+
+		expect(screen.queryByTestId('experience-dropdown')).toBeTruthy();
+	});
+
+	it('hides the experience filter dropdown on the overview route for non-LDP workspaces', () => {
+		getMatchedRoute.mockReturnValue(Routes.SITES_TOUCHPOINTS_OVERVIEW);
+		useLDPEnabled.mockReturnValue(false);
+
+		const router = {
+			params: {
+				channelId: '1',
+				experienceId: '',
+				groupId: '2',
+				title: 'page',
+				touchpoint: 'http://example.com/web/site/home'
+			}
+		};
+
+		render(
+			<Provider store={mockStore()}>
+				<MemoryRouter>
+					<TouchpointRoutes router={router} />
+				</MemoryRouter>
+			</Provider>
+		);
+
+		expect(screen.queryByTestId('experience-dropdown')).toBeNull();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97380

## What Is Being Fixed

The "all-experiences" experience filter dropdown in the page dashboard (Sites → Pages → Overview) was rendered for every workspace, including non-LDP (Liferay Data Platform) customers. Experiences is an LDP-only feature, so exposing the filter to non-LDP workspaces is incorrect.

## How It Is Being Fixed

`TouchpointRoutes` now reads the workspace plan through the `useLDPEnabled` hook — using the `groupId` already available from `router.params` — and renders the `ExperienceDropdown` only when the workspace is on an LDP plan. Gating the component in the route container rather than inside the dropdown keeps the rest of the overview sub-header (range-key selector and PDF download) visible for every plan and avoids the unnecessary page-experience request for non-LDP workspaces, since the component never mounts. New unit tests in `TouchpointRoutes` cover both cases: the dropdown is shown for LDP workspaces and hidden for non-LDP ones.

## PR Check

**pr-check: PASS** — tested on `74e480c03a66194444ea8d9dc2e6115ac6d4ef15`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "74e480c03a66194444ea8d9dc2e6115ac6d4ef15"} -->

