### PR TITLE
LPD-98771 Take Asah ERC into account when synchronizing segments

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/test/SegmentsEntryCTTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/test/SegmentsEntryCTTest.java
@@ -119,7 +119,7 @@ public class SegmentsEntryCTTest {
 					_ctCollection.getCtCollectionId())) {
 
 			segmentsEntry = _segmentsEntryLocalService.updateSegmentsEntry(
-				segmentsEntry.getSegmentsEntryId(),
+				null, segmentsEntry.getSegmentsEntryId(),
 				segmentsEntry.getSegmentsEntryKey(), nameMap,
 				segmentsEntry.getDescriptionMap(), segmentsEntry.isActive(),
 				segmentsEntry.getCriteria(),

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalService.java
@@ -83,17 +83,12 @@ public interface SegmentsEntryLocalService
 	@Indexable(type = IndexableType.REINDEX)
 	public SegmentsEntry addSegmentsEntry(SegmentsEntry segmentsEntry);
 
-	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, boolean active, String criteria,
-			ServiceContext serviceContext)
-		throws PortalException;
-
 	@Indexable(type = IndexableType.REINDEX)
 	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, boolean active, String criteria,
-			String source, ServiceContext serviceContext)
+			String externalReferenceCode, String segmentsEntryKey,
+			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
+			boolean active, String criteria, String source,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public void addSegmentsEntryClassPKs(
@@ -403,13 +398,6 @@ public interface SegmentsEntryLocalService
 			SearchContext searchContext)
 		throws PortalException;
 
-	@Indexable(type = IndexableType.REINDEX)
-	public SegmentsEntry updateSegmentsEntry(
-			long segmentsEntryId, String segmentsEntryKey,
-			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			boolean active, String criteria, ServiceContext serviceContext)
-		throws PortalException;
-
 	/**
 	 * Updates the segments entry in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *
@@ -422,6 +410,14 @@ public interface SegmentsEntryLocalService
 	 */
 	@Indexable(type = IndexableType.REINDEX)
 	public SegmentsEntry updateSegmentsEntry(SegmentsEntry segmentsEntry);
+
+	@Indexable(type = IndexableType.REINDEX)
+	public SegmentsEntry updateSegmentsEntry(
+			String externalReferenceCode, long segmentsEntryId,
+			String segmentsEntryKey, Map<Locale, String> nameMap,
+			Map<Locale, String> descriptionMap, boolean active, String criteria,
+			ServiceContext serviceContext)
+		throws PortalException;
 
 	@Override
 	@Transactional(enabled = false)
@@ -439,4 +435,4 @@ public interface SegmentsEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-455236602
+// LIFERAY-SERVICE-BUILDER-HASH:-15771358

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalServiceUtil.java
@@ -53,27 +53,16 @@ public class SegmentsEntryLocalServiceUtil {
 	}
 
 	public static SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<java.util.Locale, String> nameMap,
-			Map<java.util.Locale, String> descriptionMap, boolean active,
-			String criteria,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().addSegmentsEntry(
-			segmentsEntryKey, nameMap, descriptionMap, active, criteria,
-			serviceContext);
-	}
-
-	public static SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<java.util.Locale, String> nameMap,
+			String externalReferenceCode, String segmentsEntryKey,
+			Map<java.util.Locale, String> nameMap,
 			Map<java.util.Locale, String> descriptionMap, boolean active,
 			String criteria, String source,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addSegmentsEntry(
-			segmentsEntryKey, nameMap, descriptionMap, active, criteria, source,
-			serviceContext);
+			externalReferenceCode, segmentsEntryKey, nameMap, descriptionMap,
+			active, criteria, source, serviceContext);
 	}
 
 	public static void addSegmentsEntryClassPKs(
@@ -485,19 +474,6 @@ public class SegmentsEntryLocalServiceUtil {
 		return getService().searchSegmentsEntries(searchContext);
 	}
 
-	public static SegmentsEntry updateSegmentsEntry(
-			long segmentsEntryId, String segmentsEntryKey,
-			Map<java.util.Locale, String> nameMap,
-			Map<java.util.Locale, String> descriptionMap, boolean active,
-			String criteria,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().updateSegmentsEntry(
-			segmentsEntryId, segmentsEntryKey, nameMap, descriptionMap, active,
-			criteria, serviceContext);
-	}
-
 	/**
 	 * Updates the segments entry in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *
@@ -514,6 +490,19 @@ public class SegmentsEntryLocalServiceUtil {
 		return getService().updateSegmentsEntry(segmentsEntry);
 	}
 
+	public static SegmentsEntry updateSegmentsEntry(
+			String externalReferenceCode, long segmentsEntryId,
+			String segmentsEntryKey, Map<java.util.Locale, String> nameMap,
+			Map<java.util.Locale, String> descriptionMap, boolean active,
+			String criteria,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateSegmentsEntry(
+			externalReferenceCode, segmentsEntryId, segmentsEntryKey, nameMap,
+			descriptionMap, active, criteria, serviceContext);
+	}
+
 	public static SegmentsEntryLocalService getService() {
 		return _serviceSnapshot.get();
 	}
@@ -524,4 +513,4 @@ public class SegmentsEntryLocalServiceUtil {
 			SegmentsEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1759649487
+// LIFERAY-SERVICE-BUILDER-HASH:1799444270

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryLocalServiceWrapper.java
@@ -49,21 +49,7 @@ public class SegmentsEntryLocalServiceWrapper
 
 	@Override
 	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey,
-			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
-			boolean active, String criteria,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _segmentsEntryLocalService.addSegmentsEntry(
-			segmentsEntryKey, nameMap, descriptionMap, active, criteria,
-			serviceContext);
-	}
-
-	@Override
-	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey,
+			String externalReferenceCode, String segmentsEntryKey,
 			java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			boolean active, String criteria, String source,
@@ -71,8 +57,8 @@ public class SegmentsEntryLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _segmentsEntryLocalService.addSegmentsEntry(
-			segmentsEntryKey, nameMap, descriptionMap, active, criteria, source,
-			serviceContext);
+			externalReferenceCode, segmentsEntryKey, nameMap, descriptionMap,
+			active, criteria, source, serviceContext);
 	}
 
 	@Override
@@ -554,20 +540,6 @@ public class SegmentsEntryLocalServiceWrapper
 		return _segmentsEntryLocalService.searchSegmentsEntries(searchContext);
 	}
 
-	@Override
-	public SegmentsEntry updateSegmentsEntry(
-			long segmentsEntryId, String segmentsEntryKey,
-			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
-			boolean active, String criteria,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _segmentsEntryLocalService.updateSegmentsEntry(
-			segmentsEntryId, segmentsEntryKey, nameMap, descriptionMap, active,
-			criteria, serviceContext);
-	}
-
 	/**
 	 * Updates the segments entry in the database or adds it if it does not yet exist. Also notifies the appropriate model listeners.
 	 *
@@ -581,6 +553,21 @@ public class SegmentsEntryLocalServiceWrapper
 	@Override
 	public SegmentsEntry updateSegmentsEntry(SegmentsEntry segmentsEntry) {
 		return _segmentsEntryLocalService.updateSegmentsEntry(segmentsEntry);
+	}
+
+	@Override
+	public SegmentsEntry updateSegmentsEntry(
+			String externalReferenceCode, long segmentsEntryId,
+			String segmentsEntryKey,
+			java.util.Map<java.util.Locale, String> nameMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			boolean active, String criteria,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _segmentsEntryLocalService.updateSegmentsEntry(
+			externalReferenceCode, segmentsEntryId, segmentsEntryKey, nameMap,
+			descriptionMap, active, criteria, serviceContext);
 	}
 
 	@Override
@@ -623,4 +610,4 @@ public class SegmentsEntryLocalServiceWrapper
 	private SegmentsEntryLocalService _segmentsEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:519064866
+// LIFERAY-SERVICE-BUILDER-HASH:701262167

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryService.java
@@ -52,15 +52,10 @@ public interface SegmentsEntryService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.segments.service.impl.SegmentsEntryServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the segments entry remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link SegmentsEntryServiceUtil} if injection and service tracking are not available.
 	 */
 	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, boolean active, String criteria,
+			String externalReferenceCode, String segmentsEntryKey,
+			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
+			boolean active, String criteria, String source,
 			ServiceContext serviceContext)
