### PR TITLE
LPD-94461 Send the stage trigger in the shape the BFF exposes

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/StageConfigurationPanel.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/StageConfigurationPanel.tsx
@@ -49,6 +49,8 @@ const PickerTriggerButton = React.forwardRef<
 const selectPlaceholder = (label: string) =>
 	sub(Liferay.Language.get('select-x'), [label]) as string;
 
+const getFieldLabel = (field: ICatalogField) => field.displayName || field.name;
+
 interface IStageConfigurationPanelProps {
 	defaultExpanded?: boolean;
 	fields?: ICatalogField[];
@@ -93,14 +95,16 @@ const StageConfigurationPanel: React.FC<IStageConfigurationPanelProps> = ({
 			<Picker
 				aria-label={selectPlaceholder(Liferay.Language.get('field'))}
 				as={PickerTriggerButton}
-				items={selectableFields.map((field) => ({
-					isCalculated: !!field.parentField,
-					label: field.displayName,
-					value: field.name,
-				}))}
+				items={selectableFields
+					.map((field) => ({
+						isCalculated: !!field.parentField,
+						label: getFieldLabel(field),
+						value: field.name,
+					}))
+					.sort((a, b) => a.label.localeCompare(b.label))}
 				label={
 					selectedField
-						? selectedField.displayName
+						? getFieldLabel(selectedField)
 						: selectPlaceholder(Liferay.Language.get('field'))
 				}
 				onSelectionChange={(key) => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/StageConfigurationPanel.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/StageConfigurationPanel.tsx
@@ -288,7 +288,7 @@ const StageConfigurationPanel: React.FC<IStageConfigurationPanelProps> = ({
 				</div>
 
 				<div className="align-items-center c-gap-2 d-flex mb-4">
-					<Text weight="semi-bold">
+					<Text size={3} weight="semi-bold">
 						{Liferay.Language.get('account')}
 					</Text>
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/StageConfigurationPanel.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/StageConfigurationPanel.tsx
@@ -85,11 +85,15 @@ const StageConfigurationPanel: React.FC<IStageConfigurationPanelProps> = ({
 			(field) => field.name === value.field
 		);
 
+		const selectableFields = fields.filter((field) =>
+			resolveOperatorType(field.dataCategory, field.dataType)
+		);
+
 		return (
 			<Picker
 				aria-label={selectPlaceholder(Liferay.Language.get('field'))}
 				as={PickerTriggerButton}
-				items={fields.map((field) => ({
+				items={selectableFields.map((field) => ({
 					isCalculated: !!field.parentField,
 					label: field.displayName,
 					value: field.name,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/__tests__/StageConfigurationPanel.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/__tests__/StageConfigurationPanel.tsx
@@ -349,4 +349,48 @@ describe('StageConfigurationPanel', () => {
 			maxTimeEnabled: false,
 		});
 	});
+
+	const unresolvableField = {
+		dataCategory: null,
+		dataType: 'STRING',
+		description: '',
+		displayName: 'Uncategorized Field',
+		id: 'account.uncategorized',
+		name: 'account.uncategorized',
+		parentField: null,
+		tableName: 'account',
+	} as unknown as ICatalogField;
+
+	it('offers a field whose data category only differs in casing', () => {
+		renderPanel({
+			fields: [
+				{
+					...mockFields[0],
+					dataCategory: 'TEXT',
+				} as unknown as ICatalogField,
+			],
+		});
+
+		fireEvent.click(screen.getByText('Select Field'));
+
+		expect(screen.getByText('Industry')).toBeInTheDocument();
+	});
+
+	it('leaves out a field no condition can be built from', () => {
+		renderPanel({fields: [...mockFields, unresolvableField]});
+
+		fireEvent.click(screen.getByText('Select Field'));
+
+		expect(screen.getByText('Industry')).toBeInTheDocument();
+		expect(screen.queryByText('Uncategorized Field')).toBeNull();
+	});
+
+	it('still names a selected field that is no longer offered', () => {
+		renderPanel({
+			fields: [...mockFields, unresolvableField],
+			value: {...baseValue, field: 'account.uncategorized'},
+		});
+
+		expect(screen.getByText('Uncategorized Field')).toBeInTheDocument();
+	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/__tests__/StageConfigurationPanel.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/__tests__/StageConfigurationPanel.tsx
@@ -385,6 +385,48 @@ describe('StageConfigurationPanel', () => {
 		expect(screen.queryByText('Uncategorized Field')).toBeNull();
 	});
 
+	const unlabeledField: ICatalogField = {
+		dataCategory: 'Text',
+		dataType: 'STRING',
+		description: null,
+		displayName: null,
+		id: 'accountName',
+		name: 'accountName',
+		parentField: null,
+		tableName: 'account',
+	};
+
+	it('falls back to the field name when the catalog omits a label', () => {
+		renderPanel({fields: [...mockFields, unlabeledField]});
+
+		fireEvent.click(screen.getByText('Select Field'));
+
+		expect(screen.getByText('accountName')).toBeInTheDocument();
+	});
+
+	it('names a selected field that has no label', () => {
+		renderPanel({
+			fields: [...mockFields, unlabeledField],
+			value: {...baseValue, field: 'accountName'},
+		});
+
+		expect(screen.getByText('accountName')).toBeInTheDocument();
+	});
+
+	it('orders the offered fields by their visible label', () => {
+		renderPanel({fields: [...mockFields, unlabeledField]});
+
+		fireEvent.click(screen.getByText('Select Field'));
+
+		const labels = screen
+			.getAllByRole('option')
+			.map((option) => option.textContent);
+
+		expect(labels).toEqual(
+			[...labels].sort((a, b) => a!.localeCompare(b!))
+		);
+	});
+
 	it('still names a selected field that is no longer offered', () => {
 		renderPanel({
 			fields: [...mockFields, unresolvableField],

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
@@ -121,7 +121,7 @@ const ProcessingLifecycleEmptyState = () => (
 		icon={{
 			border: false,
 			size: Sizes.XXXLarge,
-			symbol: 'ac_ready_to_use',
+			symbol: 'ac_no_sites',
 		}}
 		spacer
 		title={Liferay.Language.get('your-dashboard-is-almost-ready')}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
@@ -239,6 +239,8 @@ const BaseLifecycle = () => {
 
 	const loading = dataSourcesLoading || lifecyclesLoading;
 
+	const title = lifecycle?.name || Liferay.Language.get('lifecycles');
+
 	const hasContent =
 		!loading &&
 		!noDataSources &&
@@ -320,7 +322,7 @@ const BaseLifecycle = () => {
 
 	return (
 		<LifecycleContextProvider lifecycleId={lifecycleId ?? ''}>
-			<BasePage documentTitle={Liferay.Language.get('lifecycles')}>
+			<BasePage documentTitle={title}>
 				<BasePage.Header
 					breadcrumbs={[
 						breadcrumbs.getHome({
@@ -334,7 +336,7 @@ const BaseLifecycle = () => {
 					<BasePage.Row>
 						<BasePage.Header.TitleSection
 							className="mb-3"
-							title={Liferay.Language.get('lifecycles')}
+							title={title}
 						/>
 
 						{hasLifecycles && authorized && (

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/BaseLifecycle.tsx
@@ -81,7 +81,11 @@ const useRequestImpl =
 		processedDate = 1700000000000,
 		totalCount = 1,
 	}: {
-		lifecycles?: {id: string; processedDate?: number | null}[];
+		lifecycles?: {
+			id: string;
+			name?: string;
+			processedDate?: number | null;
+		}[];
 		metricsLoading?: boolean;
 		processedDate?: number | null;
 		totalCount?: number;
@@ -133,7 +137,35 @@ describe('BaseLifecycle', () => {
 
 	afterEach(cleanup);
 
-	it('renders the page title', () => {
+	it('titles the page with the lifecycle name', () => {
+		mockedUseRequest.mockImplementation(
+			useRequestImpl({
+				lifecycles: [{id: '1', name: "Tiago's Lifecycle"}],
+				totalCount: 5,
+			})
+		);
+
+		renderPage();
+
+		expect(screen.getByText("Tiago's Lifecycle")).toBeInTheDocument();
+		expect(screen.queryByText('Lifecycles')).toBeNull();
+	});
+
+	it('titles the page generically when no lifecycle exists', () => {
+		mockedUseRequest.mockImplementation(
+			useRequestImpl({lifecycles: [], totalCount: 5})
+		);
+
+		renderPage();
+
+		expect(screen.getByText('Lifecycles')).toBeInTheDocument();
+	});
+
+	it('titles the page generically when the lifecycle is unnamed', () => {
+		mockedUseRequest.mockImplementation(
+			useRequestImpl({lifecycles: [{id: '1'}], totalCount: 5})
+		);
+
 		renderPage();
 
 		expect(screen.getByText('Lifecycles')).toBeInTheDocument();

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/EditLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/EditLifecycle.tsx
@@ -41,8 +41,8 @@ const buildStages = (): ILifecycleStage[] =>
 		displayOrder: index + 1,
 		id: `stage-${index}`,
 		maxDuration: 30,
-		segment: {
-			filter: '(account.annualRevenue gt 1000)',
+		accountLifecycleStageRule: {
+			filterString: '(account.annualRevenue gt 1000)',
 			filterMetadata: JSON.stringify({
 				conditionValue: '1000',
 				field: 'account.annualRevenue',

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/EditLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/EditLifecycle.tsx
@@ -37,12 +37,7 @@ const mockedUseRequest = useRequest as jest.Mock;
 
 const buildStages = (): ILifecycleStage[] =>
 	LIFECYCLE_STAGE_ORDER.map((stageType, index) => ({
-		description: 'A configured stage',
-		displayOrder: index + 1,
-		id: `stage-${index}`,
-		maxDuration: 30,
 		accountLifecycleStageRule: {
-			filterString: '(account.annualRevenue gt 1000)',
 			filterMetadata: JSON.stringify({
 				conditionValue: '1000',
 				field: 'account.annualRevenue',
@@ -50,7 +45,12 @@ const buildStages = (): ILifecycleStage[] =>
 				fieldDataType: 'NUMERIC',
 				operator: 'gt',
 			}),
+			filterString: '(account.annualRevenue gt 1000)',
 		},
+		description: 'A configured stage',
+		displayOrder: index + 1,
+		id: `stage-${index}`,
+		maxDuration: 30,
 		stageType,
 	}));
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/utils/__tests__/lifecycleOperators.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/utils/__tests__/lifecycleOperators.ts
@@ -1,0 +1,34 @@
+import {
+	OperatorType,
+	resolveOperatorType,
+} from 'lifecycle/utils/lifecycleOperators';
+
+describe('resolveOperatorType', () => {
+	it('resolves the data category sent by the catalog', () => {
+		expect(resolveOperatorType('Text', 'STRING')).toBe(OperatorType.Text);
+		expect(resolveOperatorType('Number', 'NUMERIC')).toBe(
+			OperatorType.Number
+		);
+	});
+
+	it('resolves a data category whose casing differs from the catalog', () => {
+		expect(resolveOperatorType('TEXT', 'STRING')).toBe(OperatorType.Text);
+		expect(resolveOperatorType('number', 'NUMERIC')).toBe(
+			OperatorType.Number
+		);
+	});
+
+	it('resolves a duration regardless of its casing', () => {
+		expect(resolveOperatorType('Number', 'duration')).toBe(
+			OperatorType.Duration
+		);
+	});
+
+	it('resolves nothing when the data category is missing', () => {
+		expect(resolveOperatorType(null, 'STRING')).toBeNull();
+	});
+
+	it('resolves nothing for a data category it does not know', () => {
+		expect(resolveOperatorType('Geolocation', 'STRING')).toBeNull();
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/utils/__tests__/lifecyclePayload.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/utils/__tests__/lifecyclePayload.ts
@@ -210,12 +210,7 @@ describe('stageConfigsFromLifecycle', () => {
 	it('rebuilds every stage config from the saved rule metadata', () => {
 		const configs = stageConfigsFromLifecycle([
 			{
-				description: 'Saved description',
-				displayOrder: 1,
-				id: 'stage-1',
-				maxDuration: 30,
 				accountLifecycleStageRule: {
-					filterString: '(account.annualRevenue gt 1000)',
 					filterMetadata: JSON.stringify({
 						conditionValue: '1000',
 						field: 'account.annualRevenue',
@@ -223,7 +218,12 @@ describe('stageConfigsFromLifecycle', () => {
 						fieldDataType: 'NUMERIC',
 						operator: 'gt',
 					}),
+					filterString: '(account.annualRevenue gt 1000)',
 				},
+				description: 'Saved description',
+				displayOrder: 1,
+				id: 'stage-1',
+				maxDuration: 30,
 				stageType: 'AWARE',
 			},
 		]);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/utils/__tests__/lifecyclePayload.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/utils/__tests__/lifecyclePayload.ts
@@ -151,7 +151,7 @@ describe('buildStageFilter', () => {
 });
 
 describe('buildCreateLifecyclePayload', () => {
-	it('maps every stage with its order, type, and derived segment', () => {
+	it('maps every stage with its order, type, and derived rule', () => {
 		const payload = buildCreateLifecyclePayload({
 			channelId: '123',
 			groupId: '23',
@@ -164,8 +164,15 @@ describe('buildCreateLifecyclePayload', () => {
 		expect(payload.stages).toHaveLength(6);
 		expect(payload.stages[0].displayOrder).toBe(1);
 		expect(payload.stages[0].stageType).toBe('AWARE');
-		expect(payload.stages[0].segment).toHaveProperty('filter');
-		expect(payload.stages[0].segment).toHaveProperty('filterMetadata');
+		expect(payload.stages[0].accountLifecycleStageRule).toHaveProperty(
+			'filterString'
+		);
+		expect(payload.stages[0].accountLifecycleStageRule).toHaveProperty(
+			'filterMetadata'
+		);
+		expect(payload.stages[0].accountLifecycleStageRule.name).toBe(
+			'My Lifecycle Stage AWARE Criteria'
+		);
 	});
 
 	it('sends a null maxDuration when the stage limit is disabled', () => {
@@ -200,15 +207,15 @@ describe('buildUpdateLifecyclePayload', () => {
 });
 
 describe('stageConfigsFromLifecycle', () => {
-	it('rebuilds every stage config from the saved segment metadata', () => {
+	it('rebuilds every stage config from the saved rule metadata', () => {
 		const configs = stageConfigsFromLifecycle([
 			{
 				description: 'Saved description',
 				displayOrder: 1,
 				id: 'stage-1',
 				maxDuration: 30,
-				segment: {
-					filter: '(account.annualRevenue gt 1000)',
+				accountLifecycleStageRule: {
+					filterString: '(account.annualRevenue gt 1000)',
 					filterMetadata: JSON.stringify({
 						conditionValue: '1000',
 						field: 'account.annualRevenue',

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/utils/lifecycleOperators.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/utils/lifecycleOperators.ts
@@ -77,13 +77,13 @@ export const resolveOperatorType = (
 		return null;
 	}
 
-	if (dataType === 'DURATION') {
+	if (dataType?.toUpperCase() === 'DURATION') {
 		return OperatorType.Duration;
 	}
 
-	if (dataCategory in OPERATORS_BY_TYPE) {
-		return dataCategory as OperatorType;
-	}
+	const operatorType = Object.keys(OPERATORS_BY_TYPE).find(
+		(key) => key.toLowerCase() === dataCategory.toLowerCase()
+	);
 
-	return null;
+	return (operatorType as OperatorType) ?? null;
 };

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/utils/lifecyclePayload.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/utils/lifecyclePayload.ts
@@ -11,17 +11,18 @@ import {
 	resolveOperatorType,
 } from 'lifecycle/utils/lifecycleOperators';
 
-export interface IStageSegmentPayload {
-	filter: string;
+export interface IStageRulePayload {
 	filterMetadata: string;
+	filterString: string;
+	name: string;
 }
 
 export interface IStagePayload {
+	accountLifecycleStageRule: IStageRulePayload;
 	description: string;
 	displayOrder: number;
 	id?: string;
 	maxDuration: number | null;
-	segment: IStageSegmentPayload;
 	stageType: string;
 }
 
@@ -118,17 +119,22 @@ export const buildStageFilterMetadata = (stage: IStageConfig): string =>
 		operator: stage.operator,
 	});
 
+export const buildStageRuleName = (lifecycleName: string, stageType: string) =>
+	`${lifecycleName} Stage ${stageType} Criteria`;
+
 const buildStagePayload = (
 	stage: IStageConfig,
-	index: number
+	index: number,
+	lifecycleName: string
 ): IStagePayload => ({
+	accountLifecycleStageRule: {
+		filterMetadata: buildStageFilterMetadata(stage),
+		filterString: buildStageFilter(stage),
+		name: buildStageRuleName(lifecycleName, LIFECYCLE_STAGE_ORDER[index]),
+	},
 	description: stage.description,
 	displayOrder: index + 1,
 	maxDuration: stage.maxTimeEnabled ? stage.maxTimeDays : null,
-	segment: {
-		filter: buildStageFilter(stage),
-		filterMetadata: buildStageFilterMetadata(stage),
-	},
 	stageType: LIFECYCLE_STAGE_ORDER[index],
 });
 
@@ -146,7 +152,9 @@ export const buildCreateLifecyclePayload = ({
 	channelId,
 	groupId,
 	name,
-	stages: stageConfigs.map(buildStagePayload),
+	stages: stageConfigs.map((stage, index) =>
+		buildStagePayload(stage, index, name)
+	),
 });
 
 export const buildUpdateLifecyclePayload = ({
@@ -164,7 +172,7 @@ export const buildUpdateLifecyclePayload = ({
 	lifecycleId,
 	name,
 	stages: stageConfigs.map((stage, index) => ({
-		...buildStagePayload(stage, index),
+		...buildStagePayload(stage, index, name),
 		...(stage.id ? {id: stage.id} : {}),
 	})),
 });
@@ -177,7 +185,9 @@ interface IStageFilterMetadata {
 	operator?: string | null;
 }
 
-const parseFilterMetadata = (filterMetadata?: string): IStageFilterMetadata => {
+const parseFilterMetadata = (
+	filterMetadata?: string | null
+): IStageFilterMetadata => {
 	if (!filterMetadata) {
 		return {};
 	}
@@ -202,7 +212,9 @@ export const stageConfigsFromLifecycle = (
 			return defaults[index];
 		}
 
-		const metadata = parseFilterMetadata(stage.segment?.filterMetadata);
+		const metadata = parseFilterMetadata(
+			stage.accountLifecycleStageRule?.filterMetadata
+		);
 
 		return {
 			conditionValue: metadata.conditionValue ?? null,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
@@ -1592,7 +1592,7 @@ exports[`MarketoCampaignOverview should render the connected data source with th
                     <div
                       class="h4 no-results-title"
                     >
-                      There are no properties found.
+                      No properties were found.
                     </div>
                     <div
                       class="no-results-description"
@@ -2568,7 +2568,7 @@ exports[`MarketoCampaignOverview should render the reconnect view when the data 
                     <div
                       class="h4 no-results-title"
                     >
-                      There are no properties found.
+                      No properties were found.
                     </div>
                     <div
                       class="no-results-description"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/catalog.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/catalog.ts
@@ -5,8 +5,8 @@ export type CatalogFieldDataCategory = 'Boolean' | 'Date' | 'Number' | 'Text';
 export interface ICatalogField {
 	dataCategory: CatalogFieldDataCategory;
 	dataType: string;
-	description: string;
-	displayName: string;
+	description: string | null;
+	displayName: string | null;
 	id: string;
 	name: string;
 	parentField: string | null;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/lifecycle.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/lifecycle.ts
@@ -8,17 +8,18 @@ export interface ILifecycle {
 	segmentId?: string;
 }
 
-export interface ILifecycleStageSegment {
-	filter: string;
-	filterMetadata: string;
+export interface IAccountLifecycleStageRule {
+	filterMetadata: string | null;
+	filterString: string;
+	name?: string;
 }
 
 export interface ILifecycleStage {
+	accountLifecycleStageRule?: IAccountLifecycleStageRule;
 	description: string;
 	displayOrder: number;
 	id: string;
 	maxDuration: number | null;
-	segment?: ILifecycleStageSegment;
 	stageType: string;
 }
 
@@ -55,11 +56,11 @@ export async function fetchLifecycle({
 }
 
 interface ILifecycleStagePayload {
+	accountLifecycleStageRule: IAccountLifecycleStageRule;
 	description: string;
 	displayOrder: number;
 	id?: string;
 	maxDuration: number | null;
-	segment: ILifecycleStageSegment;
 	stageType: string;
 }
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94461

## What Is Being Fixed

The stage trigger never survived a round trip. Opening a saved lifecycle showed every stage as "Unconfigured" even when the backend held a criteria rule for it, and saving from that state would have written the triggers away. Separately, the now-populated field catalog returns a null display name for all twelve base account attributes, so most of the trigger field picker rendered as blank rows.

## How It Is Being Fixed

The stage rule is read from and written to accountLifecycleStageRule holding a filterString, which is what the browser-facing mapper actually exchanges. That mapper serializes by field name and ignores the JsonProperty annotations that produce the segment and filter names, so those names only ever applied to the engine client's own hop to the backend. Reading the old shape found nothing and writing it was discarded on arrival, since unknown properties are ignored.

The field picker falls back to the field name when the catalog omits a display name, and sorts by the label it actually shows, because the catalog sorts on the same null display name and left the visible order arbitrary. Fields whose data category maps to no operator set are left out of the picker rather than offered and then refusing to configure, and the category is matched regardless of its casing.

## Why a LPD-99034 Commit Is Here

The last commit on this branch, `LPD-99034 Refresh the Marketo snapshot after the empty-state rewording`, is a cherry-pick of 7a4e0f5f6 and is not part of this work. The Marketo campaign overview snapshot on master still holds the copy that LPD-99147 reworded three days after the snapshot was committed, which fails `osbYarnTest` and therefore the whole workspace build, on any branch. Adriano's fix for it has not reached master yet, so it is carried here to keep this branch buildable. It has the same patch as the original, so it drops out on its own once that commit lands and this branch is rebased.

## PR Check

**pr-check: SKIPPED** — Source Format fails only on pre-existing violations unrelated to this branch: two stale local agent worktrees, and a 2024 `FeatureFlagManagerUtil.isEnabled(String)` call in journal-web pulled into scope by a stale `origin/master`. Workspace Build passes.

<!-- pr-check {"reason": "Source Format fails only on pre-existing violations unrelated to this branch: two stale local agent worktrees, and a 2024 FeatureFlagManagerUtil.isEnabled(String) call in journal-web pulled into scope by a stale origin/master. Workspace Build passes.", "result": "skipped", "sha": "1b64f83944594a9b5afb906dc99a7bcb83796aaa"} -->

