### PR TITLE
LPD-99886 faro-v5.0.x Format the account counts and percentages in stage cards

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/LifecycleChart.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/LifecycleChart.tsx
@@ -11,6 +11,7 @@ import {
 } from 'contacts/pages/account/utils/constants';
 import {SectionHeader} from 'shared/components/SectionHeader';
 import {sub} from 'shared/util/lang';
+import {toRounded, toThousands} from 'shared/util/numbers';
 import {useLifecycle} from 'lifecycle/context/LifecycleContext';
 
 const EMPTY_STAGES: ILifecycleStage[] = [
@@ -96,7 +97,7 @@ const StageMetrics = ({
 				<div>
 					<p className="mb-0">
 						<Text size={7} weight="bold">
-							{accountCount}
+							{toThousands(accountCount)}
 						</Text>
 					</p>
 					<Text color="secondary" size={4}>
@@ -105,7 +106,7 @@ const StageMetrics = ({
 								Liferay.Language.get(
 									'x-percent-of-all-accounts'
 								),
-								[percentage.toFixed(2)]
+								[toRounded(percentage)]
 							) as string
 						).toLowerCase()}
 					</Text>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/__tests__/LifecycleChart.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/__tests__/LifecycleChart.tsx
@@ -128,6 +128,77 @@ describe('LifecycleChart', () => {
 		).toHaveLength(4);
 	});
 
+	it('should render account counts abbreviated from a thousand upwards', () => {
+		const stagesWithLargeCounts: ILifecycleStage[] = [
+			{
+				accountCount: 5350,
+				averageStageDuration: 0,
+				conversionRateToNextStage: 10,
+				description: '',
+				percentage: 83.62,
+				stageType: LifecycleStages.AWARE,
+			},
+			{
+				accountCount: 1656000,
+				averageStageDuration: 0,
+				conversionRateToNextStage: 10,
+				description: '',
+				percentage: 15.38,
+				stageType: LifecycleStages.ENGAGED,
+			},
+			{
+				accountCount: 999,
+				averageStageDuration: 0,
+				conversionRateToNextStage: null,
+				description: '',
+				percentage: 1,
+				stageType: LifecycleStages.PIPELINE,
+			},
+		];
+
+		const {getByText, queryByText} = renderChart({
+			stages: stagesWithLargeCounts,
+		});
+
+		expect(getByText('5.35K')).toBeInTheDocument();
+		expect(getByText('1.66M')).toBeInTheDocument();
+		expect(getByText('999')).toBeInTheDocument();
+
+		expect(queryByText('5350')).toBeNull();
+		expect(queryByText('1656000')).toBeNull();
+	});
+
+	it('should render the percentage of all accounts rounded to a single decimal', () => {
+		const stagesWithLongPercentages: ILifecycleStage[] = [
+			{
+				accountCount: 1,
+				averageStageDuration: 0,
+				conversionRateToNextStage: 10,
+				description: '',
+				percentage: 83.62,
+				stageType: LifecycleStages.AWARE,
+			},
+			{
+				accountCount: 1,
+				averageStageDuration: 0,
+				conversionRateToNextStage: null,
+				description: '',
+				percentage: 50,
+				stageType: LifecycleStages.ENGAGED,
+			},
+		];
+
+		const {getByText, queryByText} = renderChart({
+			stages: stagesWithLongPercentages,
+		});
+
+		expect(getByText('83.6% of all accounts')).toBeInTheDocument();
+		expect(getByText('50% of all accounts')).toBeInTheDocument();
+
+		expect(queryByText('83.62% of all accounts')).toBeNull();
+		expect(queryByText('50.00% of all accounts')).toBeNull();
+	});
+
 	it('should show "avg. day" for non-zero averages and "no activity" otherwise', () => {
 		const {getAllByText, getByText} = renderChart({stages: sampleStages});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99886

Backport of #3725 to `faro-v5.0.x`.