### PR TITLE
LPD-97795 Refine the activity stream timeline links and empty state

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_vertical_timeline.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_vertical_timeline.scss
@@ -121,11 +121,13 @@
 		}
 
 		.subtitle {
-			display: inline-block;
+			align-items: center;
+			display: inline-flex;
 			max-width: 100%;
 
 			.text-truncate {
 				display: block;
+				min-width: 0;
 			}
 		}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_vertical_timeline.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_vertical_timeline.scss
@@ -71,7 +71,7 @@
 					.description {
 						color: $mainLighten28;
 						font-weight: $fontWeightSemiBold;
-						line-height: 16px;
+						line-height: 18px;
 					}
 
 					.timeline-panel-body-content-details {
@@ -208,10 +208,15 @@
 
 				&:hover {
 					cursor: pointer;
+
+					> .icon-root {
+						visibility: visible;
+					}
 				}
 
 				> .icon-root {
 					fill: $mainLighten28;
+					visibility: hidden;
 				}
 
 				.timeline-panel-body-content-text {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/utils/__tests__/formatAccountSessions.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/utils/__tests__/formatAccountSessions.ts
@@ -23,6 +23,7 @@ const buildSession = (
 				properties: [],
 			},
 		],
+		individualId: null,
 		languageId: 'en-US',
 		screenHeight: 1080,
 		screenWidth: 1920,
@@ -65,9 +66,9 @@ describe('formatAccountSessions', () => {
 		]);
 	});
 
