### PR TITLE
LPD-98583 Rename the segments audiences criteria key to segment

### DIFF
--- a/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/constants/AudiencesCriteriaKeys.java
+++ b/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/constants/AudiencesCriteriaKeys.java
@@ -34,7 +34,7 @@ public class AudiencesCriteriaKeys {
 
 	public static final String REQUEST_PARAMETERS = "request_parameters";
 
-	public static final String SEGMENTS = "segments";
+	public static final String SEGMENT = "segment";
 
 	public static final String TIMEZONE = "timezone";
 

--- a/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/internal/criteria/AudiencesCriteriaProviderImpl.java
+++ b/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/internal/criteria/AudiencesCriteriaProviderImpl.java
@@ -267,7 +267,7 @@ public class AudiencesCriteriaProviderImpl
 					).setInputType(
 						AudiencesCriteria.InputType.SELECT
 					).setKey(
-						AudiencesCriteriaKeys.SEGMENTS
+						AudiencesCriteriaKeys.SEGMENT
 					).setLabel(
 						_language.get(locale, "segments")
 					).setOptions(

--- a/modules/apps/audiences/audiences-service/src/main/resources/com/liferay/audiences/service/impl/dependencies/audiences-criteria-json-schema.json
+++ b/modules/apps/audiences/audiences-service/src/main/resources/com/liferay/audiences/service/impl/dependencies/audiences-criteria-json-schema.json
@@ -144,7 +144,7 @@
 							"attribute": {
 								"enum": [
 									"language",
-									"segments",
+									"segment",
 									"user_language"
 								]
 							}

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/criteria/test/AudiencesCriteriaProviderTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/criteria/test/AudiencesCriteriaProviderTest.java
@@ -120,7 +120,7 @@ public class AudiencesCriteriaProviderTest {
 			audiencesCriteriaTypes.get(2);
 
 		AudiencesCriteria audiencesCriteria = _getAudiencesCriteria(
-			audiencesCriteriaType.getAudiencesCriterias(), "segments");
+			audiencesCriteriaType.getAudiencesCriterias(), "segment");
 
 		Assert.assertEquals(
 			AudiencesCriteria.InputType.SELECT,

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/test/AudiencesEntryLocalServiceTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/test/AudiencesEntryLocalServiceTest.java
@@ -73,7 +73,7 @@ public class AudiencesEntryLocalServiceTest {
 						"value", RandomTestUtil.randomString()
 					),
 					JSONUtil.put(
-						"attribute", "segments"
+						"attribute", "segment"
 					).put(
 						"operator", "eq"
 					).put(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98583

## What Is Being Fixed

The audiences criteria key for the segments condition was registered under the plural key `segments`. The key is renamed to the singular `segment` for consistency with the rest of the criteria keys.

## How It Is Being Fixed

Rename the `AudiencesCriteriaKeys.SEGMENTS` constant (value `segments`) to `SEGMENT` (value `segment`), update `AudiencesCriteriaProviderImpl` which registers the criterion, adjust the `audiences-criteria-json-schema.json` accepted key, and update the integration tests that assert on the key.

## PR Check

**pr-check: PASS** — tested on `d98f03e465d9a2b1f9865be4046c3814127a82c3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "d98f03e465d9a2b1f9865be4046c3814127a82c3"} -->
