### PR TITLE
LPD-97931 Proxy the field catalog and selection through the controller

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -35,6 +35,7 @@ import com.liferay.osb.faro.engine.client.model.DXPOrganization;
 import com.liferay.osb.faro.engine.client.model.DXPUserGroup;
 import com.liferay.osb.faro.engine.client.model.DataSource;
 import com.liferay.osb.faro.engine.client.model.DataSourceField;
+import com.liferay.osb.faro.engine.client.model.DataSourceFieldCatalogEntry;
 import com.liferay.osb.faro.engine.client.model.DataSourceProgress;
 import com.liferay.osb.faro.engine.client.model.Distribution;
 import com.liferay.osb.faro.engine.client.model.Event;
@@ -67,6 +68,7 @@ import java.io.OutputStream;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Shinn Lok
@@ -170,6 +172,10 @@ public interface ContactsEngineClient {
 
 	public void disconnectDataSources(FaroProject faroProject)
 		throws FaroEngineClientException;
+
+	public Map<String, List<DataSourceFieldCatalogEntry>>
+		discoverDataSourceFieldCatalog(
+			FaroProject faroProject, DataSource dataSource);
 
 	public <T> T get(
 			FaroProject faroProject, Map<String, String> headers, String path,
@@ -356,6 +362,10 @@ public interface ContactsEngineClient {
 
 	public Results<DXPUserGroup> getDataSourceDXPUserGroups(
 		FaroProject faroProject, String id, String name, int cur, int delta);
+
+	public Map<String, List<DataSourceFieldCatalogEntry>>
+		getDataSourceFieldCatalog(
+			FaroProject faroProject, String id, boolean refresh);
 
 	public List<DataSourceField> getDataSourceFields(
 		FaroProject faroProject, String id, String context, int count);
@@ -641,6 +651,10 @@ public interface ContactsEngineClient {
 		FaroProject faroProject, String id, Credentials credentials,
 		Event event, String name, Provider provider, String status, String url,
 		long userId);
+
+	public void updateDataSourceFieldSelection(
+		FaroProject faroProject, String id,
+		Map<String, Set<String>> selectedFieldNames);
 
 	public FieldMapping updateFieldMapping(
 		FaroProject faroProject, String context,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -45,6 +45,7 @@ import com.liferay.osb.faro.engine.client.model.DXPOrganization;
 import com.liferay.osb.faro.engine.client.model.DXPUserGroup;
 import com.liferay.osb.faro.engine.client.model.DataSource;
 import com.liferay.osb.faro.engine.client.model.DataSourceField;
+import com.liferay.osb.faro.engine.client.model.DataSourceFieldCatalogEntry;
 import com.liferay.osb.faro.engine.client.model.DataSourceProgress;
 import com.liferay.osb.faro.engine.client.model.Distribution;
 import com.liferay.osb.faro.engine.client.model.EntityModelPagedModel;
@@ -106,6 +107,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 import org.osgi.service.component.annotations.Component;
@@ -571,6 +573,21 @@ public class ContactsEngineClientImpl
 
 		post(
 			faroProject, Rels.DATA_SOURCE_DISCONNECT_ALL, null, Void.class,
+			getUriVariables(faroProject));
+	}
+
+	@Override
+	public Map<String, List<DataSourceFieldCatalogEntry>>
+		discoverDataSourceFieldCatalog(
+			FaroProject faroProject, DataSource dataSource) {
+
+		dataSource.setWorkspaceURL(getWorkspaceURL(faroProject.getGroupId()));
+
+		return post(
+			faroProject, Rels.DATA_SOURCES_FIELDS, dataSource,
+			new ParameterizedTypeReference
+				<Map<String, List<DataSourceFieldCatalogEntry>>>() {
+			},
 			getUriVariables(faroProject));
 	}
 
@@ -1746,6 +1763,23 @@ public class ContactsEngineClientImpl
 			uriVariables);
 
 		return pagedModel.getResults();
+	}
+
+	@Override
+	public Map<String, List<DataSourceFieldCatalogEntry>>
+		getDataSourceFieldCatalog(
+			FaroProject faroProject, String id, boolean refresh) {
+
+		Map<String, Object> uriVariables = getUriVariables(faroProject, id);
+
+		uriVariables.put("refresh", refresh);
+
+		return get(
+			faroProject, Rels.DATA_SOURCE_FIELDS,
+			new ParameterizedTypeReference
+				<Map<String, List<DataSourceFieldCatalogEntry>>>() {
+			},
+			uriVariables);
 	}
 
 	@Override
@@ -3475,6 +3509,16 @@ public class ContactsEngineClientImpl
 		return put(
 			faroProject, Rels.DATA_SOURCE, dataSource, DataSource.class,
 			getUriVariables(faroProject, id));
+	}
+
+	@Override
+	public void updateDataSourceFieldSelection(
+		FaroProject faroProject, String id,
+		Map<String, Set<String>> selectedFieldNames) {
+
+		patch(
+			faroProject, Rels.DATA_SOURCE_FIELDS, id, selectedFieldNames,
+			Void.class);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/DataSourceFieldCatalogEntry.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/DataSourceFieldCatalogEntry.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.engine.client.model;
+
+/**
+ * @author Riccardo Ferrari
+ */
+public class DataSourceFieldCatalogEntry {
+
+	public DataSourceFieldCatalogEntry() {
+	}
+
+	public DataSourceFieldCatalogEntry(
+		String name, boolean required, boolean selected, String type) {
+
+		_name = name;
+		_required = required;
+		_selected = selected;
+		_type = type;
+	}
+
+	public String getName() {
+		return _name;
+	}
+
+	public String getType() {
+		return _type;
+	}
+
+	public boolean isRequired() {
+		return _required;
+	}
+
+	public boolean isSelected() {
+		return _selected;
+	}
+
+	public void setName(String name) {
+		_name = name;
+	}
+
+	public void setRequired(boolean required) {
+		_required = required;
+	}
+
+	public void setSelected(boolean selected) {
+		_selected = selected;
+	}
+
+	public void setType(String type) {
+		_type = type;
+	}
+
+	private String _name;
+	private boolean _required;
+	private boolean _selected;
+	private String _type;
+
+}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
@@ -126,6 +126,8 @@ public interface Rels {
 	public static final String DATA_SOURCE_DXP_USERS_TOTAL =
 		"data-source-dxp-users-total";
 
+	public static final String DATA_SOURCE_FIELDS = "data-source-fields";
+
 	public static final String DATA_SOURCE_METRICS_ACCOUNTS_COUNT =
 		"data-source-metrics-accounts-count";
 
@@ -149,6 +151,8 @@ public interface Rels {
 		"data-source-salesforce-users-fields";
 
 	public static final String DATA_SOURCES = "data-sources";
+
+	public static final String DATA_SOURCES_FIELDS = "data-sources-fields";
 
 	public static final String DEFINITIONS_INDIVIDUAL_ATTRIBUTES =
 		"definitions-individual-attributes";

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -36,6 +36,7 @@ import com.liferay.osb.faro.engine.client.model.DXPOrganization;
 import com.liferay.osb.faro.engine.client.model.DXPUserGroup;
 import com.liferay.osb.faro.engine.client.model.DataSource;
 import com.liferay.osb.faro.engine.client.model.DataSourceField;
+import com.liferay.osb.faro.engine.client.model.DataSourceFieldCatalogEntry;
 import com.liferay.osb.faro.engine.client.model.DataSourceProgress;
 import com.liferay.osb.faro.engine.client.model.Distribution;
 import com.liferay.osb.faro.engine.client.model.Event;
@@ -67,6 +68,7 @@ import java.io.OutputStream;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Reference;
 
@@ -301,6 +303,15 @@ public abstract class BaseMockContactsEngineClientImpl
 		throws FaroEngineClientException {
 
 		contactsEngineClient.disconnectDataSources(faroProject);
+	}
+
+	@Override
+	public Map<String, List<DataSourceFieldCatalogEntry>>
+		discoverDataSourceFieldCatalog(
+			FaroProject faroProject, DataSource dataSource) {
+
+		return contactsEngineClient.discoverDataSourceFieldCatalog(
+			faroProject, dataSource);
 	}
 
 	@Override
@@ -705,6 +716,15 @@ public abstract class BaseMockContactsEngineClientImpl
 
 		return contactsEngineClient.getDataSourceDXPUserGroups(
 			faroProject, id, name, cur, delta);
+	}
+
+	@Override
+	public Map<String, List<DataSourceFieldCatalogEntry>>
+		getDataSourceFieldCatalog(
+			FaroProject faroProject, String id, boolean refresh) {
+
+		return contactsEngineClient.getDataSourceFieldCatalog(
+			faroProject, id, refresh);
 	}
 
 	@Override
@@ -1299,6 +1319,15 @@ public abstract class BaseMockContactsEngineClientImpl
 		return contactsEngineClient.updateDataSource(
 			faroProject, id, credentials, event, name, provider, status, url,
 			userId);
+	}
+
+	@Override
+	public void updateDataSourceFieldSelection(
+		FaroProject faroProject, String id,
+		Map<String, Set<String>> selectedFieldNames) {
+
+		contactsEngineClient.updateDataSourceFieldSelection(
+			faroProject, id, selectedFieldNames);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
@@ -19,6 +19,7 @@ import com.liferay.osb.faro.engine.client.model.DXPOrganization;
 import com.liferay.osb.faro.engine.client.model.DXPUserGroup;
 import com.liferay.osb.faro.engine.client.model.DataSource;
 import com.liferay.osb.faro.engine.client.model.DataSourceField;
+import com.liferay.osb.faro.engine.client.model.DataSourceFieldCatalogEntry;
 import com.liferay.osb.faro.engine.client.model.DataSourceProgress;
 import com.liferay.osb.faro.engine.client.model.Event;
 import com.liferay.osb.faro.engine.client.model.Field;
@@ -459,6 +460,30 @@ public class DataSourceFaroController extends BaseFaroController {
 		faroProjectLocalService.updateFaroProject(faroProject);
 	}
 
+	@Path("/field-catalog")
+	@POST
+	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
+	public Map<String, List<DataSourceFieldCatalogEntry>> discoverFieldCatalog(
+			@PathParam("groupId") long groupId,
+			@FormParam("credentials") Credentials credentials,
+			@FormParam("url") String url)
+		throws Exception {
+
+		DataSource dataSource = new DataSource();
+
+		url = getURL(url);
+
+		dataSource.setCredentials(
+			processCredentials(SalesforceProvider.TYPE, credentials, url));
+
+		dataSource.setProvider(new SalesforceProvider());
+		dataSource.setUrl(url);
+
+		return contactsEngineClient.discoverDataSourceFieldCatalog(
+			faroProjectLocalService.getFaroProjectByGroupId(groupId),
+			dataSource);
+	}
+
 	public String generateDataSourceAccessToken(
 		long groupId, long faroProjectId) {
 
@@ -894,6 +919,19 @@ public class DataSourceFaroController extends BaseFaroController {
 	}
 
 	@GET
+	@Path("/{id}/field-catalog")
+	@RolesAllowed(RoleConstants.SITE_MEMBER)
+	public Map<String, List<DataSourceFieldCatalogEntry>> getFieldCatalog(
+			@PathParam("groupId") long groupId, @PathParam("id") String id,
+			@QueryParam("refresh") boolean refresh)
+		throws Exception {
+
+		return contactsEngineClient.getDataSourceFieldCatalog(
+			faroProjectLocalService.getFaroProjectByGroupId(groupId), id,
+			refresh);
+	}
+
+	@GET
 	@Path("/field_values")
 	@RolesAllowed(RoleConstants.SITE_MEMBER)
 	public List<FieldValuesDisplay> getFieldValuesDisplays(
@@ -1127,6 +1165,20 @@ public class DataSourceFaroController extends BaseFaroController {
 			DXPUserGroupDisplay::new;
 
 		return new FaroResultsDisplay(results, function);
+	}
+
+	@PATCH
+	@Path("/{id}/field-selection")
+	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
+	public void patchFieldSelection(
+			@PathParam("groupId") long groupId, @PathParam("id") String id,
+			@DefaultValue(StringPool.BLANK) @FormParam("fieldSelection")
+				FaroParam<Map<String, Set<String>>> fieldSelectionFaroParam)
+		throws Exception {
+
+		contactsEngineClient.updateDataSourceFieldSelection(
+			faroProjectLocalService.getFaroProjectByGroupId(groupId), id,
+			fieldSelectionFaroParam.getValue());
 	}
 
 	@PATCH

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroControllerTest.java
@@ -9,6 +9,7 @@ import com.liferay.osb.faro.engine.client.ContactsEngineClient;
 import com.liferay.osb.faro.engine.client.constants.FieldMappingConstants;
 import com.liferay.osb.faro.engine.client.model.DataSource;
 import com.liferay.osb.faro.engine.client.model.DataSourceField;
+import com.liferay.osb.faro.engine.client.model.DataSourceFieldCatalogEntry;
 import com.liferay.osb.faro.engine.client.model.Field;
 import com.liferay.osb.faro.engine.client.model.FieldMapping;
 import com.liferay.osb.faro.engine.client.model.Provider;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -38,9 +40,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -267,6 +271,47 @@ public class DataSourceFaroControllerTest {
 	}
 
 	@Test
+	public void testDiscoverFieldCatalog() throws Exception {
+		Map<String, List<DataSourceFieldCatalogEntry>>
+			dataSourceFieldCatalogEntries =
+				HashMapBuilder.<String, List<DataSourceFieldCatalogEntry>>put(
+					"ACCOUNT",
+					Arrays.asList(
+						new DataSourceFieldCatalogEntry(
+							"Name", true, true, "string"))
+				).build();
+
+		Mockito.when(
+			_contactsEngineClient.discoverDataSourceFieldCatalog(
+				Mockito.eq(_faroProject), Mockito.any(DataSource.class))
+		).thenReturn(
+			dataSourceFieldCatalogEntries
+		);
+
+		Assert.assertSame(
+			dataSourceFieldCatalogEntries,
+			_dataSourceFaroController.discoverFieldCatalog(
+				32719L, null, "https://test.my.salesforce.com/"));
+
+		ArgumentCaptor<DataSource> argumentCaptor = ArgumentCaptor.forClass(
+			DataSource.class);
+
+		Mockito.verify(
+			_contactsEngineClient
+		).discoverDataSourceFieldCatalog(
+			Mockito.eq(_faroProject), argumentCaptor.capture()
+		);
+
+		DataSource dataSource = argumentCaptor.getValue();
+
+		Assert.assertTrue(
+			dataSource.getProvider() instanceof SalesforceProvider);
+		Assert.assertEquals(
+			"https://test.my.salesforce.com", dataSource.getUrl());
+		Assert.assertNull(dataSource.getCredentials());
+	}
+
+	@Test
 	public void testGenerateDataSourceAccessToken() throws Exception {
 		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
 
@@ -341,6 +386,54 @@ public class DataSourceFaroControllerTest {
 		Assert.assertEquals(
 			dataSourceMappingDisplays.toString(), 13,
 			dataSourceMappingDisplays.size());
+	}
+
+	@Test
+	public void testGetFieldCatalog() throws Exception {
+		Map<String, List<DataSourceFieldCatalogEntry>>
+			dataSourceFieldCatalogEntries =
+				HashMapBuilder.<String, List<DataSourceFieldCatalogEntry>>put(
+					"ACCOUNT",
+					Arrays.asList(
+						new DataSourceFieldCatalogEntry(
+							"Industry", false, false, "picklist"),
+						new DataSourceFieldCatalogEntry(
+							"Name", true, true, "string"))
+				).build();
+
+		Mockito.when(
+			_contactsEngineClient.getDataSourceFieldCatalog(
+				_faroProject, "32783", true)
+		).thenReturn(
+			dataSourceFieldCatalogEntries
+		);
+
+		Assert.assertSame(
+			dataSourceFieldCatalogEntries,
+			_dataSourceFaroController.getFieldCatalog(32719L, "32783", true));
+
+		Mockito.verify(
+			_contactsEngineClient
+		).getDataSourceFieldCatalog(
+			_faroProject, "32783", true
+		);
+	}
+
+	@Test
+	public void testPatchFieldSelection() throws Exception {
+		Map<String, Set<String>> selectedFieldNames =
+			HashMapBuilder.<String, Set<String>>put(
+				"ACCOUNT", new HashSet<>(Arrays.asList("Industry", "Name"))
+			).build();
+
+		_dataSourceFaroController.patchFieldSelection(
+			32719L, "32783", new FaroParam<>(selectedFieldNames));
+
+		Mockito.verify(
+			_contactsEngineClient
+		).updateDataSourceFieldSelection(
+			_faroProject, "32783", selectedFieldNames
+		);
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97931

## What Is Being Fixed

The Faro BFF had no way to surface the Analytics Cloud field catalog, per-entity field selection, or wizard-time field discovery to the front end. The data source controller already exposed value displays and CSV patching, but not the field catalog endpoints, and the engine client had no methods to reach them.

## How It Is Being Fixed

The engine client gains support for the Analytics Cloud field endpoints: it registers the `data-source-fields` and `data-source-fields-discover` rels, adds a `DataSourceFieldCatalogEntry` model kept distinct from the existing `DataSourceField` values model, and adds three `ContactsEngineClient` methods that fetch a per-entity field catalog, save a per-entity selection, and discover a catalog from unsaved wizard credentials. The mock engine client mirrors these methods for tests.

The `DataSourceFaroController` then proxies the catalog, per-entity selection, and wizard-time discovery to the front end, mirroring the existing `getFieldValuesDisplays` and `patchTypeCSV` shapes. Field names stay raw Salesforce API names, so the controller adds no localization.

## PR Check

**pr-check: PASS** — tested on `0f3c4df9ee9ff0540abb6f62096940728dd34a99`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "0f3c4df9ee9ff0540abb6f62096940728dd34a99"} -->
