### PR TITLE
LPD-97396 Hide timeline data source labels for non-LDP workspaces

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/ProfileCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/ProfileCard.tsx
@@ -403,6 +403,7 @@ const ProfileCard: React.FC<IProfileCardProps> = ({
 				{...sessionsMappedResults}
 				delta={delta}
 				initialExpanded={false}
+				LDPEnabled={LDPEnabled}
 				noResultsRenderer={renderNoResults()}
 				onDeltaChange={onDeltaChange}
 				onPageChange={onPageChange}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
@@ -68,10 +68,12 @@ type ITimelineItemProps = {
 	groupId?: string;
 	initialExpanded?: boolean;
 	item: ITEM_SHAPE;
+	LDPEnabled?: boolean;
 	timeZoneId: string;
 };
 
 const TimelineItem: FC<ITimelineItemProps> = ({
+	LDPEnabled,
 	className,
 	initialExpanded = false,
 	item: {
@@ -140,6 +142,7 @@ const TimelineItem: FC<ITimelineItemProps> = ({
 								browserName={browserName}
 								device={device}
 								itemCount={nestedItems.length}
+								LDPEnabled={LDPEnabled}
 								userAgent={userAgent}
 							/>
 						)}
@@ -160,6 +163,7 @@ const TimelineItem: FC<ITimelineItemProps> = ({
 				{nestedItems && (
 					<VerticalTimeline
 						items={nestedItems}
+						LDPEnabled={LDPEnabled}
 						nested
 						timeZoneId={timeZoneId}
 					/>
@@ -206,8 +210,16 @@ const TimelinePanelBodyContentDetails: FC<{
 	browserName: string;
 	device: string;
 	itemCount: number;
+	LDPEnabled?: boolean;
 	userAgent: string;
-}> = ({applicationId, browserName, device, itemCount, userAgent}) => {
+}> = ({
+	LDPEnabled,
+	applicationId,
+	browserName,
+	device,
+	itemCount,
+	userAgent,
+}) => {
 	const {title: deviceIconTitle, ...otherIconAttributes} =
 		(DEVICE_ICONS_MAP as any)[device.toLowerCase()] || DEVICE_ICONS_MAP.any;
 
@@ -216,7 +228,7 @@ const TimelinePanelBodyContentDetails: FC<{
 	return (
 		<div className="timeline-panel-body-content-details">
 			<div className="align-items-center d-flex icon-group">
-				{applicationId && (
+				{LDPEnabled && applicationId && (
 					<div>
 						<ClayLabel
 							className={getCN('label-lg mr-5', {
@@ -372,6 +384,7 @@ type IVerticalTimelineProps = {
 	groupId?: string;
 	initialExpanded?: boolean;
 	items: ITEM_SHAPE[];
+	LDPEnabled?: boolean;
 	loading?: boolean;
 	nested?: boolean;
 	timeZoneId: string;
@@ -381,6 +394,7 @@ const VerticalTimeline: FC<IVerticalTimelineProps> = ({
 	groupId,
 	initialExpanded,
 	items = [],
+	LDPEnabled = true,
 	loading = false,
 	nested = false,
 	timeZoneId,
@@ -400,6 +414,7 @@ const VerticalTimeline: FC<IVerticalTimelineProps> = ({
 						initialExpanded={initialExpanded}
 						item={item}
 						key={i}
+						LDPEnabled={LDPEnabled}
 						timeZoneId={timeZoneId}
 					/>
 				))}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
@@ -276,4 +276,38 @@ describe('VerticalTimeline', () => {
 		expect(getByText('MARKETO')).toBeInTheDocument();
 		expect(queryByText('DXP')).not.toBeInTheDocument();
 	});
+
+	it('hides the data source label when the workspace is not on the LDP plan', () => {
+		const {queryByText} = render(
+			<DefaultComponent
+				items={[
+					createDataSourceItem({
+						applicationId: 'WebContent',
+						userAgent:
+							'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'
+					})
+				]}
+				LDPEnabled={false}
+			/>
+		);
+
+		expect(queryByText('DXP')).not.toBeInTheDocument();
+	});
+
+	it('shows the data source label when the workspace is on the LDP plan', () => {
+		const {getByText} = render(
+			<DefaultComponent
+				items={[
+					createDataSourceItem({
+						applicationId: 'WebContent',
+						userAgent:
+							'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'
+					})
+				]}
+				LDPEnabled
+			/>
+		);
+
+		expect(getByText('DXP')).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97396

## What Is Being Fixed

On Individuals > Known Individuals > [Selected Individual], the interaction-history timeline renders a data-source label (the `applicationId` badge — e.g. DXP, HUBSPOT, MARKETO) for each session. These badges are a Liferay Data Platform (LDP) feature and must not be shown to workspaces that are not on the LDP plan.

## How It Is Being Fixed

`VerticalTimeline` gains an `LDPEnabled` prop that is threaded down to the sub-component that renders the `applicationId` badge (`TimelinePanelBodyContentDetails`) and through the recursive nested timeline. The badge is now gated behind that flag. The prop defaults to `true`, so existing callers keep their current behavior.

The non-CDP `ProfileCard` — which the app renders only for non-LDP workspaces (`AppSidebarRoutes` selects it through `useLDPEnabled`) — passes its already-computed `LDPEnabled` value to the timeline, hiding the badge for those workspaces. The CDP variant is left untouched because it renders only for LDP workspaces and keeps showing the badge through the default.

## PR Check

**pr-check: PASS** — tested on `7dcb3f8b81d4d53b37671d60257af8e4ae2607ea`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "7dcb3f8b81d4d53b37671d60257af8e4ae2607ea"} -->

