### PR TITLE
LPD-98864 Add catalog fields endpoint for lifecycle stage criteria

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -27,6 +27,7 @@ import com.liferay.osb.faro.engine.client.model.AssetSummaryType;
 import com.liferay.osb.faro.engine.client.model.AssetSummaryVocabulary;
 import com.liferay.osb.faro.engine.client.model.Author;
 import com.liferay.osb.faro.engine.client.model.BlockedKeyword;
+import com.liferay.osb.faro.engine.client.model.CatalogField;
 import com.liferay.osb.faro.engine.client.model.Channel;
 import com.liferay.osb.faro.engine.client.model.ChannelDataSource;
 import com.liferay.osb.faro.engine.client.model.Credentials;
@@ -317,6 +318,11 @@ public interface ContactsEngineClient {
 	public Results<BlockedKeyword> getBlockedKeywords(
 		FaroProject faroProject, String query, int cur, int delta,
 		List<OrderByField> orderByFields);
+
+	public Results<CatalogField> getCatalogFields(
+			FaroProject faroProject, String query, String tableName, int cur,
+			int delta, String sortString)
+		throws FaroEngineClientException;
 
 	public Channel getChannel(FaroProject faroProject, String id)
 		throws FaroEngineClientException;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -37,6 +37,7 @@ import com.liferay.osb.faro.engine.client.model.AssetSummaryType;
 import com.liferay.osb.faro.engine.client.model.AssetSummaryVocabulary;
 import com.liferay.osb.faro.engine.client.model.Author;
 import com.liferay.osb.faro.engine.client.model.BlockedKeyword;
+import com.liferay.osb.faro.engine.client.model.CatalogField;
 import com.liferay.osb.faro.engine.client.model.Channel;
 import com.liferay.osb.faro.engine.client.model.ChannelDataSource;
 import com.liferay.osb.faro.engine.client.model.Credentials;
@@ -1540,6 +1541,39 @@ public class ContactsEngineClientImpl
 			faroProject, Rels.BLOCKED_KEYWORDS,
 			new ParameterizedTypeReference
 				<EntityModelPagedModel<BlockedKeyword>>() {
+			},
+			uriVariables);
+
+		return pagedModel.getResults();
+	}
+
+	@Override
+	public Results<CatalogField> getCatalogFields(
+			FaroProject faroProject, String query, String tableName, int cur,
+			int delta, String sortString)
+		throws FaroEngineClientException {
+
+		Map<String, Object> uriVariables = getUriVariables(
+			faroProject, cur, delta, null);
+
+		if (Validator.isNotNull(query)) {
+			uriVariables.put("query", query);
+		}
+
+		uriVariables.put("tableName", tableName);
+
+		if (Validator.isNotNull(sortString)) {
+			uriVariables.put(
+				"sort",
+				Arrays.asList(
+					StringUtil.replace(
+						sortString, CharPool.COLON, CharPool.COMMA)));
+		}
+
+		PagedModel<?, CatalogField> pagedModel = get(
+			faroProject, Rels.CATALOG_FIELDS,
+			new ParameterizedTypeReference
+				<EntityModelPagedModel<CatalogField>>() {
 			},
 			uriVariables);
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/CatalogField.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/CatalogField.java
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.engine.client.model;
+
+/**
+ * @author Riccardo Ferrari
+ */
+public class CatalogField {
+
+	public String getDataCategory() {
+		return _dataCategory;
+	}
+
+	public String getDataType() {
+		return _dataType;
+	}
+
+	public String getDescription() {
+		return _description;
+	}
+
+	public String getDisplayName() {
+		return _displayName;
+	}
+
+	public String getId() {
+		return _id;
+	}
+
+	public String getName() {
+		return _name;
+	}
+
+	public String getParentField() {
+		return _parentField;
+	}
+
+	public String getTableName() {
+		return _tableName;
+	}
+
+	public void setDataCategory(String dataCategory) {
+		_dataCategory = dataCategory;
+	}
+
+	public void setDataType(String dataType) {
+		_dataType = dataType;
+	}
+
+	public void setDescription(String description) {
+		_description = description;
+	}
+
+	public void setDisplayName(String displayName) {
+		_displayName = displayName;
+	}
+
+	public void setId(String id) {
+		_id = id;
+	}
+
+	public void setName(String name) {
+		_name = name;
+	}
+
+	public void setParentField(String parentField) {
+		_parentField = parentField;
+	}
+
+	public void setTableName(String tableName) {
+		_tableName = tableName;
+	}
+
+	private String _dataCategory;
+	private String _dataType;
+	private String _description;
+	private String _displayName;
+	private String _id;
+	private String _name;
+	private String _parentField;
+	private String _tableName;
+
+}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
@@ -90,6 +90,8 @@ public interface Rels {
 
 	public static final String BULK = "bulk";
 
+	public static final String CATALOG_FIELDS = "catalog-fields";
+
 	public static final String CHANNEL = "channel";
 
 	public static final String CHANNEL_CLEAR = "channel-clear";

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -28,6 +28,7 @@ import com.liferay.osb.faro.engine.client.model.AssetSummaryType;
 import com.liferay.osb.faro.engine.client.model.AssetSummaryVocabulary;
 import com.liferay.osb.faro.engine.client.model.Author;
 import com.liferay.osb.faro.engine.client.model.BlockedKeyword;
+import com.liferay.osb.faro.engine.client.model.CatalogField;
 import com.liferay.osb.faro.engine.client.model.Channel;
 import com.liferay.osb.faro.engine.client.model.ChannelDataSource;
 import com.liferay.osb.faro.engine.client.model.Credentials;
@@ -609,6 +610,16 @@ public abstract class BaseMockContactsEngineClientImpl
 
 		return contactsEngineClient.getBlockedKeywords(
 			faroProject, query, cur, delta, orderByFields);
+	}
+
+	@Override
+	public Results<CatalogField> getCatalogFields(
+			FaroProject faroProject, String query, String tableName, int cur,
+			int delta, String sortString)
+		throws FaroEngineClientException {
+
+		return contactsEngineClient.getCatalogFields(
+			faroProject, query, tableName, cur, delta, sortString);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/application/MainApplication.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/application/MainApplication.java
@@ -7,6 +7,7 @@ package com.liferay.osb.faro.web.internal.application;
 
 import com.liferay.osb.faro.web.internal.constants.FaroConstants;
 import com.liferay.osb.faro.web.internal.controller.main.BlockedKeywordsFaroController;
+import com.liferay.osb.faro.web.internal.controller.main.CatalogFaroController;
 import com.liferay.osb.faro.web.internal.controller.main.ChannelFaroController;
 import com.liferay.osb.faro.web.internal.controller.main.DefinitionsFaroController;
 import com.liferay.osb.faro.web.internal.controller.main.GlobalPreferencesFaroController;
@@ -48,6 +49,7 @@ public class MainApplication extends BaseApplication {
 		Set<Object> controllers = new HashSet<>();
 
 		controllers.add(_blockedKeywordsFaroController);
+		controllers.add(_catalogFaroController);
 		controllers.add(_channelFaroController);
 		controllers.add(_definitionsFaroController);
 		controllers.add(_globalPreferencesFaroController);
@@ -66,6 +68,9 @@ public class MainApplication extends BaseApplication {
 
 	@Reference
 	private BlockedKeywordsFaroController _blockedKeywordsFaroController;
+
+	@Reference
+	private CatalogFaroController _catalogFaroController;
 
 	@Reference
 	private ChannelFaroController _channelFaroController;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/CatalogFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/CatalogFaroController.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.web.internal.controller.main;
+
+import com.liferay.osb.faro.engine.client.model.CatalogField;
+import com.liferay.osb.faro.engine.client.model.Results;
+import com.liferay.osb.faro.web.internal.controller.BaseFaroController;
+import com.liferay.osb.faro.web.internal.controller.FaroController;
+import com.liferay.osb.faro.web.internal.model.display.FaroFDSResultsDisplay;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.RoleConstants;
+
+import jakarta.annotation.security.RolesAllowed;
+
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Riccardo Ferrari
+ */
+@Component(service = {CatalogFaroController.class, FaroController.class})
+@Path("/{groupId}/catalog")
+@Produces(MediaType.APPLICATION_JSON)
+public class CatalogFaroController extends BaseFaroController {
+
+	@GET
+	@Path("/fields")
+	@RolesAllowed(RoleConstants.SITE_MEMBER)
+	public FaroFDSResultsDisplay getCatalogFieldsFaroFDSResultsDisplay(
+			@PathParam("groupId") long groupId,
+			@QueryParam("query") String query,
+			@QueryParam("tableName") String tableName,
+			@QueryParam("page") int page, @QueryParam("pageSize") int pageSize,
+			@DefaultValue(StringPool.BLANK) @QueryParam("sort") String
+				sortString)
+		throws Exception {
+
+		Results<CatalogField> results = contactsEngineClient.getCatalogFields(
+			faroProjectLocalService.getFaroProjectByGroupId(groupId), query,
+			tableName, page, pageSize, sortString);
+
+		return new FaroFDSResultsDisplay(results, page, pageSize);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98864

## What Is Being Fixed

The Account lifecycle-stage builder's field picker needs the list of catalog fields available for a given gold entity so users can build stage criteria. The asah backend exposes this as `GET /catalog/fields` (LPD-98593), but there was no Faro BFF endpoint for the Frontend Data Set to consume.

## How It Is Being Fixed

Adds a Faro BFF that adapts the asah catalog read to the `FaroFDSResultsDisplay` envelope the FDS binds to. On the engine-client side, a new `catalog-fields` rel and a paginated `getCatalogFields` method deserialize the asah `PageDTO` into `Results<CatalogField>`, reusing the shared `getUriVariables` helper so 1-based FE paging becomes asah's 0-based `page`/`size` and `sort` is passed through. A new `CatalogFaroController` under the main application exposes `GET main/{groupId}/catalog/fields`, wrapping the results in the envelope. The new interface method is also implemented on the mock engine client.

## Why Are There No Tests?

This mirrors the existing individual-attributes BFF path (`DefinitionsFaroController.getIndividualAttributes` and its engine-client method), which Faro leaves untested — no test tier exists for these BFF controllers or engine-client methods. The change is a thin pass-through adapter, and the workspace build (including the JS suite, 3429 tests) passed.

## PR Check

**pr-check: PASS** — tested on `1365a50d72947`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "1365a50d7294793f49057513424479ad6f5764ff"} -->
