### PR TITLE
LPD-98242 faro-v5.0.x Apply the light color scheme after Clay upgrade

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/main.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/main.scss
@@ -4,6 +4,8 @@
 
 :root {
 	@include clay-css($cadmin-c-root);
+
+	color-scheme: light;
 }
 
 @import 'variables';


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98242

Backport of #3654 to `faro-v5.0.x`.