-		throws PortalException;
-
-	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, boolean active, String criteria,
-			String source, ServiceContext serviceContext)
 		throws PortalException;
 
 	public void addSegmentsEntryClassPKs(
@@ -122,10 +117,11 @@ public interface SegmentsEntryService extends BaseService {
 		throws PortalException;
 
 	public SegmentsEntry updateSegmentsEntry(
-			long segmentsEntryId, String segmentsEntryKey,
-			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			boolean active, String criteria, ServiceContext serviceContext)
+			String externalReferenceCode, long segmentsEntryId,
+			String segmentsEntryKey, Map<Locale, String> nameMap,
+			Map<Locale, String> descriptionMap, boolean active, String criteria,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2113349780
+// LIFERAY-SERVICE-BUILDER-HASH:-268141050

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryServiceUtil.java
@@ -33,27 +33,16 @@ public class SegmentsEntryServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.segments.service.impl.SegmentsEntryServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<java.util.Locale, String> nameMap,
-			Map<java.util.Locale, String> descriptionMap, boolean active,
-			String criteria,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().addSegmentsEntry(
-			segmentsEntryKey, nameMap, descriptionMap, active, criteria,
-			serviceContext);
-	}
-
-	public static SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<java.util.Locale, String> nameMap,
+			String externalReferenceCode, String segmentsEntryKey,
+			Map<java.util.Locale, String> nameMap,
 			Map<java.util.Locale, String> descriptionMap, boolean active,
 			String criteria, String source,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addSegmentsEntry(
-			segmentsEntryKey, nameMap, descriptionMap, active, criteria, source,
-			serviceContext);
+			externalReferenceCode, segmentsEntryKey, nameMap, descriptionMap,
+			active, criteria, source, serviceContext);
 	}
 
 	public static void addSegmentsEntryClassPKs(
@@ -149,16 +138,16 @@ public class SegmentsEntryServiceUtil {
 	}
 
 	public static SegmentsEntry updateSegmentsEntry(
-			long segmentsEntryId, String segmentsEntryKey,
-			Map<java.util.Locale, String> nameMap,
+			String externalReferenceCode, long segmentsEntryId,
+			String segmentsEntryKey, Map<java.util.Locale, String> nameMap,
 			Map<java.util.Locale, String> descriptionMap, boolean active,
 			String criteria,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateSegmentsEntry(
-			segmentsEntryId, segmentsEntryKey, nameMap, descriptionMap, active,
-			criteria, serviceContext);
+			externalReferenceCode, segmentsEntryId, segmentsEntryKey, nameMap,
+			descriptionMap, active, criteria, serviceContext);
 	}
 
 	public static SegmentsEntryService getService() {
@@ -170,4 +159,4 @@ public class SegmentsEntryServiceUtil {
 			SegmentsEntryServiceUtil.class, SegmentsEntryService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:600949036
+// LIFERAY-SERVICE-BUILDER-HASH:1236481517

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsEntryServiceWrapper.java
@@ -30,21 +30,7 @@ public class SegmentsEntryServiceWrapper
 
 	@Override
 	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey,
-			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
-			boolean active, String criteria,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _segmentsEntryService.addSegmentsEntry(
-			segmentsEntryKey, nameMap, descriptionMap, active, criteria,
-			serviceContext);
-	}
-
-	@Override
-	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey,
+			String externalReferenceCode, String segmentsEntryKey,
 			java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			boolean active, String criteria, String source,
@@ -52,8 +38,8 @@ public class SegmentsEntryServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _segmentsEntryService.addSegmentsEntry(
-			segmentsEntryKey, nameMap, descriptionMap, active, criteria, source,
-			serviceContext);
+			externalReferenceCode, segmentsEntryKey, nameMap, descriptionMap,
+			active, criteria, source, serviceContext);
 	}
 
 	@Override
