### PR TITLE
LPD-97354 Remove the border from the card root

### DIFF
--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -1,0 +1,30 @@
+name: Cancel runs on PR close
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel in-progress and queued runs for this PR branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          CURRENT_RUN: ${{ github.run_id }}
+        run: |
+          set -uo pipefail
+
+          for status in in_progress queued; do
+            gh run list --repo "$REPO" --branch "$BRANCH" --status "$status" --json databaseId --jq '.[].databaseId' \
+              | while read -r run_id; do
+                if [ -n "$run_id" ] && [ "$run_id" != "$CURRENT_RUN" ]; then
+                  echo "Cancelling $status run $run_id"
+                  gh run cancel "$run_id" --repo "$REPO" || true
+                fi
+              done
+          done

--- a/.github/workflows/osb-faro-web-ship.yml
+++ b/.github/workflows/osb-faro-web-ship.yml
@@ -1,0 +1,193 @@
+name: osb-faro-web ship to liferay-ac
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ship:
+    if: |
+      github.event.issue.pull_request != null &&
+      (github.event.comment.body == '/pr' || startsWith(github.event.comment.body, '/pr ')) &&
+      github.event.comment.user.login == github.event.issue.user.login
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ship to liferay-ac
+        env:
+          FORK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_TOKEN: ${{ secrets.LIFERAY_AC_PR_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -uo pipefail
+
+          target_branch="master"
+          ci_forward=true
+          force=false
+
+          if [ "$COMMENT_BODY" != "/pr" ]; then
+            args="${COMMENT_BODY#/pr }"
+            for token in $args; do
+              case "$token" in
+                --no-ci-forward) ci_forward=false ;;
+                --force) force=true ;;
+                *) target_branch="$token" ;;
+              esac
+            done
+          fi
+
+          export GH_TOKEN="$FORK_TOKEN"
+          gh pr view "$PR" --repo "$REPO" --json title,body,headRefName,baseRefName,labels,state > /tmp/pr.json
+
+          state=$(jq -r '.state' /tmp/pr.json)
+          base=$(jq -r '.baseRefName' /tmp/pr.json)
+          branch=$(jq -r '.headRefName' /tmp/pr.json)
+
+          if [ "$state" != "OPEN" ]; then
+            gh pr comment "$PR" --repo "$REPO" --body "$(cat <<MSG
+          > [!WARNING]
+          > Cannot ship: PR is not open (state: $state).
+          MSG
+          )"
+            exit 1
+          fi
+
+          if [ "$base" != "master" ]; then
+            gh pr comment "$PR" --repo "$REPO" --body "$(cat <<MSG
+          > [!WARNING]
+          > Cannot ship: PR base is \`$base\`, expected \`master\`.
+          MSG
+          )"
+            exit 1
+          fi
+
+          if [ "$force" != "true" ]; then
+            has_tests=$(jq -r '.labels[] | select(.name == "unit tests passed") | .name' /tmp/pr.json)
+
+            if [ -z "$has_tests" ]; then
+              gh pr comment "$PR" --repo "$REPO" --body "$(cat <<MSG
+          > [!WARNING]
+          > Cannot ship: the \`unit tests passed\` label is required. Wait for CI to finish, or use \`--force\` to bypass.
+          MSG
+          )"
+              exit 1
+            fi
+          fi
+
+          head_branch="${branch}-onto-${target_branch}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add upstream "https://x-access-token:${UPSTREAM_TOKEN}@github.com/liferay-ac/liferay-portal.git"
+
+          git fetch origin master "$branch" 2>/dev/null
+
+          if ! git fetch upstream "$target_branch" 2>/tmp/fetch-error.log; then
+            error_msg=$(cat /tmp/fetch-error.log)
+            export GH_TOKEN="$FORK_TOKEN"
+            gh pr comment "$PR" --repo "$REPO" --body "$(cat <<MSG
+          > [!CAUTION]
+          > Failed to ship: could not fetch target branch \`$target_branch\` from \`liferay-ac/liferay-portal\`.
+          >
+          > \`\`\`
+          > $error_msg
+          > \`\`\`
+          MSG
+          )"
+            exit 1
+          fi
+
+          commits=$(git rev-list --no-merges --reverse "origin/master..origin/$branch")
+
+          if [ -z "$commits" ]; then
+            export GH_TOKEN="$FORK_TOKEN"
+            gh pr comment "$PR" --repo "$REPO" --body "$(cat <<MSG
+          > [!CAUTION]
+          > Failed to ship: branch \`$branch\` has no commits beyond \`origin/master\`. Nothing to cherry-pick onto \`$target_branch\`.
+          MSG
+          )"
+            exit 1
+          fi
+
+          git checkout -B "$head_branch" "upstream/$target_branch"
+
+          for c in $commits; do
+            if ! git cherry-pick "$c" 2>/tmp/cp-error.log; then
+              error_msg=$(cat /tmp/cp-error.log)
+              git cherry-pick --abort 2>/dev/null || true
+              export GH_TOKEN="$FORK_TOKEN"
+              gh pr comment "$PR" --repo "$REPO" --body "$(cat <<MSG
+          > [!CAUTION]
+          > Failed to ship: cherry-pick of commit \`$c\` onto \`$target_branch\` had a conflict.
+          >
+          > \`\`\`
+          > $error_msg
+          > \`\`\`
+          MSG
+          )"
+              exit 1
+            fi
+          done
+
+          git push --force-with-lease origin "$head_branch"
+
+          export GH_TOKEN="$UPSTREAM_TOKEN"
+          existing=$(gh pr list --repo liferay-ac/liferay-portal --head "interaminense:$head_branch" --base "$target_branch" --state open --json url --jq '.[0].url // ""')
+
+          if [ -n "$existing" ]; then
+            export GH_TOKEN="$FORK_TOKEN"
+            gh pr comment "$PR" --repo "$REPO" --body "$(cat <<MSG
+          > [!WARNING]
+          > Cannot ship: an upstream PR for branch \`$head_branch\` against base \`$target_branch\` already exists at $existing
+          MSG
+          )"
+            exit 1
+          fi
+
+          export GH_TOKEN="$UPSTREAM_TOKEN"
+          title=$(jq -r '.title' /tmp/pr.json)
+          jq -r '.body' /tmp/pr.json > /tmp/body.txt
+          if ! upstream_url=$(gh pr create --repo liferay-ac/liferay-portal --head "interaminense:$head_branch" --base "$target_branch" --title "$title" --body-file /tmp/body.txt 2>/tmp/gh-error.log); then
+            error_msg=$(cat /tmp/gh-error.log)
+            export GH_TOKEN="$FORK_TOKEN"
+            gh pr comment "$PR" --repo "$REPO" --body "$(cat <<MSG
+          > [!CAUTION]
+          > Failed to ship: could not create PR in \`liferay-ac/liferay-portal\` with base \`$target_branch\`.
+          >
+          > \`\`\`
+          > $error_msg
+          > \`\`\`
+          MSG
+          )"
+            exit 1
+          fi
+
+          fork_pr_url="https://github.com/$REPO/pull/$PR"
+
+          gh pr comment "$upstream_url" --body "$(cat <<MSG
+          > [!IMPORTANT]
+          > All checks passed from $fork_pr_url :rocket:!
+          MSG
+          )"
+
+          if [ "$ci_forward" = "true" ]; then
+            gh pr comment "$upstream_url" --body "ci:forward"
+          fi
+
+          export GH_TOKEN="$FORK_TOKEN"
+          gh pr close "$PR" --repo "$REPO" --comment "$(cat <<MSG
+          > [!IMPORTANT]
+          > Shipped upstream at $upstream_url. Closing this fork PR.
+          MSG
+          )"

--- a/.github/workflows/osb-faro-web-test.yml
+++ b/.github/workflows/osb-faro-web-test.yml
@@ -1,0 +1,239 @@
+name: osb-faro-web checks
+
+on:
+  pull_request_target:
+    branches:
+      - master
+    paths:
+      - 'workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/**'
+
+concurrency:
+  group: faro-web-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    defaults:
+      run:
+        working-directory: workspaces/liferay-osbfaro-workspace
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+          cache-dependency-path: workspaces/liferay-osbfaro-workspace/yarn.lock
+
+      - run: yarn install --frozen-lockfile
+
+      - run: yarn workspace osb-faro-web test
+
+      - name: Label and comment on tests success
+        if: success()
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr edit "$PR" --repo "$REPO" --remove-label "unit tests failed" || true
+          gh pr edit "$PR" --repo "$REPO" --add-label "unit tests passed"
+          gh pr comment "$PR" --repo "$REPO" --body "$(cat <<'EOF'
+          > [!TIP]
+          > **Unit tests passed** — all `yarn test` cases are green.
+          EOF
+          )"
+
+      - name: Label and comment on tests failure
+        if: failure()
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          XML_PATH: workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/TEST-frontend-js.xml
+        run: |
+          cat > "$RUNNER_TEMP/parse.mjs" <<'PARSER'
+          /**
+           * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+           * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+           */
+
+          /**
+           * Reads the JUnit XML emitted by @liferay/jest-junit-reporter (TEST-frontend-js.xml)
+           * and prints a Markdown summary of the failing tests to stdout, for posting as a
+           * pull request comment. Falls back to a generic message when no failing testcases
+           * can be parsed (for example, the run crashed before producing a report).
+           *
+           * Usage: XML_PATH=path/to/TEST-frontend-js.xml node faro-web-test-failures.mjs
+           */
+
+          import {readFileSync} from 'fs';
+
+          const MAX_COMMENT = 60000;
+          const MAX_DETAIL = 2000;
+          const MAX_SUMMARY = 300;
+
+          const xmlPath = process.env.XML_PATH || process.argv[2];
+
+          function decodeEntities(value) {
+          	return value
+          		.replace(/&lt;/g, '<')
+          		.replace(/&gt;/g, '>')
+          		.replace(/&quot;/g, '"')
+          		.replace(/&apos;/g, "'")
+          		.replace(/&amp;/g, '&');
+          }
+
+          // The reporter dots the absolute directory path. Keep the part from "src" on and
+          // turn it back into a slash path so the location reads like a directory again.
+
+          function cleanLocation(classname) {
+          	const index = classname.indexOf('.src.');
+          	const tail = index >= 0 ? classname.slice(index + 1) : classname;
+
+          	return tail.replace(/\./g, '/');
+          }
+
+          // Drop the jest internal stack frames so the detail shows the assertion and the
+          // test's own frames, not the runner's plumbing.
+
+          function trimStack(detail) {
+          	return detail
+          		.split('\n')
+          		.filter((line) => !/^\s*at .*\/node_modules\//.test(line))
+          		.join('\n')
+          		.trim();
+          }
+
+          let xml = '';
+
+          try {
+          	xml = readFileSync(xmlPath, 'utf8');
+          }
+          catch {
+
+          	// Leave xml empty so the fallback message is emitted below.
+
+          }
+
+          const failures = [];
+          const testcaseRegExp = /<testcase\b([^>]*)>([\s\S]*?)<\/testcase>/g;
+
+          let match;
+
+          while ((match = testcaseRegExp.exec(xml)) !== null) {
+          	const attributes = match[1];
+          	const failureMatch = match[2].match(
+          		/<failure\b([^>]*)>([\s\S]*?)<\/failure>/
+          	);
+
+          	if (!failureMatch) {
+          		continue;
+          	}
+
+          	const classnameMatch = attributes.match(/\bclassname="([^"]*)"/);
+          	const messageMatch = failureMatch[1].match(/\bmessage="([^"]*)"/);
+          	const nameMatch = attributes.match(/\bname="([^"]*)"/);
+
+          	failures.push({
+          		detail: trimStack(decodeEntities(failureMatch[2])),
+          		location: classnameMatch
+          			? cleanLocation(decodeEntities(classnameMatch[1]))
+          			: '',
+          		message: messageMatch ? decodeEntities(messageMatch[1]) : '',
+          		name: nameMatch ? decodeEntities(nameMatch[1]) : '(unknown test)',
+          	});
+          }
+
+          if (failures.length === 0) {
+          	process.stdout.write(
+          		[
+          			'> [!CAUTION]',
+          			'> **Unit tests failed** — `yarn test` reported a failure, but no ' +
+          				'individual failing tests could be parsed (the run may have ' +
+          				'crashed before producing results). Check the workflow logs.',
+          			'',
+          		].join('\n')
+          	);
+
+          	process.exit(0);
+          }
+
+          const plural = failures.length === 1 ? '' : 's';
+          const lines = [
+          	'> [!CAUTION]',
+          	`> **Unit tests failed** — ${failures.length} failing test${plural}. Fix ` +
+          		'locally with `yarn workspace osb-faro-web test` and push again.',
+          	'',
+          	`**Failing test${plural}:**`,
+          	'',
+          ];
+
+          for (const failure of failures) {
+          	const summary = failure.message.split('\n')[0].slice(0, MAX_SUMMARY);
+
+          	lines.push(`- **${failure.name}**${summary ? ` — \`${summary}\`` : ''}`);
+          }
+
+          let body = lines.join('\n');
+
+          const detailChunks = [];
+
+          let remaining = MAX_COMMENT - body.length - 100;
+
+          for (const failure of failures) {
+          	const header = failure.location
+          		? `${failure.location}\n${failure.name}`
+          		: failure.name;
+          	const chunk = `${header}\n\n${failure.detail.slice(0, MAX_DETAIL)}`;
+
+          	if (chunk.length > remaining) {
+          		detailChunks.push('... (remaining failure details truncated)');
+
+          		break;
+          	}
+
+          	remaining -= chunk.length;
+
+          	detailChunks.push(chunk);
+          }
+
+          if (detailChunks.length) {
+          	body +=
+          		'\n\n<details><summary>Failure details</summary>\n\n```text\n' +
+          		detailChunks.join('\n\n') +
+          		'\n```\n\n</details>';
+          }
+
+          process.stdout.write(body + '\n');
+          PARSER
+          node "$RUNNER_TEMP/parse.mjs" > "$RUNNER_TEMP/tests-comment.md"
+          gh pr edit "$PR" --repo "$REPO" --remove-label "unit tests passed" || true
+          gh pr edit "$PR" --repo "$REPO" --add-label "unit tests failed"
+          gh pr comment "$PR" --repo "$REPO" --body-file "$RUNNER_TEMP/tests-comment.md"
+
+  pr-ready:
+    needs: [unit-tests]
+    if: success()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment ready for /pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr comment "$PR" --repo "$REPO" --body "$(cat <<'EOF'
+          > [!IMPORTANT]
+          > All checks passed :tada:. You can now comment /pr to send this PR upstream to liferay-ac/liferay-portal.
+          EOF
+          )"

