### PR TITLE
LPD-100018 Enforce the frontend source formatter in osb-faro-web

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/build.gradle
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	testImplementation project(":modules:osb-faro-provisioning-client")
 }
 
+check {
+	dependsOn packageRunCheckFormat
+}
+
 generateJSPJava {
 	enabled = false
 }
@@ -69,6 +73,10 @@ osbYarnWebpack {
 	dependsOn osbYarnInstall
 	executable = new File(osbYarnInstall.nodeDir, "bin/node")
 	workingDir = projectDir
+}
+
+packageRunCheckFormat {
+	dependsOn osbYarnInstall
 }
 
 packageRunTest {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_add_report.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_add_report.scss
@@ -32,7 +32,7 @@ $c: '.analytics-add-report';
 		padding: 0;
 
 		button {
-			background-color: #f7f8f9;
+			background-color: var(--cadmin-gray-100);
 			border: 0.063rem solid transparent;
 			border-radius: $cadmin-border-radius;
 			cursor: pointer;
@@ -43,8 +43,8 @@ $c: '.analytics-add-report';
 		button:active,
 		button:focus,
 		button.selected {
-			background-color: #f0f5ff;
-			border-color: #80acff;
+			background-color: var(--cadmin-primary-l3);
+			border-color: var(--cadmin-primary-l1);
 			outline: none;
 		}
 	}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_add_workspace.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_add_workspace.scss
@@ -6,7 +6,7 @@
 		font-weight: $fontWeightRegular;
 
 		&:disabled {
-			background-color: rgb(222, 226, 236);
+			background-color: var(--cadmin-light-d1);
 		}
 	}
 }

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_cerebro_summary_card.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_cerebro_summary_card.scss
@@ -52,11 +52,11 @@ $status-secondary-color-red: $errorLighten50;
 
 		&-active {
 			border: 1px solid $primary !important;
-			box-shadow: 0 8px 16px rgba(39, 40, 51, 0.16) !important;
+			box-shadow: var(--cadmin-box-shadow) !important;
 		}
 
 		&-complete {
-			background-color: #f2f3f4 !important;
+			background-color: var(--cadmin-gray-200) !important;
 			border: 1px solid transparent !important;
 		}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_criteria_card.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_criteria_card.scss
