### PR TITLE
LPD-97354 Remove the border from the card root

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_card.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_card.scss
@@ -1,5 +1,4 @@
 .card-root {
-	border: 1px solid $cadmin-secondary-l3;
 	border-radius: 8px;
 	box-shadow: none;
 	display: flex;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97354

## What Is Being Fixed

The `.card-root` element rendered a 1px solid border that is no longer part of the intended card design.

## How It Is Being Fixed

Removes the `border` declaration from the `.card-root` rule in `_card.scss`, leaving the border radius, box shadow, and layout properties untouched.

## Why Are There No Tests?

The change is a purely visual CSS adjustment (removing a single border declaration) with no logic to exercise, so it cannot be meaningfully covered by a unit test.

## PR Check

**pr-check: PASS** — tested on `de5ebf1f2453b5a06712bc687b41c6b972dbb952`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "de5ebf1f2453b5a06712bc687b41c6b972dbb952"} -->

Resent from interaminense/liferay-portal#521