### PR TITLE
LPD-99894 Copy the access token when the copy button is clicked

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
@@ -1592,7 +1592,7 @@ exports[`MarketoCampaignOverview should render the connected data source with th
                     <div
                       class="h4 no-results-title"
                     >
-                      There are no properties found.
+                      No properties were found.
                     </div>
                     <div
                       class="no-results-description"
@@ -2568,7 +2568,7 @@ exports[`MarketoCampaignOverview should render the reconnect view when the data 
                     <div
                       class="h4 no-results-title"
                     >
-                      There are no properties found.
+                      No properties were found.
                     </div>
                     <div
                       class="no-results-description"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/CopyButton.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/CopyButton.tsx
@@ -1,7 +1,7 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import Clipboard from 'clipboard';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {ButtonProps} from '@clayui/button';
 
 interface ICopyButtonProps {
@@ -21,9 +21,19 @@ const CopyButton: React.FC<ICopyButtonProps> = ({
 	...otherProps
 }) => {
 	const [title, setTitle] = useState(Liferay.Language.get('click-to-copy'));
+	const buttonRef = useRef(null);
 
 	useEffect(() => {
-		const _clipboard = new Clipboard('[data-clipboard-text]');
+		if (!buttonRef.current) {
+			return;
+		}
+
+		// Bind to the button itself instead of the '[data-clipboard-text]'
+		// selector: a selector delegates the listener to document.body, which
+		// never sees the click when an ancestor stops its propagation (as the
+		// table row actions do to keep the row from being selected).
+
+		const _clipboard = new Clipboard(buttonRef.current);
 
 		_clipboard.on('success', (event) => {
 			setTitle(Liferay.Language.get('copied'));
@@ -41,6 +51,7 @@ const CopyButton: React.FC<ICopyButtonProps> = ({
 			data-clipboard-text={text}
 			displayType={displayType}
 			onClick={onClick}
+			ref={buttonRef}
 			title={title}
 			{...otherProps}
 		>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/CopyButton.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/CopyButton.jsx
@@ -1,6 +1,7 @@
 import CopyButton from '../CopyButton';
 import React from 'react';
-import {cleanup, render} from '@testing-library/react';
+import StopClickPropagation from 'shared/components/table/cell-components/StopClickPropagation';
+import {cleanup, fireEvent, render} from '@testing-library/react';
 
 jest.unmock('react-dom');
 
@@ -13,5 +14,19 @@ describe('CopyButton', () => {
 		);
 
 		expect(container).toMatchSnapshot();
+	});
+
+	it('should copy the text when an ancestor stops the click propagation', () => {
+		document.execCommand = jest.fn(() => true);
+
+		const {getByRole} = render(
+			<StopClickPropagation>
+				<CopyButton displayType='secondary' text='foo' />
+			</StopClickPropagation>
+		);
+
+		fireEvent.click(getByRole('button'));
+
+		expect(document.execCommand).toHaveBeenCalledWith('copy');
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99894
https://liferay.atlassian.net/browse/LPD-99034

## What Is Being Fixed

The Click to Copy button next to an active token on the workspace Access Tokens page did nothing: clicking it neither wrote the token to the clipboard nor changed the tooltip to Copied, and no error reached the console.

`CopyButton` registered clipboard.js with the CSS selector `'[data-clipboard-text]'`, and a selector makes clipboard.js delegate its click listener to `document.body`. In the token table the button is wrapped by `StopClickPropagation`, the span every `Table` row action sits inside so that clicking an action does not select the row. React attaches its listeners to the application root container, and its synthetic `stopPropagation()` also stops the native event, so the click never reached `document.body` and the delegated clipboard handler never ran.

## How It Is Being Fixed

`CopyButton` now binds clipboard.js to the button element through a ref, the way `CopyInputValue` already did. The listener sits on the button itself and runs in the target phase, before any ancestor can stop the propagation, so the row action keeps swallowing the click for row selection while the copy still happens. Binding by element also removes the cross-talk the selector form had, where every mounted instance registered its own `document.body` delegate matching every `[data-clipboard-text]` node, so one click flipped every button's Copied state.

The regression test renders the button inside `StopClickPropagation` and asserts the copy is performed, which fails on the previous implementation. The fix was also verified manually against analytics-stg for both places `CopyButton` is used: the Access Tokens row and the event definition code snippet.

The second commit refreshes the `MarketoCampaignOverview` snapshot, which was left stale by the empty-state rewording and fails the module's Jest suite on master, independently of this change.

## PR Check

**pr-check: PASS** — tested on `1e899f9fe1766bef4f35c38a011a62e21200d2d9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

Source Format and Workspace Build were run through safe equivalents. This branch lives in a git worktree whose `node_modules` is a symlink into the main checkout, so the `ant format-source-current-branch` and `./gradlew build` entry points could not run — their `yarnInstall` step would have written through the symlink into the main checkout. Source Format ran node-scripts' `formatSourceFiles --check` (the same formatter `portalYarnFormatCurrentBranch` invokes) over the branch diff. Workspace Build ran the module's full Jest suite (688 suites, 3559 tests, 584 snapshots, all passing) plus the production webpack build.

<!-- pr-check {"result": "success", "sha": "1e899f9fe1766bef4f35c38a011a62e21200d2d9"} -->

Resent from interaminense/liferay-portal#544