### PR TITLE
LPD-98583 Add a segments condition to the audiences criteria

### DIFF
--- a/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/constants/AudiencesCriteriaKeys.java
+++ b/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/constants/AudiencesCriteriaKeys.java
@@ -34,6 +34,8 @@ public class AudiencesCriteriaKeys {
 
 	public static final String REQUEST_PARAMETERS = "request_parameters";
 
+	public static final String SEGMENTS = "segments";
+
 	public static final String TIMEZONE = "timezone";
 
 	public static final String URL = "url";

--- a/modules/apps/audiences/audiences-service/build.gradle
+++ b/modules/apps/audiences/audiences-service/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:portal:portal-json-validator")
+	compileOnly project(":apps:segments:segments-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/internal/criteria/AudiencesCriteriaProviderImpl.java
+++ b/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/internal/criteria/AudiencesCriteriaProviderImpl.java
@@ -26,6 +26,8 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.segments.constants.SegmentsEntryConstants;
+import com.liferay.segments.service.SegmentsEntryLocalService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -246,16 +248,39 @@ public class AudiencesCriteriaProviderImpl
 		long companyId, Locale locale) {
 
 		try {
+			List<AudiencesCriteria> audiencesCriterias = new ArrayList<>();
+
+			List<AudiencesCriteria.Option> segmentsOptions =
+				TransformUtil.transform(
+					_segmentsEntryLocalService.getSegmentsEntriesBySource(
+						companyId,
+						SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
+						QueryUtil.ALL_POS, QueryUtil.ALL_POS, null),
+					segmentsEntry -> new AudiencesCriteria.Option(
+						segmentsEntry.getName(locale),
+						segmentsEntry.getExternalReferenceCode()));
+
+			if (!segmentsOptions.isEmpty()) {
+				audiencesCriterias.add(
+					AudiencesCriteriaBuilder.setIcon(
+						"users"
+					).setInputType(
+						AudiencesCriteria.InputType.SELECT
+					).setKey(
+						AudiencesCriteriaKeys.SEGMENTS
+					).setLabel(
+						_language.get(locale, "segments")
+					).setOptions(
+						segmentsOptions
+					).setType(
+						AudiencesCriteria.Type.STRING
+					).build());
+			}
+
 			List<CET> cets = _cetManager.getCETs(
 				companyId, null,
 				ClientExtensionEntryConstants.TYPE_AUDIENCES_CUSTOM_ATTRIBUTES,
 				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null);
-
-			if (cets.isEmpty()) {
-				return null;
-			}
-
-			List<AudiencesCriteria> audiencesCriterias = new ArrayList<>();
 
 			for (CET cet : cets) {
 				AudiencesCustomAttributesCET audiencesCustomAttributesCET =
@@ -289,6 +314,10 @@ public class AudiencesCriteriaProviderImpl
 							type
 						).build());
 				}
+			}
+
+			if (audiencesCriterias.isEmpty()) {
+				return null;
 			}
 
 			return new AudiencesCriteriaType(
@@ -375,5 +404,8 @@ public class AudiencesCriteriaProviderImpl
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private SegmentsEntryLocalService _segmentsEntryLocalService;
 
 }

--- a/modules/apps/audiences/audiences-service/src/main/resources/com/liferay/audiences/service/impl/dependencies/audiences-criteria-json-schema.json
+++ b/modules/apps/audiences/audiences-service/src/main/resources/com/liferay/audiences/service/impl/dependencies/audiences-criteria-json-schema.json
@@ -144,6 +144,7 @@
 							"attribute": {
 								"enum": [
 									"language",
+									"segments",
 									"user_language"
 								]
 							}
@@ -230,6 +231,7 @@
 								"pathname",
 								"referrer",
 								"request_parameters",
+								"segments",
 								"timezone",
 								"url",
 								"user_agent",

