### PR TITLE
LPD-97671 List asset summary types regardless of the time range

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_title_editor.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_title_editor.scss
@@ -39,6 +39,7 @@
 	.title-input {
 		background-color: transparent;
 		border-width: 0;
+		color: $main;
 		width: 100%;
 
 		&:focus {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/SelectPageAssetInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/SelectPageAssetInput.tsx
@@ -256,7 +256,7 @@ const SelectPageAssetInput: React.FC<ISelectPageAssetInputProps> = ({
 			groupId: string;
 			page: number;
 			pageSize: number;
-			rangeKey: number;
+			rangeKey: null;
 		},
 		{items: AssetSummaryType[]}
 	>({
@@ -267,7 +267,7 @@ const SelectPageAssetInput: React.FC<ISelectPageAssetInputProps> = ({
 			groupId,
 			page: 1,
 			pageSize: 100,
-			rangeKey: -1,
+			rangeKey: null,
 		},
 	});
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/__tests__/SelectPageAssetInput.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/__tests__/SelectPageAssetInput.jsx
@@ -615,6 +615,18 @@ describe('SelectPageAssetInput', () => {
 
 			expect(API.assets.searchTypes).toHaveBeenCalled();
 		});
+
+		it('should request asset-summary-types with a null rangeKey so recently tracked object definitions still list', () => {
+			// A null rangeKey lifts the time-range restriction (LPD-97671):
+			// CMS objects whose only activity is recent (e.g. the last 24
+			// hours) must still surface as selectable asset types.
+
+			renderAndFlush({action: 'download'});
+
+			expect(API.assets.searchTypes).toHaveBeenCalledWith(
+				expect.objectContaining({rangeKey: null})
+			);
+		});
 	});
 
 	describe('modal columns', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/assets.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/assets.ts
@@ -1,5 +1,4 @@
 import sendRequest from 'shared/util/request';
-import {RangeKeyTimeRanges} from '../util/constants';
 
 export type TopAssetMetric =
 	| 'downloadsMetric'
@@ -55,7 +54,7 @@ interface ISearchAssetTypes {
 	groupId: string;
 	page?: number;
 	pageSize?: number;
-	rangeKey?: number;
+	rangeKey?: number | null;
 }
 
 export async function searchTypes({
@@ -63,7 +62,7 @@ export async function searchTypes({
 	groupId,
 	page = 1,
 	pageSize = 10,
-	rangeKey = Number(RangeKeyTimeRanges.Last30Days),
+	rangeKey,
 }: ISearchAssetTypes): Promise<{
 	items: Array<{id: string; name: string}>;
 	totalCount: number;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97671

## What Is Being Fixed

The segment behavior editor's page/asset picker was not listing CMS object definitions whose activity was only recent (e.g. tracked in the last 24 hours). The asset-summary-types request restricted its results to a fixed time range (the last 30 days), so recently tracked object definitions were dropped and never offered as selectable asset types.

## How It Is Being Fixed

The picker now sends a null `rangeKey` on the asset-summary-types request, which lifts the time-range restriction so every compatible object definition surfaces regardless of activity recency. The `searchTypes` API no longer defaults `rangeKey` to the last 30 days; it forwards whatever the caller provides. The `SelectPageAssetInput` test is extended to assert the request goes out with a null `rangeKey`, so a regression back to a time-bounded value is caught.

This branch also carries an unrelated one-line fix for the title input text color, which now uses the main text color.

## PR Check

**pr-check: PASS** — tested on `36e93d4be9a92a749ecbda581bd7b938d38e974b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "36e93d4be9a92a749ecbda581bd7b938d38e974b"} -->