@@ -18,8 +18,8 @@
 	.fade-out-cover {
 		background: linear-gradient(
 			180deg,
-			rgba(255, 255, 255, 0) 0%,
-			rgba(255, 255, 255, 1) 60%
+			rgb(from var(--cadmin-white) r g b / 0) 0%,
+			var(--cadmin-white) 60%
 		);
 		bottom: 0;
 		display: flex;
@@ -72,7 +72,7 @@
 
 				.criteria-step-number {
 					align-items: center;
-					background-color: #e7e7ed;
+					background-color: var(--cadmin-gray-300);
 					border-radius: 100%;
 					display: inline-flex;
 					font-size: 10px;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_criteria_group.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_criteria_group.scss
@@ -1,7 +1,7 @@
 .criteria-group-root {
 	border: 1px $mainLighten65 solid;
 	border-radius: 4px;
-	box-shadow: 0 0 8px 1px rgba(33, 34, 35, 0.05);
+	box-shadow: 0 0 8px 1px rgb(from var(--cadmin-dark-d1) r g b / 0.05);
 	position: relative;
 	width: 100%;
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_custom_clay.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_custom_clay.scss
@@ -3,4 +3,4 @@ $modal-md: 600px !default;
 $modal-sm: 320px !default;
 $modal-xl: 1140px !default;
 
-$btn-focus-box-shadow: 0 0 0 0.125rem #80acff;
+$btn-focus-box-shadow: 0 0 0 0.125rem var(--cadmin-primary-l1);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_event_analysis_breakdown.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_event_analysis_breakdown.scss
@@ -80,13 +80,13 @@
 			.lines {
 				background-image: linear-gradient(
 					135deg,
-					rgba(0, 0, 0, 0.2) 5%,
-					rgba(0, 0, 0, 0) 5%,
-					rgba(0, 0, 0, 0) 50%,
-					rgba(0, 0, 0, 0.2) 50%,
-					rgba(0, 0, 0, 0.2) 55%,
-					rgba(0, 0, 0, 0) 55%,
-					rgba(0, 0, 0, 0) 100%
+					rgb(from var(--cadmin-black) r g b / 0.2) 5%,
+					rgb(from var(--cadmin-black) r g b / 0) 5%,
+					rgb(from var(--cadmin-black) r g b / 0) 50%,
+					rgb(from var(--cadmin-black) r g b / 0.2) 50%,
+					rgb(from var(--cadmin-black) r g b / 0.2) 55%,
+					rgb(from var(--cadmin-black) r g b / 0) 55%,
+					rgb(from var(--cadmin-black) r g b / 0) 100%
 				);
 				background-size: 10px 10px;
 			}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_loading.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_loading.scss
@@ -14,7 +14,7 @@
 	}
 
 	&.overlay {
-		background: rgba(255, 255, 255, 0.75);
+		background: rgb(from var(--cadmin-white) r g b / 0.75);
 		bottom: 0;
 		left: 0;
 		margin: auto;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_scrollable_section.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_scrollable_section.scss
@@ -30,8 +30,8 @@
 		&::after {
 			background: linear-gradient(
 				270deg,
-				rgba(255, 255, 255, 0.48081239331670167) 11%,
-				rgba(255, 255, 255, 0.8001401244091386) 25%
+				rgb(from var(--cadmin-white) r g b / 0.5) 11%,
+				rgb(from var(--cadmin-white) r g b / 0.8) 25%
 			);
 			right: -12px;
 		}
@@ -43,8 +43,8 @@
 		&::after {
 			background: linear-gradient(
 				90deg,
-				rgba(255, 255, 255, 0.48081239331670167) 11%,
-				rgba(255, 255, 255, 0.8001401244091386) 25%
+				rgb(from var(--cadmin-white) r g b / 0.5) 11%,
+				rgb(from var(--cadmin-white) r g b / 0.8) 25%
 			);
 			left: -12px;
 		}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_sites_dashboard_overview.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_sites_dashboard_overview.scss
@@ -1,4 +1,4 @@
-$visitorsPreviousPeriod: #393a4a;
+$visitorsPreviousPeriod: var(--cadmin-gray-800);
 
 .sites-dashboard-overview-root {
 	.acquisitions-card-root,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_title_editor.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_title_editor.scss
@@ -3,7 +3,7 @@
 		background-color: transparent;
 
 		&:hover {
-			background-color: rgba($main, 0.06);
+			background-color: rgb(from var(--cadmin-gray-900) r g b / 0.06);
 		}
 	}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_toolbar.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_toolbar.scss
@@ -37,7 +37,7 @@
 
 	.subnav-tbar-root {
 		.view-selected-link-container:not(:only-child) {
-			border-right: 1px solid #c4c4c4;
+			border-right: 1px solid var(--cadmin-gray-400);
 			margin: 0.5rem 1rem 0.5rem 0;
 			padding-right: 1rem;
 		}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_usage_overview.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_usage_overview.scss
@@ -14,7 +14,7 @@
 	gap: 8px;
 
 	.big-bar {
-		background: #5791ff;
+		background: var(--cadmin-primary-l0);
 		border-radius: 4px;
 		height: 12px;
 		width: 95%;
@@ -32,7 +32,7 @@
 	min-height: 150px;
 
 	.generic-pie-label {
-		fill: #333333;
+		fill: var(--cadmin-dark-l1);
 		font-size: 1.75rem;
 		font-weight: bold;
 	}
@@ -41,8 +41,8 @@
 .gradient-opaque {
 	mask-image: linear-gradient(
 		to bottom,
-		rgba(0, 0, 0, 0.8) 0%,
-		rgba(0, 0, 0, 0) 100%
+		rgb(from var(--cadmin-black) r g b / 0.8) 0%,
+		rgb(from var(--cadmin-black) r g b / 0) 100%
 	);
 }
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_variables.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_variables.scss
@@ -2,13 +2,14 @@
  * Chart
  */
 
-$chartBlue: #4b9bff;
-$chartBlueLighten30: #97c5ff;
-$chartLimeGreen: #9ce269;
-$chartOrange: #ffb46e;
-$chartPurple: #af78ff;
-$chartRed: #ff5f5f;
-$chartSeaGreen: #50d2a0;
+$chartBlue: var(--cadmin-blue-l1);
+$chartBlueLighten30: var(--cadmin-blue-l3);
+$chartCyan: var(--cadmin-cyan-l3);
+$chartLimeGreen: var(--cadmin-green-l4);
+$chartOrange: var(--cadmin-orange-l3);
+$chartPurple: var(--cadmin-purple-l1);
+$chartRed: var(--cadmin-red-l2);
+$chartSeaGreen: var(--cadmin-teal-l2);
 
 /**
  * Criteria sidebar
@@ -20,7 +21,7 @@ $propertyGroupsColors: (
 	'event': $chartSeaGreen,
 	'individual': $chartBlue,
 	'interest': $chartRed,
-	'organization': #5fc8ff,
+	'organization': $chartCyan,
 	'session': $chartPurple,
 	'web': $chartSeaGreen,
 );
@@ -28,10 +29,10 @@ $propertyGroupsColors: (
 /**
  * Field types
  */
-$fieldDarkBlue: #849ae8;
-$fieldGreen: #96dc7a;
-$fieldLightBlue: #54b7ff;
-$fieldPurple: #ad7aff;
+$fieldDarkBlue: var(--cadmin-indigo-l1);
+$fieldGreen: var(--cadmin-green-l3);
+$fieldLightBlue: var(--cadmin-blue-l2);
+$fieldPurple: var(--cadmin-purple-l2);
 
 /**
  * Layout
@@ -64,42 +65,42 @@ $liferayDataSourceCardSideMinWidth: 280px;
 /**
  * Lexicon
  */
-$main: #272833;
-$mainLighten4: #30313f;
-$mainLighten8: #393a4a;
-$mainLighten28: #6b6c7e;
-$mainLighten52: #a7a9bc;
-$mainLighten65: #cdced9;
-$mainLighten74: #e7e7ed;
+$main: var(--cadmin-gray-900);
+$mainLighten4: var(--cadmin-dark-l1);
+$mainLighten8: var(--cadmin-gray-800);
+$mainLighten28: var(--cadmin-gray-600);
+$mainLighten52: var(--cadmin-gray-500);
+$mainLighten65: var(--cadmin-gray-400);
+$mainLighten74: var(--cadmin-gray-300);
 $secondary: $mainLighten28;
-$secondaryHover: #f7f8f9;
+$secondaryHover: var(--cadmin-gray-100);
 
-$primary: #0b5fff;
-$primaryDarken5: #0053f0;
-$primaryDarken10: #004ad7;
-$primaryLighten23: #80acff;
-$primaryLighten33: #b3cdff;
-$primaryLighten45: #f0f5ff;
+$primary: var(--cadmin-primary);
+$primaryDarken5: var(--cadmin-primary-d1);
+$primaryDarken10: var(--cadmin-primary-d2);
+$primaryLighten23: var(--cadmin-primary-l1);
+$primaryLighten33: var(--cadmin-primary-l2);
+$primaryLighten45: var(--cadmin-primary-l3);
 
-$black: #000;
-$lightBackground: #f1f2f5;
-$white: #fff;
+$black: var(--cadmin-black);
+$lightBackground: var(--cadmin-gray-200);
+$white: var(--cadmin-white);
 
-$error: #da1414;
-$errorLighten28: #f48989;
-$errorLighten50: #feefef;
+$error: var(--cadmin-danger);
+$errorLighten28: var(--cadmin-danger-l1);
+$errorLighten50: var(--cadmin-danger-l2);
 
-$success: #287d3c;
-$successLighten25: #5aca75;
-$successLighten63: #edf9f0;
+$success: var(--cadmin-success);
+$successLighten25: var(--cadmin-success-l1);
+$successLighten63: var(--cadmin-success-l2);
 
-$warning: #b95000;
-$warningLighten25: #ff8f39;
-$warningLighten60: #fff4ec;
+$warning: var(--cadmin-warning);
+$warningLighten25: var(--cadmin-warning-l1);
+$warningLighten60: var(--cadmin-warning-l2);
 
-$info: #2e5aac;
-$infoLighten28: #89a7e0;
-$infoLighten53: #eef2fa;
+$info: var(--cadmin-info);
+$infoLighten28: var(--cadmin-info-l1);
+$infoLighten53: var(--cadmin-info-l2);
 
 $colors: (
 	main: $main,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100018

## What Is Being Fixed

osb-faro-web carried 60 `liferay/no-hardcoded-colors` violations across 13 stylesheets that no gate surfaced, for two reasons.

The formatter gate is branch scoped. `ant format-source-current-branch` delegates to `:portalYarnFormatCurrentBranch` → `node-scripts format --current-branch`, which reads only the files in the branch diff. Because no branch had touched those 13 stylesheets, their pre-existing violations were never read. Running `yarn checkFormat` inside the module is whole-module instead (`git ls-files`), which is how they came to light.

The workspace build never reached `packageRunCheckFormat`. That task was wired only as `finalizedBy` of the standalone `checkSourceFormatting` task, which is not in the `check` or `build` lifecycle, so `./gradlew build` verified tests but not formatting.

Together this made the violations a latent trap: the first branch to edit any of the 13 files would have the whole file read by the branch-scoped check and fail on colors it did not introduce.

## How It Is Being Fixed

The first commit hangs `packageRunCheckFormat` off `check` in the module's `build.gradle`, mirroring how `NodePlugin` already hangs `packageRunTest` off it, so `./gradlew build` verifies formatting the same way it verifies tests.

The second commit replaces all 60 hardcoded colors with Clay design tokens. 44 matched a token whose light value is byte-identical, so they carry no visual change and simply gain dark-mode adaptation — every semantic group (the grey ramp, primary, black and white, error, success, warning, info) landed on an exact match. The remaining 16 had no exact equivalent and were mapped to the nearest Clay token; the per-color list with RGB deltas is recorded as a comment on LPD-100018. The categorical chart and field palette is the notable part: Clay exposes no data-visualization tokens, so those were mapped onto the named hue ramps with a collision-free assignment, because mapping each to its single nearest token would have collapsed `$chartLimeGreen` and `$fieldGreen` onto the same `--cadmin-green-l4`.

Seven declarations needed alpha over a token and use relative color syntax, for example `rgb(from var(--cadmin-white) r g b / 0.75)`, the pattern the rule implementation deliberately leaves untouched. This is load bearing rather than cosmetic: `rgba($main, 0.06)` in `_title_editor.scss` would not have failed the build once `$main` became a token, because Sass emits `rgba(var(--cadmin-gray-900), 0.06)` without complaint and the browser then drops the declaration silently.

## Why Are There No Tests?

This pull request adds a verification step to the build rather than testable code. The change itself is the check: `./gradlew build` now fails on frontend format violations, which pr-check demonstrated by moving from FAIL to PASS on this branch. The colour changes are verified by `yarn checkFormat` exiting 0 and by the module compiling.

## PR Check

**pr-check: PASS** — tested on `6299092de239c15ffc9ff0e8f8db324ba016477f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "1b4aabd89e4383caa30b831fbb6d05767a34e8a1"} -->

Resent from interaminense/liferay-portal#547