### PR TITLE
LPD-100048 Keep the analytics title aligned with the canonical URL

### DIFF
--- a/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
+++ b/modules/apps/analytics/analytics-web/src/main/resources/META-INF/resources/dynamic_include/top_head.jsp
@@ -23,6 +23,14 @@
 	var analyticsExternalReferenceCode =
 		'<%= (String)request.getAttribute(AnalyticsWebKeys.ANALYTICS_EXTERNAL_REFERENCE_CODE) %>';
 
+	// Snapshot the page title in the same script block that publishes
+	// themeDisplay, so both are refreshed at the same point of a SPA
+	// transition. Reading document.title when the event is created instead
+	// pairs the incoming page's title with the outgoing page's canonical URL,
+	// because SPA updates the title before it re-evaluates this block.
+
+	var analyticsPageTitle = document.title;
+
 	var cookieManagers = {
 		'cookie.onetrust': {
 			checkConsent: () => {
@@ -148,6 +156,7 @@
 						themeDisplay.getScopeGroupIdOrLiveGroupId();
 					request.context.layoutExternalReferenceCode =
 						analyticsExternalReferenceCode;
+					request.context.title = analyticsPageTitle;
 
 					return request;
 				};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100048

## What Is Being Fixed

During a SennaJS SPA transition the analytics event context is assembled from two sources that are refreshed at different points. The title comes from `document.title`, which SPA updates early in `App.js#updateHistory_`, before the surface flip. The canonical URL comes from `themeDisplay.getCanonicalURL()`, published by a `data-senna-track="temporary"` script that is only re-evaluated later, at `App.js#evaluateScripts`.

Any event created in that window ships one page's title paired with the previous page's canonical URL. `pageViewed` is unaffected because it is sent on `endNavigate`, after the window, but impression and visibility events fire as the new content renders, which falls inside the window by construction. In Analytics Cloud this surfaces as a page in Sites > Pages labelled with a different page's name, and the label drifts over time as new stray associations arrive. Page view metrics are correctly attributed; only the displayed title is wrong.

This is the root cause of LPP-64829 and LPP-64830.

## How It Is Being Fixed

The title is no longer read from the DOM at the moment the event is created. It is snapshotted into `analyticsPageTitle` inside the same `senna="temporary"` script block that publishes `themeDisplay`, and `dxpMiddleware` sets `request.context.title` from that snapshot.

Because both values now come from a block that is refreshed at a single point of the transition, they always describe the same page. During the window both hold the outgoing page's values, which is consistent and matches the canonical URL the event is already attributed to.

The snapshot is safe on a normal page load: the analytics include is registered at `top_head.jsp#post`, which renders after the `<title>` element.

Note that `context.url` still lags behind `context.canonicalUrl` inside the window. That field is not used by the Sites > Pages report and is out of scope here.

## Why Are There No Tests?

The change is a two-line JSP edit with no unit-testable seam: the value is produced by a JSP scriptlet and consumed by an inline middleware, neither of which is reachable from the module's test source set. It was validated on a local bundle by capturing the SDK's outbound payloads across six SPA navigations before and after the change: mismatched contexts went from 2 to 0.

## PR Check

**pr-check: PASS** — tested on `8fed0bb93387dde11401944848d93c73f893b65a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JSP Compile | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "8fed0bb93387dde11401944848d93c73f893b65a"} -->
