### PR TITLE
LPD-97795 faro-v5.0.x Link account activity sessions to individuals

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/utils/__tests__/formatAccountSessions.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/utils/__tests__/formatAccountSessions.ts
@@ -23,6 +23,7 @@ const buildSession = (
 				properties: [],
 			},
 		],
+		individualId: null,
 		languageId: 'en-US',
 		screenHeight: 1080,
 		screenWidth: 1920,
@@ -65,9 +66,9 @@ describe('formatAccountSessions', () => {
 		]);
 	});
 
-	it('marks a session without a userName as anonymous', () => {
+	it('marks a session without an individualId as anonymous', () => {
 		const [, userHeader] = formatAccountSessions([
-			buildSession({userName: null}),
+			buildSession({individualId: null, userName: null}),
 		]);
 
 		expect(userHeader.userHeader).toBe(true);
@@ -75,38 +76,61 @@ describe('formatAccountSessions', () => {
 		expect(userHeader.title).toBe(ANONYMOUS);
 	});
 
-	it('marks a session with a userName as a known individual', () => {
+	it('marks a session with an individualId as a known individual', () => {
 		const [, userHeader] = formatAccountSessions([
-			buildSession({userName: 'Grace Hopper'}),
+			buildSession({individualId: 'ind-1', userName: 'Grace Hopper'}),
 		]);
 
 		expect(userHeader.isAnonymous).toBe(false);
 		expect(userHeader.title).toBe('Grace Hopper');
 	});
 
-	it('links a known individual to their page keyed by userId', () => {
+	it('links a known individual to their page by individualId', () => {
 		const [, userHeader] = formatAccountSessions(
-			[buildSession({userId: 'abc123', userName: 'Grace Hopper'})],
+			[
+				buildSession({
+					individualId: 'ind-1',
+					userId: 'abc123',
+					userName: 'Grace Hopper',
+				}),
+			],
 			{channelId: '420253908131944590', groupId: 'liferay.com'}
 		);
 
 		expect(userHeader.title).toBe('Grace Hopper');
 		expect(userHeader.userHeaderUrl).toBe(
-			'/workspace/liferay.com/420253908131944590/contacts/individuals/known-individuals/abc123'
+			'/workspace/liferay.com/420253908131944590/contacts/individuals/known-individuals/ind-1'
 		);
 	});
 
-	it('shows the userId instead of "Anonymous" for a nameless individual', () => {
+	it('links an anonymous session by its userId when there is no individualId', () => {
 		const [, userHeader] = formatAccountSessions(
-			[buildSession({userId: 'anon999', userName: null})],
+			[buildSession({userId: 'abc123', userName: null})],
 			{channelId: '420253908131944590', groupId: 'liferay.com'}
 		);
 
 		expect(userHeader.isAnonymous).toBe(true);
-		expect(userHeader.title).toBe('anon999');
+		expect(userHeader.title).toBe('abc123');
 		expect(userHeader.userHeaderUrl).toBe(
-			'/workspace/liferay.com/420253908131944590/contacts/individuals/known-individuals/anon999'
+			'/workspace/liferay.com/420253908131944590/contacts/individuals/known-individuals/abc123'
 		);
+	});
+
+	it('does not link a session without an individualId or userId', () => {
+		const [, userHeader] = formatAccountSessions(
+			[
+				buildSession({
+					individualId: null,
+					userId: null,
+					userName: 'Grace Hopper',
+				}),
+			],
+			{channelId: '420253908131944590', groupId: 'liferay.com'}
+		);
+
+		expect(userHeader.isAnonymous).toBe(true);
+		expect(userHeader.title).toBe('Grace Hopper');
+		expect(userHeader.userHeaderUrl).toBeUndefined();
 	});
 
 	it('orders days most-recent first and sums the day event totals', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/utils/formatAccountSessions.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/utils/formatAccountSessions.ts
@@ -42,9 +42,12 @@ const toSessionItem = (
 
 /**
  * Formats account user sessions for the shared VerticalTimeline component. The
- * sessions are grouped by day and then by individual (userName), so each day
- * renders a header per individual — known (with the user icon) or anonymous
- * (with the anonymize icon) — followed by that individual's sessions.
+ * sessions are grouped by day and then by individual, so each day renders a
+ * header per individual followed by that individual's sessions. A session that
+ * carries an `individualId` is resolved (the user icon); one without is
+ * anonymous (the anonymize icon). Either way the header links to the profile
+ * page — by `individualId` when present, otherwise by `userId` — as long as one
+ * of the two ids is available.
  *
  * Unlike the individual timeline's shared `formatSessions`, this reads the
  * correct session field names, so account session attributes populate.
@@ -96,18 +99,20 @@ export const formatAccountSessions = (
 		});
 
 		sessionsByUser.forEach((userSessions) => {
-			const {userId, userName} = userSessions[0];
+			const {individualId, userId, userName} = userSessions[0];
+
+			const linkId = individualId || userId;
 
 			items.push({
-				isAnonymous: userName == null,
+				isAnonymous: !individualId,
 				title: userName || userId || Liferay.Language.get('anonymous'),
 				userHeader: true,
 				userHeaderUrl:
-					userId && context.channelId && context.groupId
+					linkId && context.channelId && context.groupId
 						? toRoute(Routes.CONTACTS_INDIVIDUAL, {
 								channelId: context.channelId,
 								groupId: context.groupId,
-								id: userId,
+								id: linkId,
 							})
 						: undefined,
 			});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AccountUserSessionQuery.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AccountUserSessionQuery.ts
@@ -25,6 +25,7 @@ export interface AccountUserSession {
 	devicePixelRatio: number;
 	deviceType: string;
 	events: AccountUserSessionEvent[];
+	individualId: string | null;
 	languageId: string;
 	screenHeight: number;
 	screenWidth: number;
@@ -109,6 +110,7 @@ export default gql`
 						referrer
 						url
 					}
+					individualId
 					languageId
 					screenHeight
 					screenWidth


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97795

Backport of interaminense/liferay-portal#533 to `faro-v5.0.x`. Carries only the account activity session individual-id linking fix; the other #533 commits were already backported via #3679.
