### PR TITLE
LPD-97795 Normalize the activity stream trend count and percentage

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/ActivityStreamCard.tsx
@@ -14,7 +14,7 @@ import {isNil} from 'lodash';
 import {mapListResultsToProps} from 'shared/util/mappers';
 import {sub} from 'shared/util/lang';
 import {Text} from '@clayui/core';
-import {toRounded} from 'shared/util/numbers';
+import {toRounded, toThousands} from 'shared/util/numbers';
 import {TrendClassification} from 'segment/types';
 import {withEmpty} from 'cerebro-shared/hocs/utils';
 import {withError, withLoading, WrapSafeResults} from 'shared/hoc/util';
@@ -137,7 +137,11 @@ const ActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 												Liferay.Language.get(
 													'x-activities'
 												),
-												[trendSummary.value]
+												[
+													toThousands(
+														trendSummary.value
+													),
+												]
 											)}
 										</Text>
 									</div>
@@ -179,7 +183,7 @@ const ActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 														Math.abs(
 															trendSummary.percentage
 														),
-														2
+														1
 													)}%`}
 												</span>,
 											],


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97795

## What Is Being Fixed

The account activity stream's trend summary printed its raw numbers without normalization: the activities count was rendered in full (e.g. `1623456789`) instead of abbreviated, and the "vs. previous period" percentage used two decimal places rather than the app's standard one.

## How It Is Being Fixed

The count now goes through `toThousands` (e.g. `1.62B`), and the percentage uses `toRounded(…, 1)`, matching the trend formatting already used by `MetricCard`.

## PR Check

**pr-check: PASS** — tested on `00ea18a4058db07f9595646cf4752321a5d475a5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "00ea18a4058db07f9595646cf4752321a5d475a5"} -->

Resent from interaminense/liferay-portal#534