### PR TITLE
LPD-99300 Add contactsConfiguration to Marketo campaign endpoints

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/provider/MarketoCampaignProvider.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/provider/MarketoCampaignProvider.java
@@ -19,6 +19,10 @@ public class MarketoCampaignProvider implements Provider {
 		return _channelsConfiguration;
 	}
 
+	public ContactsConfiguration getContactsConfiguration() {
+		return _contactsConfiguration;
+	}
+
 	@Override
 	public String getType() {
 		return TYPE;
@@ -30,6 +34,27 @@ public class MarketoCampaignProvider implements Provider {
 		_channelsConfiguration = channelsConfiguration;
 	}
 
+	public void setContactsConfiguration(
+		ContactsConfiguration contactsConfiguration) {
+
+		_contactsConfiguration = contactsConfiguration;
+	}
+
+	public static class ContactsConfiguration {
+
+		public boolean isEnableAllLeads() {
+			return _enableAllLeads;
+		}
+
+		public void setEnableAllLeads(boolean enableAllLeads) {
+			_enableAllLeads = enableAllLeads;
+		}
+
+		private boolean _enableAllLeads;
+
+	}
+
 	private ChannelsConfiguration _channelsConfiguration;
+	private ContactsConfiguration _contactsConfiguration;
 
 }

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
@@ -313,6 +313,9 @@ public class DataSourceFaroController extends BaseFaroController {
 			@PathParam("groupId") long groupId,
 			@DefaultValue(StringPool.BLANK) @FormParam("channelsConfiguration")
 				FaroParam<ChannelsConfiguration> channelsConfigurationFaroParam,
+			@DefaultValue(StringPool.BLANK) @FormParam("contactsConfiguration")
+				FaroParam<MarketoCampaignProvider.ContactsConfiguration>
+					contactsConfigurationFaroParam,
 			@FormParam("credentials") Credentials credentials,
 			@FormParam("name") String name,
 			@DefaultValue("ACTIVE") @FormParam("status") String status,
@@ -324,6 +327,8 @@ public class DataSourceFaroController extends BaseFaroController {
 
 		marketoCampaignProvider.setChannelsConfiguration(
 			channelsConfigurationFaroParam.getValue());
+		marketoCampaignProvider.setContactsConfiguration(
+			contactsConfigurationFaroParam.getValue());
 
 		return create(
 			groupId, credentials, marketoCampaignProvider, name, url, null,
@@ -1376,6 +1381,9 @@ public class DataSourceFaroController extends BaseFaroController {
 			@PathParam("groupId") long groupId, @PathParam("id") String id,
 			@DefaultValue(StringPool.BLANK) @FormParam("channelsConfiguration")
 				FaroParam<ChannelsConfiguration> channelsConfigurationFaroParam,
+			@DefaultValue(StringPool.BLANK) @FormParam("contactsConfiguration")
+				FaroParam<MarketoCampaignProvider.ContactsConfiguration>
+					contactsConfigurationFaroParam,
 			@FormParam("credentials") Credentials credentials,
 			@FormParam("name") String name, @FormParam("status") String status,
 			@FormParam("url") String url)
@@ -1385,16 +1393,27 @@ public class DataSourceFaroController extends BaseFaroController {
 
 		ChannelsConfiguration channelsConfiguration =
 			channelsConfigurationFaroParam.getValue();
+		MarketoCampaignProvider.ContactsConfiguration contactsConfiguration =
+			contactsConfigurationFaroParam.getValue();
 
-		if (channelsConfiguration != null) {
+		if ((channelsConfiguration != null) ||
+			(contactsConfiguration != null)) {
+
 			DataSource dataSource = contactsEngineClient.getDataSource(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId), id);
 
 			marketoCampaignProvider =
 				(MarketoCampaignProvider)dataSource.getProvider();
 
-			marketoCampaignProvider.setChannelsConfiguration(
-				channelsConfiguration);
+			if (channelsConfiguration != null) {
+				marketoCampaignProvider.setChannelsConfiguration(
+					channelsConfiguration);
+			}
+
+			if (contactsConfiguration != null) {
+				marketoCampaignProvider.setContactsConfiguration(
+					contactsConfiguration);
+			}
 		}
 
 		return update(
@@ -1724,6 +1743,9 @@ public class DataSourceFaroController extends BaseFaroController {
 			@PathParam("groupId") long groupId, @PathParam("id") String id,
 			@DefaultValue(StringPool.BLANK) @FormParam("channelsConfiguration")
 				FaroParam<ChannelsConfiguration> channelsConfigurationFaroParam,
+			@DefaultValue(StringPool.BLANK) @FormParam("contactsConfiguration")
+				FaroParam<MarketoCampaignProvider.ContactsConfiguration>
+					contactsConfigurationFaroParam,
 			@FormParam("credentials") Credentials credentials,
 			@FormParam("name") String name, @FormParam("status") String status,
 			@FormParam("url") String url)
@@ -1734,6 +1756,8 @@ public class DataSourceFaroController extends BaseFaroController {
 
 		marketoCampaignProvider.setChannelsConfiguration(
 			channelsConfigurationFaroParam.getValue());
+		marketoCampaignProvider.setContactsConfiguration(
+			contactsConfigurationFaroParam.getValue());
 
 		return update(
 			groupId, id, credentials, null, null, 0, name, false,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99300

## What Is Being Fixed

The Marketo Campaign data source endpoints exposed only a channels configuration, so there was no way to configure which leads a Marketo Campaign data source syncs.

## How It Is Being Fixed

Added a ContactsConfiguration (holding an enableAllLeads flag) to MarketoCampaignProvider, mirroring the configuration classes already on the other providers. Wired a contactsConfiguration form parameter into the three /marketo-campaign handlers in DataSourceFaroController: createTypeMarketoCampaign and updateTypeMarketoCampaign set it unconditionally, while patchTypeMarketoCampaign fetches the existing provider when either configuration is present and applies each one only when supplied.

## Why Are There No Tests?

The change is pure passthrough wiring of a contactsConfiguration form parameter into MarketoCampaignProvider, mirroring the existing channelsConfiguration pattern, with no new logic branch to cover.

## PR Check

**pr-check: SKIPPED** — Workspace Build fails on a local Windows node-path tooling issue unrelated to the diff; Source Format passed and both modules compiled.

<!-- pr-check {"reason": "Workspace Build fails on a local Windows node-path tooling issue unrelated to the diff; Source Format passed and both modules compiled.", "result": "skipped", "sha": "399b6ff650807b7a713bc4174d08940183ca1b5a"} -->