@@ -166,7 +152,8 @@ public class SegmentsEntryServiceWrapper
 
 	@Override
 	public SegmentsEntry updateSegmentsEntry(
-			long segmentsEntryId, String segmentsEntryKey,
+			String externalReferenceCode, long segmentsEntryId,
+			String segmentsEntryKey,
 			java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			boolean active, String criteria,
@@ -174,8 +161,8 @@ public class SegmentsEntryServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _segmentsEntryService.updateSegmentsEntry(
-			segmentsEntryId, segmentsEntryKey, nameMap, descriptionMap, active,
-			criteria, serviceContext);
+			externalReferenceCode, segmentsEntryId, segmentsEntryKey, nameMap,
+			descriptionMap, active, criteria, serviceContext);
 	}
 
 	@Override
@@ -191,4 +178,4 @@ public class SegmentsEntryServiceWrapper
 	private SegmentsEntryService _segmentsEntryService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-208650748
+// LIFERAY-SERVICE-BUILDER-HASH:-2092707456

--- a/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/service/packageinfo
+++ b/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/service/packageinfo
@@ -1,1 +1,1 @@
-version 18.2.0
+version 19.0.0

--- a/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/upgrade/v1_0_0/ContentTargetingUpgradeProcess.java
+++ b/modules/apps/segments/segments-content-targeting-upgrade/src/main/java/com/liferay/segments/content/targeting/upgrade/internal/upgrade/v1_0_0/ContentTargetingUpgradeProcess.java
@@ -222,8 +222,8 @@ public class ContentTargetingUpgradeProcess extends UpgradeProcess {
 					LocaleThreadLocal.setSiteDefaultLocale(defaultLocale);
 
 					_segmentsEntryLocalService.addSegmentsEntry(
-						"ct_" + userSegmentId, nameMap, descriptionMap, true,
-						_getCriteria(userSegmentId),
+						null, "ct_" + userSegmentId, nameMap, descriptionMap,
+						true, _getCriteria(userSegmentId),
 						SegmentsEntryConstants.SOURCE_DEFAULT, serviceContext);
 				}
 				finally {

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/staged/model/repository/SegmentsEntryStagedModelRepository.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/exportimport/staged/model/repository/SegmentsEntryStagedModelRepository.java
@@ -44,6 +44,7 @@ public class SegmentsEntryStagedModelRepository
 		}
 
 		return _segmentsEntryLocalService.addSegmentsEntry(
+			segmentsEntry.getExternalReferenceCode(),
 			segmentsEntry.getSegmentsEntryKey(), segmentsEntry.getNameMap(),
 			segmentsEntry.getDescriptionMap(), segmentsEntry.isActive(),
 			segmentsEntry.getCriteria(), segmentsEntry.getSource(),

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/http/SegmentsEntryServiceHttp.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/http/SegmentsEntryServiceHttp.java
@@ -42,52 +42,8 @@ import com.liferay.segments.service.SegmentsEntryServiceUtil;
 public class SegmentsEntryServiceHttp {
 
 	public static com.liferay.segments.model.SegmentsEntry addSegmentsEntry(
-			HttpPrincipal httpPrincipal, String segmentsEntryKey,
-			java.util.Map<java.util.Locale, String> nameMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
-			boolean active, String criteria,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				SegmentsEntryServiceUtil.class, "addSegmentsEntry",
-				_addSegmentsEntryParameterTypes0);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, segmentsEntryKey, nameMap, descriptionMap, active,
-				criteria, serviceContext);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.segments.model.SegmentsEntry)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static com.liferay.segments.model.SegmentsEntry addSegmentsEntry(
-			HttpPrincipal httpPrincipal, String segmentsEntryKey,
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			String segmentsEntryKey,
 			java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			boolean active, String criteria, String source,
@@ -97,11 +53,11 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "addSegmentsEntry",
-				_addSegmentsEntryParameterTypes1);
+				_addSegmentsEntryParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, segmentsEntryKey, nameMap, descriptionMap, active,
-				criteria, source, serviceContext);
+				methodKey, externalReferenceCode, segmentsEntryKey, nameMap,
+				descriptionMap, active, criteria, source, serviceContext);
 
 			Object returnObj = null;
 
@@ -139,7 +95,7 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "addSegmentsEntryClassPKs",
-				_addSegmentsEntryClassPKsParameterTypes2);
+				_addSegmentsEntryClassPKsParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsEntryId, classPKs, serviceContext);
@@ -175,7 +131,7 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "deleteSegmentsEntry",
-				_deleteSegmentsEntryParameterTypes3);
+				_deleteSegmentsEntryParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsEntryId);
@@ -215,7 +171,7 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "deleteSegmentsEntryClassPKs",
-				_deleteSegmentsEntryClassPKsParameterTypes4);
+				_deleteSegmentsEntryClassPKsParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsEntryId, classPKs);
@@ -254,7 +210,7 @@ public class SegmentsEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class,
 				"fetchSegmentsEntryByExternalReferenceCode",
-				_fetchSegmentsEntryByExternalReferenceCodeParameterTypes5);
+				_fetchSegmentsEntryByExternalReferenceCodeParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsEntryERC, groupId);
@@ -293,7 +249,7 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "getSegmentsEntries",
-				_getSegmentsEntriesParameterTypes6);
+				_getSegmentsEntriesParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -328,7 +284,7 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "getSegmentsEntries",
-				_getSegmentsEntriesParameterTypes7);
+				_getSegmentsEntriesParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, start, end, orderByComparator);
@@ -365,7 +321,7 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "getSegmentsEntries",
-				_getSegmentsEntriesParameterTypes8);
+				_getSegmentsEntriesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, sources, start, end, orderByComparator);
@@ -398,7 +354,7 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "getSegmentsEntriesCount",
-				_getSegmentsEntriesCountParameterTypes9);
+				_getSegmentsEntriesCountParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -429,7 +385,7 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "getSegmentsEntriesCount",
-				_getSegmentsEntriesCountParameterTypes10);
+				_getSegmentsEntriesCountParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, sources);
@@ -462,7 +418,7 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "getSegmentsEntry",
-				_getSegmentsEntryParameterTypes11);
+				_getSegmentsEntryParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsEntryId);
@@ -505,7 +461,7 @@ public class SegmentsEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class,
 				"getSegmentsEntryByExternalReferenceCode",
