### PR TITLE
LPD-73222 faro-v5.0.x Enable audit logging on Analytics Cloud

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-docker/cloud/Dockerfile.ext
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-docker/cloud/Dockerfile.ext
@@ -14,6 +14,8 @@ RUN mkdir -p $LIFERAY_HOME/tomcat/lib/org/apache/catalina/util && \
 COPY --chown=liferay:liferay docker/resources/context.xml $LIFERAY_HOME/tomcat/conf/
 COPY --chown=liferay:liferay docker/resources/rewrite.config $LIFERAY_HOME/tomcat/webapps/ROOT/WEB-INF/
 COPY --chown=liferay:liferay docker/resources/system-ext.properties $LIFERAY_HOME/tomcat/webapps/ROOT/WEB-INF/classes/
+COPY --chown=liferay:liferay docker/resources/portal-log4j-ext.xml $LIFERAY_HOME/tomcat/webapps/ROOT/WEB-INF/classes/META-INF/
+COPY --chown=liferay:liferay docker/resources/log_layout.json $LIFERAY_HOME/tomcat/webapps/ROOT/WEB-INF/classes/META-INF/
 COPY --chown=liferay:liferay docker/resources/log4j $LIFERAY_HOME/osgi/log4j/
 COPY --chown=liferay:liferay docker/configs/osgi/configs $LIFERAY_HOME/osgi/configs/
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-docker/cloud/configs/osgi/configs/com.liferay.portal.security.audit.router.configuration.LoggingAuditMessageProcessorConfiguration.config
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-docker/cloud/configs/osgi/configs/com.liferay.portal.security.audit.router.configuration.LoggingAuditMessageProcessorConfiguration.config
@@ -1,0 +1,2 @@
+enabled="true"
+logMessageFormat="JSON"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-73222

## What Is Being Fixed

Analytics Cloud has no structured audit logging, which makes it impossible to investigate security incidents. DXP's audit router runs by default, but the processor that actually emits audit events to the log, `LoggingAuditMessageProcessor`, ships disabled and defaults to CSV formatting. Separately, the cloud Docker image never copied `portal-log4j-ext.xml` or `log_layout.json` into the built image, so a JSON-structured GCP logging layout and an audit-logger-at-INFO override already sitting in the source tree never reached a running container.

## How It Is Being Fixed

Adds an OSGi configuration for `LoggingAuditMessageProcessorConfiguration` that enables the processor and sets its output format to JSON. Adds the two missing `COPY` instructions to `Dockerfile.ext` so `portal-log4j-ext.xml` and `log_layout.json` land in `$LIFERAY_HOME/tomcat/webapps/ROOT/WEB-INF/classes/META-INF`, matching the same convention already used by the wedeploy pipeline's setup script. Together, audit events (login, logout, auth failures, impersonation, and user/role/organization/user group CRUD) now flow to stdout as JSON lines that GCP Logging can pick up from the container.

## Why Are There No Tests?

This is a Docker image build wiring and OSGi configuration change, not application logic; there is no unit or integration test surface for a static `.config` file or a Dockerfile `COPY` path. It is verified by deploying the image and confirming a login/logout event appears as a JSON line in the container's stdout logs.

## PR Check

**pr-check: SKIPPED** — Config/build-only change; no compilable Java/JS to validate via pr-check.

<!-- pr-check {"reason": "Config/build-only change; no compilable Java/JS to validate via pr-check", "result": "skipped", "sha": "1f0aefb328c8e009cc418c18951ffb97b30848a9"} -->