--- a/modules/apps/audiences/audiences-test/build.gradle
+++ b/modules/apps/audiences/audiences-test/build.gradle
@@ -3,5 +3,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:audiences:audiences-api")
 	testIntegrationImplementation project(":apps:client-extension:client-extension-api")
 	testIntegrationImplementation project(":apps:frontend-js:frontend-js-audiences-api")
+	testIntegrationImplementation project(":apps:segments:segments-api")
+	testIntegrationImplementation project(":apps:segments:segments-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/criteria/test/AudiencesCriteriaProviderTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/criteria/test/AudiencesCriteriaProviderTest.java
@@ -50,7 +50,9 @@ public class AudiencesCriteriaProviderTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void testGetAudiencesCriteriaTypes() throws Exception {
+	public void testGetBrowserAttributesAudiencesCriteriaType()
+		throws Exception {
+
 		List<AudiencesCriteriaType> audiencesCriteriaTypes =
 			_audiencesCriteriaProvider.getAudiencesCriteriaTypes(
 				TestPropsValues.getCompanyId(), LocaleUtil.getDefault());
@@ -72,7 +74,7 @@ public class AudiencesCriteriaProviderTest {
 	}
 
 	@Test
-	public void testGetAudiencesCriteriaTypesWithCustomAttribute()
+	public void testGetCustomAudiencesCriteriaTypeWithCustomAttribute()
 		throws Exception {
 
 		String name = RandomTestUtil.randomString();

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/criteria/test/AudiencesCriteriaProviderTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/criteria/test/AudiencesCriteriaProviderTest.java
@@ -16,11 +16,17 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.segments.constants.SegmentsEntryConstants;
+import com.liferay.segments.criteria.Criteria;
+import com.liferay.segments.criteria.CriteriaSerializer;
+import com.liferay.segments.model.SegmentsEntry;
+import com.liferay.segments.test.util.SegmentsTestUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -99,6 +105,36 @@ public class AudiencesCriteriaProviderTest {
 	}
 
 	@Test
+	public void testGetCustomAudiencesCriteriaTypeWithSegment()
+		throws Exception {
+
+		SegmentsEntry segmentsEntry = _addSegmentsEntry();
+
+		List<AudiencesCriteriaType> audiencesCriteriaTypes =
+			_audiencesCriteriaProvider.getAudiencesCriteriaTypes(
+				TestPropsValues.getCompanyId(), LocaleUtil.getDefault());
+
+		AudiencesCriteriaType audiencesCriteriaType =
+			audiencesCriteriaTypes.get(2);
+
+		AudiencesCriteria audiencesCriteria = _getAudiencesCriteria(
+			audiencesCriteriaType.getAudiencesCriterias(), "segments");
+
+		Assert.assertEquals(
+			AudiencesCriteria.InputType.SELECT,
+			audiencesCriteria.getInputType());
+		Assert.assertEquals(
+			AudiencesCriteria.Type.STRING, audiencesCriteria.getType());
+
+		AudiencesCriteria.Option option = _getOption(
+			audiencesCriteria.getOptions(),
+			segmentsEntry.getSegmentsEntryKey());
+
+		Assert.assertEquals(
+			segmentsEntry.getName(LocaleUtil.getDefault()), option.getLabel());
+	}
+
+	@Test
 	public void testGetGeneralAttributesAudiencesCriteriaType()
 		throws Exception {
 
@@ -158,12 +194,38 @@ public class AudiencesCriteriaProviderTest {
 				).buildString()));
 	}
 
+	private SegmentsEntry _addSegmentsEntry() throws Exception {
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
+			CriteriaSerializer.serialize(new Criteria()),
+			SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId()));
+
+		_segmentsEntries.add(segmentsEntry);
+
+		return segmentsEntry;
+	}
+
 	private AudiencesCriteria _getAudiencesCriteria(
 		List<AudiencesCriteria> audiencesCriterias, String key) {
 
 		for (AudiencesCriteria audiencesCriteria : audiencesCriterias) {
 			if (key.equals(audiencesCriteria.getKey())) {
 				return audiencesCriteria;
+			}
+		}
+
+		return null;
+	}
+
+	private AudiencesCriteria.Option _getOption(
+		List<AudiencesCriteria.Option> options, String value) {
+
+		for (AudiencesCriteria.Option option : options) {
+			if (value.equals(option.getValue())) {
+				return option;
 			}
 		}
 
@@ -179,5 +241,8 @@ public class AudiencesCriteriaProviderTest {
 
 	@Inject
 	private ClientExtensionEntryLocalService _clientExtensionEntryLocalService;
+
+	@DeleteAfterTestRun
+	private final List<SegmentsEntry> _segmentsEntries = new ArrayList<>();
 
 }

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/test/AudiencesEntryLocalServiceTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/test/AudiencesEntryLocalServiceTest.java
@@ -62,7 +62,9 @@ public class AudiencesEntryLocalServiceTest {
 			StringBundler.concat(
 				"{\"conjunction\": \"AND\", \"rules\": [{\"attribute\": ",
 				"\"url\", \"operator\": \"eq\", \"value\": \"",
-				RandomTestUtil.randomString(), "\"}]}"),
+				RandomTestUtil.randomString(),
+				"\"}, {\"attribute\": \"segments\", \"operator\": \"eq\", ",
+				"\"value\": \"", RandomTestUtil.randomString(), "\"}]}"),
 			name);
 
 		Assert.assertEquals(

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalService.java
@@ -315,6 +315,11 @@ public interface SegmentsEntryLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<SegmentsEntry> getSegmentsEntriesBySource(
+		long companyId, String source, int start, int end,
+		OrderByComparator<SegmentsEntry> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<SegmentsEntry> getSegmentsEntriesBySource(
 		String source, int start, int end,
 		OrderByComparator<SegmentsEntry> orderByComparator);
 
@@ -434,4 +439,4 @@ public interface SegmentsEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-55443365
+// LIFERAY-SERVICE-BUILDER-HASH:-455236602

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalServiceUtil.java
@@ -366,6 +366,14 @@ public class SegmentsEntryLocalServiceUtil {
 	}
 
 	public static List<SegmentsEntry> getSegmentsEntriesBySource(
+		long companyId, String source, int start, int end,
+		OrderByComparator<SegmentsEntry> orderByComparator) {
+
+		return getService().getSegmentsEntriesBySource(
+			companyId, source, start, end, orderByComparator);
+	}
+
+	public static List<SegmentsEntry> getSegmentsEntriesBySource(
 		String source, int start, int end,
 		OrderByComparator<SegmentsEntry> orderByComparator) {
 
@@ -516,4 +524,4 @@ public class SegmentsEntryLocalServiceUtil {
 			SegmentsEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1670083519
+// LIFERAY-SERVICE-BUILDER-HASH:-1759649487

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalServiceWrapper.java
@@ -418,6 +418,16 @@ public class SegmentsEntryLocalServiceWrapper
 
 	@Override
 	public java.util.List<SegmentsEntry> getSegmentsEntriesBySource(
+		long companyId, String source, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SegmentsEntry>
+			orderByComparator) {
+
+		return _segmentsEntryLocalService.getSegmentsEntriesBySource(
+			companyId, source, start, end, orderByComparator);
+	}
+
+	@Override
+	public java.util.List<SegmentsEntry> getSegmentsEntriesBySource(
 		String source, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<SegmentsEntry>
 			orderByComparator) {
@@ -613,4 +623,4 @@ public class SegmentsEntryLocalServiceWrapper
 	private SegmentsEntryLocalService _segmentsEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1709283244
+// LIFERAY-SERVICE-BUILDER-HASH:519064866

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/persistence/SegmentsEntryPersistence.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/persistence/SegmentsEntryPersistence.java
@@ -899,6 +899,102 @@ public interface SegmentsEntryPersistence
 	public int filterCountByG_SRC(long[] groupIds, String[] sources);
 
 	/**
+	 * Returns an ordered range of all the segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching segments entries
+	 */
+	public java.util.List<SegmentsEntry> findByC_SRC(
+		long companyId, String source, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SegmentsEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first segments entry in the ordered set where companyId = &#63; and source = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching segments entry
+	 * @throws NoSuchEntryException if a matching segments entry could not be found
+	 */
+	public SegmentsEntry findByC_SRC_First(
+			long companyId, String source,
+			com.liferay.portal.kernel.util.OrderByComparator<SegmentsEntry>
+				orderByComparator)
+		throws NoSuchEntryException;
+
+	/**
+	 * Returns the first segments entry in the ordered set where companyId = &#63; and source = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching segments entry, or <code>null</code> if a matching segments entry could not be found
+	 */
+	public SegmentsEntry fetchByC_SRC_First(
+		long companyId, String source,
+		com.liferay.portal.kernel.util.OrderByComparator<SegmentsEntry>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the segments entries where companyId = &#63; and source = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching segments entries
+	 */
+	public java.util.List<SegmentsEntry> findByC_SRC(
+		long companyId, String[] sources, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SegmentsEntry>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Removes all the segments entries where companyId = &#63; and source = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 */
+	public void removeByC_SRC(long companyId, String source);
+
+	/**
+	 * Returns the number of segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @return the number of matching segments entries
+	 */
+	public int countByC_SRC(long companyId, String source);
+
+	/**
+	 * Returns the number of segments entries where companyId = &#63; and source = any &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @return the number of matching segments entries
+	 */
+	public int countByC_SRC(long companyId, String[] sources);
+
+	/**
 	 * Returns an ordered range of all the segments entries where groupId = &#63; and active = &#63; and source = &#63;.
 	 *
 	 * <p>
@@ -2041,6 +2137,122 @@ public interface SegmentsEntryPersistence
 	}
 
 	/**
+	 * Returns all the segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @return the matching segments entries
+	 */
+	public default java.util.List<SegmentsEntry> findByC_SRC(
+		long companyId, String source) {
+
+		return findByC_SRC(
+			companyId, source,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @return the range of matching segments entries
+	 */
+	public default java.util.List<SegmentsEntry> findByC_SRC(
+		long companyId, String source, int start, int end) {
+
+		return findByC_SRC(companyId, source, start, end, null, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching segments entries
+	 */
+	public default java.util.List<SegmentsEntry> findByC_SRC(
+		long companyId, String source, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SegmentsEntry>
+			orderByComparator) {
+
+		return findByC_SRC(
+			companyId, source, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns all the segments entries where companyId = &#63; and source = any &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @return the matching segments entries
+	 */
+	public default java.util.List<SegmentsEntry> findByC_SRC(
+		long companyId, String[] sources) {
+
+		return findByC_SRC(
+			companyId, sources,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS,
+			com.liferay.portal.kernel.dao.orm.QueryUtil.ALL_POS, null, true);
+	}
+
+	/**
+	 * Returns a range of all the segments entries where companyId = &#63; and source = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @return the range of matching segments entries
+	 */
+	public default java.util.List<SegmentsEntry> findByC_SRC(
+		long companyId, String[] sources, int start, int end) {
+
+		return findByC_SRC(companyId, sources, start, end, null, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the segments entries where companyId = &#63; and source = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching segments entries
+	 */
+	public default java.util.List<SegmentsEntry> findByC_SRC(
+		long companyId, String[] sources, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<SegmentsEntry>
+			orderByComparator) {
+
+		return findByC_SRC(
+			companyId, sources, start, end, orderByComparator, true);
+	}
+
+	/**
 	 * Returns all the segments entries where groupId = &#63; and active = &#63; and source = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -2237,4 +2449,4 @@ public interface SegmentsEntryPersistence
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1030634594
+// LIFERAY-SERVICE-BUILDER-HASH:1224424585

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/persistence/SegmentsEntryUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/persistence/SegmentsEntryUtil.java
@@ -1153,6 +1153,120 @@ public class SegmentsEntryUtil {
 	}
 
 	/**
+	 * Returns an ordered range of all the segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching segments entries
+	 */
+	public static List<SegmentsEntry> findByC_SRC(
+		long companyId, String source, int start, int end,
+		OrderByComparator<SegmentsEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_SRC(
+			companyId, source, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first segments entry in the ordered set where companyId = &#63; and source = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching segments entry
+	 * @throws NoSuchEntryException if a matching segments entry could not be found
+	 */
+	public static SegmentsEntry findByC_SRC_First(
+			long companyId, String source,
+			OrderByComparator<SegmentsEntry> orderByComparator)
+		throws com.liferay.segments.exception.NoSuchEntryException {
+
+		return getPersistence().findByC_SRC_First(
+			companyId, source, orderByComparator);
+	}
+
+	/**
+	 * Returns the first segments entry in the ordered set where companyId = &#63; and source = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching segments entry, or <code>null</code> if a matching segments entry could not be found
+	 */
+	public static SegmentsEntry fetchByC_SRC_First(
+		long companyId, String source,
+		OrderByComparator<SegmentsEntry> orderByComparator) {
+
+		return getPersistence().fetchByC_SRC_First(
+			companyId, source, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the segments entries where companyId = &#63; and source = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching segments entries
+	 */
+	public static List<SegmentsEntry> findByC_SRC(
+		long companyId, String[] sources, int start, int end,
+		OrderByComparator<SegmentsEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_SRC(
+			companyId, sources, start, end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Removes all the segments entries where companyId = &#63; and source = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 */
+	public static void removeByC_SRC(long companyId, String source) {
+		getPersistence().removeByC_SRC(companyId, source);
+	}
+
+	/**
+	 * Returns the number of segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @return the number of matching segments entries
+	 */
+	public static int countByC_SRC(long companyId, String source) {
+		return getPersistence().countByC_SRC(companyId, source);
+	}
+
+	/**
+	 * Returns the number of segments entries where companyId = &#63; and source = any &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @return the number of matching segments entries
+	 */
+	public static int countByC_SRC(long companyId, String[] sources) {
+		return getPersistence().countByC_SRC(companyId, sources);
+	}
+
+	/**
 	 * Returns an ordered range of all the segments entries where groupId = &#63; and active = &#63; and source = &#63;.
 	 *
 	 * <p>
@@ -2297,6 +2411,114 @@ public class SegmentsEntryUtil {
 	}
 
 	/**
+	 * Returns all the segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @return the matching segments entries
+	 */
+	public static List<SegmentsEntry> findByC_SRC(
+		long companyId, String source) {
+
+		return getPersistence().findByC_SRC(companyId, source);
+	}
+
+	/**
+	 * Returns a range of all the segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @return the range of matching segments entries
+	 */
+	public static List<SegmentsEntry> findByC_SRC(
+		long companyId, String source, int start, int end) {
+
+		return getPersistence().findByC_SRC(companyId, source, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching segments entries
+	 */
+	public static List<SegmentsEntry> findByC_SRC(
+		long companyId, String source, int start, int end,
+		OrderByComparator<SegmentsEntry> orderByComparator) {
+
+		return getPersistence().findByC_SRC(
+			companyId, source, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns all the segments entries where companyId = &#63; and source = any &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @return the matching segments entries
+	 */
+	public static List<SegmentsEntry> findByC_SRC(
+		long companyId, String[] sources) {
+
+		return getPersistence().findByC_SRC(companyId, sources);
+	}
+
+	/**
+	 * Returns a range of all the segments entries where companyId = &#63; and source = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @return the range of matching segments entries
+	 */
+	public static List<SegmentsEntry> findByC_SRC(
+		long companyId, String[] sources, int start, int end) {
+
+		return getPersistence().findByC_SRC(companyId, sources, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the segments entries where companyId = &#63; and source = any &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.segments.model.impl.SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching segments entries
+	 */
+	public static List<SegmentsEntry> findByC_SRC(
+		long companyId, String[] sources, int start, int end,
+		OrderByComparator<SegmentsEntry> orderByComparator) {
+
+		return getPersistence().findByC_SRC(
+			companyId, sources, start, end, orderByComparator);
+	}
+
+	/**
 	 * Returns all the segments entries where groupId = &#63; and active = &#63; and source = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -2493,4 +2715,4 @@ public class SegmentsEntryUtil {
 	private static volatile SegmentsEntryPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1583929424
+// LIFERAY-SERVICE-BUILDER-HASH:-1363665030

--- a/modules/apps/segments/segments-service/service.xml
+++ b/modules/apps/segments/segments-service/service.xml
@@ -64,6 +64,10 @@
 			<finder-column arrayable-operator="OR" name="groupId" />
 			<finder-column arrayable-operator="OR" name="source" />
 		</finder>
+		<finder name="C_SRC" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column arrayable-operator="OR" name="source" />
+		</finder>
 		<finder name="G_A_SRC" return-type="Collection">
 			<finder-column arrayable-operator="OR" name="groupId" />
 			<finder-column name="active" />

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
@@ -357,6 +357,15 @@ public class SegmentsEntryLocalServiceImpl
 
 	@Override
 	public List<SegmentsEntry> getSegmentsEntriesBySource(
+		long companyId, String source, int start, int end,
+		OrderByComparator<SegmentsEntry> orderByComparator) {
+
+		return segmentsEntryPersistence.findByC_SRC(
+			companyId, source, start, end, orderByComparator);
+	}
+
+	@Override
+	public List<SegmentsEntry> getSegmentsEntriesBySource(
 		String source, int start, int end,
 		OrderByComparator<SegmentsEntry> orderByComparator) {
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/persistence/impl/SegmentsEntryPersistenceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/persistence/impl/SegmentsEntryPersistenceImpl.java
@@ -1326,6 +1326,139 @@ public class SegmentsEntryPersistenceImpl
 			new Object[] {groupIds, ArrayUtil.sortedUnique(sources)}, groupIds);
 	}
 
+	private CollectionPersistenceFinder<SegmentsEntry, NoSuchEntryException>
+		_collectionPersistenceFinderByC_SRC;
+
+	/**
+	 * Returns an ordered range of all the segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching segments entries
+	 */
+	@Override
+	public List<SegmentsEntry> findByC_SRC(
+		long companyId, String source, int start, int end,
+		OrderByComparator<SegmentsEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByC_SRC.find(
+			finderCache, new Object[] {companyId, new String[] {source}}, start,
+			end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first segments entry in the ordered set where companyId = &#63; and source = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching segments entry
+	 * @throws NoSuchEntryException if a matching segments entry could not be found
+	 */
+	@Override
+	public SegmentsEntry findByC_SRC_First(
+			long companyId, String source,
+			OrderByComparator<SegmentsEntry> orderByComparator)
+		throws NoSuchEntryException {
+
+		return _collectionPersistenceFinderByC_SRC.findFirst(
+			finderCache, new Object[] {companyId, new String[] {source}},
+			orderByComparator);
+	}
+
+	/**
+	 * Returns the first segments entry in the ordered set where companyId = &#63; and source = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching segments entry, or <code>null</code> if a matching segments entry could not be found
+	 */
+	@Override
+	public SegmentsEntry fetchByC_SRC_First(
+		long companyId, String source,
+		OrderByComparator<SegmentsEntry> orderByComparator) {
+
+		return _collectionPersistenceFinderByC_SRC.fetchFirst(
+			finderCache, new Object[] {companyId, new String[] {source}},
+			orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the segments entries where companyId = &#63; and source = &#63;, optionally using the finder cache.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>SegmentsEntryModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @param start the lower bound of the range of segments entries
+	 * @param end the upper bound of the range of segments entries (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching segments entries
+	 */
+	@Override
+	public List<SegmentsEntry> findByC_SRC(
+		long companyId, String[] sources, int start, int end,
+		OrderByComparator<SegmentsEntry> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByC_SRC.find(
+			finderCache,
+			new Object[] {companyId, ArrayUtil.sortedUnique(sources)}, start,
+			end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Removes all the segments entries where companyId = &#63; and source = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 */
+	@Override
+	public void removeByC_SRC(long companyId, String source) {
+		_collectionPersistenceFinderByC_SRC.remove(
+			finderCache, new Object[] {companyId, new String[] {source}});
+	}
+
+	/**
+	 * Returns the number of segments entries where companyId = &#63; and source = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param source the source
+	 * @return the number of matching segments entries
+	 */
+	@Override
+	public int countByC_SRC(long companyId, String source) {
+		return _collectionPersistenceFinderByC_SRC.count(
+			finderCache, new Object[] {companyId, new String[] {source}});
+	}
+
+	/**
+	 * Returns the number of segments entries where companyId = &#63; and source = any &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param sources the sources
+	 * @return the number of matching segments entries
+	 */
+	@Override
+	public int countByC_SRC(long companyId, String[] sources) {
+		return _collectionPersistenceFinderByC_SRC.count(
+			finderCache,
+			new Object[] {companyId, ArrayUtil.sortedUnique(sources)});
+	}
+
 	private FilterCollectionPersistenceFinder
 		<SegmentsEntry, NoSuchEntryException>
 			_collectionPersistenceFinderByG_A_SRC;
@@ -2267,6 +2400,34 @@ public class SegmentsEntryPersistenceImpl
 					"segmentsEntry.", "source", FinderColumn.Type.STRING, "=",
 					false, true, true, SegmentsEntry::getSource));
 
+		_collectionPersistenceFinderByC_SRC = new CollectionPersistenceFinder<>(
+			this,
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_SRC",
+				new String[] {
+					Long.class.getName(), String.class.getName(),
+					Integer.class.getName(), Integer.class.getName(),
+					OrderByComparator.class.getName()
+				},
+				new String[] {"companyId", "source"}, true),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_SRC",
+				new String[] {Long.class.getName(), String.class.getName()},
+				new String[] {"companyId", "source"}, 0, 2, true, null),
+			new FinderPath(
+				FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByC_SRC",
+				new String[] {Long.class.getName(), String.class.getName()},
+				new String[] {"companyId", "source"}, 0, 2, false, null),
+			_SQL_SELECT_SEGMENTSENTRY_WHERE, _SQL_COUNT_SEGMENTSENTRY_WHERE,
+			SegmentsEntryModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "", "",
+			null,
+			new FinderColumn<>(
+				"segmentsEntry.", "companyId", FinderColumn.Type.LONG, "=",
+				true, true, SegmentsEntry::getCompanyId),
+			new ArrayableFinderColumn<>(
+				"segmentsEntry.", "source", FinderColumn.Type.STRING, "=",
+				false, true, true, SegmentsEntry::getSource));
+
 		_collectionPersistenceFinderByG_A_SRC =
 			new FilterCollectionPersistenceFinder<>(
 				this,
@@ -2392,4 +2553,4 @@ public class SegmentsEntryPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:648879012
+// LIFERAY-SERVICE-BUILDER-HASH:634004374

--- a/modules/apps/segments/segments-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/segments/segments-service/src/main/resources/META-INF/sql/indexes.sql
@@ -4,12 +4,12 @@ create index IX_9B8A5E80 on SExperienceAudienceEntryRel (groupId, segmentsExperi
 create unique index IX_1F1DEAC2 on SExperienceAudienceEntryRel (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);
 
 create index IX_F6225631 on SegmentsEntry (active_);
-create index IX_C6E84946 on SegmentsEntry (groupId, active_, source[$COLUMN_LENGTH:75$]);
+create index IX_2E0C3F77 on SegmentsEntry (groupId, active_);
 create unique index IX_E42D8589 on SegmentsEntry (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);
 create unique index IX_DB53F1B1 on SegmentsEntry (groupId, segmentsEntryKey[$COLUMN_LENGTH:75$], ctCollectionId);
-create index IX_1EDBDAA1 on SegmentsEntry (groupId, source[$COLUMN_LENGTH:75$]);
+create index IX_9B28F988 on SegmentsEntry (groupId, source[$COLUMN_LENGTH:75$], active_);
 create unique index IX_78D59000 on SegmentsEntry (groupId, uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
-create index IX_90AB04A7 on SegmentsEntry (source[$COLUMN_LENGTH:75$]);
+create index IX_8F676121 on SegmentsEntry (source[$COLUMN_LENGTH:75$], companyId);
 create index IX_8046BADC on SegmentsEntry (uuid_[$COLUMN_LENGTH:75$]);
 
 create index IX_64CBABA8 on SegmentsEntryRel (classNameId, classPK, groupId);

--- a/modules/apps/segments/segments-service/src/main/resources/service.properties
+++ b/modules/apps/segments/segments-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.segments.service
-    build.number=14
-    build.date=1783869338203
+    build.number=15
+    build.date=1784298039340

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryPersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsEntryPersistenceTest.java
@@ -339,6 +339,24 @@ public class SegmentsEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByC_SRC() throws Exception {
+		_persistence.countByC_SRC(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByC_SRC(0L, "null");
+
+		_persistence.countByC_SRC(0L, (String)null);
+	}
+
+	@Test
+	public void testCountByC_SRCArrayable() throws Exception {
+		_persistence.countByC_SRC(
+			RandomTestUtil.nextLong(),
+			new String[] {
+				RandomTestUtil.randomString(), "", "null", null, null
+			});
+	}
+
+	@Test
 	public void testCountByG_A_SRC() throws Exception {
 		_persistence.countByG_A_SRC(
 			RandomTestUtil.nextLong(), RandomTestUtil.randomBoolean(), "");
@@ -771,4 +789,4 @@ public class SegmentsEntryPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:717790671
+// LIFERAY-SERVICE-BUILDER-HASH:934953616


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98583

## What Is Being Fixed

The audiences builder could not target an audience by Analytics Cloud segment membership. There was no criteria for segments, and the audiences criteria JSON schema rejected a "segments" attribute, so such a condition could not be saved.

## How It Is Being Fixed

Added a "C_SRC" finder (company ID and source) to SegmentsEntry, plus a matching getSegmentsEntriesBySource(long, String, ...) local service method, to look up segments scoped to a company and source.

Added a Segments criteria to the Custom criteria type in AudiencesCriteriaProviderImpl, populated from the OSB segments (ASAH_FARO_BACKEND source) through the new finder. It is a STRING select whose options are the segment name and key, mirroring how language and user_language selects work.

Allowed the "segments" attribute in the audiences criteria JSON schema with the eq and not_eq operators and a string value, consistent with the rule the frontend generates for a STRING select, so an audience with a segment condition validates and saves.

## PR Check

**pr-check: PASS** — tested on `22d26ff67a38e23418974091d1ca63424fedb4bb`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Per-Module Compile (touched modules) | PASS |
| Integration Test Compile | PASS |

Cross-Module Compile and Full Portal Build were trimmed by developer decision: the segments-api change is a binary-compatible method addition (99 consumers), and the four touched modules compile cleanly.

<!-- pr-check {"result": "success", "sha": "22d26ff67a38e23418974091d1ca63424fedb4bb"} -->
