### PR TITLE
LPD-96105 Add link to the account page from individuals header

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_base_page.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_base_page.scss
@@ -83,7 +83,6 @@
 			.subtitle,
 			.subtitle a {
 				color: $secondary;
-				font-size: $fontSizeExtraSmall;
 				line-height: 28px;
 			}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutes.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutes.tsx
@@ -7,7 +7,7 @@ import getCN from 'classnames';
 import Loading from 'shared/components/Loading';
 import React, {lazy, Suspense, useContext} from 'react';
 import RouteNotFound from 'shared/components/RouteNotFound';
-import {buildHeaderSubtitle} from './utils/utils';
+import {buildHeaderSubtitle, IndividualHeaderData} from './utils/utils';
 import {ChannelContext} from 'shared/context/channel';
 import {compose, withIndividual} from 'shared/hoc';
 import {CSVType} from 'shared/components/download-report/utils';
@@ -72,11 +72,7 @@ interface IIndividualProfileRoutesProps {
 	individual: {
 		id: string;
 		name?: string;
-		toJS: () => {
-			accountName: string;
-			lastSessionCountry: string;
-			properties: {email: string};
-		};
+		toJS: () => IndividualHeaderData;
 	};
 }
 
@@ -135,7 +131,10 @@ export const IndividualProfileRoutes = ({
 				groupId={groupId}
 			>
 				<BasePage.Header.TitleSection
-					subtitle={buildHeaderSubtitle(individual.toJS())}
+					subtitle={buildHeaderSubtitle(individual.toJS(), {
+						channelId,
+						groupId,
+					})}
 					title={entityName}
 				/>
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutesCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/ProfileRoutesCDP.tsx
@@ -7,7 +7,7 @@ import getCN from 'classnames';
 import Loading from 'shared/components/Loading';
 import React, {lazy, Suspense, useContext} from 'react';
 import RouteNotFound from 'shared/components/RouteNotFound';
-import {buildHeaderSubtitle} from './utils/utils';
+import {buildHeaderSubtitle, IndividualHeaderData} from './utils/utils';
 import {ChannelContext} from 'shared/context/channel';
 import {compose, withIndividual} from 'shared/hoc';
 import {CSVType} from 'shared/components/download-report/utils';
@@ -79,11 +79,7 @@ interface IIndividualProfileRoutesCDPProps {
 	individual: {
 		id: string;
 		name?: string;
-		toJS: () => {
-			accountName: string;
-			lastSessionCountry: string;
-			properties: {email: string};
-		};
+		toJS: () => IndividualHeaderData;
 	};
 }
 
@@ -142,7 +138,10 @@ export const IndividualProfileRoutesCDP = ({
 				groupId={groupId}
 			>
 				<BasePage.Header.TitleSection
-					subtitle={buildHeaderSubtitle(individual.toJS())}
+					subtitle={buildHeaderSubtitle(individual.toJS(), {
+						channelId,
+						groupId,
+					})}
 					title={entityName}
 				/>
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutes.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutes.jsx.snap
@@ -73,7 +73,7 @@ exports[`IndividualProfileRoutes should render 1`] = `
             class="subtitle"
           >
             <span
-              class="text-4 text-secondary"
+              class="text-3 text-secondary"
             />
           </div>
         </div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutesCDP.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutesCDP.jsx.snap
@@ -73,7 +73,7 @@ exports[`IndividualProfileRoutes should render 1`] = `
             class="subtitle"
           >
             <span
-              class="text-4 text-secondary"
+              class="text-3 text-secondary"
             />
           </div>
         </div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/utils/__tests__/utils.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/utils/__tests__/utils.tsx
@@ -1,0 +1,44 @@
+import {Routes, toRoute} from 'shared/util/router';
+import {buildHeaderSubtitle} from '../utils';
+import {cleanup, render} from '@testing-library/react';
+
+jest.unmock('react-dom');
+
+describe('buildHeaderSubtitle', () => {
+	const context = {channelId: '123', groupId: 'liferay.com'};
+
+	afterEach(cleanup);
+
+	it('links the account name to its account page when an account id exists', () => {
+		const individual = {
+			accountName: 'Acme Corporation',
+			accounts: [{accountName: 'Acme Corporation', id: 'acc-1'}],
+			lastSessionCountry: 'Brazil',
+			properties: {email: 'jane@acme.com'},
+		};
+
+		const {getByRole} = render(buildHeaderSubtitle(individual, context));
+
+		const link = getByRole('link', {name: 'Acme Corporation'});
+
+		expect(link.getAttribute('href')).toBe(
+			toRoute(Routes.CONTACTS_ACCOUNT, {...context, id: 'acc-1'})
+		);
+	});
+
+	it('renders the account name as plain text when there is no account id', () => {
+		const individual = {
+			accountName: 'Acme Corporation',
+			accounts: [],
+			lastSessionCountry: 'Brazil',
+			properties: {email: 'jane@acme.com'},
+		};
+
+		const {container, queryByRole} = render(
+			buildHeaderSubtitle(individual, context)
+		);
+
+		expect(queryByRole('link')).toBeNull();
+		expect(container.textContent).toContain('Acme Corporation');
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/utils/utils.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/utils/utils.tsx
@@ -1,19 +1,50 @@
+import ClayLink from '@clayui/link';
 import React from 'react';
+import {Routes, toRoute} from 'shared/util/router';
 import {Text} from '@clayui/core';
 
-export const buildHeaderSubtitle = (individual: {
+export type IndividualHeaderData = {
 	accountName: string;
+	accounts?: Array<{id?: string}>;
 	lastSessionCountry: string;
 	properties: {email: string};
-}) => {
+};
+
+export const buildHeaderSubtitle = (
+	individual: IndividualHeaderData,
+	{channelId, groupId}: {channelId: string; groupId: string}
+) => {
 	const {email} = individual.properties;
-	const {accountName, lastSessionCountry} = individual;
+	const {accountName, accounts, lastSessionCountry} = individual;
+
+	const accountId = accounts?.[0]?.id;
+
+	const account =
+		accountName && accountId ? (
+			<ClayLink
+				href={toRoute(Routes.CONTACTS_ACCOUNT, {
+					channelId,
+					groupId,
+					id: accountId,
+				})}
+			>
+				{accountName}
+			</ClayLink>
+		) : (
+			accountName
+		);
+
+	const items = [email, account, lastSessionCountry].filter(Boolean);
 
 	return (
-		<Text color="secondary" size={4}>
-			{[email, accountName, lastSessionCountry]
-				.filter(Boolean)
-				.join(' | ')}
+		<Text color="secondary" size={3}>
+			{items.map((item, index) => (
+				<React.Fragment key={index}>
+					{index > 0 && ' | '}
+
+					{item}
+				</React.Fragment>
+			))}
 		</Text>
 	);
 };


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96105

## What Is Being Fixed

From an individual's profile there was no quick way to reach that individual's account: the account name in the profile header subtitle was plain text.

## How It Is Being Fixed

`buildHeaderSubtitle` now renders the account name in the individual profile header as a link to the account page (`Routes.CONTACTS_ACCOUNT`), resolved from the individual's first account id, with `channelId` and `groupId` threaded in as routing context. Both `IndividualProfileRoutes` and `IndividualProfileRoutesCDP` pass that context, and a shared `IndividualHeaderData` type keeps the `toJS()` shape in one place. The subtitle's `font-size` override is dropped so the linked name renders at the header's intended size.

## PR Check

**pr-check: PASS** — tested on `43f73bd53b86af69af5e6f8e77e9ca7bb55e9daa`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

Workspace Build was verified via the production webpack build and the affected jest suites (utils 2/2 and the ProfileRoutes snapshots 3/3 passing); the full `./gradlew build` jest suite was not run locally.

<!-- pr-check {"result": "success", "sha": "43f73bd53b86af69af5e6f8e77e9ca7bb55e9daa"} -->

Resent from interaminense/liferay-portal#523