### PR TITLE
LPD-99909 Fix blank overview page for Marketo webhook data sources

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/registry.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/registry.ts
@@ -34,6 +34,12 @@ describe('connector registry', () => {
 			expect(config?.type).toBe(DataSourceTypes.MarketoEventStream);
 		});
 
+		it('resolves each connector from the provider type literal the backend sends', () => {
+			expect(getConnectorConfig('DEMANDBASE')?.slug).toBe('demandbase');
+			expect(getConnectorConfig('HUBSPOT')?.slug).toBe('hubspot');
+			expect(getConnectorConfig('MARKETO')?.slug).toBe('marketo');
+		});
+
 		it('is case-insensitive on the lookup key', () => {
 			expect(getConnectorConfig('demandbase')?.slug).toBe('demandbase');
 			expect(getConnectorConfig('HuBsPoT')?.slug).toBe('hubspot');

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/constants.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/constants.ts
@@ -1,0 +1,36 @@
+import {DataSourceTypes} from '../constants';
+
+/**
+ * The provider type literals the API sends on a data source's `providerType`.
+ *
+ * Backend sources of truth:
+ *
+ * - `com.liferay.osb.asah.common.model.ProviderType` (osb-asah)
+ * - `*Provider.TYPE` under
+ *   `osb-faro-engine-client/.../engine/client/model/provider` (osb-faro)
+ *
+ * `DataSourceTypes` values are matched against these literals to pick the
+ * page for `/settings/data-source/:id`, so a value that drifts from this
+ * list renders a blank page rather than failing loudly.
+ */
+const BACKEND_PROVIDER_TYPES = [
+	'CSV',
+	'DEMANDBASE',
+	'HUBSPOT',
+	'LIFERAY',
+	'MARKETO',
+	'MARKETO_CAMPAIGN',
+	'SALESFORCE',
+];
+
+describe('DataSourceTypes', () => {
+	it('matches the provider type literals the backend sends', () => {
+		expect(Object.values(DataSourceTypes).sort()).toEqual(
+			[...BACKEND_PROVIDER_TYPES].sort()
+		);
+	});
+
+	it('maps the marketo event stream to the MARKETO literal the backend sends', () => {
+		expect(DataSourceTypes.MarketoEventStream).toBe('MARKETO');
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/constants.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/constants.ts
@@ -107,7 +107,7 @@ export enum DataSourceTypes {
 	Hubspot = 'HUBSPOT',
 	Liferay = 'LIFERAY',
 	MarketoCampaign = 'MARKETO_CAMPAIGN',
-	MarketoEventStream = 'MARKETO_EVENT_STREAM',
+	MarketoEventStream = 'MARKETO',
 	Salesforce = 'SALESFORCE',
 }
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99909

## What Is Being Fixed

Opening a Marketo webhook data source at `/settings/data-source/:id` rendered a blank page. The frontend's `DataSourceTypes.MarketoEventStream` value was `MARKETO_EVENT_STREAM`, but the backend sends `MARKETO` as the data source's `providerType`. The page for that route is picked by matching `providerType` against the `DataSourceTypes` values, so nothing matched and the route rendered empty instead of failing loudly.

## How It Is Being Fixed

`DataSourceTypes.MarketoEventStream` now carries the `MARKETO` literal the backend actually sends. To keep the enum from drifting again, a new unit test asserts the full set of `DataSourceTypes` values against the provider type literals declared by the backend, and documents where those literals live. The connector registry test also gained a case that resolves each connector from the exact literal the backend sends, rather than only exercising the case-insensitive lookup.

## PR Check

**pr-check: PASS** — tested on `58bcf4451627ace4c57af1e1a3c47c99282b10fa`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "58bcf4451627ace4c57af1e1a3c47c99282b10fa"} -->