-				_getSegmentsEntryByExternalReferenceCodeParameterTypes12);
+				_getSegmentsEntryByExternalReferenceCodeParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsEntryERC, groupId);
@@ -548,7 +504,7 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "searchSegmentsEntries",
-				_searchSegmentsEntriesParameterTypes13);
+				_searchSegmentsEntriesParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, keywords, params, start, end,
@@ -584,8 +540,8 @@ public class SegmentsEntryServiceHttp {
 	}
 
 	public static com.liferay.segments.model.SegmentsEntry updateSegmentsEntry(
-			HttpPrincipal httpPrincipal, long segmentsEntryId,
-			String segmentsEntryKey,
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long segmentsEntryId, String segmentsEntryKey,
 			java.util.Map<java.util.Locale, String> nameMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			boolean active, String criteria,
@@ -595,11 +551,12 @@ public class SegmentsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsEntryServiceUtil.class, "updateSegmentsEntry",
-				_updateSegmentsEntryParameterTypes14);
+				_updateSegmentsEntryParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, segmentsEntryId, segmentsEntryKey, nameMap,
-				descriptionMap, active, criteria, serviceContext);
+				methodKey, externalReferenceCode, segmentsEntryId,
+				segmentsEntryKey, nameMap, descriptionMap, active, criteria,
+				serviceContext);
 
 			Object returnObj = null;
 
