### PR TITLE
LPD-97397 Show a button instead of a dropdown for a single data source

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
@@ -175,6 +175,40 @@ const typeFormatter = (type: DataSourceTypes): string => {
 	}
 };
 
+interface IDataSourceNavItem {
+	label: string;
+	onClick: () => void;
+}
+
+interface IAddDataSourceNavProps {
+	items: IDataSourceNavItem[];
+}
+
+export const AddDataSourceNav: React.FC<IAddDataSourceNavProps> = ({items}) => {
+	if (items.length === 1) {
+		const [{onClick}] = items;
+
+		return (
+			<ClayButton displayType="primary" onClick={onClick} size="sm">
+				{Liferay.Language.get('add-data-source')}
+			</ClayButton>
+		);
+	}
+
+	return (
+		<ClayDropDownWithItems
+			items={items}
+			trigger={
+				<ClayButton displayType="primary" size="sm">
+					{Liferay.Language.get('add-data-source')}
+
+					<ClayIcon className="ml-2" symbol="caret-bottom" />
+				</ClayButton>
+			}
+		/>
+	);
+};
+
 interface IDataSourceListProps extends React.HTMLAttributes<HTMLElement> {}
 
 const DataSourceList: React.FC<IDataSourceListProps> = ({className}) => {
@@ -276,17 +310,8 @@ const DataSourceList: React.FC<IDataSourceListProps> = ({className}) => {
 		},
 	}));
 
-	const renderDataSourcesDropdown = () => (
-		<ClayDropDownWithItems
-			items={[...dataSourceItems, ...connectorItems]}
-			trigger={
-				<ClayButton displayType="primary" size="sm">
-					{Liferay.Language.get('add-data-source')}
-
-					<ClayIcon className="ml-2" symbol="caret-bottom" />
-				</ClayButton>
-			}
-		/>
+	const renderAddDataSourceNav = () => (
+		<AddDataSourceNav items={[...dataSourceItems, ...connectorItems]} />
 	);
 
 	const renderNoResults = () => {
@@ -407,7 +432,7 @@ const DataSourceList: React.FC<IDataSourceListProps> = ({className}) => {
 					page={page}
 					query={query}
 					renderNav={
-						currentUser.isAdmin() ? renderDataSourcesDropdown : null
+						currentUser.isAdmin() ? renderAddDataSourceNav : null
 					}
 					rowIdentifier="id"
 					showCheckbox={false}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/__tests__/DataSourceList.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/__tests__/DataSourceList.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import {DataSourceName, disableRow, StatusRenderer} from '../DataSourceList';
+import {
+	AddDataSourceNav,
+	DataSourceName,
+	disableRow,
+	StatusRenderer
+} from '../DataSourceList';
 import {DataSourceStates, DataSourceTypes} from 'shared/util/constants';
 import {MemoryRouter} from 'react-router-dom';
-import {render} from '@testing-library/react';
+import {fireEvent, render} from '@testing-library/react';
 
 jest.unmock('react-dom');
 
@@ -22,6 +27,43 @@ describe('DataSourceList exports', () => {
 			expect(disableRow({state: DataSourceStates.Disconnected})).toBe(
 				false
 			);
+		});
+	});
+
+	describe('AddDataSourceNav', () => {
+		it('renders a button that navigates directly when only one data source option is available', () => {
+			const onClick = jest.fn();
+
+			const {container, getByText} = render(
+				<AddDataSourceNav items={[{label: 'Liferay DXP', onClick}]} />
+			);
+
+			expect(getByText('Add Data Source')).toBeInTheDocument();
+
+			fireEvent.click(container.querySelector('button'));
+
+			expect(onClick).toHaveBeenCalledTimes(1);
+		});
+
+		it('renders a dropdown that does not navigate directly when more than one data source option is available', () => {
+			const firstOnClick = jest.fn();
+			const secondOnClick = jest.fn();
+
+			const {container, getByText} = render(
+				<AddDataSourceNav
+					items={[
+						{label: 'Liferay DXP', onClick: firstOnClick},
+						{label: 'Salesforce', onClick: secondOnClick}
+					]}
+				/>
+			);
+
+			expect(getByText('Add Data Source')).toBeInTheDocument();
+
+			fireEvent.click(container.querySelector('button'));
+
+			expect(firstOnClick).not.toHaveBeenCalled();
+			expect(secondOnClick).not.toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97397

## What Is Being Fixed

On the Data Sources list page in osb-faro-web, the "Add Data Source" control is always rendered as a dropdown listing every data-source type the user's plan allows. When the plan allows only one option — typically "Liferay DXP" on non-LDP plans, where Salesforce and the third-party connectors are filtered out — the user is shown a dropdown containing a single item, which is unnecessary friction.

## How It Is Being Fixed

The dropdown-building logic in DataSourceList is extracted into a small, exported AddDataSourceNav component that receives the combined list of available items. When exactly one option is available it renders a direct primary "Add Data Source" button whose click reuses the item's existing navigation straight to the onboarding URL. When two or more options are available it keeps rendering the existing ClayDropDownWithItems unchanged. Exporting the component lets the button-versus-dropdown behavior be unit-tested directly.

## PR Check

**pr-check: PASS** — tested on `68834d3a3e43c8311bb9d72550b419579735afbf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

Workspace Build was scoped to `:modules:osb-faro-web:build` (webpack + full jest suite, 3313 passed); the full-workspace build fails only on the unrelated `osb-faro-contacts-demo` module due to a missing `elasticsearch-snapshot:1.3.0` artifact in this environment.

<!-- pr-check {"result": "success", "sha": "68834d3a3e43c8311bb9d72550b419579735afbf"} -->

