### PR TITLE
LPD-97381 Hide account and segment filters for non-LDP workspaces

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
@@ -1,5 +1,5 @@
 import List from 'assets/pages/List';
-import mockStore from 'test/mock-store';
+import mockStore, {mockStoreDataLDP} from 'test/mock-store';
 import React from 'react';
 import {ChannelContext} from 'shared/context/channel';
 import {cleanup, fireEvent, render, screen} from '@testing-library/react';
@@ -16,6 +16,7 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 	FrontendDataSet: ({
 		emptyState,
 		filters,
+		groupedFilters,
 		id,
 		itemsActions,
 	}: {
@@ -25,6 +26,7 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 			title?: string;
 		};
 		filters?: any[];
+		groupedFilters?: any[];
 		id: string;
 		itemsActions?: Array<{onClick?: (item: any) => void}>;
 	}) => (
@@ -41,6 +43,10 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 				</div>
 			)}
 			<div data-testid="fds-filters">{JSON.stringify(filters)}</div>
+
+			<div data-testid="fds-grouped-filters">
+				{JSON.stringify(groupedFilters)}
+			</div>
 
 			<button
 				data-testid="trigger-info-panel"
@@ -228,16 +234,22 @@ const buildHistory = (path = '/workspace/23/123/assets') => {
 	return history;
 };
 
-const store = mockStore();
+// LDP is enabled by default so the account/segment filters, which are LDP-only,
+// stay present for the shared assertions and the snapshot.
+
+const store = mockStore(mockStoreDataLDP);
 
 // Helper: wrap List in the minimum context providers it needs.
 
 const renderList = (
-	{queryString = ''}: {queryString?: string} = {},
+	{
+		queryString = '',
+		store: storeOverride = store,
+	}: {queryString?: string; store?: typeof store} = {},
 	history = buildHistory(`/workspace/23/123/assets${queryString}`)
 ) =>
 	render(
-		<Provider store={store}>
+		<Provider store={storeOverride}>
 			<ChannelContext.Provider value={mockChannelContext() as any}>
 				<Router history={history}>
 					<List />
@@ -420,6 +432,78 @@ describe('List', () => {
 
 			expect(accountFilter.preloadedData).toEqual({
 				selectedItems: [{label: 'Acme Corp', value: 'acc-1'}],
+			});
+		});
+	});
+
+	describe('filter by people (LDP gating)', () => {
+		const getFilterIds = () =>
+			JSON.parse(screen.getByTestId('fds-filters').textContent).map(
+				(filter: {id: string}) => filter.id
+			);
+
+		const getGroupedFilters = () =>
+			JSON.parse(screen.getByTestId('fds-grouped-filters').textContent);
+
+		describe('when LDP is enabled', () => {
+			it('should include the account and segment filters', () => {
+				renderList();
+
+				const ids = getFilterIds();
+
+				expect(ids).toContain('accountIds');
+				expect(ids).toContain('segmentIds');
+			});
+
+			it('should render the "Filter by People" grouped filter', () => {
+				renderList();
+
+				const labels = getGroupedFilters().map(
+					(group: {label: string}) => group.label
+				);
+
+				expect(labels).toContain('Filter by People');
+			});
+		});
+
+		describe('when LDP is not enabled', () => {
+			const nonLDPStore = mockStore();
+
+			it('should not include the account filter', () => {
+				renderList({store: nonLDPStore});
+
+				expect(getFilterIds()).not.toContain('accountIds');
+			});
+
+			it('should not include the segment filter', () => {
+				renderList({store: nonLDPStore});
+
+				expect(getFilterIds()).not.toContain('segmentIds');
+			});
+
+			it('should not render the "Filter by People" grouped filter', () => {
+				renderList({store: nonLDPStore});
+
+				const labels = getGroupedFilters().map(
+					(group: {label: string}) => group.label
+				);
+
+				expect(labels).not.toContain('Filter by People');
+			});
+
+			it('should keep the "Filter by" grouped filter with its filters', () => {
+				renderList({store: nonLDPStore});
+
+				const groupedFilters = getGroupedFilters();
+
+				expect(groupedFilters).toHaveLength(1);
+				expect(groupedFilters[0].label).toBe('Filter By');
+				expect(groupedFilters[0].filters).toEqual([
+					'assetType',
+					'tags/id',
+					'categories/id',
+					'mimeType',
+				]);
 			});
 		});
 	});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