--- a/.github/workflows/sync-fork-master.yml
+++ b/.github/workflows/sync-fork-master.yml
@@ -1,0 +1,75 @@
+name: Sync fork master with liferay
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 10,16 * * *"  # 07:00 and 13:00 BRT (UTC-3)
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.SYNC_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync from upstream, preserve fork-only commits
+        run: |
+          set -euo pipefail
+
+          git remote add upstream https://github.com/liferay/liferay-portal.git
+          git fetch --no-tags upstream master
+
+          upstream_sha=$(git rev-parse upstream/master)
+          current_base=$(git merge-base master upstream/master)
+
+          if [ "$current_base" = "$upstream_sha" ]; then
+            echo "Already in sync with upstream"
+            exit 0
+          fi
+
+          # Replay only genuinely fork-only commits. Upstream rewrites its
+          # master history, so commits synced in a previous run can be stranded
+          # here even though their changes already landed upstream under a
+          # different SHA. `git cherry` marks those "-" (patch already present
+          # upstream); keep only the "+" commits so they are never re-applied.
+          extra_commits=$(git cherry upstream/master master | sed -n 's/^+ //p')
+
+          if [ -z "$extra_commits" ]; then
+            echo "No fork-only commits; fast-forwarding to upstream"
+            git reset --hard upstream/master
+            git push --force-with-lease origin master
+            exit 0
+          fi
+
+          echo "Resetting to upstream/master and replaying fork commits:"
+          echo "$extra_commits"
+          git reset --hard upstream/master
+
+          for sha in $extra_commits; do
+            echo "Cherry-picking $sha"
+            git cherry-pick --empty=drop -x "$sha" || {
+              echo "::error::Cherry-pick of $sha failed. Manual intervention needed."
+              git cherry-pick --abort || true
+              exit 1
+            }
+          done
+
+          git push --force-with-lease origin master
+
+  keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1.2.1

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_card.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_card.scss
@@ -1,5 +1,4 @@
 .card-root {
-	border: 1px solid $cadmin-secondary-l3;
 	border-radius: 8px;
 	box-shadow: none;
 	display: flex;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97354

## What Is Being Fixed

The `.card-root` element declared its own border (`border: 1px solid $cadmin-secondary-l3;`), which became redundant after updating the Clay packages to 3.165.0 — the card border is now provided by Clay's own card styling, producing a doubled border.

## How It Is Being Fixed

Removes the redundant `border` declaration from `.card-root` in `_card.scss`, leaving Clay's card border as the single source of truth.

## Why Are There No Tests?

The change is a purely visual CSS adjustment (removing one redundant border declaration) with no logic to exercise in a unit test; visual regression is the appropriate coverage vehicle.

## PR Check

**pr-check: PASS** — tested on `858beded4cf692d8b3d9bd1a13ea3626f5972b46`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "858beded4cf692d8b3d9bd1a13ea3626f5972b46"} -->