-	it('marks a session without a userName as anonymous', () => {
+	it('marks a session without an individualId as anonymous', () => {
 		const [, userHeader] = formatAccountSessions([
-			buildSession({userName: null}),
+			buildSession({individualId: null, userName: null}),
 		]);
 
 		expect(userHeader.userHeader).toBe(true);
@@ -75,38 +76,61 @@ describe('formatAccountSessions', () => {
 		expect(userHeader.title).toBe(ANONYMOUS);
 	});
 
-	it('marks a session with a userName as a known individual', () => {
+	it('marks a session with an individualId as a known individual', () => {
 		const [, userHeader] = formatAccountSessions([
-			buildSession({userName: 'Grace Hopper'}),
+			buildSession({individualId: 'ind-1', userName: 'Grace Hopper'}),
 		]);
 
 		expect(userHeader.isAnonymous).toBe(false);
 		expect(userHeader.title).toBe('Grace Hopper');
 	});
 
-	it('links a known individual to their page keyed by userId', () => {
+	it('links a known individual to their page by individualId', () => {
 		const [, userHeader] = formatAccountSessions(
-			[buildSession({userId: 'abc123', userName: 'Grace Hopper'})],
+			[
+				buildSession({
+					individualId: 'ind-1',
+					userId: 'abc123',
+					userName: 'Grace Hopper',
+				}),
+			],
 			{channelId: '420253908131944590', groupId: 'liferay.com'}
 		);
 
 		expect(userHeader.title).toBe('Grace Hopper');
 		expect(userHeader.userHeaderUrl).toBe(
-			'/workspace/liferay.com/420253908131944590/contacts/individuals/known-individuals/abc123'
+			'/workspace/liferay.com/420253908131944590/contacts/individuals/known-individuals/ind-1'
 		);
 	});
 
-	it('shows the userId instead of "Anonymous" for a nameless individual', () => {
+	it('links an anonymous session by its userId when there is no individualId', () => {
 		const [, userHeader] = formatAccountSessions(
-			[buildSession({userId: 'anon999', userName: null})],
+			[buildSession({userId: 'abc123', userName: null})],
 			{channelId: '420253908131944590', groupId: 'liferay.com'}
 		);
 
 		expect(userHeader.isAnonymous).toBe(true);
-		expect(userHeader.title).toBe('anon999');
+		expect(userHeader.title).toBe('abc123');
 		expect(userHeader.userHeaderUrl).toBe(
-			'/workspace/liferay.com/420253908131944590/contacts/individuals/known-individuals/anon999'
+			'/workspace/liferay.com/420253908131944590/contacts/individuals/known-individuals/abc123'
 		);
+	});
+
+	it('does not link a session without an individualId or userId', () => {
+		const [, userHeader] = formatAccountSessions(
+			[
+				buildSession({
+					individualId: null,
+					userId: null,
+					userName: 'Grace Hopper',
+				}),
+			],
+			{channelId: '420253908131944590', groupId: 'liferay.com'}
+		);
+
+		expect(userHeader.isAnonymous).toBe(true);
+		expect(userHeader.title).toBe('Grace Hopper');
+		expect(userHeader.userHeaderUrl).toBeUndefined();
 	});
 
 	it('orders days most-recent first and sums the day event totals', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/utils/formatAccountSessions.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/utils/formatAccountSessions.ts
@@ -42,9 +42,12 @@ const toSessionItem = (
 
 /**
  * Formats account user sessions for the shared VerticalTimeline component. The
- * sessions are grouped by day and then by individual (userName), so each day
- * renders a header per individual — known (with the user icon) or anonymous
- * (with the anonymize icon) — followed by that individual's sessions.
+ * sessions are grouped by day and then by individual, so each day renders a
+ * header per individual followed by that individual's sessions. A session that
+ * carries an `individualId` is resolved (the user icon); one without is
+ * anonymous (the anonymize icon). Either way the header links to the profile
+ * page — by `individualId` when present, otherwise by `userId` — as long as one
+ * of the two ids is available.
  *
  * Unlike the individual timeline's shared `formatSessions`, this reads the
  * correct session field names, so account session attributes populate.
@@ -96,18 +99,20 @@ export const formatAccountSessions = (
 		});
 
 		sessionsByUser.forEach((userSessions) => {
-			const {userId, userName} = userSessions[0];
+			const {individualId, userId, userName} = userSessions[0];
+
+			const linkId = individualId || userId;
 
 			items.push({
-				isAnonymous: userName == null,
+				isAnonymous: !individualId,
 				title: userName || userId || Liferay.Language.get('anonymous'),
 				userHeader: true,
 				userHeaderUrl:
-					userId && context.channelId && context.groupId
+					linkId && context.channelId && context.groupId
 						? toRoute(Routes.CONTACTS_INDIVIDUAL, {
 								channelId: context.channelId,
 								groupId: context.groupId,
-								id: userId,
+								id: linkId,
 							})
 						: undefined,
 			});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/AccountMembership.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/AccountMembership.tsx
@@ -10,6 +10,7 @@ import {
 } from 'shared/components/GeneralInfoSection';
 import {formatUTCDate} from 'shared/util/date';
 import {Map} from 'immutable';
+import {Routes, toRoute} from 'shared/util/router';
 import {SectionHeader} from 'shared/components/SectionHeader';
 
 function formatCurrency(
@@ -66,7 +67,9 @@ const dateKeys = ['createdDate', 'lastActivityDate'];
 
 interface IAccountMembershipProps {
 	accountData?: Map<string, any>;
+	channelId?: string;
 	children?: React.ReactNode;
+	groupId?: string;
 	loading?: boolean;
 	showEmptyState?: boolean;
 }
@@ -88,7 +91,9 @@ const ACCOUNT_MEMBERSHIP_LABEL_MAP: Record<string, string> = {
 
 const AccountMembership: React.FC<IAccountMembershipProps> = ({
 	accountData,
+	channelId,
 	children: emptyState,
+	groupId,
 	loading = false,
 	showEmptyState = false,
 }) => {
@@ -110,9 +115,24 @@ const AccountMembership: React.FC<IAccountMembershipProps> = ({
 		return data;
 	};
 
+	const getHref = (key: string): string | undefined => {
+		const accountId = accountData?.get('id');
+
+		if (key === 'accountName' && accountId && channelId && groupId) {
+			return toRoute(Routes.CONTACTS_ACCOUNT, {
+				channelId,
+				groupId,
+				id: accountId,
+			});
+		}
+
+		return undefined;
+	};
+
 	const sectionContent = accountData ? (
 		<GeneralInfoSection
 			config={accountMembershipConfig}
+			getHref={getHref}
 			getValue={getValue}
 			languageMap={ACCOUNT_MEMBERSHIP_LABEL_MAP}
 			loading={loading}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/AccountMembership.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/AccountMembership.tsx
@@ -70,4 +70,27 @@ describe('Account Membership', () => {
 			)
 		).not.toThrow();
 	});
+
+	it('links the account name to the account page', () => {
+		const {getByRole} = render(
+			<AccountMembership
+				accountData={fromJS(mockData)}
+				channelId="420253908131944590"
+				groupId="liferay.com"
+			/>
+		);
+
+		expect(getByRole('link', {name: 'Acme Corporation'})).toHaveAttribute(
+			'href',
+			'/workspace/liferay.com/420253908131944590/contacts/accounts/001xx000003DGbYAAW'
+		);
+	});
+
+	it('does not link the account name without a channel and group', () => {
+		const {queryByRole} = render(
+			<AccountMembership accountData={fromJS(mockData)} />
+		);
+
+		expect(queryByRole('link', {name: 'Acme Corporation'})).toBeNull();
+	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/IndividualProfileCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/IndividualProfileCDP.tsx
@@ -21,6 +21,7 @@ enum IndividualProfileCDPCards {
 }
 
 interface IIndividualProfileCDPProps {
+	channelId: string;
 	groupId: string;
 	individual: Individual;
 }
@@ -121,6 +122,7 @@ const ProfileCDPEmptyState: React.FC<IProfileCDPEmptyStateProps> = ({
 };
 
 const IndividualProfileCDP: React.FC<IIndividualProfileCDPProps> = ({
+	channelId,
 	groupId,
 	individual,
 }) => {
@@ -158,6 +160,8 @@ const IndividualProfileCDP: React.FC<IIndividualProfileCDPProps> = ({
 
 			<AccountMembership
 				accountData={individual.getIn(['accounts', 0])}
+				channelId={channelId}
+				groupId={groupId}
 				loading={dataSourceLoading}
 				showEmptyState={showEmptyState}
 			>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/ActivityStreamCard.tsx
@@ -100,6 +100,15 @@ const ActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 		!activityHistory.length ||
 		activityHistory.every(({totalEvents}) => !totalEvents);
 
+	// The mapped total counts events, which stays positive even when a search
+	// or filter leaves no sessions to show. Treat the session list as empty
+	// whenever there are no session items so the timeline renders its empty
+	// state (and hides pagination) instead of a blank list.
+
+	const sessionsTotal = sessionsMappedResults.items?.length
+		? sessionsMappedResults.total
+		: 0;
+
 	return (
 		<>
 			<Card.Body className="pb-0">
@@ -241,6 +250,7 @@ const ActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 							onPageChange={onPageChange}
 							page={page}
 							timeZoneId={timeZoneId}
+							total={sessionsTotal}
 						/>
 					</Card.Body>
 				</WrapSafeResults>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/GeneralInfoSection.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/GeneralInfoSection.tsx
@@ -1,5 +1,6 @@
 import Card from './Card';
 import classNames from 'classnames';
+import ClayLink from '@clayui/link';
 import Icon from '@clayui/icon';
 import Loading from './Loading';
 import React from 'react';
@@ -18,11 +19,13 @@ export type DataDrivenConfig = {
 
 const InfoItem = ({
 	className,
+	href,
 	icon,
 	label,
 	value,
 }: {
 	className?: string;
+	href?: string;
 	icon?: string;
 	label: string;
 	value: string;
@@ -40,18 +43,30 @@ const InfoItem = ({
 			<Text color="secondary" size={3}>
 				{label}
 			</Text>
-			<span
-				className="font-weight-semi-bold text-break text-dark"
-				style={{wordBreak: 'break-all'}}
-			>
-				{value}
-			</span>
+
+			{href ? (
+				<ClayLink
+					className="font-weight-semi-bold text-break text-dark"
+					href={href}
+					style={{wordBreak: 'break-all'}}
+				>
+					{value}
+				</ClayLink>
+			) : (
+				<span
+					className="font-weight-semi-bold text-break text-dark"
+					style={{wordBreak: 'break-all'}}
+				>
+					{value}
+				</span>
+			)}
 		</div>
 	</div>
 );
 
 interface IGeneralInfoSectionProps {
 	config: DataDrivenConfig;
+	getHref?: (key: string) => string | undefined;
 	getValue: (key: string) => string | undefined;
 	languageMap: Record<string, string>;
 	loading?: boolean;
@@ -59,6 +74,7 @@ interface IGeneralInfoSectionProps {
 
 export const GeneralInfoSection: React.FC<IGeneralInfoSectionProps> = ({
 	config,
+	getHref,
 	getValue,
 	languageMap,
 	loading,
@@ -84,6 +100,11 @@ export const GeneralInfoSection: React.FC<IGeneralInfoSectionProps> = ({
 										return (
 											<InfoItem
 												className={item.className}
+												href={
+													rawValue
+														? getHref?.(item.key)
+														: undefined
+												}
 												icon={item.icon}
 												key={item.key}
 												label={languageMap[item.key]}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
@@ -388,7 +388,9 @@ const TimelinePanelBodyContentText: FC<{
 					rel="noopener noreferrer"
 					target="_blank"
 				>
-					<TextTruncate title={subtitle} />
+					<ClayIcon fontSize={8} symbol="shortcut" />
+
+					<TextTruncate className="mb-1" title={subtitle} />
 				</ClayLink>
 			)}
 		</div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/ActivityStreamCard.tsx
@@ -95,4 +95,19 @@ describe('ActivityStreamCard', () => {
 
 		expect(container.querySelector('.trend-summary')).toBeNull();
 	});
+
+	it('renders the no-results content when there are events but no sessions', () => {
+		const {container, getByText} = renderCard({
+			sessionsMappedResults: {
+				empty: false,
+				error: null,
+				items: [],
+				loading: false,
+				total: 6,
+			},
+		});
+
+		expect(getByText('No sessions here')).toBeInTheDocument();
+		expect(container.querySelector('.pagination-bar-root')).toBeNull();
+	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/VerticalTimeline.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/VerticalTimeline.jsx.snap
@@ -100,8 +100,17 @@ exports[`VerticalTimeline should render with a header and initialExpanded 1`] = 
                   rel="noopener noreferrer"
                   target="_blank"
                 >
+                  <svg
+                    class="lexicon-icon lexicon-icon-shortcut"
+                    font-size="8"
+                    role="presentation"
+                  >
+                    <use
+                      href="#shortcut"
+                    />
+                  </svg>
                   <span
-                    class="text-truncate"
+                    class="text-truncate mb-1"
                     data-tooltip="false"
                     title=""
                   >
@@ -225,8 +234,17 @@ Firefox"
                           rel="noopener noreferrer"
                           target="_blank"
                         >
+                          <svg
+                            class="lexicon-icon lexicon-icon-shortcut"
+                            font-size="8"
+                            role="presentation"
+                          >
+                            <use
+                              href="#shortcut"
+                            />
+                          </svg>
                           <span
-                            class="text-truncate"
+                            class="text-truncate mb-1"
                             data-tooltip="false"
                             title=""
                           >
@@ -298,8 +316,17 @@ Firefox"
                           rel="noopener noreferrer"
                           target="_blank"
                         >
+                          <svg
+                            class="lexicon-icon lexicon-icon-shortcut"
+                            font-size="8"
+                            role="presentation"
+                          >
+                            <use
+                              href="#shortcut"
+                            />
+                          </svg>
                           <span
-                            class="text-truncate"
+                            class="text-truncate mb-1"
                             data-tooltip="false"
                             title=""
                           >
@@ -420,8 +447,17 @@ Firefox"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
+                  <svg
+                    class="lexicon-icon lexicon-icon-shortcut"
+                    font-size="8"
+                    role="presentation"
+                  >
+                    <use
+                      href="#shortcut"
+                    />
+                  </svg>
                   <span
-                    class="text-truncate"
+                    class="text-truncate mb-1"
                     data-tooltip="false"
                     title=""
                   >
@@ -543,8 +579,17 @@ Firefox"
                           rel="noopener noreferrer"
                           target="_blank"
                         >
+                          <svg
+                            class="lexicon-icon lexicon-icon-shortcut"
+                            font-size="8"
+                            role="presentation"
+                          >
+                            <use
+                              href="#shortcut"
+                            />
+                          </svg>
                           <span
-                            class="text-truncate"
+                            class="text-truncate mb-1"
                             data-tooltip="false"
                             title=""
                           >
@@ -616,8 +661,17 @@ Firefox"
                           rel="noopener noreferrer"
                           target="_blank"
                         >
+                          <svg
+                            class="lexicon-icon lexicon-icon-shortcut"
+                            font-size="8"
+                            role="presentation"
+                          >
+                            <use
+                              href="#shortcut"
+                            />
+                          </svg>
                           <span
-                            class="text-truncate"
+                            class="text-truncate mb-1"
                             data-tooltip="false"
                             title=""
                           >
@@ -706,8 +760,17 @@ Firefox"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
+                  <svg
+                    class="lexicon-icon lexicon-icon-shortcut"
+                    font-size="8"
+                    role="presentation"
+                  >
+                    <use
+                      href="#shortcut"
+                    />
+                  </svg>
                   <span
-                    class="text-truncate"
+                    class="text-truncate mb-1"
                     data-tooltip="false"
                     title=""
                   >
@@ -840,8 +903,17 @@ Firefox"
                           rel="noopener noreferrer"
                           target="_blank"
                         >
+                          <svg
+                            class="lexicon-icon lexicon-icon-shortcut"
+                            font-size="8"
+                            role="presentation"
+                          >
+                            <use
+                              href="#shortcut"
+                            />
+                          </svg>
                           <span
-                            class="text-truncate"
+                            class="text-truncate mb-1"
                             data-tooltip="false"
                             title=""
                           >
@@ -915,8 +987,17 @@ Firefox"
                           rel="noopener noreferrer"
                           target="_blank"
                         >
+                          <svg
+                            class="lexicon-icon lexicon-icon-shortcut"
+                            font-size="8"
+                            role="presentation"
+                          >
+                            <use
+                              href="#shortcut"
+                            />
+                          </svg>
                           <span
-                            class="text-truncate"
+                            class="text-truncate mb-1"
                             data-tooltip="false"
                             title=""
                           >

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AccountUserSessionQuery.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AccountUserSessionQuery.ts
@@ -25,6 +25,7 @@ export interface AccountUserSession {
 	devicePixelRatio: number;
 	deviceType: string;
 	events: AccountUserSessionEvent[];
+	individualId: string | null;
 	languageId: string;
 	screenHeight: number;
 	screenWidth: number;
@@ -109,6 +110,7 @@ export default gql`
 						referrer
 						url
 					}
+					individualId
 					languageId
 					screenHeight
 					screenWidth

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/getEventDashboardUrl.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/getEventDashboardUrl.ts
@@ -65,6 +65,70 @@ describe('getEventDashboardUrl', () => {
 		);
 	});
 
+	it('builds an asset dashboard link for a blog event using entryId', () => {
+		const event = buildEvent({
+			applicationId: 'Blog',
+			assetTitle: 'A Guide to Headless CMS',
+			name: 'blogViewed',
+			properties: [{name: 'entryId', value: '372644605'}],
+		});
+
+		expect(getEventDashboardUrl(event, CONTEXT)).toBe(
+			'/workspace/liferay.com/420253908131944590/assets/blogs/372644605/page/Any/A%20Guide%20to%20Headless%20CMS/blog?rangeKey=30'
+		);
+	});
+
+	it('builds an asset dashboard link for a document event using fileEntryId', () => {
+		const event = buildEvent({
+			applicationId: 'Document',
+			assetTitle: 'Liferay-vs-Adobe',
+			name: 'documentPreviewed',
+			properties: [{name: 'fileEntryId', value: '527759973'}],
+		});
+
+		expect(getEventDashboardUrl(event, CONTEXT)).toBe(
+			'/workspace/liferay.com/420253908131944590/assets/documents-and-media/527759973/page/Any/Liferay-vs-Adobe/document?rangeKey=30'
+		);
+	});
+
+	it('builds an object-entry dashboard link using the external reference code and object definition name', () => {
+		const event = buildEvent({
+			applicationId: 'ObjectEntry',
+			assetTitle: 'England vs Argentina',
+			name: 'objectEntryViewed',
+			properties: [
+				{name: 'externalReferenceCode', value: 'match-102'},
+				{name: 'objectDefinitionName', value: 'WorldCupMatch'},
+			],
+		});
+
+		expect(getEventDashboardUrl(event, CONTEXT)).toBe(
+			'/workspace/liferay.com/420253908131944590/assets/object-entry/match-102/page/Any/England%20vs%20Argentina/WorldCupMatch?rangeKey=30'
+		);
+	});
+
+	it('returns undefined for an asset event missing its id property', () => {
+		const event = buildEvent({
+			applicationId: 'Document',
+			assetTitle: 'Untracked download',
+			name: 'documentPreviewed',
+			properties: [],
+		});
+
+		expect(getEventDashboardUrl(event, CONTEXT)).toBeUndefined();
+	});
+
+	it('returns undefined for an object-entry event missing the object definition name', () => {
+		const event = buildEvent({
+			applicationId: 'ObjectEntry',
+			assetTitle: 'England vs Argentina',
+			name: 'objectEntryViewed',
+			properties: [{name: 'externalReferenceCode', value: 'match-102'}],
+		});
+
+		expect(getEventDashboardUrl(event, CONTEXT)).toBeUndefined();
+	});
+
 	it('returns undefined for a webhook event', () => {
 		expect(
 			getEventDashboardUrl(buildEvent(), {...CONTEXT, isWebhook: true})
@@ -73,8 +137,8 @@ describe('getEventDashboardUrl', () => {
 
 	it('returns undefined for an unmapped application id', () => {
 		const event = buildEvent({
-			applicationId: 'Blog',
-			properties: [{name: 'entryId', value: '1'}],
+			applicationId: 'CustomEvent',
+			properties: [{name: 'customId', value: '1'}],
 		});
 
 		expect(getEventDashboardUrl(event, CONTEXT)).toBeUndefined();

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/getEventDashboardUrl.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/getEventDashboardUrl.ts
@@ -12,6 +12,16 @@ const ASSET_APPLICATIONS: Record<
 	string,
 	{idProperty: string; route: string; type: string}
 > = {
+	[AssetTypes.Blog]: {
+		idProperty: 'entryId',
+		route: Routes.ASSETS_BLOGS_OVERVIEW,
+		type: 'blog',
+	},
+	[AssetTypes.Document]: {
+		idProperty: 'fileEntryId',
+		route: Routes.ASSETS_DOCUMENTS_AND_MEDIA_OVERVIEW,
+		type: 'document',
+	},
 	[AssetTypes.Form]: {
 		idProperty: 'formId',
 		route: Routes.ASSETS_FORMS_OVERVIEW,
@@ -61,9 +71,13 @@ const buildQuery = (rangeSelectors?: RangeSelectors): string => {
  * - Asset events (identified by their `applicationId`) link to the asset
  *   dashboard, using the type-specific id property as the asset id; the
  *   touchpoint is always "Any".
+ * - Object-entry events link to the object-entry dashboard, using the entry's
+ *   external reference code as the asset id and the object definition name as
+ *   the dashboard type.
  * - pageViewed events link to the page (touchpoint) dashboard, using the
  *   canonical URL as the touchpoint.
- * - Anything else (e.g. unmapped application ids) returns undefined.
+ * - Anything else (e.g. unmapped application ids or events missing their id
+ *   property) returns undefined.
  */
 export const getEventDashboardUrl = (
 	event: UserSessionEvent,
@@ -90,6 +104,26 @@ export const getEventDashboardUrl = (
 			groupId,
 			touchpoint: 'Any',
 			type: assetApplication.type,
+			...(title && {title}),
+		})}${buildQuery(rangeSelectors)}`;
+	}
+
+	if (event.applicationId === AssetTypes.ObjectEntry) {
+		const assetId = getProperty(event, 'externalReferenceCode');
+		const type = getProperty(event, 'objectDefinitionName');
+
+		if (!assetId || !type) {
+			return undefined;
+		}
+
+		const title = event.assetTitle || event.pageTitle;
+
+		return `${toRoute(Routes.ASSETS_OBJECT_ENTRY_OVERVIEW, {
+			assetId,
+			channelId,
+			groupId,
+			touchpoint: 'Any',
+			type,
 			...(title && {title}),
 		})}${buildQuery(rangeSelectors)}`;
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97795

## What Is Being Fixed

Follow-up gaps in the unified account/individual activity stream timeline. The individual profile's account-membership card did not link the account name back to its dashboard. The timeline's external-link subtitles gave no visual cue that they open in a new tab. The session list rendered blank — instead of an empty state with a clear-search action — when a search or filter matched events but returned no sessions. Only web content, form, and page events linked to a dashboard, leaving blog, document, and object-entry events unlinked. And the account activity-stream session headers linked by a data-source user id and keyed their known/anonymous icon off the presence of a name rather than a resolved individual. The branch also carries the earlier caret-hover and description line-height polish.

## How It Is Being Fixed

`GeneralInfoSection` takes an optional `getHref`, so the account-membership card links the account name to the account page, and `IndividualProfileCDP` threads the channel and group through. The external-link subtitle now renders a shortcut icon before the URL, with the subtitle switched to inline-flex so the icon and the truncated text stay on one line. `ActivityStreamCard` derives the paginated timeline's total from the session items, so an empty session list always shows the empty state (and hides pagination) even when the event-count metric is still positive. `getEventDashboardUrl` maps blog (`entryId`), document (`fileEntryId`), and object-entry (external reference code plus object definition name) events to their dashboards. Finally, the account session query now returns `individualId`, and the session header links to the individual by that id (falling back to `userId`), showing the anonymous icon only when no `individualId` is present.

## PR Check

**pr-check: PASS** — tested on `c4fa4b99c4fb46249fecb829578a3cf691e9b6b4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "c4fa4b99c4fb46249fecb829578a3cf691e9b6b4"} -->

Resent from interaminense/liferay-portal#533