@@ -131,6 +131,11 @@ exports[`List rendering should match the snapshot 1`] = `
           >
             [{"apiURL":"/o/faro/contacts/23/account/search?channelId=123&filter=(rangeKey eq '30')","autocompleteEnabled":true,"entityFieldType":"string","id":"accountIds","itemKey":"id","itemLabel":"accountName","label":"Accounts","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/individual_segment/search?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"segmentIds","itemKey":"id","itemLabel":"name","label":"Segments","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-types?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"assetType","itemKey":"name","itemLabel":"name","label":"Type","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-tags?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"tags/id","itemKey":"id","itemLabel":"name","label":"Tags","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-categories?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"categories/id","itemKey":"id","itemLabel":"name","label":"Categories","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-mime-types?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"mimeType","itemKey":"id","itemLabel":"name","label":"File Type","multiple":true,"type":"selection"}]
           </div>
+          <div
+            data-testid="fds-grouped-filters"
+          >
+            [{"filters":["assetType","tags/id","categories/id","mimeType"],"label":"Filter By"},{"filters":["accountIds","segmentIds"],"label":"Filter by People"}]
+          </div>
           <button
             data-testid="trigger-info-panel"
           >

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
@@ -22,6 +22,7 @@ import {
 import {toThousands} from 'shared/util/numbers';
 import {useChannelContext} from 'shared/context/channel';
 import {useHistory, useLocation, useParams} from 'react-router-dom';
+import {useLDPEnabled} from 'shared/hooks/useLDPEnabled';
 import {useQueryRangeSelectors} from 'shared/hooks/useQueryRangeSelectors';
 
 const {cur: DEFAULT_CUR} = FaroConstants.pagination;
@@ -140,6 +141,7 @@ const List = () => {
 	const {selectedChannel} = useChannelContext();
 	const {channelId, groupId} = useParams();
 	const initialRangeSelectors = useQueryRangeSelectors();
+	const LDPEnabled = useLDPEnabled({groupId: groupId!});
 
 	const searchParams = new URLSearchParams(search);
 	const accountId = searchParams.get('accountId');
@@ -163,35 +165,42 @@ const List = () => {
 
 	const filters = useMemo(
 		() => [
-			{
-				apiURL: `/o/faro/contacts/${groupId}/account/search?channelId=${channelId}&filter=(rangeKey eq '${rangeSelectors.rangeKey}')`,
-				autocompleteEnabled: true,
-				entityFieldType: 'string',
-				id: 'accountIds',
-				itemKey: 'id',
-				itemLabel: 'accountName',
-				label: Liferay.Language.get('accounts'),
-				multiple: true,
-				...(accountId && {
-					preloadedData: {
-						selectedItems: [
-							{label: accountName || accountId, value: accountId},
-						],
-					},
-				}),
-				type: 'selection',
-			},
-			{
-				apiURL: `/o/faro/contacts/${groupId}/individual_segment/search?channelId=${channelId}&${rangeSelectorParams}`,
-				autocompleteEnabled: true,
-				entityFieldType: 'string',
-				id: 'segmentIds',
-				itemKey: 'id',
-				itemLabel: 'name',
-				label: Liferay.Language.get('segments'),
-				multiple: true,
-				type: 'selection',
-			},
+			...(LDPEnabled
+				? [
+						{
+							apiURL: `/o/faro/contacts/${groupId}/account/search?channelId=${channelId}&filter=(rangeKey eq '${rangeSelectors.rangeKey}')`,
+							autocompleteEnabled: true,
+							entityFieldType: 'string',
+							id: 'accountIds',
+							itemKey: 'id',
+							itemLabel: 'accountName',
+							label: Liferay.Language.get('accounts'),
+							multiple: true,
+							...(accountId && {
+								preloadedData: {
+									selectedItems: [
+										{
+											label: accountName || accountId,
+											value: accountId,
+										},
+									],
+								},
+							}),
+							type: 'selection',
+						},
+						{
+							apiURL: `/o/faro/contacts/${groupId}/individual_segment/search?channelId=${channelId}&${rangeSelectorParams}`,
+							autocompleteEnabled: true,
+							entityFieldType: 'string',
+							id: 'segmentIds',
+							itemKey: 'id',
+							itemLabel: 'name',
+							label: Liferay.Language.get('segments'),
+							multiple: true,
+							type: 'selection',
+						},
+					]
+				: []),
 			{
 				apiURL: `/o/faro/contacts/${groupId}/asset-summary-types?channelId=${channelId}&${rangeSelectorParams}`,
 				autocompleteEnabled: true,
@@ -237,7 +246,14 @@ const List = () => {
 				type: 'selection',
 			},
 		],
-		[accountId, accountName, channelId, groupId, rangeSelectorParams]
+		[
+			accountId,
+			accountName,
+			channelId,
+			groupId,
+			LDPEnabled,
+			rangeSelectorParams,
+		]
 	);
 
 	return (
@@ -315,10 +331,19 @@ const List = () => {
 								],
 								label: Liferay.Language.get('filter-by'),
 							},
-							{
-								filters: ['accountIds', 'segmentIds'],
-								label: Liferay.Language.get('filter-by-people'),
-							},
+							...(LDPEnabled
+								? [
+										{
+											filters: [
+												'accountIds',
+												'segmentIds',
+											],
+											label: Liferay.Language.get(
+												'filter-by-people'
+											),
+										},
+									]
+								: []),
 						]}
 						id="assetTable"
 						itemsActions={[


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97381

## What Is Being Fixed

On the assets dashboard (route `/workspace/{groupId}/{channelId}/assets`), the asset list groups the account and segment filters under a **Filter by People** label. Accounts and segments are LDP-only concepts, so this group was showing for non-LDP workspaces where it has no meaning.

## How It Is Being Fixed

The List page now reads the workspace plan through the `useLDPEnabled` hook. The account (`accountIds`) and segment (`segmentIds`) filter definitions and the **Filter by People** grouped-filter label are included only when LDP is enabled; the **Filter by** group (type, tags, categories, file type) stays visible for every plan. The List unit test defaults to the LDP mock store so the existing account-filter assertions and the snapshot keep covering the LDP experience, exposes the grouped filters in the FrontendDataSet mock, and adds coverage asserting the people filters and their label are hidden for non-LDP and shown for LDP.

## PR Check

**pr-check: PASS** — tested on `3b3e1f1894c36ceaa98e1f66ae7ea9654e2a14ec`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "3b3e1f1894c36ceaa98e1f66ae7ea9654e2a14ec"} -->

