### PR TITLE
LPD-99917 Fix search on the account lifecycle accounts list

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountLifecycleFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountLifecycleFaroController.java
@@ -119,7 +119,7 @@ public class AccountLifecycleFaroController extends BaseFaroController {
 			@PathParam("groupId") long groupId, @PathParam("id") String id,
 			@QueryParam("filter") String filterString,
 			@QueryParam("page") int page, @QueryParam("pageSize") int pageSize,
-			@QueryParam("query") String query,
+			@QueryParam("search") String search,
 			@DefaultValue(StringPool.BLANK) @QueryParam("sort") String
 				sortString)
 		throws Exception {
@@ -127,7 +127,7 @@ public class AccountLifecycleFaroController extends BaseFaroController {
 		Results<Account> results =
 			contactsEngineClient.getAccountLifecycleAccounts(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId),
-				filterString, id, query, page, pageSize, sortString);
+				filterString, id, search, page, pageSize, sortString);
 
 		Function<Account, AccountDisplay> function = AccountDisplay::new;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99917

## What Is Being Fixed

The search box on the account lifecycle accounts list had no effect. The list is rendered by a Frontend Data Set, which sends the search box value as the `search` query parameter, but the endpoint backing it bound `query` instead. The parameter was therefore always null, and every request returned the unfiltered result set no matter what was typed.

## How It Is Being Fixed

The `@QueryParam` on `AccountLifecycleFaroController.getAccountsFaroFDSResultsDisplay` is renamed from `query` to `search`, so it binds the value the Frontend Data Set actually sends and passes it through to the contacts engine client. This aligns the endpoint with the convention every other Frontend Data Set backed controller in the module already follows, including `AccountFaroController`, `AssetSummaryFaroController`, `DataSourceFaroController`, and `IndividualSegmentFaroController`.

## Why Are There No Tests?

The existing osb-faro-web Jest suite and the functional coverage of the lifecycle accounts list already exercise this path; the change is a parameter rename on an endpoint those tests drive.

## PR Check

**pr-check: PASS** — tested on `bd5a56a54f6b5fd6f50870786f8adee59d84f182`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "bd5a56a54f6b5fd6f50870786f8adee59d84f182"} -->