@@ -634,63 +591,57 @@ public class SegmentsEntryServiceHttp {
 
 	private static final Class<?>[] _addSegmentsEntryParameterTypes0 =
 		new Class[] {
-			String.class, java.util.Map.class, java.util.Map.class,
-			boolean.class, String.class,
+			String.class, String.class, java.util.Map.class,
+			java.util.Map.class, boolean.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _addSegmentsEntryParameterTypes1 =
-		new Class[] {
-			String.class, java.util.Map.class, java.util.Map.class,
-			boolean.class, String.class, String.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _addSegmentsEntryClassPKsParameterTypes2 =
+	private static final Class<?>[] _addSegmentsEntryClassPKsParameterTypes1 =
 		new Class[] {
 			long.class, long[].class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _deleteSegmentsEntryParameterTypes3 =
+	private static final Class<?>[] _deleteSegmentsEntryParameterTypes2 =
 		new Class[] {long.class};
 	private static final Class<?>[]
-		_deleteSegmentsEntryClassPKsParameterTypes4 = new Class[] {
+		_deleteSegmentsEntryClassPKsParameterTypes3 = new Class[] {
 			long.class, long[].class
 		};
 	private static final Class<?>[]
-		_fetchSegmentsEntryByExternalReferenceCodeParameterTypes5 =
+		_fetchSegmentsEntryByExternalReferenceCodeParameterTypes4 =
 			new Class[] {String.class, long.class};
-	private static final Class<?>[] _getSegmentsEntriesParameterTypes6 =
+	private static final Class<?>[] _getSegmentsEntriesParameterTypes5 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getSegmentsEntriesParameterTypes7 =
+	private static final Class<?>[] _getSegmentsEntriesParameterTypes6 =
 		new Class[] {
 			long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getSegmentsEntriesParameterTypes8 =
+	private static final Class<?>[] _getSegmentsEntriesParameterTypes7 =
 		new Class[] {
 			long.class, String[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getSegmentsEntriesCountParameterTypes9 =
+	private static final Class<?>[] _getSegmentsEntriesCountParameterTypes8 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getSegmentsEntriesCountParameterTypes10 =
+	private static final Class<?>[] _getSegmentsEntriesCountParameterTypes9 =
 		new Class[] {long.class, String[].class};
-	private static final Class<?>[] _getSegmentsEntryParameterTypes11 =
+	private static final Class<?>[] _getSegmentsEntryParameterTypes10 =
 		new Class[] {long.class};
 	private static final Class<?>[]
-		_getSegmentsEntryByExternalReferenceCodeParameterTypes12 = new Class[] {
+		_getSegmentsEntryByExternalReferenceCodeParameterTypes11 = new Class[] {
 			String.class, long.class
 		};
-	private static final Class<?>[] _searchSegmentsEntriesParameterTypes13 =
+	private static final Class<?>[] _searchSegmentsEntriesParameterTypes12 =
 		new Class[] {
 			long.class, long.class, String.class, java.util.LinkedHashMap.class,
 			int.class, int.class, com.liferay.portal.kernel.search.Sort.class
 		};
-	private static final Class<?>[] _updateSegmentsEntryParameterTypes14 =
+	private static final Class<?>[] _updateSegmentsEntryParameterTypes13 =
 		new Class[] {
-			long.class, String.class, java.util.Map.class, java.util.Map.class,
-			boolean.class, String.class,
+			String.class, long.class, String.class, java.util.Map.class,
+			java.util.Map.class, boolean.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:597784507
+// LIFERAY-SERVICE-BUILDER-HASH:-1512865323

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
@@ -88,9 +88,10 @@ public class SegmentsEntryLocalServiceImpl
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, boolean active, String criteria,
-			String source, ServiceContext serviceContext)
+			String externalReferenceCode, String segmentsEntryKey,
+			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
+			boolean active, String criteria, String source,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		// Segments entry
@@ -114,6 +115,7 @@ public class SegmentsEntryLocalServiceImpl
 			segmentsEntryId);
 
 		segmentsEntry.setUuid(serviceContext.getUuid());
+		segmentsEntry.setExternalReferenceCode(externalReferenceCode);
 		segmentsEntry.setGroupId(groupId);
 		segmentsEntry.setCompanyId(user.getCompanyId());
 		segmentsEntry.setUserId(user.getUserId());

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
@@ -413,9 +413,10 @@ public class SegmentsEntryLocalServiceImpl
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public SegmentsEntry updateSegmentsEntry(
-			long segmentsEntryId, String segmentsEntryKey,
-			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			boolean active, String criteria, ServiceContext serviceContext)
+			String externalReferenceCode, long segmentsEntryId,
+			String segmentsEntryKey, Map<Locale, String> nameMap,
+			Map<Locale, String> descriptionMap, boolean active, String criteria,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		// Segments entry
@@ -431,6 +432,7 @@ public class SegmentsEntryLocalServiceImpl
 		_validateName(segmentsEntry.getGroupId(), nameMap);
 		_validateSegmentsExperiment(segmentsEntry);
 
+		segmentsEntry.setExternalReferenceCode(externalReferenceCode);
 		segmentsEntry.setModifiedDate(
 			serviceContext.getModifiedDate(new Date()));
 		segmentsEntry.setSegmentsEntryKey(segmentsEntryKey);

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryLocalServiceImpl.java
@@ -85,18 +85,6 @@ import org.osgi.service.component.annotations.Reference;
 public class SegmentsEntryLocalServiceImpl
 	extends SegmentsEntryLocalServiceBaseImpl {
 
-	@Override
-	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, boolean active, String criteria,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		return segmentsEntryLocalService.addSegmentsEntry(
-			segmentsEntryKey, nameMap, descriptionMap, active, criteria, null,
-			serviceContext);
-	}
-
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public SegmentsEntry addSegmentsEntry(

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryServiceImpl.java
@@ -44,22 +44,6 @@ public class SegmentsEntryServiceImpl extends SegmentsEntryServiceBaseImpl {
 	public SegmentsEntry addSegmentsEntry(
 			String segmentsEntryKey, Map<Locale, String> nameMap,
 			Map<Locale, String> descriptionMap, boolean active, String criteria,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		_portletResourcePermission.check(
-			getPermissionChecker(), serviceContext.getScopeGroupId(),
-			SegmentsActionKeys.MANAGE_SEGMENTS_ENTRIES);
-
-		return segmentsEntryLocalService.addSegmentsEntry(
-			segmentsEntryKey, nameMap, descriptionMap, active, criteria,
-			serviceContext);
-	}
-
-	@Override
-	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, boolean active, String criteria,
 			String source, ServiceContext serviceContext)
 		throws PortalException {
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryServiceImpl.java
@@ -192,17 +192,18 @@ public class SegmentsEntryServiceImpl extends SegmentsEntryServiceBaseImpl {
 
 	@Override
 	public SegmentsEntry updateSegmentsEntry(
-			long segmentsEntryId, String segmentsEntryKey,
-			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
-			boolean active, String criteria, ServiceContext serviceContext)
+			String externalReferenceCode, long segmentsEntryId,
+			String segmentsEntryKey, Map<Locale, String> nameMap,
+			Map<Locale, String> descriptionMap, boolean active, String criteria,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		_segmentsEntryResourcePermission.check(
 			getPermissionChecker(), segmentsEntryId, ActionKeys.UPDATE);
 
 		return segmentsEntryLocalService.updateSegmentsEntry(
-			segmentsEntryId, segmentsEntryKey, nameMap, descriptionMap, active,
-			criteria, serviceContext);
+			externalReferenceCode, segmentsEntryId, segmentsEntryKey, nameMap,
+			descriptionMap, active, criteria, serviceContext);
 	}
 
 	@Reference

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsEntryServiceImpl.java
@@ -42,9 +42,10 @@ public class SegmentsEntryServiceImpl extends SegmentsEntryServiceBaseImpl {
 
 	@Override
 	public SegmentsEntry addSegmentsEntry(
-			String segmentsEntryKey, Map<Locale, String> nameMap,
-			Map<Locale, String> descriptionMap, boolean active, String criteria,
-			String source, ServiceContext serviceContext)
+			String externalReferenceCode, String segmentsEntryKey,
+			Map<Locale, String> nameMap, Map<Locale, String> descriptionMap,
+			boolean active, String criteria, String source,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		_portletResourcePermission.check(
@@ -52,8 +53,8 @@ public class SegmentsEntryServiceImpl extends SegmentsEntryServiceBaseImpl {
 			SegmentsActionKeys.MANAGE_SEGMENTS_ENTRIES);
 
 		return segmentsEntryLocalService.addSegmentsEntry(
-			segmentsEntryKey, nameMap, descriptionMap, active, criteria, source,
-			serviceContext);
+			externalReferenceCode, segmentsEntryKey, nameMap, descriptionMap,
+			active, criteria, source, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/segments/segments-test-util/src/main/java/com/liferay/segments/test/util/SegmentsTestUtil.java
+++ b/modules/apps/segments/segments-test-util/src/main/java/com/liferay/segments/test/util/SegmentsTestUtil.java
@@ -96,7 +96,7 @@ public class SegmentsTestUtil {
 		throws PortalException {
 
 		return SegmentsEntryLocalServiceUtil.addSegmentsEntry(
-			segmentsEntryKey,
+			null, segmentsEntryKey,
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), name
 			).build(),

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/security/permission/resource/test/SegmentsEntryModelResourcePermissionWrapperTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/security/permission/resource/test/SegmentsEntryModelResourcePermissionWrapperTest.java
@@ -86,7 +86,7 @@ public class SegmentsEntryModelResourcePermissionWrapperTest {
 	public void testContainsWithSourceAsahFaroBackend() throws Exception {
 		SegmentsEntry segmentsEntry =
 			_segmentsEntryLocalService.addSegmentsEntry(
-				RandomTestUtil.randomString(),
+				null, RandomTestUtil.randomString(),
 				Collections.singletonMap(
 					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
 				Collections.singletonMap(

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/upgrade/v3_1_1/test/SegmentsEntryUpgradeProcessTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/upgrade/v3_1_1/test/SegmentsEntryUpgradeProcessTest.java
@@ -126,7 +126,7 @@ public class SegmentsEntryUpgradeProcessTest {
 		throws Exception {
 
 		_segmentsEntryLocalService.addSegmentsEntry(
-			RandomTestUtil.randomString(),
+			null, RandomTestUtil.randomString(),
 			Collections.singletonMap(locale, RandomTestUtil.randomString()),
 			Collections.singletonMap(locale, RandomTestUtil.randomString()),
 			true, criteria, SegmentsEntryConstants.SOURCE_DEFAULT,

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/upgrade/v3_3_0/test/SegmentsEntryExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/upgrade/v3_3_0/test/SegmentsEntryExternalReferenceCodeUpgradeProcessTest.java
@@ -42,7 +42,7 @@ public class SegmentsEntryExternalReferenceCodeUpgradeProcessTest
 
 		return new ExternalReferenceCodeModel[] {
 			_segmentsEntryLocalService.addSegmentsEntry(
-				RandomTestUtil.randomString(),
+				null, RandomTestUtil.randomString(),
 				Collections.singletonMap(
 					defaultLocale, RandomTestUtil.randomString()),
 				Collections.singletonMap(

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/upgrade/v4_0_0/test/SegmentsExperienceUpgradeProcessTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/upgrade/v4_0_0/test/SegmentsExperienceUpgradeProcessTest.java
@@ -217,7 +217,7 @@ public class SegmentsExperienceUpgradeProcessTest
 		Locale defaultLocale = LocaleUtil.getSiteDefault();
 
 		return _segmentsEntryLocalService.addSegmentsEntry(
-			RandomTestUtil.randomString(),
+			null, RandomTestUtil.randomString(),
 			Collections.singletonMap(
 				defaultLocale, RandomTestUtil.randomString()),
 			Collections.singletonMap(

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryLocalServiceTest.java
@@ -519,7 +519,7 @@ public class SegmentsEntryLocalServiceTest {
 				RandomTestUtil.randomLocaleStringMap(),
 				RandomTestUtil.randomLocaleStringMap(),
 				RandomTestUtil.randomBoolean(),
-				CriteriaSerializer.serialize(new Criteria()),
+				CriteriaSerializer.serialize(new Criteria()), null,
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		Assert.assertEquals(

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryLocalServiceTest.java
@@ -664,8 +664,8 @@ public class SegmentsEntryLocalServiceTest {
 
 		SegmentsEntry updatedSegmentsEntry =
 			_segmentsEntryLocalService.updateSegmentsEntry(
-				segmentsEntry.getSegmentsEntryId(), segmentsEntryKey, nameMap,
-				descriptionMap, false, criteria,
+				null, segmentsEntry.getSegmentsEntryId(), segmentsEntryKey,
+				nameMap, descriptionMap, false, criteria,
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		Assert.assertEquals(
@@ -695,7 +695,7 @@ public class SegmentsEntryLocalServiceTest {
 		_addSegmentsExperiment(segmentsEntry);
 
 		_segmentsEntryLocalService.updateSegmentsEntry(
-			segmentsEntry.getSegmentsEntryId(),
+			null, segmentsEntry.getSegmentsEntryId(),
 			segmentsEntry.getSegmentsEntryKey(), segmentsEntry.getNameMap(),
 			segmentsEntry.getDescriptionMap(), segmentsEntry.isActive(),
 			segmentsEntry.getCriteria(),
@@ -718,7 +718,7 @@ public class SegmentsEntryLocalServiceTest {
 		AssertUtils.assertFailure(
 			LockedSegmentsEntryException.class, null,
 			() -> _segmentsEntryLocalService.updateSegmentsEntry(
-				segmentsEntry.getSegmentsEntryId(),
+				null, segmentsEntry.getSegmentsEntryId(),
 				segmentsEntry.getSegmentsEntryKey(), segmentsEntry.getNameMap(),
 				segmentsEntry.getDescriptionMap(), segmentsEntry.isActive(),
 				segmentsEntry.getCriteria(),
@@ -737,7 +737,7 @@ public class SegmentsEntryLocalServiceTest {
 
 		SegmentsEntry updatedSegmentsEntry =
 			_segmentsEntryLocalService.updateSegmentsEntry(
-				segmentsEntry.getSegmentsEntryId(),
+				null, segmentsEntry.getSegmentsEntryId(),
 				segmentsEntry.getSegmentsEntryKey(), segmentsEntry.getNameMap(),
 				segmentsEntry.getDescriptionMap(), segmentsEntry.isActive(),
 				segmentsEntry.getCriteria(),
@@ -761,7 +761,7 @@ public class SegmentsEntryLocalServiceTest {
 		AssertUtils.assertFailure(
 			SegmentsEntryKeyException.class, null,
 			() -> _segmentsEntryLocalService.updateSegmentsEntry(
-				segmentsEntry.getSegmentsEntryId(), segmentsEntryKey,
+				null, segmentsEntry.getSegmentsEntryId(), segmentsEntryKey,
 				segmentsEntry.getNameMap(), segmentsEntry.getDescriptionMap(),
 				segmentsEntry.isActive(), segmentsEntry.getCriteria(),
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId())));
@@ -783,7 +783,7 @@ public class SegmentsEntryLocalServiceTest {
 
 		SegmentsEntry updatedSegmentsEntry =
 			_segmentsEntryLocalService.updateSegmentsEntry(
-				segmentsEntry.getSegmentsEntryId(),
+				null, segmentsEntry.getSegmentsEntryId(),
 				segmentsEntry.getSegmentsEntryKey(), segmentsEntry.getNameMap(),
 				segmentsEntry.getDescriptionMap(), false,
 				CriteriaSerializer.serialize(new Criteria()),
@@ -809,7 +809,7 @@ public class SegmentsEntryLocalServiceTest {
 
 		SegmentsEntry updatedSegmentsEntry =
 			_segmentsEntryLocalService.updateSegmentsEntry(
-				segmentsEntry.getSegmentsEntryId(),
+				null, segmentsEntry.getSegmentsEntryId(),
 				segmentsEntry.getSegmentsEntryKey(), segmentsEntry.getNameMap(),
 				segmentsEntry.getDescriptionMap(), false,
 				CriteriaSerializer.serialize(criteria),

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryLocalServiceTest.java
@@ -515,7 +515,7 @@ public class SegmentsEntryLocalServiceTest {
 	private void _testAddSegmentsEntryWithoutSource() throws Exception {
 		SegmentsEntry segmentsEntry =
 			_segmentsEntryLocalService.addSegmentsEntry(
-				RandomTestUtil.randomString(),
+				null, RandomTestUtil.randomString(),
 				RandomTestUtil.randomLocaleStringMap(),
 				RandomTestUtil.randomLocaleStringMap(),
 				RandomTestUtil.randomBoolean(),

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryServiceTest.java
@@ -80,7 +80,7 @@ public class SegmentsEntryServiceTest {
 		throws Exception {
 
 		_segmentsEntryService.addSegmentsEntry(
-			RandomTestUtil.randomString(),
+			null, RandomTestUtil.randomString(),
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(), true,
 			CriteriaSerializer.serialize(new Criteria()),
@@ -106,7 +106,7 @@ public class SegmentsEntryServiceTest {
 				_groupUser, PermissionCheckerFactoryUtil.create(_groupUser))) {
 
 			_segmentsEntryService.addSegmentsEntry(
-				RandomTestUtil.randomString(),
+				null, RandomTestUtil.randomString(),
 				RandomTestUtil.randomLocaleStringMap(),
 				RandomTestUtil.randomLocaleStringMap(), true,
 				CriteriaSerializer.serialize(new Criteria()),
@@ -124,7 +124,7 @@ public class SegmentsEntryServiceTest {
 				_groupUser, PermissionCheckerFactoryUtil.create(_groupUser))) {
 
 			_segmentsEntryService.addSegmentsEntry(
-				RandomTestUtil.randomString(),
+				null, RandomTestUtil.randomString(),
 				RandomTestUtil.randomLocaleStringMap(),
 				RandomTestUtil.randomLocaleStringMap(), true,
 				RandomTestUtil.randomString(),

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsEntryServiceTest.java
@@ -324,7 +324,7 @@ public class SegmentsEntryServiceTest {
 				_groupUser, PermissionCheckerFactoryUtil.create(_groupUser))) {
 
 			_segmentsEntryService.updateSegmentsEntry(
-				segmentsEntry.getSegmentsEntryId(),
+				null, segmentsEntry.getSegmentsEntryId(),
 				segmentsEntry.getSegmentsEntryKey(), segmentsEntry.getNameMap(),
 				segmentsEntry.getDescriptionMap(), segmentsEntry.isActive(),
 				segmentsEntry.getCriteria(), serviceContext);
@@ -348,7 +348,7 @@ public class SegmentsEntryServiceTest {
 				guestUser, PermissionCheckerFactoryUtil.create(guestUser))) {
 
 			_segmentsEntryService.updateSegmentsEntry(
-				segmentsEntry.getSegmentsEntryId(),
+				null, segmentsEntry.getSegmentsEntryId(),
 				RandomTestUtil.randomString(),
 				RandomTestUtil.randomLocaleStringMap(),
 				RandomTestUtil.randomLocaleStringMap(), true,
@@ -365,7 +365,8 @@ public class SegmentsEntryServiceTest {
 				_group, TestPropsValues.getUserId()));
 
 		_segmentsEntryService.updateSegmentsEntry(
-			segmentsEntry.getSegmentsEntryId(), RandomTestUtil.randomString(),
+			null, segmentsEntry.getSegmentsEntryId(),
+			RandomTestUtil.randomString(),
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(), true,
 			CriteriaSerializer.serialize(new Criteria()),

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/portlet/action/UpdateSegmentsEntryMVCActionCommand.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/portlet/action/UpdateSegmentsEntryMVCActionCommand.java
@@ -101,7 +101,7 @@ public class UpdateSegmentsEntryMVCActionCommand extends BaseMVCActionCommand {
 				String source = null;
 
 				segmentsEntry = _segmentsEntryService.addSegmentsEntry(
-					segmentsEntryKey, nameMap, descriptionMap, active,
+					null, segmentsEntryKey, nameMap, descriptionMap, active,
 					CriteriaSerializer.serialize(criteria), source,
 					serviceContext);
 			}

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/portlet/action/UpdateSegmentsEntryMVCActionCommand.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/portlet/action/UpdateSegmentsEntryMVCActionCommand.java
@@ -106,10 +106,13 @@ public class UpdateSegmentsEntryMVCActionCommand extends BaseMVCActionCommand {
 					serviceContext);
 			}
 			else {
+				segmentsEntry = _segmentsEntryService.getSegmentsEntry(
+					segmentsEntryId);
+
 				segmentsEntry = _segmentsEntryService.updateSegmentsEntry(
-					segmentsEntryId, segmentsEntryKey, nameMap, descriptionMap,
-					active, CriteriaSerializer.serialize(criteria),
-					serviceContext);
+					segmentsEntry.getExternalReferenceCode(), segmentsEntryId,
+					segmentsEntryKey, nameMap, descriptionMap, active,
+					CriteriaSerializer.serialize(criteria), serviceContext);
 			}
 
 			String redirect = ParamUtil.getString(actionRequest, "redirect");

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -3996,7 +3996,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 
 			if (segmentsEntry == null) {
 				segmentsEntry = _segmentsEntryLocalService.addSegmentsEntry(
-					jsonObject.getString("segmentsEntryKey"),
+					null, jsonObject.getString("segmentsEntryKey"),
 					SiteInitializerUtil.toMap(
 						jsonObject.getString("name_i18n")),
 					null, jsonObject.getBoolean("active", true),

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -4003,7 +4003,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 					jsonObject.get(
 						"criteria"
 					).toString(),
-					serviceContext);
+					null, serviceContext);
 			}
 			else {
 				segmentsEntry = _segmentsEntryLocalService.updateSegmentsEntry(

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -4007,6 +4007,7 @@ public class BundleSiteInitializer implements SiteInitializer {
 			}
 			else {
 				segmentsEntry = _segmentsEntryLocalService.updateSegmentsEntry(
+					segmentsEntry.getExternalReferenceCode(),
 					segmentsEntry.getSegmentsEntryId(),
 					jsonObject.getString("segmentsEntryKey"),
 					SiteInitializerUtil.toMap(

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/IndividualSegment.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/IndividualSegment.java
@@ -36,6 +36,10 @@ public class IndividualSegment {
 		return _embeddedResources;
 	}
 
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
 	public String getFilter() {
 		return _filter;
 	}
@@ -88,6 +92,10 @@ public class IndividualSegment {
 		_embeddedResources = embeddedResources;
 	}
 
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		_externalReferenceCode = externalReferenceCode;
+	}
+
 	public void setFilter(String filter) {
 		_filter = filter;
 	}
@@ -129,7 +137,8 @@ public class IndividualSegment {
 		return StringBundler.concat(
 			"{author=", _author, ", dateCreated=", _dateCreated,
 			", dateModified=", _dateModified, ", embeddedResources=",
-			_embeddedResources, ", filter=", _filter, ", filterMetadata=",
+			_embeddedResources, ", externalReferenceCode=",
+			_externalReferenceCode, ", filter=", _filter, ", filterMetadata=",
 			_filterMetadata, ", id=", _id, ", individualCount=",
 			_individualCount, ", name=", _name, ", scope=", _scope,
 			", segmentType=", _segmentType, ", state=", _state, ", status=",
@@ -164,6 +173,7 @@ public class IndividualSegment {
 	private Date _dateCreated;
 	private Date _dateModified;
 	private Map<String, Object> _embeddedResources = new HashMap<>();
+	private String _externalReferenceCode;
 	private String _filter;
 	private String _filterMetadata;
 	private String _id;

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/scheduler/CheckIndividualSegmentsSchedulerJobConfiguration.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/scheduler/CheckIndividualSegmentsSchedulerJobConfiguration.java
@@ -115,8 +115,9 @@ public class CheckIndividualSegmentsSchedulerJobConfiguration
 
 			if (segmentsEntry == null) {
 				_segmentsEntryLocalService.addSegmentsEntry(
-					individualSegment.getId(), nameMap, Collections.emptyMap(),
-					true, null, SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
+					null, individualSegment.getId(), nameMap,
+					Collections.emptyMap(), true, null,
+					SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
 					serviceContext);
 
 				return;

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/scheduler/CheckIndividualSegmentsSchedulerJobConfiguration.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/scheduler/CheckIndividualSegmentsSchedulerJobConfiguration.java
@@ -124,8 +124,9 @@ public class CheckIndividualSegmentsSchedulerJobConfiguration
 			}
 
 			_segmentsEntryLocalService.updateSegmentsEntry(
-				segmentsEntry.getSegmentsEntryId(), individualSegment.getId(),
-				nameMap, null, true, null, serviceContext);
+				null, segmentsEntry.getSegmentsEntryId(),
+				individualSegment.getId(), nameMap, null, true, null,
+				serviceContext);
 		}
 		catch (PortalException portalException) {
 			_log.error(

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/scheduler/CheckIndividualSegmentsSchedulerJobConfiguration.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/scheduler/CheckIndividualSegmentsSchedulerJobConfiguration.java
@@ -115,18 +115,18 @@ public class CheckIndividualSegmentsSchedulerJobConfiguration
 
 			if (segmentsEntry == null) {
 				_segmentsEntryLocalService.addSegmentsEntry(
-					null, individualSegment.getId(), nameMap,
-					Collections.emptyMap(), true, null,
-					SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
+					individualSegment.getExternalReferenceCode(),
+					individualSegment.getId(), nameMap, Collections.emptyMap(),
+					true, null, SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
 					serviceContext);
 
 				return;
 			}
 
 			_segmentsEntryLocalService.updateSegmentsEntry(
-				null, segmentsEntry.getSegmentsEntryId(),
-				individualSegment.getId(), nameMap, null, true, null,
-				serviceContext);
+				individualSegment.getExternalReferenceCode(),
+				segmentsEntry.getSegmentsEntryId(), individualSegment.getId(),
+				nameMap, null, true, null, serviceContext);
 		}
 		catch (PortalException portalException) {
 			_log.error(

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/AsahSegmentsEntryResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/AsahSegmentsEntryResourceImpl.java
@@ -66,6 +66,7 @@ public class AsahSegmentsEntryResourceImpl
 			}
 			else {
 				segmentsEntry = _segmentsEntryLocalService.updateSegmentsEntry(
+					segmentsEntry.getExternalReferenceCode(),
 					segmentsEntry.getSegmentsEntryId(),
 					asahSegmentsEntry.getId(), nameMap, null, true, null,
 					serviceContext);

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/AsahSegmentsEntryResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/AsahSegmentsEntryResourceImpl.java
@@ -59,8 +59,9 @@ public class AsahSegmentsEntryResourceImpl
 
 			if (segmentsEntry == null) {
 				segmentsEntry = _segmentsEntryLocalService.addSegmentsEntry(
-					asahSegmentsEntry.getId(), nameMap, Collections.emptyMap(),
-					true, null, SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
+					null, asahSegmentsEntry.getId(), nameMap,
+					Collections.emptyMap(), true, null,
+					SegmentsEntryConstants.SOURCE_ASAH_FARO_BACKEND,
 					serviceContext);
 			}
 			else {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98771

## What Is Being Fixed

When synchronizing segments from Analytics Cloud (Asah), the individual segment's external reference code was not taken into account, so the synchronized SegmentsEntry did not carry the Asah ERC.

## How It Is Being Fixed

An externalReferenceCode is threaded through the addSegmentsEntry and updateSegmentsEntry service methods (local and remote), and the older addSegmentsEntry overload that did not take a source is removed so every caller passes one. The Asah connector now syncs the individual segment external reference code when it checks segments.

## PR Check

**pr-check: PASS** — tested on `f93e8951a085caeca057e1082f07888495ce8992`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Baseline | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "f93e8951a085caeca057e1082f07888495ce8992"} -->
