### PR TITLE
LPD-99242 Create account lifecycles with stages and a channel ID

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -76,8 +76,8 @@ import java.util.Set;
 public interface ContactsEngineClient {
 
 	public AccountLifecycle addAccountLifecycle(
-		FaroProject faroProject, String description, String name,
-		String segmentId);
+		FaroProject faroProject, AccountLifecycle accountLifecycle,
+		String channelId);
 
 	public Results<BlockedKeyword> addBlockedKeywords(
 		FaroProject faroProject, List<String> keywords);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -132,18 +132,16 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public AccountLifecycle addAccountLifecycle(
-		FaroProject faroProject, String description, String name,
-		String segmentId) {
+		FaroProject faroProject, AccountLifecycle accountLifecycle,
+		String channelId) {
 
-		AccountLifecycle accountLifecycle = new AccountLifecycle();
+		Map<String, Object> uriVariables = getUriVariables(faroProject);
 
-		accountLifecycle.setDescription(description);
-		accountLifecycle.setName(name);
-		accountLifecycle.setSegmentId(segmentId);
+		uriVariables.put("channelId", channelId);
 
 		return post(
 			faroProject, Rels.ACCOUNT_LIFECYCLES, accountLifecycle,
-			AccountLifecycle.class);
+			AccountLifecycle.class, uriVariables);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/AccountLifecycleStage.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/AccountLifecycleStage.java
@@ -5,6 +5,8 @@
 
 package com.liferay.osb.faro.engine.client.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * @author Riccardo Ferrari
  */
@@ -12,6 +14,11 @@ public class AccountLifecycleStage {
 
 	public String getAccountLifecycleId() {
 		return _accountLifecycleId;
+	}
+
+	@JsonProperty("segment")
+	public AccountLifecycleStageRule getAccountLifecycleStageRule() {
+		return _accountLifecycleStageRule;
 	}
 
 	public String getDescription() {
@@ -42,6 +49,12 @@ public class AccountLifecycleStage {
 		_accountLifecycleId = accountLifecycleId;
 	}
 
+	public void setAccountLifecycleStageRule(
+		AccountLifecycleStageRule accountLifecycleStageRule) {
+
+		_accountLifecycleStageRule = accountLifecycleStageRule;
+	}
+
 	public void setDescription(String description) {
 		_description = description;
 	}
@@ -67,6 +80,7 @@ public class AccountLifecycleStage {
 	}
 
 	private String _accountLifecycleId;
+	private AccountLifecycleStageRule _accountLifecycleStageRule;
 	private String _description;
 	private Integer _displayOrder;
 	private String _id;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -80,11 +80,11 @@ public abstract class BaseMockContactsEngineClientImpl
 
 	@Override
 	public AccountLifecycle addAccountLifecycle(
-		FaroProject faroProject, String description, String name,
-		String segmentId) {
+		FaroProject faroProject, AccountLifecycle accountLifecycle,
+		String channelId) {
 
 		return contactsEngineClient.addAccountLifecycle(
-			faroProject, description, name, segmentId);
+			faroProject, accountLifecycle, channelId);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountLifecycleFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountLifecycleFaroController.java
@@ -11,10 +11,13 @@ import com.liferay.osb.faro.engine.client.model.AccountLifecycleMetric;
 import com.liferay.osb.faro.engine.client.model.AccountLifecycleStageMetric;
 import com.liferay.osb.faro.engine.client.model.Results;
 import com.liferay.osb.faro.web.internal.controller.BaseFaroController;
+import com.liferay.osb.faro.web.internal.exception.FaroException;
 import com.liferay.osb.faro.web.internal.model.display.FaroFDSResultsDisplay;
 import com.liferay.osb.faro.web.internal.model.display.contacts.AccountDisplay;
+import com.liferay.osb.faro.web.internal.param.FaroParam;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.annotation.security.RolesAllowed;
 
@@ -46,14 +49,18 @@ public class AccountLifecycleFaroController extends BaseFaroController {
 	@RolesAllowed(RoleConstants.SITE_MEMBER)
 	public AccountLifecycle createAccountLifecycle(
 			@PathParam("groupId") long groupId,
-			@FormParam("description") String description,
-			@FormParam("name") String name,
-			@FormParam("segmentId") String segmentId)
+			@FormParam("accountLifecycle") FaroParam<AccountLifecycle>
+				accountLifecycleFaroParam,
+			@QueryParam("channelId") String channelId)
 		throws Exception {
+
+		if (Validator.isNull(channelId)) {
+			throw new FaroException("Invalid channel ID: " + channelId);
+		}
 
 		return contactsEngineClient.addAccountLifecycle(
 			faroProjectLocalService.getFaroProjectByGroupId(groupId),
-			description, name, segmentId);
+			accountLifecycleFaroParam.getValue(), channelId);
 	}
 
 	@GET


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99242

## What Is Being Fixed

The Account Lifecycle create wizard needs to create a lifecycle in a single call — its name and description plus all of its stages, each with its own segment trigger — scoped to a channel. The previous Faro create endpoint accepted only a flat description/name/segmentId, so it could carry neither the stages nor their triggers and had no notion of a channel. The asah counterpart (LPD-98390) already accepts the full lifecycle and a channelId query param and no longer requires segmentId; the Faro layers were not yet wired to it.

## How It Is Being Fixed

The engine client method addAccountLifecycle now takes a fully populated AccountLifecycle plus a channelId and posts it to the account-lifecycles rel with channelId as a uri variable, letting the rel template expand {?channelId}; the old description/name/segmentId decomposition is gone. Each AccountLifecycleStage gained a nested segment trigger, carried by a new AccountLifecycleStageSegment model renamed from the misnamed AccountLifecycleStageRule, since the payload it holds is a segment rather than a rule. The mock engine client mirrors the new signature. The faro-web controller now accepts channelId as a query param plus the AccountLifecycle request body, requires the channel ID, resolves the project from the group, and forwards to the engine client.

## Why Are There No Tests?

Per the Faro convention, tests are added only where the touched controllers and clients already have them, and none of the three changed classes (AccountLifecycleFaroController, ContactsEngineClient/Impl, BaseMockContactsEngineClientImpl) has an existing Java test. The wizard flow is exercised by the FE jest suite, which is owned by the FE team and out of scope for this Java-only ticket, and the backend create/validation logic is covered by unit tests in the asah counterpart, LPD-98390.

## PR Check

**pr-check: PASS** — tested on `580b84f94b0dca50fc68d09c4e3b7903c35797ac`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "580b84f94b0dca50fc68d09c4e3b7903c35797ac"} -->
