### PR TITLE
LPD-97606 Sort the asset table by the selected top assets metric

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
@@ -19,6 +19,7 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 		groupedFilters,
 		id,
 		itemsActions,
+		sorts,
 	}: {
 		emptyState?: {
 			description?: React.ReactNode;
@@ -29,8 +30,11 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 		groupedFilters?: any[];
 		id: string;
 		itemsActions?: Array<{onClick?: (item: any) => void}>;
+		sorts?: any[];
 	}) => (
 		<div data-testid="fds-component" id={id}>
+			<div data-testid="fds-sorts">{JSON.stringify(sorts ?? null)}</div>
+
 			{emptyState && (
 				<div data-testid="fds-empty-state">
 					<div data-testid="fds-empty-state-title">
@@ -434,6 +438,66 @@ describe('List', () => {
 				selectedItems: [{label: 'Acme Corp', value: 'acc-1'}],
 			});
 		});
+	});
+
+	describe('sort by metric (orderBy)', () => {
+		const SORTABLE_KEYS = [
+			'assetTitle',
+			'assetType',
+			'viewsMetric',
+			'impressionsMetric',
+			'downloadsMetric',
+		];
+
+		const getSorts = () =>
+			JSON.parse(screen.getByTestId('fds-sorts').textContent);
+
+		it('should not pass any sort when no orderBy is in the URL', () => {
+			renderList();
+
+			expect(getSorts()).toBeNull();
+		});
+
+		it('should ignore an unknown orderBy value', () => {
+			renderList({queryString: '?orderBy=bogusMetric'});
+
+			expect(getSorts()).toBeNull();
+		});
+
+		it('should offer every sortable column as a sort option', () => {
+			renderList({queryString: '?orderBy=viewsMetric'});
+
+			const sorts = getSorts();
+
+			expect(sorts.map((sort: {key: string}) => sort.key)).toEqual(
+				SORTABLE_KEYS
+			);
+
+			sorts.forEach((sort: {direction: string; label: string}) => {
+				expect(sort.direction).toBe('desc');
+				expect(sort.label).toBeTruthy();
+			});
+		});
+
+		['viewsMetric', 'impressionsMetric', 'downloadsMetric'].forEach(
+			(metric) => {
+				it(`should mark only the ${metric} column active when it is the orderBy`, () => {
+					renderList({queryString: `?orderBy=${metric}`});
+
+					const activeSorts = getSorts().filter(
+						(sort: {active: boolean}) => sort.active
+					);
+
+					expect(activeSorts).toEqual([
+						expect.objectContaining({
+							active: true,
+							direction: 'desc',
+							key: metric,
+						}),
+					]);
+				});
+			}
+		);
 	});
 
 	describe('filter by people (LDP gating)', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
@@ -96,6 +96,11 @@ exports[`List rendering should match the snapshot 1`] = `
           id="assetTable"
         >
           <div
+            data-testid="fds-sorts"
+          >
+            null
+          </div>
+          <div
             data-testid="fds-empty-state"
           >
             <div

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
@@ -135,6 +135,39 @@ const assetsEmptyStateDescription = (
 	</>
 );
 
+const TABLE_FIELDS = [
+	{
+		contentRenderer: 'assetTitleRenderer',
+		fieldName: 'assetTitle',
+		label: Liferay.Language.get('title'),
+		sortable: true,
+		truncate: true,
+	},
+	{
+		fieldName: 'assetType',
+		label: Liferay.Language.get('type'),
+		sortable: true,
+	},
+	{
+		contentRenderer: 'assetMetricRenderer',
+		fieldName: 'viewsMetric',
+		label: Liferay.Language.get('views'),
+		sortable: true,
+	},
+	{
+		contentRenderer: 'assetMetricRenderer',
+		fieldName: 'impressionsMetric',
+		label: Liferay.Language.get('impressions'),
+		sortable: true,
+	},
+	{
+		contentRenderer: 'assetMetricRenderer',
+		fieldName: 'downloadsMetric',
+		label: Liferay.Language.get('downloads'),
+		sortable: true,
+	},
+];
+
 const List = () => {
 	const history = useHistory();
 	const {search} = useLocation();
@@ -146,6 +179,18 @@ const List = () => {
 	const searchParams = new URLSearchParams(search);
 	const accountId = searchParams.get('accountId');
 	const accountName = searchParams.get('accountName');
+	const orderBy = searchParams.get('orderBy');
+
+	const sortableFields = TABLE_FIELDS.filter((field) => field.sortable);
+
+	const sorts = sortableFields.some((field) => field.fieldName === orderBy)
+		? sortableFields.map((field) => ({
+				active: field.fieldName === orderBy,
+				direction: 'desc' as const,
+				key: field.fieldName,
+				label: field.label,
+			}))
+		: undefined;
 
 	const [rangeSelectors, setRangeSelectors] = useState<RangeSelectors>(
 		initialRangeSelectors
@@ -380,6 +425,7 @@ const List = () => {
 						pagination={pagination}
 						showPagination
 						snapshotsEnabled
+						sorts={sorts}
 						views={[
 							{
 								contentRenderer: 'table',
@@ -387,50 +433,7 @@ const List = () => {
 								label: Liferay.Language.get('default-view'),
 								name: 'table',
 								schema: {
-									fields: [
-										{
-											contentRenderer:
-												'assetTitleRenderer',
-											fieldName: 'assetTitle',
-											label: Liferay.Language.get(
-												'title'
-											),
-											sortable: true,
-											truncate: true,
-										},
-										{
-											fieldName: 'assetType',
-											label: Liferay.Language.get('type'),
-											sortable: true,
-										},
-										{
-											contentRenderer:
-												'assetMetricRenderer',
-											fieldName: 'viewsMetric',
-											label: Liferay.Language.get(
-												'views'
-											),
-											sortable: true,
-										},
-										{
-											contentRenderer:
-												'assetMetricRenderer',
-											fieldName: 'impressionsMetric',
-											label: Liferay.Language.get(
-												'impressions'
-											),
-											sortable: true,
-										},
-										{
-											contentRenderer:
-												'assetMetricRenderer',
-											fieldName: 'downloadsMetric',
-											label: Liferay.Language.get(
-												'downloads'
-											),
-											sortable: true,
-										},
-									],
+									fields: TABLE_FIELDS,
 								},
 								thumbnail: 'table',
 							},

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/TopAssets.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/TopAssets.tsx
@@ -333,6 +333,7 @@ const TopAssets: React.FC<ITopAssetsProps> = ({account, className}) => {
 									setUriQueryValues(
 										{
 											accountId,
+											orderBy: selectedMetric,
 											...(accountName && {accountName}),
 										},
 										toRoute(Routes.ASSETS, {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopAssets.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/TopAssets.tsx
@@ -377,6 +377,32 @@ describe('TopAssets', () => {
 			expect(pushedURL).toContain('accountId=acc-1');
 			expect(pushedURL).toContain('accountName=Acme');
 		});
+
+		it('should pass the default metric (Impressions) as the orderBy param', () => {
+			render(<TopAssets account={ACCOUNT} />);
+
+			fireEvent.click(screen.getByRole('button', {name: 'View All'}));
+
+			const pushedURL = mockPush.mock.calls[0][0];
+
+			expect(pushedURL).toContain('orderBy=impressionsMetric');
+		});
+
+		it('should pass the metric selected in the Group By picker as the orderBy param', () => {
+			render(<TopAssets account={ACCOUNT} />);
+
+			fireEvent.click(
+				screen.getAllByRole('combobox', {name: 'Group By'})[0]
+			);
+
+			fireEvent.click(screen.getAllByRole('option', {name: 'Views'})[0]);
+
+			fireEvent.click(screen.getByRole('button', {name: 'View All'}));
+
+			const pushedURL = mockPush.mock.calls[0][0];
+
+			expect(pushedURL).toContain('orderBy=viewsMetric');
+		});
 	});
 
 	describe('loading state', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97606

## What Is Being Fixed

The "View all" button in the account profile's Top Assets card links to the asset table with the account filter pre-applied, but it did not carry the metric selected in the card's "Group by" control. As a result, the asset table was not sorted by the selected metric type. In addition, the asset table's sort control only exposed the single column that came selected through the URL.

## How It Is Being Fixed

The Top Assets "View all" action now appends the selected metric as an `orderBy` query parameter. The asset list reads that parameter and initializes the FrontendDataSet with a descending active sort on the matching column. The sort options are derived from the table's sortable columns as a single source of truth, so the sort control lists every sortable column while keeping the URL-selected metric active.

## PR Check

**pr-check: PASS** — tested on `63e3ff3d6427e0a045987ea05ed1e572202ad6c2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "63e3ff3d6427e0a045987ea05ed1e572202ad6c2"} -->
