### PR TITLE
LPD-90890 Let behavior criteria target any asset type

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/CriteriaSidebarCollapse.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/CriteriaSidebarCollapse.tsx
@@ -11,7 +11,6 @@ import {
 	RelationalOperators,
 	TimeSpans,
 } from '../utils/constants';
-import {getEventId, getSupportedApplicationIds} from '../utils/activity-keys';
 import {createCustomValueMap} from '../utils/custom-inputs';
 import {FieldOwnerTypes} from 'shared/util/constants';
 import {jsDatetoYYYYMMDD} from '../utils/utils';
@@ -136,23 +135,16 @@ export const getDefaultValue = (property: Property): any => {
 				{key: 'operator', value: RelationalOperators.GE},
 				{key: 'value', value: 1},
 			]);
-		case PropertyTypes.Behavior: {
-			const applicationId = getSupportedApplicationIds(name)[0];
+		case PropertyTypes.Behavior:
+
+			// No asset type is seeded: the criterion starts without an asset
+			// filter so the picker shows the "Select a type" placeholder and the
+			// user must choose a type (or Page) before the segment can be saved.
 
 			return createCustomValueMap([
 				{
 					key: 'criterionGroup',
 					value: [
-						{
-							operatorName: RelationalOperators.EQ,
-							propertyName: 'applicationId',
-							value: applicationId,
-						},
-						{
-							operatorName: RelationalOperators.EQ,
-							propertyName: 'eventId',
-							value: getEventId(applicationId, name),
-						},
 						{
 							operatorName: FunctionalOperators.Contains,
 							propertyName: 'attribute/',
@@ -168,7 +160,6 @@ export const getDefaultValue = (property: Property): any => {
 				{key: 'operator', value: RelationalOperators.GE},
 				{key: 'value', value: 1},
 			]);
-		}
 		case PropertyTypes.Tag:
 		case PropertyTypes.Vocabulary:
 			return createCustomValueMap([

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/CriteriaSidebarItem.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/CriteriaSidebarItem.tsx
@@ -9,7 +9,7 @@ import {Property} from 'shared/util/records';
 import {PropertyTypes} from '../utils/constants';
 
 const TYPE_ICON_MAP = {
-	[PropertyTypes.Behavior]: 'ac_event_analysis',
+	[PropertyTypes.Behavior]: 'click',
 	[PropertyTypes.Boolean]: 'check',
 	[PropertyTypes.AccountDate]: 'date',
 	[PropertyTypes.AccountNumber]: 'integer',
@@ -17,7 +17,7 @@ const TYPE_ICON_MAP = {
 	[PropertyTypes.Date]: 'date',
 	[PropertyTypes.DateTime]: 'date',
 	[PropertyTypes.Duration]: 'time',
-	[PropertyTypes.Event]: 'ac_event_analysis',
+	[PropertyTypes.Event]: 'click',
 	[PropertyTypes.Number]: 'integer',
 	[PropertyTypes.OrganizationBoolean]: 'check',
 	[PropertyTypes.OrganizationDate]: 'date',
@@ -59,7 +59,11 @@ export const beginDrag = ({
 
 	if (type === PropertyTypes.Behavior) {
 		touched = {asset: false, dateFilter: false, occurenceCount: false};
-		valid = {asset: true, dateFilter: true, occurenceCount: true};
+
+		// asset starts invalid: a behavior criterion requires the user to select
+		// an asset type (or Page) before the segment can be saved.
+
+		valid = {asset: false, dateFilter: true, occurenceCount: true};
 	}
 	else if (type === PropertyTypes.Event) {
 		touched = {occurenceCount: false};

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/__tests__/CriteriaSidebarCollapse.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/__tests__/CriteriaSidebarCollapse.jsx
@@ -312,35 +312,28 @@ describe('getDefaultValue', () => {
 		).toBe('true');
 	});
 
-	it('should return a single-type CustomValueMap (applicationId, eventId, day, operator and value) for PropertyTypes.Behavior', () => {
+	it('should seed no asset type for PropertyTypes.Behavior', () => {
 		const result = getDefaultValue(
 			new Property({name: 'download', type: PropertyTypes.Behavior})
 		);
 
-		// A behavior requires a type; it starts on the first the event supports
-		// (Download -> Document): applicationId eq 'Document' and eventId eq
-		// 'documentDownloaded'.
+		// A behavior no longer seeds an asset type: the criterion starts with the
+		// day and (empty) attribute filters but no applicationId/eventId, so the
+		// picker shows the "Select a Type" placeholder and the user must choose a
+		// type before saving.
 
-		const applicationIdIdx = getIndexFromPropertyName(
-			result,
-			'applicationId'
-		);
+		const items = result.getIn(['criterionGroup', 'items']);
 
-		expect(applicationIdIdx).toBeGreaterThanOrEqual(0);
-		expect(
-			result.getIn(['criterionGroup', 'items', applicationIdIdx, 'value'])
-		).toBe('Document');
-
-		const eventIdIdx = getIndexFromPropertyName(result, 'eventId');
-
-		expect(eventIdIdx).toBeGreaterThanOrEqual(0);
-		expect(
-			result.getIn(['criterionGroup', 'items', eventIdIdx, 'value'])
-		).toBe('documentDownloaded');
-
+		expect(items.size).toBe(2);
 		expect(getIndexFromPropertyName(result, 'day')).toBeGreaterThanOrEqual(
 			0
 		);
+
+		expect(getIndexFromPropertyName(result, 'applicationId')).toBeLessThan(
+			0
+		);
+		expect(getIndexFromPropertyName(result, 'eventId')).toBeLessThan(0);
+
 		expect(result.get('operator')).toBeTruthy();
 		expect(result.get('value')).toBe(1);
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/__tests__/CriteriaSidebarItem.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/__tests__/CriteriaSidebarItem.jsx
@@ -37,7 +37,7 @@ describe('CriteriaSidebarItem', () => {
 			expect(validateSegmentInputs(criterion)).toBe(true);
 		});
 
-		it('should not seed an invalid attribute flag for a Behavior criterion', () => {
+		it('should seed a Behavior criterion invalid until an asset type is chosen', () => {
 			const {criterion} = beginDrag({
 				defaultValue: {},
 				name: 'download',
@@ -45,8 +45,14 @@ describe('CriteriaSidebarItem', () => {
 				type: PropertyTypes.Behavior
 			});
 
-			expect(every(criterion.valid, Boolean)).toBe(true);
-			expect(validateSegmentInputs(criterion)).toBe(true);
+			// The asset flag starts invalid so Save stays disabled until the
+			// user picks a type; every other flag is seeded valid.
+
+			expect(criterion.valid.asset).toBe(false);
+			expect(criterion.valid.dateFilter).toBe(true);
+			expect(criterion.valid.occurenceCount).toBe(true);
+
+			expect(validateSegmentInputs(criterion)).toBe(false);
 		});
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/BehaviorInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/BehaviorInput.tsx
@@ -187,6 +187,12 @@ export class BehaviorInput extends React.Component<
 
 		const previousEventId = this.getEventId();
 
+		// An empty applicationId means the user is in Asset Type mode without a
+		// type chosen yet: the criterion carries no asset filter and stays invalid
+		// until a type (or Page) is selected.
+
+		const hasAssetType = !!applicationId;
+
 		const activityKeys = selections.map(({activityKey}) => activityKey);
 
 		if (selections.length) {
@@ -196,28 +202,16 @@ export class BehaviorInput extends React.Component<
 			});
 		}
 
-		// Specific assets -> match them by activityKey (a flat item, or an "or"
-		// group for N). No specific asset -> match every asset of the selected
-		// type via applicationId + eventId ("triggered Download on Documents").
+		// No type chosen -> no asset filter. No specific asset -> match every
+		// asset of the selected type via applicationId + eventId ("triggered
+		// Download on Documents"). Specific assets -> match them by activityKey (a
+		// flat item, or an "or" group for N).
 
-		const assetItems = activityKeys.length
-			? [
-					activityKeys.length > 1
-						? {
-								conjunctionName: Conjunctions.Or,
-								items: activityKeys.map((activityKey) => ({
-									operatorName: RelationalOperators.EQ,
-									propertyName: ACTIVITY_KEY,
-									value: activityKey,
-								})),
-							}
-						: {
-								operatorName: RelationalOperators.EQ,
-								propertyName: ACTIVITY_KEY,
-								value: activityKeys[0],
-							},
-				]
-			: [
+		let assetItems: any[] = [];
+
+		if (hasAssetType) {
+			if (!activityKeys.length) {
+				assetItems = [
 					{
 						operatorName: RelationalOperators.EQ,
 						propertyName: 'applicationId',
@@ -229,6 +223,29 @@ export class BehaviorInput extends React.Component<
 						value: eventId,
 					},
 				];
+			}
+			else if (activityKeys.length === 1) {
+				assetItems = [
+					{
+						operatorName: RelationalOperators.EQ,
+						propertyName: ACTIVITY_KEY,
+						value: activityKeys[0],
+					},
+				];
+			}
+			else {
+				assetItems = [
+					{
+						conjunctionName: Conjunctions.Or,
+						items: activityKeys.map((activityKey) => ({
+							operatorName: RelationalOperators.EQ,
+							propertyName: ACTIVITY_KEY,
+							value: activityKey,
+						})),
+					},
+				];
+			}
+		}
 
 		const items = value.getIn(['criterionGroup', 'items']) as List<any>;
 
@@ -243,7 +260,7 @@ export class BehaviorInput extends React.Component<
 
 		onChange({
 			touched: {...touched, asset: true},
-			valid: {...valid, asset: true},
+			valid: {...valid, asset: hasAssetType},
 			value: value.setIn(
 				['criterionGroup', 'items'],
 				List([

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/__tests__/BehaviorInput.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/__tests__/BehaviorInput.jsx
@@ -230,6 +230,31 @@ describe('BehaviorInput', () => {
 
 			expect(valid.asset).toBe(true);
 		});
+
+		it('should clear the asset filter and mark it invalid when no type is selected', () => {
+			const onChange = jest.fn();
+			const ref = renderWithRef(onChange);
+
+			ref.current.handlePageAssetSelect({
+				applicationId: '',
+				eventId: '',
+				selections: []
+			});
+
+			const {valid, value} = onChange.mock.calls[0][0];
+
+			const propertyNames = value
+				.getIn(['criterionGroup', 'items'])
+				.map(item => item.get('propertyName'))
+				.toArray();
+
+			// No asset type -> no applicationId/eventId/activityKey items, and the
+			// asset validity is false so the segment cannot be saved yet.
+
+			expect(propertyNames).not.toContain('applicationId');
+			expect(propertyNames).not.toContain(ACTIVITY_KEY);
+			expect(valid.asset).toBe(false);
+		});
 	});
 
 	describe('attribute filter', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/__tests__/__snapshots__/BehaviorInput.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/__tests__/__snapshots__/BehaviorInput.jsx.snap
@@ -55,12 +55,12 @@ exports[`BehaviorInput should render 1`] = `
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="Asset Type"
-          class="form-control form-control-select form-control-select-secondary operator-input"
+          class="form-control form-control-select-secondary operator-input form-control-select"
           role="combobox"
           tabindex="0"
           type="button"
         >
-          Blogs
+          Select a Type
         </button>
       </div>
       <div
@@ -283,12 +283,12 @@ exports[`BehaviorInput should render w/ data 1`] = `
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="Asset Type"
-          class="form-control form-control-select form-control-select-secondary operator-input"
+          class="form-control form-control-select-secondary operator-input form-control-select"
           role="combobox"
           tabindex="0"
           type="button"
         >
-          Blogs
+          Select a Type
         </button>
       </div>
       <div

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/SelectPageAssetInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/SelectPageAssetInput.tsx
@@ -2,7 +2,9 @@ import * as API from 'shared/api';
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import Form from 'shared/components/form';
+import getCN from 'classnames';
 import Label from 'shared/components/Label';
+import Loading, {Align} from 'shared/components/Loading';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {close, modalTypes, open} from 'shared/actions/modals';
 import {connect, ConnectedProps} from 'react-redux';
@@ -11,10 +13,7 @@ import {
 	activityAssetsListColumns,
 	detailsListColumns,
 } from 'shared/util/table-columns';
-import {
-	getEventId,
-	getSupportedApplicationIds,
-} from '../../utils/activity-keys';
+import {getEventId} from '../../utils/activity-keys';
 import {Option, Picker} from '@clayui/core';
 import {OrderedMap} from 'immutable';
 import {useLDPEnabled} from 'shared/hooks/useLDPEnabled';
@@ -117,29 +116,18 @@ export const getAssetTypeLabel = (
 	fallbackName: string = typeId
 ): string => PREDEFINED_ASSET_TYPE_LABELS[typeId] ?? fallbackName;
 
-// The asset types an action can target: the fixed DXP types for every DXP
-// applicationId it supports (Click -> blogs + webContent), plus — only when the
-// event supports ObjectEntry — the object-definition names, which are dynamic
-// and come from the asset-summary-types request. Exported to unit-test the
-// per-event picker contents.
+// Every asset type the picker offers, independent of the behavior: the fixed DXP
+// types plus the object-definition names (dynamic, from the asset-summary-types
+// request, fetched only on LDP plans). Exported to unit-test the picker contents.
 
 export const getCompatibleAssetTypes = (
-	assetSummaryTypes: AssetSummaryType[],
-	action: string | undefined
+	assetSummaryTypes: AssetSummaryType[]
 ): AssetSummaryType[] => {
-	const supportedApplicationIds = getSupportedApplicationIds(action);
+	const dxpTypes = Object.values(DXP_ASSET_TYPES);
 
-	const dxpTypes = supportedApplicationIds
-		.map((applicationId) => DXP_ASSET_TYPES[applicationId])
-		.filter(Boolean);
-
-	const objectDefinitionTypes = supportedApplicationIds.includes(
-		'ObjectEntry'
-	)
-		? assetSummaryTypes.filter(
-				(type) => resolveApplicationId(type.id) === 'ObjectEntry'
-			)
-		: [];
+	const objectDefinitionTypes = assetSummaryTypes.filter(
+		(type) => resolveApplicationId(type.id) === 'ObjectEntry'
+	);
 
 	return [...dxpTypes, ...objectDefinitionTypes];
 };
@@ -190,6 +178,36 @@ const PAGE_OR_ASSET_TYPE_OPTIONS = [
 	{label: Liferay.Language.get('asset-type'), value: 'assetType'},
 ];
 
+// A Picker trigger that mirrors the default Clay select trigger, but swaps the
+// caret (the form-control-select background) for a loading spinner while the
+// asset types load and disables itself, keeping the placeholder value visible.
+
+interface IAssetTypeTriggerProps
+	extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+	label?: string;
+	loading?: boolean;
+}
+
+const AssetTypeTrigger = React.forwardRef<
+	HTMLButtonElement,
+	IAssetTypeTriggerProps
+>(({label, loading, ...rest}, ref) => (
+	<button
+		{...rest}
+		className={getCN(
+			'form-control form-control-select-secondary operator-input',
+			{'form-control-select': !loading}
+		)}
+		disabled={loading}
+		ref={ref}
+		type="button"
+	>
+		{label}
+
+		{loading && <Loading align={Align.Right} />}
+	</button>
+));
+
 const connector = connect(null, {close, open});
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
@@ -228,17 +246,15 @@ const SelectPageAssetInput: React.FC<ISelectPageAssetInputProps> = ({
 	);
 
 	// The type the picker starts on: the DXP slug for the applicationId hint (on
-	// drop/reload) or, failing that, the first type the event supports.
-	// ObjectEntry has no synchronous slug, so it falls back and the reload effect
-	// refines it once the object-definition types load.
+	// drop/reload). A new criterion starts with no type, showing the "Select a
+	// type" placeholder; the reload effect refines an ObjectEntry hint once the
+	// object-definition types load.
 
 	const [assetType, setAssetType] = useState<string>(
 		() =>
 			(applicationId && applicationId !== 'Page'
 				? DXP_ASSET_TYPES[applicationId]?.id
-				: undefined) ??
-			DXP_ASSET_TYPES[getSupportedApplicationIds(action)[0]]?.id ??
-			''
+				: undefined) ?? ''
 	);
 
 	// Preselect the reloaded type only once, so it never fights a later user
@@ -246,21 +262,14 @@ const SelectPageAssetInput: React.FC<ISelectPageAssetInputProps> = ({
 
 	const didPreselectRef = useRef(false);
 
-	// Only ObjectEntry-supporting actions need the (dynamic) object-definition
-	// types from asset-summary-types; the rest offer just the fixed DXP types.
-
-	const objectEntrySupported =
-		getSupportedApplicationIds(action).includes('ObjectEntry');
-
 	// Object definitions only exist on LDP plans, so a non-LDP plan has no
-	// object-definition types to fetch. Skip asset-summary-types unless the
-	// action supports ObjectEntry AND the plan is LDP.
+	// object-definition types to fetch — it offers just the fixed DXP types.
 
 	const ldpEnabled = useLDPEnabled({groupId});
 
-	const shouldRequestAssetTypes = objectEntrySupported && ldpEnabled;
+	const shouldRequestAssetTypes = ldpEnabled;
 
-	const {data: assetTypesData} = useRequest<
+	const {data: assetTypesData, loading} = useRequest<
 		{
 			channelId: string;
 			groupId: string;
@@ -281,9 +290,16 @@ const SelectPageAssetInput: React.FC<ISelectPageAssetInputProps> = ({
 		},
 	});
 
+	// All-or-nothing loading: while the (LDP-only) asset-summary-types request is
+	// in flight, the type picker shows a loading indicator instead of a partial
+	// list. Guarded by shouldRequestAssetTypes because useRequest leaves `loading`
+	// true when the request is skipped (non-LDP), which must not block the picker.
+
+	const isLoadingAssetTypes = shouldRequestAssetTypes && loading;
+
 	const compatibleAssetTypes = useMemo(
-		() => getCompatibleAssetTypes(assetTypesData?.items ?? [], action),
-		[action, assetTypesData]
+		() => getCompatibleAssetTypes(assetTypesData?.items ?? []),
+		[assetTypesData]
 	);
 
 	// The type dropdown offers the types compatible with the event; a type is
@@ -296,6 +312,21 @@ const SelectPageAssetInput: React.FC<ISelectPageAssetInputProps> = ({
 				value: id,
 			})),
 		[compatibleAssetTypes]
+	);
+
+	// The label shown on the collapsed picker: the selected type's label, or the
+	// "Select a type" placeholder when nothing is chosen yet.
+
+	const assetTypeLabel = useMemo(
+		() =>
+			assetType
+				? getAssetTypeLabel(
+						assetType,
+						compatibleAssetTypes.find(({id}) => id === assetType)
+							?.name
+					)
+				: Liferay.Language.get('select-a-type'),
+		[assetType, compatibleAssetTypes]
 	);
 
 	// On reload, preselect the type matching the saved applicationId. DXP types
@@ -347,6 +378,20 @@ const SelectPageAssetInput: React.FC<ISelectPageAssetInputProps> = ({
 		typeValue: string = assetType,
 		isPageValue: boolean = isPage
 	) => {
+
+		// No asset type selected yet (and not Page): report an empty applicationId
+		// so the behavior criterion stays invalid until the user picks a type.
+
+		if (!isPageValue && !typeValue) {
+			onSelectionsChange?.({
+				applicationId: '',
+				eventId: '',
+				selections: [],
+			});
+
+			return;
+		}
+
 		const applicationId = isPageValue
 			? 'Page'
 			: resolveApplicationId(typeValue);
@@ -454,12 +499,11 @@ const SelectPageAssetInput: React.FC<ISelectPageAssetInputProps> = ({
 	const handleSelectorTypeChange = (value: SelectorType) => {
 		const nextIsPage = value === 'page';
 
-		// Switching to Asset Type starts on the first compatible type (a type is
-		// required); switching to Page keeps the current type value (unused).
+		// Switching to Asset Type clears the selection so the user must pick a
+		// type (the criterion is invalid until then); switching to Page keeps the
+		// current type value (unused).
 
-		const nextAssetType = nextIsPage
-			? assetType
-			: compatibleAssetTypes[0]?.id ?? '';
+		const nextAssetType = nextIsPage ? assetType : '';
 
 		setSelectorType(value);
 		setAssetType(nextAssetType);
@@ -507,12 +551,15 @@ const SelectPageAssetInput: React.FC<ISelectPageAssetInputProps> = ({
 				<Form.GroupItem shrink>
 					<Picker
 						aria-label={Liferay.Language.get('asset-type')}
+						as={AssetTypeTrigger}
 						className="operator-input"
 						items={assetTypeOptions}
+						label={assetTypeLabel}
+						loading={isLoadingAssetTypes}
 						onSelectionChange={(value) =>
 							handleAssetTypeChange(value as string)
 						}
-						selectedKey={assetType}
+						selectedKey={assetType || undefined}
 					>
 						{({label, value}) => (
 							<Option key={value}>{label}</Option>
@@ -582,6 +629,9 @@ const SelectPageAssetInput: React.FC<ISelectPageAssetInputProps> = ({
 				<Form.GroupItem shrink>
 					<ClayButton
 						className="button-root"
+						disabled={
+							!isPage && (!assetType || isLoadingAssetTypes)
+						}
 						displayType="secondary"
 						onClick={handleOpenModal}
 					>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/__tests__/SelectPageAssetInput.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/__tests__/SelectPageAssetInput.jsx
@@ -71,7 +71,7 @@ describe('getAssetTypeLabel', () => {
 	});
 });
 
-describe('getCompatibleAssetTypes (asset types the picker loads per event)', () => {
+describe('getCompatibleAssetTypes (asset types the picker offers)', () => {
 	// The request (asset-summary-types) returns only ObjectEntry object-
 	// definition names here (no DXP types), to prove the DXP types the picker
 	// offers are fixed by the mapping, not read from the request.
@@ -81,43 +81,10 @@ describe('getCompatibleAssetTypes (asset types the picker loads per event)', () 
 		{id: 'C_MyNewStructure', name: 'C_MyNewStructure'}
 	];
 
-	const compatibleIds = action =>
-		getCompatibleAssetTypes(OBJECT_DEFINITION_TYPES, action).map(
-			({id}) => id
-		);
-
-	it('should offer the fixed Blog and WebContent types for click', () => {
-		expect(compatibleIds('click')).toEqual(['blogs', 'webContent']);
-	});
-
-	it('should offer the fixed Blog type for comment', () => {
-		expect(compatibleIds('comment')).toEqual(['blogs']);
-	});
-
-	it('should offer Document plus the ObjectEntry object definitions for download', () => {
-		expect(compatibleIds('download')).toEqual([
-			'document',
-			'CMSBasicDocument',
-			'C_MyNewStructure'
-		]);
-	});
-
-	it('should offer Blog, Document, WebContent and the object definitions for impression', () => {
-		expect(compatibleIds('impression')).toEqual([
-			'blogs',
-			'document',
-			'webContent',
-			'CMSBasicDocument',
-			'C_MyNewStructure'
-		]);
-	});
-
-	it('should offer the fixed Form type for submit', () => {
-		expect(compatibleIds('submit')).toEqual(['forms']);
-	});
-
-	it('should offer every DXP type plus the object definitions for view', () => {
-		expect(compatibleIds('view')).toEqual([
+	it('should offer every DXP type plus the object definitions, independent of the event', () => {
+		expect(
+			getCompatibleAssetTypes(OBJECT_DEFINITION_TYPES).map(({id}) => id)
+		).toEqual([
 			'blogs',
 			'document',
 			'forms',
@@ -127,18 +94,31 @@ describe('getCompatibleAssetTypes (asset types the picker loads per event)', () 
 		]);
 	});
 
-	it('should omit object definitions for events that do not support ObjectEntry', () => {
-		expect(compatibleIds('click')).not.toContain('CMSBasicDocument');
-		expect(compatibleIds('submit')).not.toContain('CMSBasicDocument');
+	it('should offer the fixed DXP types when no object definitions are available', () => {
+		expect(getCompatibleAssetTypes([]).map(({id}) => id)).toEqual([
+			'blogs',
+			'document',
+			'forms',
+			'webContent'
+		]);
 	});
 
-	it('should keep every type when the action is unknown', () => {
-		expect(compatibleIds(undefined)).toEqual([
+	it('should include only the asset-summary types that resolve to ObjectEntry', () => {
+		// DXP-typed asset-summary items are already covered by the fixed types,
+		// so they are not duplicated from the request; only object definitions
+		// (which resolve to ObjectEntry) are appended.
+
+		const withDxpNoise = [
+			{id: 'blog', name: 'blog'},
+			{id: 'document', name: 'document'},
+			{id: 'C_MyNewStructure', name: 'C_MyNewStructure'}
+		];
+
+		expect(getCompatibleAssetTypes(withDxpNoise).map(({id}) => id)).toEqual([
 			'blogs',
 			'document',
 			'forms',
 			'webContent',
-			'CMSBasicDocument',
 			'C_MyNewStructure'
 		]);
 	});
@@ -162,20 +142,23 @@ describe('SelectPageAssetInput', () => {
 		fireEvent.click(getByRole('combobox', {name}));
 
 	describe('default asset type', () => {
-		it('should preselect the first compatible type with an add-assets button', () => {
-			const {getAllByRole, getByText} = render(
+		it('should show the placeholder and disable add-assets until a type is chosen', async () => {
+			const {getAllByRole, getByRole, getByText} = render(
 				<DefaultComponent action='view' />
 			);
 
-			// The Page | Asset Type picker plus the asset-type picker, which
-			// defaults to the first compatible type (Blogs) — a type is required.
+			// Once the asset types load, no type is preselected: the picker shows
+			// the "Select a Type" placeholder and add-assets stays disabled.
+
+			await waitFor(() =>
+				expect(
+					getByRole('combobox', {name: 'Asset Type'})
+				).toBeEnabled()
+			);
 
 			expect(getAllByRole('combobox')).toHaveLength(2);
-			expect(getByText('Blogs')).toBeTruthy();
-
-			// A type is always selected, so a specific asset can be picked at once.
-
-			expect(getByText(/add assets/i)).toBeTruthy();
+			expect(getByText('Select a Type')).toBeTruthy();
+			expect(getByRole('button', {name: /add assets/i})).toBeDisabled();
 		});
 
 		it('should not emit anything on mount', () => {
@@ -235,7 +218,7 @@ describe('SelectPageAssetInput', () => {
 	});
 
 	describe('asset type selector', () => {
-		it('should reveal the add-assets button and emit the type after choosing a type', () => {
+		it('should emit the type and enable add-assets after choosing a type', async () => {
 			const onSelectionsChange = jest.fn();
 
 			const {getByRole, getByText} = render(
@@ -245,12 +228,18 @@ describe('SelectPageAssetInput', () => {
 				/>
 			);
 
-			// Default is the first type (Blogs); choose a different one.
+			// Wait for the picker to finish loading, then choose a type.
+
+			await waitFor(() =>
+				expect(
+					getByRole('combobox', {name: 'Asset Type'})
+				).toBeEnabled()
+			);
 
 			openPicker(getByRole, 'Asset Type');
 			fireEvent.click(getByText('Web Content'));
 
-			expect(getByText(/add assets/i)).toBeTruthy();
+			expect(getByRole('button', {name: /add assets/i})).toBeEnabled();
 			expect(onSelectionsChange).toHaveBeenCalledWith({
 				applicationId: 'WebContent',
 				eventId: 'webContentViewed',
@@ -258,10 +247,23 @@ describe('SelectPageAssetInput', () => {
 			});
 		});
 
-		it('should open the modal with the select-asset config', () => {
-			const {getByText} = render(<DefaultComponent action='view' />);
+		it('should open the modal with the select-asset config', async () => {
+			const {getByRole, getByText} = render(
+				<DefaultComponent action='view' />
+			);
 
-			fireEvent.click(getByText(/add assets/i));
+			// Choose a type so the add-assets button becomes available.
+
+			await waitFor(() =>
+				expect(
+					getByRole('combobox', {name: 'Asset Type'})
+				).toBeEnabled()
+			);
+
+			openPicker(getByRole, 'Asset Type');
+			fireEvent.click(getByText('Web Content'));
+
+			fireEvent.click(getByRole('button', {name: /add assets/i}));
 
 			const config = open.mock.calls[0][1];
 
@@ -339,6 +341,7 @@ describe('SelectPageAssetInput', () => {
 			const {getAllByLabelText} = render(
 				<DefaultComponent
 					action='download'
+					applicationId='Document'
 					onSelectionsChange={onSelectionsChange}
 					selectedItems={[
 						{
@@ -407,29 +410,46 @@ describe('SelectPageAssetInput', () => {
 			expect(getAllByRole('combobox')).toHaveLength(1);
 		});
 
-		it('should offer a specific asset immediately (the first type is preselected)', () => {
-			const {getByText} = render(<DefaultComponent action='click' />);
+		it('should show the placeholder and disable add-assets until a type is chosen', async () => {
+			const {getByRole, getByText} = render(
+				<DefaultComponent action='click' />
+			);
 
-			// Click defaults to its first type (Blogs), so a specific asset can
-			// be picked right away.
+			// Asset-only actions still start with no type: the picker shows the
+			// placeholder and add-assets stays disabled until a type is chosen.
 
-			expect(getByText('Blogs')).toBeTruthy();
-			expect(getByText(/add assets/i)).toBeTruthy();
+			await waitFor(() =>
+				expect(
+					getByRole('combobox', {name: 'Asset Type'})
+				).toBeEnabled()
+			);
+
+			expect(getByText('Select a Type')).toBeTruthy();
+			expect(getByRole('button', {name: /add assets/i})).toBeDisabled();
 		});
 
-		it('should build a valid activityKey from the default click type', () => {
+		it('should build a valid activityKey from the chosen click type', async () => {
 			const onSelectionsChange = jest.fn();
 
-			const {getByText} = render(
+			const {getByRole, getByText} = render(
 				<DefaultComponent
 					action='click'
 					onSelectionsChange={onSelectionsChange}
 				/>
 			);
 
-			// Click defaults to Blog; pick a specific asset for it.
+			// Choose the Blog type, then pick a specific asset for it.
 
-			fireEvent.click(getByText(/add assets/i));
+			await waitFor(() =>
+				expect(
+					getByRole('combobox', {name: 'Asset Type'})
+				).toBeEnabled()
+			);
+
+			openPicker(getByRole, 'Asset Type');
+			fireEvent.click(getByText('Blogs'));
+
+			fireEvent.click(getByRole('button', {name: /add assets/i}));
 
 			const {onSubmit} = open.mock.calls[0][1];
 
@@ -454,16 +474,22 @@ describe('SelectPageAssetInput', () => {
 	});
 
 	describe('applicationId inference (reload)', () => {
-		it('should default to the asset-type selector when no applicationId is provided', () => {
-			const {getAllByRole, getByText} = render(
+		it('should default to the asset-type selector when no applicationId is provided', async () => {
+			const {getAllByRole, getByRole, getByText} = render(
 				<DefaultComponent action='view' />
 			);
 
-			// Asset Type mode (the default): Page | Asset Type picker + the
-			// asset-type picker, starting at the first type (Blogs).
+			// Asset Type mode (the default): once loaded, the Page | Asset Type
+			// picker + the asset-type picker, showing the placeholder.
+
+			await waitFor(() =>
+				expect(
+					getByRole('combobox', {name: 'Asset Type'})
+				).toBeEnabled()
+			);
 
 			expect(getAllByRole('combobox')).toHaveLength(2);
-			expect(getByText('Blogs')).toBeTruthy();
+			expect(getByText('Select a Type')).toBeTruthy();
 		});
 
 		it('should use the page selector for a Page applicationId', () => {
@@ -487,11 +513,20 @@ describe('SelectPageAssetInput', () => {
 
 	describe('asset type filtering', () => {
 		it('should query activity/asset with the applicationId resolved from the selected type', async () => {
-			const {getByText} = render(<DefaultComponent action='download' />);
+			const {getByRole} = render(
+				<DefaultComponent action='download' applicationId='Document' />
+			);
 
-			// Download defaults to its first type, Document (Documents and Media).
+			// The reloaded Document type is preselected; wait for loading, then
+			// open the asset modal.
 
-			fireEvent.click(getByText(/add assets/i));
+			await waitFor(() =>
+				expect(
+					getByRole('button', {name: /add assets/i})
+				).toBeEnabled()
+			);
+
+			fireEvent.click(getByRole('button', {name: /add assets/i}));
 
 			const {dataSourceFn} = open.mock.calls[0][1];
 
@@ -545,19 +580,27 @@ describe('SelectPageAssetInput', () => {
 			);
 		});
 
-		it('should build activityKeys (applicationId#eventId#assetId) on submit', () => {
+		it('should build activityKeys (applicationId#eventId#assetId) on submit', async () => {
 			const onSelectionsChange = jest.fn();
 
-			const {getByText} = render(
+			const {getByRole} = render(
 				<DefaultComponent
 					action='download'
+					applicationId='Document'
 					onSelectionsChange={onSelectionsChange}
 				/>
 			);
 
-			// Download defaults to Document (Documents and Media).
+			// The reloaded Document type is preselected; wait for loading, then
+			// open the asset modal.
 
-			fireEvent.click(getByText(/add assets/i));
+			await waitFor(() =>
+				expect(
+					getByRole('button', {name: /add assets/i})
+				).toBeEnabled()
+			);
+
+			fireEvent.click(getByRole('button', {name: /add assets/i}));
 
 			const {onSubmit} = open.mock.calls[0][1];
 
@@ -600,16 +643,25 @@ describe('SelectPageAssetInput', () => {
 		it('should not request asset-summary-types when the plan is not LDP', () => {
 			useLDPEnabled.mockReturnValue(false);
 
-			// Download supports ObjectEntry, so the request would normally run;
-			// a non-LDP plan has no object-definition types, so it is skipped.
+			// A non-LDP plan has no object-definition types, so the request is
+			// skipped and only the fixed DXP types are offered.
 
 			renderAndFlush({action: 'download'});
 
 			expect(API.assets.searchTypes).not.toHaveBeenCalled();
 		});
 
-		it('should request asset-summary-types for an ObjectEntry-supporting action on an LDP plan', () => {
+		it('should request asset-summary-types on an LDP plan', () => {
 			renderAndFlush({action: 'download'});
+
+			expect(API.assets.searchTypes).toHaveBeenCalled();
+		});
+
+		it('should request asset-summary-types on an LDP plan even for an event with no ObjectEntry support', () => {
+			// The request no longer depends on the event: comment maps only to
+			// Blog, yet the object definitions are still fetched on LDP.
+
+			renderAndFlush({action: 'comment'});
 
 			expect(API.assets.searchTypes).toHaveBeenCalled();
 		});
@@ -624,6 +676,60 @@ describe('SelectPageAssetInput', () => {
 			expect(API.assets.searchTypes).toHaveBeenCalledWith(
 				expect.objectContaining({rangeKey: null})
 			);
+		});
+	});
+
+	describe('asset type loading', () => {
+		// Drive the request with jest fake timers (like the LDP-gating tests) so
+		// the flush is deterministic and unaffected by fake/real timer toggling
+		// elsewhere in the file.
+
+		beforeEach(() => {
+			jest.useFakeTimers();
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
+		});
+
+		it('should show a spinner inside the disabled picker while the LDP request is in flight', async () => {
+			const {container, getByRole} = render(
+				<DefaultComponent action='view' />
+			);
+
+			// While loading: the picker is present but disabled, showing the
+			// placeholder and a spinner inside (all-or-nothing, no partial list).
+
+			const trigger = getByRole('combobox', {name: 'Asset Type'});
+
+			expect(trigger).toBeDisabled();
+			expect(trigger).toHaveTextContent('Select a Type');
+			expect(container.querySelector('.loading-root')).toBeTruthy();
+
+			// Flush the request (debounce timer + resolved-promise microtask).
+
+			await act(async () => {
+				jest.runAllTimers();
+			});
+
+			// Once it resolves, the picker is enabled and the spinner clears.
+
+			expect(getByRole('combobox', {name: 'Asset Type'})).toBeEnabled();
+			expect(container.querySelector('.loading-root')).toBeNull();
+		});
+
+		it('should render the asset types immediately without loading on a non-LDP plan', () => {
+			useLDPEnabled.mockReturnValue(false);
+
+			const {container, getByRole} = render(
+				<DefaultComponent action='view' />
+			);
+
+			// No request is made, so there is no loading — the fixed DXP types
+			// are available at once.
+
+			expect(container.querySelector('.loading-root')).toBeNull();
+			expect(getByRole('combobox', {name: 'Asset Type'})).toBeTruthy();
 		});
 	});
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/__tests__/activity-keys.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/__tests__/activity-keys.js
@@ -1,48 +1,6 @@
-import {
-	getActionFromEventId,
-	getEventId,
-	getSupportedApplicationIds,
-} from '../activity-keys';
+import {getActionFromEventId, getEventId} from '../activity-keys';
 
 describe('activity-keys', () => {
-	describe('getSupportedApplicationIds', () => {
-		it('should map each event action to the applicationIds that support it', () => {
-			expect(getSupportedApplicationIds('click')).toEqual([
-				'Blog',
-				'WebContent',
-			]);
-			expect(getSupportedApplicationIds('comment')).toEqual(['Blog']);
-			expect(getSupportedApplicationIds('download')).toEqual([
-				'Document',
-				'ObjectEntry',
-			]);
-			expect(getSupportedApplicationIds('impression')).toEqual([
-				'Blog',
-				'Document',
-				'ObjectEntry',
-				'WebContent',
-			]);
-			expect(getSupportedApplicationIds('submit')).toEqual(['Form']);
-			expect(getSupportedApplicationIds('view')).toEqual([
-				'Blog',
-				'Document',
-				'Form',
-				'ObjectEntry',
-				'WebContent',
-			]);
-		});
-
-		it('should return every applicationId for an unknown action', () => {
-			expect(getSupportedApplicationIds(undefined)).toEqual([
-				'Blog',
-				'Document',
-				'Form',
-				'ObjectEntry',
-				'WebContent',
-			]);
-		});
-	});
-
 	describe('getEventId', () => {
 		it('should resolve the analytics eventId for supported pairs', () => {
 			expect(getEventId('WebContent', 'click')).toBe('webContentClicked');

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/activity-keys.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/activity-keys.ts
@@ -46,22 +46,6 @@ export const getEventId = (
 	(applicationId === 'Page' ? 'pageViewed' : '');
 
 /**
- * The applicationIds that support an action, derived from EVENT_ID_MAP — the
- * asset types whose analytics events include that action (e.g. click ->
- * [Blog, WebContent], download -> [Document, ObjectEntry]). Used to offer only
- * the compatible asset types per event. An unknown action yields every
- * applicationId so nothing is filtered out.
- */
-export const getSupportedApplicationIds = (
-	action: string | undefined
-): string[] =>
-	action
-		? Object.keys(EVENT_ID_MAP).filter(
-				(applicationId) => EVENT_ID_MAP[applicationId][action]
-			)
-		: Object.keys(EVENT_ID_MAP);
-
-/**
  * Inverse of EVENT_ID_MAP (plus pageViewed): maps a stored, application-specific
  * eventId back to its generic WEB_BEHAVIORS action. Every "viewed" variant
  * collapses to `view`, "downloaded" to `download`, and so on.

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process.
 select-a-metric=Select a Metric
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage.
+select-a-type=Select a Type
 select-account=Select Account
 select-all=Select All
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items.

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ar.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ar.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_bg.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_bg.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ca.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ca.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_cs.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_cs.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_da.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_da.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_de.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_de.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_de_AT.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_de_AT.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_de_CH.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_de_CH.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_el.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_el.properties
@@ -1368,6 +1368,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_en.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_en.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process.
 select-a-metric=Select a Metric
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage.
+select-a-type=Select a Type
 select-account=Select Account
 select-all=Select All
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items.

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_en_AU.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_en_AU.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_en_CA.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_en_CA.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_en_GB.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_en_GB.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_en_IE.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_en_IE.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_es.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_es.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Seleccione un rango de fechas para exportar la lista de exclusión. La descarga puede tardar un par de minutos en procesarse.
 select-a-metric=Seleccione una métrica
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Seleccione un servidor para guardar sus datos. Esto podría afectar a la política de la organización sobre el almacenamiento de datos de usuario.
+select-a-type=Select a Type (Automatic Copy)
 select-account=Seleccionar cuenta
 select-all=Seleccionar todo
 select-an-interaction-period-for-the-selected-items=Seleccione un período de interacción para los elementos seleccionados.

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_es_AR.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_es_AR.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Seleccione un rango de fechas para exportar la lista de exclusión. La descarga puede tardar un par de minutos en procesarse.
 select-a-metric=Seleccione una métrica
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Seleccione un servidor para guardar sus datos. Esto podría afectar a la política de la organización sobre el almacenamiento de datos de usuario.
+select-a-type=Select a Type (Automatic Copy)
 select-account=Seleccionar cuenta
 select-all=Seleccionar todo
 select-an-interaction-period-for-the-selected-items=Seleccione un período de interacción para los elementos seleccionados.

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_es_CO.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_es_CO.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Seleccione un rango de fechas para exportar la lista de exclusión. La descarga puede tardar un par de minutos en procesarse.
 select-a-metric=Seleccione una métrica
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Seleccione un servidor para guardar sus datos. Esto podría afectar a la política de la organización sobre el almacenamiento de datos de usuario.
+select-a-type=Select a Type (Automatic Copy)
 select-account=Seleccionar cuenta
 select-all=Seleccionar todo
 select-an-interaction-period-for-the-selected-items=Seleccione un período de interacción para los elementos seleccionados.

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_es_MX.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_es_MX.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Seleccione un rango de fechas para exportar la lista de exclusión. La descarga puede tardar un par de minutos en procesarse.
 select-a-metric=Seleccione una métrica
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Seleccione un servidor para guardar sus datos. Esto podría afectar a la política de la organización sobre el almacenamiento de datos de usuario.
+select-a-type=Select a Type (Automatic Copy)
 select-account=Seleccionar cuenta
 select-all=Seleccionar todo
 select-an-interaction-period-for-the-selected-items=Seleccione un período de interacción para los elementos seleccionados.

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_et.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_et.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_eu.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_eu.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fa.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fa.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fi.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fi.properties
@@ -1369,6 +1369,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fr.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fr.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fr_BE.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fr_BE.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fr_CA.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fr_CA.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fr_CH.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_fr_CH.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_gl.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_gl.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_hi_IN.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_hi_IN.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_hr.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_hr.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_hr_BA.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_hr_BA.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_hu.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_hu.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_in.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_in.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_it.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_it.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_it_CH.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_it_CH.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_iw.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_iw.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ja.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ja.properties
@@ -1367,6 +1367,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=抑制リストをエクスポートする日付範囲を選択してください。ダウンロード処理には数分かかる場合があります。
 select-a-metric=メトリックを選択
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=データを保管するサーバーを選択してください。これは、あなたが所属する組織のユーザー データ保管ポリシーに影響する可能性があります。
+select-a-type=Select a Type (Automatic Copy)
 select-account=アカウントを選択
 select-all=すべて選択
 select-an-interaction-period-for-the-selected-items=選択した項目に対するインタラクション期間を選択してください。

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_kk.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_kk.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_km.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_km.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ko.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ko.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_lo.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_lo.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_lt.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_lt.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_mk.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_mk.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ms.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ms.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_my.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_my.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_nb.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_nb.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_nl.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_nl.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_nl_BE.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_nl_BE.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_no.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_no.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_pl.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_pl.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_pt_BR.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_pt_BR.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Selecionar um período para exportar sua lista de supressão. Seu download pode levar alguns minutos para ser processado.
 select-a-metric=Selecionar uma métrica
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Selecionar um serviço para armazenar seus dados. Isto pode ter consequências na política de sua organização sobre o armazenamento dos dados do usuário.
+select-a-type=Select a Type (Automatic Copy)
 select-account=Selecionar conta
 select-all=Selecionar tudo
 select-an-interaction-period-for-the-selected-items=Selecionar um período de interação para os itens selecionados.

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_pt_PT.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_pt_PT.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Selecionar um período para exportar sua lista de supressão. Seu download pode levar alguns minutos para ser processado.
 select-a-metric=Selecionar uma métrica
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Selecionar um serviço para armazenar seus dados. Isto pode ter consequências na política de sua organização sobre o armazenamento dos dados do usuário.
+select-a-type=Select a Type (Automatic Copy)
 select-account=Selecionar conta
 select-all=Selecionar tudo
 select-an-interaction-period-for-the-selected-items=Selecionar um período de interação para os itens selecionados.

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ro.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ro.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ru.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ru.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_sk.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_sk.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_sl.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_sl.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_sr_RS.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_sr_RS.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_sv.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_sv.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ta_IN.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_ta_IN.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_th.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_th.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_tr.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_tr.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_uk.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_uk.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_vi.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_vi.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_zh_CN.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_zh_CN.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_zh_TW.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/resources/content/Language_zh_TW.properties
@@ -1370,6 +1370,7 @@ select-a-date-range-to-export-your-request-log.-your-download-may-take-a-couple-
 select-a-date-range-to-export-your-suppression-list.-your-download-may-take-a-couple-minutes-to-process=Select a date range to export your suppression list. Your download may take a couple minutes to process. (Automatic Copy)
 select-a-metric=Select a Metric (Automatic Copy)
 select-a-server-to-store-your-data.-this-could-have-implications-to-your-organizations-policy-on-user-data-storage=Select a server to store your data. This could have implications to your organization's policy on user data storage. (Automatic Copy)
+select-a-type=Select a Type (Automatic Copy)
 select-account=Select Account (Automatic Copy)
 select-all=Select All (Automatic Copy)
 select-an-interaction-period-for-the-selected-items=Select an interaction period for the selected items. (Automatic Copy)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90890

## What Is Being Fixed

In the dynamic segment editor, a Behavior criterion's asset-type picker was filtered by the selected event: only the asset types whose analytics event supported that action were offered, and a type was preselected by default. This follow-up makes the picker offer every asset type regardless of the event, require an explicit selection before the segment can be saved, and show a loading state while the (LDP-only) object-definition types load. The event criteria sidebar icon is also updated.

## How It Is Being Fixed

The asset-type picker now lists every type — the four fixed DXP types plus all object-definition names — independently of the behavior, and the object-definition request runs on any LDP plan rather than only for ObjectEntry-supporting events. The picker no longer preselects a type; it shows a "Select a Type" placeholder, and the behavior criterion is seeded without a default type and starts invalid so Save stays disabled until the user picks a type (or Page). While the object-definition request is in flight, the picker renders a spinner inside the disabled trigger instead of a partial list. Finally, the event criteria sidebar icon (default and custom events) changed from ac_event_analysis to click.

Resent from interaminense/liferay-portal#524