### PR TITLE
LPD-98591 Fix the Assets dashboard 500 on a custom date range

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -283,8 +283,9 @@ public interface ContactsEngineClient {
 
 	public Results<AssetSummary> getAssetSummaries(
 		FaroProject faroProject, long channelId, String filterString,
-		String keywords, String objectType, int rangeKey, String selectedMetric,
-		int cur, int delta, String sortString);
+		String keywords, String objectType, String rangeEnd, int rangeKey,
+		String rangeStart, String selectedMetric, int cur, int delta,
+		String sortString);
 
 	public Results<AssetSummaryCategory> getAssetSummaryCategories(
 		FaroProject faroProject, String accountId, long channelId,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -1248,8 +1248,9 @@ public class ContactsEngineClientImpl
 	@Override
 	public Results<AssetSummary> getAssetSummaries(
 		FaroProject faroProject, long channelId, String filterString,
-		String keywords, String objectType, int rangeKey, String selectedMetric,
-		int cur, int delta, String sortString) {
+		String keywords, String objectType, String rangeEnd, int rangeKey,
+		String rangeStart, String selectedMetric, int cur, int delta,
+		String sortString) {
 
 		Map<String, Object> uriVariables = getUriVariables(
 			faroProject, cur, delta, null);
@@ -1266,7 +1267,13 @@ public class ContactsEngineClientImpl
 			uriVariables.put("objectType", objectType);
 		}
 
-		uriVariables.put("rangeKey", rangeKey);
+		if ((rangeEnd != null) && (rangeStart != null)) {
+			uriVariables.put("rangeEnd", rangeEnd);
+			uriVariables.put("rangeStart", rangeStart);
+		}
+		else {
+			uriVariables.put("rangeKey", rangeKey);
+		}
 
 		if (Validator.isNotNull(selectedMetric)) {
 			uriVariables.put("selectedMetric", selectedMetric);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -530,12 +530,14 @@ public abstract class BaseMockContactsEngineClientImpl
 
 	public Results<AssetSummary> getAssetSummaries(
 		FaroProject faroProject, long channelId, String filterString,
-		String keywords, String objectType, int rangeKey, String selectedMetric,
-		int cur, int delta, String sortString) {
+		String keywords, String objectType, String rangeEnd, int rangeKey,
+		String rangeStart, String selectedMetric, int cur, int delta,
+		String sortString) {
 
 		return contactsEngineClient.getAssetSummaries(
 			faroProject, channelId, filterString, keywords, objectType,
-			rangeKey, selectedMetric, cur, delta, sortString);
+			rangeEnd, rangeKey, rangeStart, selectedMetric, cur, delta,
+			sortString);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AssetSummaryFaroController.java
@@ -38,7 +38,9 @@ public class AssetSummaryFaroController extends BaseFaroController {
 				@QueryParam("objectType") String objectType,
 				@QueryParam("page") int page,
 				@DefaultValue("20") @QueryParam("pageSize") int pageSize,
+				@QueryParam("rangeEnd") String rangeEnd,
 				@DefaultValue("90") @QueryParam("rangeKey") int rangeKey,
+				@QueryParam("rangeStart") String rangeStart,
 				@QueryParam("search") String search,
 				@QueryParam("selectedMetric") String selectedMetric,
 				@DefaultValue(StringPool.BLANK) @QueryParam("sort") String
@@ -48,8 +50,8 @@ public class AssetSummaryFaroController extends BaseFaroController {
 		return new FaroFDSResultsDisplay<>(
 			contactsEngineClient.getAssetSummaries(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId),
-				channelId, filterString, search, objectType, rangeKey,
-				selectedMetric, page, pageSize, sortString),
+				channelId, filterString, search, objectType, rangeEnd, rangeKey,
+				rangeStart, selectedMetric, page, pageSize, sortString),
 			AssetSummaryDisplay::new, page, pageSize);
 	}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
@@ -386,8 +386,8 @@ describe('List', () => {
 			const apiURL = getMimeTypeFilterApiURL();
 
 			expect(apiURL).not.toContain('rangeKey=CUSTOM');
-            expect(apiURL).toContain('rangeEnd=2024-03-01');
-            expect(apiURL).toContain('rangeStart=2024-01-01');
+			expect(apiURL).toContain('rangeEnd=2024-03-01');
+			expect(apiURL).toContain('rangeStart=2024-01-01');
 		});
 
 		it('should send the range key for a preset range', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
@@ -371,6 +371,36 @@ describe('List', () => {
 		});
 	});
 
