### PR TITLE
LPD-97861 Rename the segments audiences criteria key to segment

### DIFF
--- a/modules/apps/audiences/audiences-service/src/main/resources/com/liferay/audiences/service/impl/dependencies/audiences-criteria-json-schema.json
+++ b/modules/apps/audiences/audiences-service/src/main/resources/com/liferay/audiences/service/impl/dependencies/audiences-criteria-json-schema.json
@@ -231,7 +231,7 @@
 								"pathname",
 								"referrer",
 								"request_parameters",
-								"segments",
+								"segment",
 								"timezone",
 								"url",
 								"user_agent",

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/attributes/segment.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/attributes/segment.ts
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export function getSegments(acSegments: Set<string>): Set<string> {
+export function getSegment(acSegments: Set<string>): Set<string> {
 	return acSegments;
 }

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/check.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/check.ts
@@ -28,7 +28,7 @@ const ATTRIBUTES: Attribute[] = [
 	'pathname',
 	'referrer',
 	'request_parameters',
-	'segments',
+	'segment',
 	'timezone',
 	'url',
 	'user_agent',

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/index.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/detection/index.ts
@@ -17,7 +17,7 @@ import {getLocalHour} from './attributes/local_hour';
 import {getPathname} from './attributes/pathname';
 import {getReferrer} from './attributes/referrer';
 import {getRequestParameters} from './attributes/request_parameters';
-import {getSegments} from './attributes/segments';
+import {getSegment} from './attributes/segment';
 import {getTimezone} from './attributes/timezone';
 import {getUrl} from './attributes/url';
 import {getUserAgent} from './attributes/user_agent';
@@ -138,8 +138,8 @@ export class Detection {
 		else if (attr === 'request_parameters') {
 			return getRequestParameters();
 		}
-		else if (attr === 'segments') {
-			return getSegments(await this._getAcSegments());
+		else if (attr === 'segment') {
+			return getSegment(await this._getAcSegments());
 		}
 		else if (attr === 'timezone') {
 			return getTimezone();

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/index.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/resources/META-INF/resources/main/index.ts
@@ -55,7 +55,7 @@ export type Attribute =
 	| 'pathname'
 	| 'referrer'
 	| `request_parameters`
-	| 'segments'
+	| 'segment'
 	| 'timezone'
 	| 'url'
 	| 'user_agent';

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/attributes.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/attributes.test.ts
@@ -16,7 +16,7 @@ import {getLocalHour} from '../src/main/resources/META-INF/resources/main/detect
 import {getPathname} from '../src/main/resources/META-INF/resources/main/detection/attributes/pathname';
 import {getReferrer} from '../src/main/resources/META-INF/resources/main/detection/attributes/referrer';
 import {getRequestParameters} from '../src/main/resources/META-INF/resources/main/detection/attributes/request_parameters';
-import {getSegments} from '../src/main/resources/META-INF/resources/main/detection/attributes/segments';
+import {getSegment} from '../src/main/resources/META-INF/resources/main/detection/attributes/segment';
 import {getTimezone} from '../src/main/resources/META-INF/resources/main/detection/attributes/timezone';
 import {getUrl} from '../src/main/resources/META-INF/resources/main/detection/attributes/url';
 import {getUserAgent} from '../src/main/resources/META-INF/resources/main/detection/attributes/user_agent';
@@ -231,9 +231,9 @@ describe('attributes', () => {
 		});
 	});
 
-	describe('attribute segments', () => {
+	describe('attribute segment', () => {
 		it('works and returns a Set<string>', async () => {
-			const value = getSegments(
+			const value = getSegment(
 				new Set(['SEGMENT_BATCH', 'SEGMENT_REAL_TIME'])
 			);
 

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/check.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/check.test.ts
@@ -248,7 +248,7 @@ describe('check', () => {
 				check(
 					withRule(
 						leafRule({
-							attribute: 'segments',
+							attribute: 'segment',
 							operator: 'includes',
 							value: 123,
 						})

--- a/modules/apps/frontend-js/frontend-js-audiences-web/test/detection.test.ts
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/test/detection.test.ts
@@ -381,10 +381,10 @@ describe('detection', () => {
 		});
 	});
 
-	describe('attribute segments', () => {
+	describe('attribute segment', () => {
 		it('positive test', async () => {
 			mockAudiencesDefinitionWithAttribute(
-				'segments',
+				'segment',
 				'includes',
 				'SEGMENT_REAL_TIME'
 			);
@@ -396,7 +396,7 @@ describe('detection', () => {
 
 		it('negative test', async () => {
 			mockAudiencesDefinitionWithAttribute(
-				'segments',
+				'segment',
 				'includes',
 				'NON_EXISTENT_SEGMENT'
 			);


### PR DESCRIPTION
Renames the audiences criteria attribute key from `segments` to `segment` across the audiences criteria JSON schema and the `frontend-js-audiences-web` detection layer (attribute module, check, index, type union) and its tests.
