### PR TITLE
LPD-99886 Format the account counts and percentages in stage cards

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/LifecycleChart.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/LifecycleChart.tsx
@@ -11,6 +11,7 @@ import {
 } from 'contacts/pages/account/utils/constants';
 import {SectionHeader} from 'shared/components/SectionHeader';
 import {sub} from 'shared/util/lang';
+import {toRounded, toThousands} from 'shared/util/numbers';
 import {useLifecycle} from 'lifecycle/context/LifecycleContext';
 
 const EMPTY_STAGES: ILifecycleStage[] = [
@@ -96,7 +97,7 @@ const StageMetrics = ({
 				<div>
 					<p className="mb-0">
 						<Text size={7} weight="bold">
-							{accountCount}
+							{toThousands(accountCount)}
 						</Text>
 					</p>
 					<Text color="secondary" size={4}>
@@ -105,7 +106,7 @@ const StageMetrics = ({
 								Liferay.Language.get(
 									'x-percent-of-all-accounts'
 								),
-								[percentage.toFixed(2)]
+								[toRounded(percentage)]
 							) as string
 						).toLowerCase()}
 					</Text>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/__tests__/LifecycleChart.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/__tests__/LifecycleChart.tsx
@@ -128,6 +128,77 @@ describe('LifecycleChart', () => {
 		).toHaveLength(4);
 	});
 
+	it('should render account counts abbreviated from a thousand upwards', () => {
+		const stagesWithLargeCounts: ILifecycleStage[] = [
+			{
+				accountCount: 5350,
+				averageStageDuration: 0,
+				conversionRateToNextStage: 10,
+				description: '',
+				percentage: 83.62,
+				stageType: LifecycleStages.AWARE,
+			},
+			{
+				accountCount: 1656000,
+				averageStageDuration: 0,
+				conversionRateToNextStage: 10,
+				description: '',
+				percentage: 15.38,
+				stageType: LifecycleStages.ENGAGED,
+			},
+			{
+				accountCount: 999,
+				averageStageDuration: 0,
+				conversionRateToNextStage: null,
+				description: '',
+				percentage: 1,
+				stageType: LifecycleStages.PIPELINE,
+			},
+		];
+
+		const {getByText, queryByText} = renderChart({
+			stages: stagesWithLargeCounts,
+		});
+
+		expect(getByText('5.35K')).toBeInTheDocument();
+		expect(getByText('1.66M')).toBeInTheDocument();
+		expect(getByText('999')).toBeInTheDocument();
+
+		expect(queryByText('5350')).toBeNull();
+		expect(queryByText('1656000')).toBeNull();
+	});
+
+	it('should render the percentage of all accounts rounded to a single decimal', () => {
+		const stagesWithLongPercentages: ILifecycleStage[] = [
+			{
+				accountCount: 1,
+				averageStageDuration: 0,
+				conversionRateToNextStage: 10,
+				description: '',
+				percentage: 83.62,
+				stageType: LifecycleStages.AWARE,
+			},
+			{
+				accountCount: 1,
+				averageStageDuration: 0,
+				conversionRateToNextStage: null,
+				description: '',
+				percentage: 50,
+				stageType: LifecycleStages.ENGAGED,
+			},
+		];
+
+		const {getByText, queryByText} = renderChart({
+			stages: stagesWithLongPercentages,
+		});
+
+		expect(getByText('83.6% of all accounts')).toBeInTheDocument();
+		expect(getByText('50% of all accounts')).toBeInTheDocument();
+
+		expect(queryByText('83.62% of all accounts')).toBeNull();
+		expect(queryByText('50.00% of all accounts')).toBeNull();
+	});
+
 	it('should show "avg. day" for non-zero averages and "no activity" otherwise', () => {
 		const {getAllByText, getByText} = renderChart({stages: sampleStages});
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
@@ -1592,7 +1592,7 @@ exports[`MarketoCampaignOverview should render the connected data source with th
                     <div
                       class="h4 no-results-title"
                     >
-                      There are no properties found.
+                      No properties were found.
                     </div>
                     <div
                       class="no-results-description"
@@ -2568,7 +2568,7 @@ exports[`MarketoCampaignOverview should render the reconnect view when the data 
                     <div
                       class="h4 no-results-title"
                     >
-                      There are no properties found.
+                      No properties were found.
                     </div>
                     <div
                       class="no-results-description"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99886
https://liferay.atlassian.net/browse/LPD-99034

## What Is Being Fixed

The Accounts by Stage card on the Lifecycle dashboard rendered each stage's account count as a raw number and its share of all accounts with two fixed decimals, bypassing the shared helpers in `shared/util/numbers`. A stage holding 5350 accounts read `5350` instead of `5.35K`, and its share read `83.62%` instead of `83.6%`. Because `toFixed` does not go through `Intl.NumberFormat`, neither value respected the user's locale either.

## How It Is Being Fixed

`StageMetrics` now formats the count with `toThousands` and the percentage with `toRounded`, the same helpers every other account metric already relies on — `TotalAccounts`, `UniqueVisitors` and `TopAssets` for counts, `MetricCard` for percentages. Two tests cover the new behavior: counts abbreviate from a thousand upwards while smaller ones stay untouched, and percentages round to a single decimal without a trailing zero precision.

The branch also carries the `LPD-99034` snapshot refresh. Without it the workspace build fails on a stale Marketo snapshot inherited from master, unrelated to this change.

## PR Check

**pr-check: PASS** — tested on `07f5951a37e61998818b759909b55c20242fef61`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "07f5951a37e61998818b759909b55c20242fef61"} -->

Resent from interaminense/liferay-portal#543