### PR TITLE
LPD-99689 Disable Add Event Attribute until an asset type is chosen

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/BehaviorInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/BehaviorInput.tsx
@@ -446,6 +446,13 @@ export class BehaviorInput extends React.Component<
 			Map({propertyName: ATTRIBUTE_PROPERTY_PREFIX})
 		).toJS();
 
+		// Event attributes are read per event, so there is nothing to filter on
+		// until an asset type is chosen. Keep the button in place (disabled, like
+		// its "Add Assets" sibling) instead of swapping in a section that renders
+		// nothing.
+
+		const eventId = this.getEventId();
+
 		return (
 			<div className="criteria-statement">
 				<Form.Group autoFit className="page-asset-criteria">
@@ -495,10 +502,10 @@ export class BehaviorInput extends React.Component<
 					</Form.Group>
 				)}
 
-				{this.state.showAttributeFilter ? (
+				{this.state.showAttributeFilter && eventId ? (
 					<AttributeFilterSection
 						conjunctionCriterion={attributeConjunctionCriterion}
-						eventId={this.getEventId()}
+						eventId={eventId}
 						onChange={this.handleAttributeConjunctionChange}
 						onClear={this.handleClearAttributeFilter}
 						touched={touched}
@@ -508,6 +515,7 @@ export class BehaviorInput extends React.Component<
 					<Form.Group autoFit>
 						<ClayButton
 							className="button-root"
+							disabled={!eventId}
 							displayType="secondary"
 							onClick={this.handleShowAttributeFilterClick}
 						>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/__tests__/BehaviorInput.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/__tests__/BehaviorInput.jsx
@@ -258,6 +258,33 @@ describe('BehaviorInput', () => {
 	});
 
 	describe('attribute filter', () => {
+		const valueWithoutAssetType = createCustomValueMap([
+			{key: 'criterionGroup', value: []},
+			{key: 'operator', value: RelationalOperators.GE},
+			{key: 'value', value: ''}
+		]);
+
+		it('should disable the "Add Event Attribute" button until an asset type is selected', () => {
+			const {getByText} = render(
+				<DefaultComponent value={valueWithoutAssetType} />
+			);
+
+			expect(
+				getByText('Add Event Attribute').closest('button').disabled
+			).toBe(true);
+		});
+
+		it('should keep the "Add Event Attribute" button when there is no event to read attributes from', () => {
+			const {getByText, queryByTestId} = render(
+				<DefaultComponent value={valueWithoutAssetType} />
+			);
+
+			fireEvent.click(getByText('Add Event Attribute'));
+
+			expect(queryByTestId('attribute-filter-section')).toBeNull();
+			expect(getByText('Add Event Attribute')).toBeTruthy();
+		});
+
 		it('should show the "Add Event Attribute" button when there is no attribute criterion', () => {
 			const {getByText, queryByTestId} = render(<DefaultComponent />);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99689

## What Is Being Fixed

On an event criterion in the segment editor, clicking "Add Event Attribute" before an Asset Type is selected made the button disappear without rendering anything in its place, leaving the criterion with no attribute filter and no way to recover short of removing it and starting over. LPD-90890 introduced a valid intermediate state in which the criterion carries no asset filter yet, so it holds no `eventId`, and `AttributeFilterSection` renders `null` when the event id is empty.

## How It Is Being Fixed

The attribute section is now rendered only when there is an event to read attributes from, and the button is disabled until then. That matches its "Add Assets" sibling in the same row, which is already disabled while no type is chosen, so the affordance is never replaced by nothing.

## PR Check

**pr-check: PASS** — tested on `e906f551267d9e5e1077b9b463ba514bbee64604`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "e906f551267d9e5e1077b9b463ba514bbee64604"} -->

Resent from interaminense/liferay-portal#540