+	describe('range selector params', () => {
+		const getMimeTypeFilterApiURL = () =>
+			JSON.parse(screen.getByTestId('fds-filters').textContent).find(
+				(filter: {id: string}) => filter.id === 'mimeType'
+			).apiURL;
+
+		it('should omit the range key and send the range bounds for a custom range', () => {
+			renderList({
+				queryString:
+					'?rangeKey=CUSTOM&rangeStart=2024-01-01&rangeEnd=2024-03-01',
+			});
+
+			const apiURL = getMimeTypeFilterApiURL();
+
+			expect(apiURL).not.toContain('rangeKey=CUSTOM');
+            expect(apiURL).toContain('rangeEnd=2024-03-01');
+            expect(apiURL).toContain('rangeStart=2024-01-01');
+		});
+
+		it('should send the range key for a preset range', () => {
+			renderList({queryString: '?rangeKey=7'});
+
+			const apiURL = getMimeTypeFilterApiURL();
+
+			expect(apiURL).toContain('rangeKey=7');
+			expect(apiURL).not.toContain('rangeEnd=');
+			expect(apiURL).not.toContain('rangeStart=');
+		});
+	});
+
 	describe('account filter', () => {
 		const getFilters = () =>
 			JSON.parse(screen.getByTestId('fds-filters').textContent);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
@@ -4,7 +4,7 @@ import Card from 'shared/components/Card';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import ClaySticker from '@clayui/sticker';
-import FaroConstants from 'shared/util/constants';
+import FaroConstants, {RangeKeyTimeRanges} from 'shared/util/constants';
 import React, {useMemo, useState} from 'react';
 import URLConstants from 'shared/util/url-constants';
 import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
@@ -200,12 +200,10 @@ const List = () => {
 
 	let rangeSelectorParams = `rangeKey=${rangeSelectors.rangeKey}`;
 
-	if (rangeSelectors.rangeEnd) {
-		rangeSelectorParams += `&rangeEnd=${rangeSelectors.rangeEnd}`;
-	}
-
-	if (rangeSelectors.rangeStart) {
-		rangeSelectorParams += `&rangeStart=${rangeSelectors.rangeStart}`;
+	if (rangeSelectors.rangeKey === RangeKeyTimeRanges.CustomRange) {
+		rangeSelectorParams =
+			`rangeEnd=${rangeSelectors.rangeEnd}` +
+			`&rangeStart=${rangeSelectors.rangeStart}`;
 	}
 
 	const filters = useMemo(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98591

## What Is Being Fixed

The Assets dashboard returned a 500 error whenever a custom date range was selected; the page stayed empty. The frontend sent rangeKey=CUSTOM to the asset summary endpoints, which the faro controllers cannot bind to their numeric rangeKey parameter, so the request failed before reaching the analytics backend.

## How It Is Being Fixed

On the Assets page we now omit rangeKey for a custom range and send only rangeStart and rangeEnd, matching the convention used by the other analytics dashboards. We also let the asset summary faro controller and its engine client accept and forward rangeStart and rangeEnd so the table honors the selected custom range instead of falling back to the default range.

## PR Check

**pr-check: PASS** — tested on `5d81724f471c291a37d75bb1761f174b7fece9b1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "5d81724f471c291a37d75bb1761f174b7fece9b1"} -->
