### PR TITLE
LPD-98242 Apply the light color scheme after the Clay CSS upgrade

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/main.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/main.scss
@@ -4,6 +4,8 @@
 
 :root {
 	@include clay-css($cadmin-c-root);
+
+	color-scheme: light;
 }
 
 @import 'variables';


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98242

## What Is Being Fixed

After upgrading the `@clayui/css` package to 3.165.0, osb-faro-web renders several elements with dark colors on machines whose operating system or browser prefers a dark color scheme. On the Lifecycle report the stage bars (`.stage-metrics__bar`), the badges, and the browser scrollbar all appear dark instead of the app's intended light palette. Clay 3.165.0 added dark-mode support: its cadmin `:root` now declares `color-scheme: light dark` and defines every `--cadmin-*` token with the CSS `light-dark()` function (for example, `--cadmin-indigo-l2: light-dark(#99a3ff, #384cff)`). Because osb-faro-web includes this map at `:root` in `main.scss` and is a light-only UI, it inherited `color-scheme: light dark`, so on a dark-mode machine every token resolves to its dark variant and native controls such as scrollbars render dark.

## How It Is Being Fixed

Pin `color-scheme: light` at `:root` in `main.scss`, right after the `clay-css($cadmin-c-root)` include so it wins the cascade over the map's `light dark` value. Because `color-scheme` is inherited, the single declaration cascades across the whole tree, forcing every `light-dark()` token to resolve to its light value and keeping native controls light.

## Why Are There No Tests?

This is a global CSS-only fix that pins `color-scheme: light` at `:root` in `main.scss`. There is no runtime logic to unit-test, and osb-faro-web's Jest setup mocks `react-dom` (its tests assert logic, not rendered styles), so a meaningful automated test is not feasible. The fix was verified visually on the Lifecycle report and by confirming the compiled CSS forces `color-scheme: light`.

## PR Check

**pr-check: PASS** — tested on `94fdcbe145bb6cda78756de5b38122dcc54fd756`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "94fdcbe145bb6cda78756de5b38122dcc54fd756"} -->
