### PR TITLE
LPD-99361 Support account lifecycle edit and processing

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -644,8 +644,7 @@ public interface ContactsEngineClient {
 	public void setEngineURL(String engineURL);
 
 	public AccountLifecycle updateAccountLifecycle(
-		FaroProject faroProject, String description, String id, String name,
-		String segmentId);
+		FaroProject faroProject, AccountLifecycle accountLifecycle);
 
 	public void updateAccountLifecycleStageRule(
 		FaroProject faroProject, String filterMetadata, String filterString,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -3486,19 +3486,12 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public AccountLifecycle updateAccountLifecycle(
-		FaroProject faroProject, String description, String id, String name,
-		String segmentId) {
-
-		AccountLifecycle accountLifecycle = new AccountLifecycle();
-
-		accountLifecycle.setDescription(description);
-		accountLifecycle.setId(id);
-		accountLifecycle.setName(name);
-		accountLifecycle.setSegmentId(segmentId);
+		FaroProject faroProject, AccountLifecycle accountLifecycle) {
 
 		return put(
 			faroProject, Rels.ACCOUNT_LIFECYCLE, accountLifecycle,
-			AccountLifecycle.class, getUriVariables(faroProject, id));
+			AccountLifecycle.class,
+			getUriVariables(faroProject, accountLifecycle.getId()));
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/AccountLifecycle.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/AccountLifecycle.java
@@ -5,6 +5,7 @@
 
 package com.liferay.osb.faro.engine.client.model;
 
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -22,6 +23,14 @@ public class AccountLifecycle {
 
 	public String getName() {
 		return _name;
+	}
+
+	public Date getProcessedDate() {
+		if (_processedDate == null) {
+			return null;
+		}
+
+		return new Date(_processedDate.getTime());
 	}
 
 	public String getSegmentId() {
@@ -44,6 +53,12 @@ public class AccountLifecycle {
 		_name = name;
 	}
 
+	public void setProcessedDate(Date processedDate) {
+		if (processedDate != null) {
+			_processedDate = new Date(processedDate.getTime());
+		}
+	}
+
 	public void setSegmentId(String segmentId) {
 		_segmentId = segmentId;
 	}
@@ -55,6 +70,7 @@ public class AccountLifecycle {
 	private String _description;
 	private String _id;
 	private String _name;
+	private Date _processedDate;
 	private String _segmentId;
 	private List<AccountLifecycleStage> _stages;
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -1308,11 +1308,10 @@ public abstract class BaseMockContactsEngineClientImpl
 
 	@Override
 	public AccountLifecycle updateAccountLifecycle(
-		FaroProject faroProject, String description, String id, String name,
-		String segmentId) {
+		FaroProject faroProject, AccountLifecycle accountLifecycle) {
 
 		return contactsEngineClient.updateAccountLifecycle(
-			faroProject, description, id, name, segmentId);
+			faroProject, accountLifecycle);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountLifecycleFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountLifecycleFaroController.java
@@ -139,14 +139,18 @@ public class AccountLifecycleFaroController extends BaseFaroController {
 	@RolesAllowed(RoleConstants.SITE_MEMBER)
 	public AccountLifecycle updateAccountLifecycle(
 			@PathParam("groupId") long groupId, @PathParam("id") String id,
-			@FormParam("description") String description,
-			@FormParam("name") String name,
-			@FormParam("segmentId") String segmentId)
+			@FormParam("accountLifecycle") FaroParam<AccountLifecycle>
+				accountLifecycleFaroParam)
 		throws Exception {
+
+		AccountLifecycle accountLifecycle =
+			accountLifecycleFaroParam.getValue();
+
+		accountLifecycle.setId(id);
 
 		return contactsEngineClient.updateAccountLifecycle(
 			faroProjectLocalService.getFaroProjectByGroupId(groupId),
-			description, id, name, segmentId);
+			accountLifecycle);
 	}
 
 	@Path("/{id}/stages/{stageId}/rules")


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99361

## What Is Being Fixed

The Faro BFF could not fully support the account lifecycle edit form or a "processing" state. On update it sent only the name, description, and a single `segmentId`, so stage-level segment triggers and durations could not be saved. The read model also had no field to tell the frontend that a lifecycle was still being processed by the engine.

## How It Is Being Fixed

This is the Faro-side counterpart to the asah account lifecycle edit + processing work, building on LPD-99242 (create). The engine client's `updateAccountLifecycle` now takes a populated `AccountLifecycle` and PUTs the full body — name, description, and every stage with its nested `segment` trigger and `maxDuration` — to the existing `ACCOUNT_LIFECYCLE` rel, mirroring the create path minus `channelId` (an edit updates existing stage segments rather than creating them), and drops `segmentId`. The `AccountLifecycleFaroController` update endpoint accepts the full `AccountLifecycle` body like the create endpoint, stamping the path id onto it. The read model gains a read-only `processedDate` that deserializes from the engine response and surfaces to the frontend, so the UI can show a processing state; `getAccountLifecycle` already round-trips each stage's `segment` from LPD-99242, so no read-path code changed. The mock engine client's override is updated to the new signature.

End-to-end this depends on the pending asah edit + processing endpoints (GET returning each stage's `segment`, PUT accepting the full body, and `AccountLifecycleDTO` exposing `processedDate`); the Java compiles and is contract-correct without them.

## Why Are There No Tests?

Following the Faro convention of adding tests only where the touched controllers and clients already have them: neither `AccountLifecycleFaroController` nor `ContactsEngineClientImpl` has an existing test (the engine-client module's only unit test is `FilterBuilderTest`), and the preceding sibling ticket LPD-99242 (create) shipped with no tests for the same reason. The change is exercised by the workspace build's compile and the existing JavaScript suite.

## PR Check

**pr-check: PASS** — tested on `292a90874b973d438c522612c4336fb329916e26`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "292a90874b973d438c522612c4336fb329916e26"} -->
