### PR TITLE
LPD-97931 Add FDS-shaped field-catalog endpoint

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -174,7 +174,7 @@ public interface ContactsEngineClient {
 		throws FaroEngineClientException;
 
 	public Map<String, List<DataSourceFieldCatalogEntry>>
-		discoverDataSourceFieldCatalog(
+		discoverDataSourceFieldCatalogEntries(
 			FaroProject faroProject, DataSource dataSource);
 
 	public <T> T get(
@@ -364,8 +364,14 @@ public interface ContactsEngineClient {
 		FaroProject faroProject, String id, String name, int cur, int delta);
 
 	public Map<String, List<DataSourceFieldCatalogEntry>>
-		getDataSourceFieldCatalog(
+		getDataSourceFieldCatalogEntries(
 			FaroProject faroProject, String id, boolean refresh);
+
+	public Results<DataSourceFieldCatalogEntry>
+			getDataSourceFieldCatalogEntries(
+				FaroProject faroProject, String entityType, String filterString,
+				String id, String search, int cur, int delta, String sortString)
+		throws FaroEngineClientException;
 
 	public List<DataSourceField> getDataSourceFields(
 		FaroProject faroProject, String id, String context, int count);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -578,7 +578,7 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public Map<String, List<DataSourceFieldCatalogEntry>>
-		discoverDataSourceFieldCatalog(
+		discoverDataSourceFieldCatalogEntries(
 			FaroProject faroProject, DataSource dataSource) {
 
 		dataSource.setWorkspaceURL(getWorkspaceURL(faroProject.getGroupId()));
@@ -1767,7 +1767,7 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public Map<String, List<DataSourceFieldCatalogEntry>>
-		getDataSourceFieldCatalog(
+		getDataSourceFieldCatalogEntries(
 			FaroProject faroProject, String id, boolean refresh) {
 
 		Map<String, Object> uriVariables = getUriVariables(faroProject, id);
@@ -1780,6 +1780,46 @@ public class ContactsEngineClientImpl
 				<Map<String, List<DataSourceFieldCatalogEntry>>>() {
 			},
 			uriVariables);
+	}
+
+	@Override
+	public Results<DataSourceFieldCatalogEntry>
+			getDataSourceFieldCatalogEntries(
+				FaroProject faroProject, String entityType, String filterString,
+				String id, String search, int cur, int delta, String sortString)
+		throws FaroEngineClientException {
+
+		Map<String, Object> uriVariables = getUriVariables(
+			faroProject, cur, delta, null);
+
+		uriVariables.put("entityType", entityType);
+
+		if (Validator.isNotNull(filterString)) {
+			uriVariables.put("filter", filterString);
+		}
+
+		uriVariables.put("id", id);
+
+		if (Validator.isNotNull(search)) {
+			uriVariables.put("search", search);
+		}
+
+		if (Validator.isNotNull(sortString)) {
+			uriVariables.put(
+				"sort",
+				Arrays.asList(
+					StringUtil.replace(
+						sortString, CharPool.COLON, CharPool.COMMA)));
+		}
+
+		PagedModel<?, DataSourceFieldCatalogEntry> pagedModel = get(
+			faroProject, Rels.DATA_SOURCE_FIELDS,
+			new ParameterizedTypeReference
+				<EntityModelPagedModel<DataSourceFieldCatalogEntry>>() {
+			},
+			uriVariables);
+
+		return pagedModel.getResults();
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -307,10 +307,10 @@ public abstract class BaseMockContactsEngineClientImpl
 
 	@Override
 	public Map<String, List<DataSourceFieldCatalogEntry>>
-		discoverDataSourceFieldCatalog(
+		discoverDataSourceFieldCatalogEntries(
 			FaroProject faroProject, DataSource dataSource) {
 
-		return contactsEngineClient.discoverDataSourceFieldCatalog(
+		return contactsEngineClient.discoverDataSourceFieldCatalogEntries(
 			faroProject, dataSource);
 	}
 
@@ -720,11 +720,23 @@ public abstract class BaseMockContactsEngineClientImpl
 
 	@Override
 	public Map<String, List<DataSourceFieldCatalogEntry>>
-		getDataSourceFieldCatalog(
+		getDataSourceFieldCatalogEntries(
 			FaroProject faroProject, String id, boolean refresh) {
 
-		return contactsEngineClient.getDataSourceFieldCatalog(
+		return contactsEngineClient.getDataSourceFieldCatalogEntries(
 			faroProject, id, refresh);
+	}
+
+	@Override
+	public Results<DataSourceFieldCatalogEntry>
+			getDataSourceFieldCatalogEntries(
+				FaroProject faroProject, String entityType, String filterString,
+				String id, String search, int cur, int delta, String sortString)
+		throws FaroEngineClientException {
+
+		return contactsEngineClient.getDataSourceFieldCatalogEntries(
+			faroProject, entityType, filterString, id, search, cur, delta,
+			sortString);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
@@ -51,6 +51,7 @@ import com.liferay.osb.faro.web.internal.controller.FaroController;
 import com.liferay.osb.faro.web.internal.exception.FaroException;
 import com.liferay.osb.faro.web.internal.exception.FaroValidationException;
 import com.liferay.osb.faro.web.internal.helper.ContactsCSVHelper;
+import com.liferay.osb.faro.web.internal.model.display.FaroFDSResultsDisplay;
 import com.liferay.osb.faro.web.internal.model.display.FaroResultsDisplay;
 import com.liferay.osb.faro.web.internal.model.display.contacts.ChannelDataSourceDisplay;
 import com.liferay.osb.faro.web.internal.model.display.contacts.DXPGroupDisplay;
@@ -463,10 +464,11 @@ public class DataSourceFaroController extends BaseFaroController {
 	@Path("/field-catalog")
 	@POST
 	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
-	public Map<String, List<DataSourceFieldCatalogEntry>> discoverFieldCatalog(
-			@PathParam("groupId") long groupId,
-			@FormParam("credentials") Credentials credentials,
-			@FormParam("url") String url)
+	public Map<String, List<DataSourceFieldCatalogEntry>>
+			discoverDataSourceFieldCatalogEntries(
+				@PathParam("groupId") long groupId,
+				@FormParam("credentials") Credentials credentials,
+				@FormParam("url") String url)
 		throws Exception {
 
 		DataSource dataSource = new DataSource();
@@ -479,7 +481,7 @@ public class DataSourceFaroController extends BaseFaroController {
 		dataSource.setProvider(new SalesforceProvider());
 		dataSource.setUrl(url);
 
-		return contactsEngineClient.discoverDataSourceFieldCatalog(
+		return contactsEngineClient.discoverDataSourceFieldCatalogEntries(
 			faroProjectLocalService.getFaroProjectByGroupId(groupId),
 			dataSource);
 	}
@@ -538,6 +540,44 @@ public class DataSourceFaroController extends BaseFaroController {
 			groupId,
 			contactsEngineClient.getDataSource(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId), id));
+	}
+
+	@GET
+	@Path("/{id}/field-catalog")
+	@RolesAllowed(RoleConstants.SITE_MEMBER)
+	public Map<String, List<DataSourceFieldCatalogEntry>>
+			getDataSourceFieldCatalogEntries(
+				@PathParam("groupId") long groupId, @PathParam("id") String id,
+				@QueryParam("refresh") boolean refresh)
+		throws Exception {
+
+		return contactsEngineClient.getDataSourceFieldCatalogEntries(
+			faroProjectLocalService.getFaroProjectByGroupId(groupId), id,
+			refresh);
+	}
+
+	@GET
+	@Path("/{id}/field-catalog/{entityType}")
+	@RolesAllowed(RoleConstants.SITE_MEMBER)
+	public FaroFDSResultsDisplay<DataSourceFieldCatalogEntry>
+			getDataSourceFieldCatalogEntriesFaroFDSResultsDisplay(
+				@PathParam("groupId") long groupId, @PathParam("id") String id,
+				@PathParam("entityType") String entityType,
+				@QueryParam("filter") String filterString,
+				@QueryParam("page") int page,
+				@QueryParam("pageSize") int pageSize,
+				@QueryParam("search") String search,
+				@DefaultValue(StringPool.BLANK) @QueryParam("sort") String
+					sortString)
+		throws Exception {
+
+		Results<DataSourceFieldCatalogEntry> results =
+			contactsEngineClient.getDataSourceFieldCatalogEntries(
+				faroProjectLocalService.getFaroProjectByGroupId(groupId),
+				entityType, filterString, id, search, page, pageSize,
+				sortString);
+
+		return new FaroFDSResultsDisplay<>(results, page, pageSize);
 	}
 
 	@Path("/data_source_id")
@@ -916,19 +956,6 @@ public class DataSourceFaroController extends BaseFaroController {
 	@Override
 	public int[] getEntityTypes() {
 		return _ENTITY_TYPES.clone();
-	}
-
-	@GET
-	@Path("/{id}/field-catalog")
-	@RolesAllowed(RoleConstants.SITE_MEMBER)
-	public Map<String, List<DataSourceFieldCatalogEntry>> getFieldCatalog(
-			@PathParam("groupId") long groupId, @PathParam("id") String id,
-			@QueryParam("refresh") boolean refresh)
-		throws Exception {
-
-		return contactsEngineClient.getDataSourceFieldCatalog(
-			faroProjectLocalService.getFaroProjectByGroupId(groupId), id,
-			refresh);
 	}
 
 	@GET

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroControllerTest.java
@@ -19,6 +19,7 @@ import com.liferay.osb.faro.model.FaroProject;
 import com.liferay.osb.faro.service.FaroProjectLocalService;
 import com.liferay.osb.faro.util.FaroPropsValues;
 import com.liferay.osb.faro.web.internal.helper.ContactsCSVHelper;
+import com.liferay.osb.faro.web.internal.model.display.FaroFDSResultsDisplay;
 import com.liferay.osb.faro.web.internal.model.display.contacts.DataSourceMappingDisplay;
 import com.liferay.osb.faro.web.internal.param.FaroParam;
 import com.liferay.portal.json.JSONFactoryImpl;
@@ -271,7 +272,7 @@ public class DataSourceFaroControllerTest {
 	}
 
 	@Test
-	public void testDiscoverFieldCatalog() throws Exception {
+	public void testDiscoverDataSourceFieldCatalogEntries() throws Exception {
 		Map<String, List<DataSourceFieldCatalogEntry>>
 			dataSourceFieldCatalogEntries =
 				HashMapBuilder.<String, List<DataSourceFieldCatalogEntry>>put(
@@ -282,7 +283,7 @@ public class DataSourceFaroControllerTest {
 				).build();
 
 		Mockito.when(
-			_contactsEngineClient.discoverDataSourceFieldCatalog(
+			_contactsEngineClient.discoverDataSourceFieldCatalogEntries(
 				Mockito.eq(_faroProject), Mockito.any(DataSource.class))
 		).thenReturn(
 			dataSourceFieldCatalogEntries
@@ -290,7 +291,7 @@ public class DataSourceFaroControllerTest {
 
 		Assert.assertSame(
 			dataSourceFieldCatalogEntries,
-			_dataSourceFaroController.discoverFieldCatalog(
+			_dataSourceFaroController.discoverDataSourceFieldCatalogEntries(
 				32719L, null, "https://test.my.salesforce.com/"));
 
 		ArgumentCaptor<DataSource> argumentCaptor = ArgumentCaptor.forClass(
@@ -298,7 +299,7 @@ public class DataSourceFaroControllerTest {
 
 		Mockito.verify(
 			_contactsEngineClient
-		).discoverDataSourceFieldCatalog(
+		).discoverDataSourceFieldCatalogEntries(
 			Mockito.eq(_faroProject), argumentCaptor.capture()
 		);
 
@@ -338,6 +339,79 @@ public class DataSourceFaroControllerTest {
 
 		Assert.assertNotNull(token);
 		Assert.assertFalse(token.isEmpty());
+	}
+
+	@Test
+	public void testGetDataSourceFieldCatalogEntries() throws Exception {
+		Map<String, List<DataSourceFieldCatalogEntry>>
+			dataSourceFieldCatalogEntries =
+				HashMapBuilder.<String, List<DataSourceFieldCatalogEntry>>put(
+					"ACCOUNT",
+					Arrays.asList(
+						new DataSourceFieldCatalogEntry(
+							"Industry", false, false, "picklist"),
+						new DataSourceFieldCatalogEntry(
+							"Name", true, true, "string"))
+				).build();
+
+		Mockito.when(
+			_contactsEngineClient.getDataSourceFieldCatalogEntries(
+				_faroProject, "32783", true)
+		).thenReturn(
+			dataSourceFieldCatalogEntries
+		);
+
+		Assert.assertSame(
+			dataSourceFieldCatalogEntries,
+			_dataSourceFaroController.getDataSourceFieldCatalogEntries(
+				32719L, "32783", true));
+
+		Mockito.verify(
+			_contactsEngineClient
+		).getDataSourceFieldCatalogEntries(
+			_faroProject, "32783", true
+		);
+	}
+
+	@Test
+	public void testGetDataSourceFieldCatalogEntriesFaroFDSResultsDisplay()
+		throws Exception {
+
+		Results<DataSourceFieldCatalogEntry> results = new Results<>(
+			Arrays.asList(
+				new DataSourceFieldCatalogEntry(
+					"Industry", false, false, "picklist"),
+				new DataSourceFieldCatalogEntry("Name", true, true, "string")),
+			93);
+
+		Mockito.when(
+			_contactsEngineClient.getDataSourceFieldCatalogEntries(
+				_faroProject, "ACCOUNT", "type eq 'string'", "32783", "Na", 1,
+				20, "name:asc")
+		).thenReturn(
+			results
+		);
+
+		FaroFDSResultsDisplay<DataSourceFieldCatalogEntry>
+			faroFDSResultsDisplay =
+				_dataSourceFaroController.
+					getDataSourceFieldCatalogEntriesFaroFDSResultsDisplay(
+						32719L, "32783", "ACCOUNT", "type eq 'string'", 1, 20,
+						"Na", "name:asc");
+
+		Assert.assertEquals(
+			results.getItems(), faroFDSResultsDisplay.getItems());
+		Assert.assertEquals(5, faroFDSResultsDisplay.getLastPage());
+		Assert.assertEquals(1, faroFDSResultsDisplay.getPage());
+		Assert.assertEquals(20, faroFDSResultsDisplay.getPageSize());
+		Assert.assertEquals(93, faroFDSResultsDisplay.getTotalCount());
+
+		Mockito.verify(
+			_contactsEngineClient
+		).getDataSourceFieldCatalogEntries(
+			_faroProject, "ACCOUNT", "type eq 'string'", "32783", "Na", 1, 20,
+			"name:asc"
+		);
 	}
 
 	@Test
@@ -386,37 +460,6 @@ public class DataSourceFaroControllerTest {
 		Assert.assertEquals(
 			dataSourceMappingDisplays.toString(), 13,
 			dataSourceMappingDisplays.size());
-	}
-
-	@Test
-	public void testGetFieldCatalog() throws Exception {
-		Map<String, List<DataSourceFieldCatalogEntry>>
-			dataSourceFieldCatalogEntries =
-				HashMapBuilder.<String, List<DataSourceFieldCatalogEntry>>put(
-					"ACCOUNT",
-					Arrays.asList(
-						new DataSourceFieldCatalogEntry(
-							"Industry", false, false, "picklist"),
-						new DataSourceFieldCatalogEntry(
-							"Name", true, true, "string"))
-				).build();
-
-		Mockito.when(
-			_contactsEngineClient.getDataSourceFieldCatalog(
-				_faroProject, "32783", true)
-		).thenReturn(
-			dataSourceFieldCatalogEntries
-		);
-
-		Assert.assertSame(
-			dataSourceFieldCatalogEntries,
-			_dataSourceFaroController.getFieldCatalog(32719L, "32783", true));
-
-		Mockito.verify(
-			_contactsEngineClient
-		).getDataSourceFieldCatalog(
-			_faroProject, "32783", true
-		);
 	}
 
 	@Test


### PR DESCRIPTION
## What

Adds a paginated, FDS-shaped field-catalog endpoint to `DataSourceFaroController`:

`GET /o/faro/contacts/{groupId}/data_source/{id}/field-catalog/{entityType}`

The Salesforce field picker is being rebuilt on a **Frontend Data Set**, which appends `page` (1-based), `pageSize`, `search`, `filter` (OData), and `sort` (`name:asc`) to its `apiURL` and expects a paginated response **per entity type**:

```json
{ "items": [ { "name": "...", "type": "...", "required": false, "selected": false } ],
  "page": 1, "pageSize": 20, "lastPage": 5, "totalCount": 93 }
```

## How

- **`osb-faro-engine-client`** — new `ContactsEngineClient#getDataSourceFieldCatalogPage(...)` returning `Results<DataSourceFieldCatalogEntry>`, modeled on `getAccountLifecycleAccounts`. It reuses the existing `Rels.DATA_SOURCE_FIELDS` rel (routed by the `entityType` param), maps FDS's 1-based `page` to AC's 0-based page via `getUriVariables` (`page = cur - 1`), and translates `name:asc` → `["name,asc"]`.
- **`osb-faro-mock-engine-client`** — delegating override in `BaseMockContactsEngineClientImpl`.
- **`osb-faro-web`** — thin pass-through controller method (`@RolesAllowed(SITE_MEMBER)`) that forwards the FDS params and wraps the result in the existing `FaroFDSResultsDisplay`. No new DTO/model/rel/language keys.
- The existing full-map `field-catalog` reads (`POST /field-catalog`, `GET /{id}/field-catalog`) are **untouched**.

## Testing

- Added `DataSourceFaroControllerTest#testGetFieldCatalogFaroFDSResultsDisplay` — asserts the FDS shape (`items`, `page`, `pageSize`, `lastPage`, `totalCount`) and parameter forwarding. Passes.
- `formatSource` is clean.

## Depends on

- **LPD-97992** — the AC paginated read on the reused `GET /data-sources/{id}/fields?entityType=…` endpoint. This forwards to it; land AC first so the `entityType` route exists at runtime.