### PR TITLE
LPD-100043 Add an Overview route and page for accounts

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/Overview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/Overview.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Overview: React.FC = () => <div>{'Account Overview page'}</div>;
+
+export default Overview;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
@@ -24,6 +24,11 @@ const Overview = lazy(
 const NAV_ITEMS = [
 	{
 		exact: true,
+		label: Liferay.Language.get('overview'),
+		route: Routes.CONTACTS_ACCOUNT_OVERVIEW,
+	},
+	{
+		exact: true,
 		label: Liferay.Language.get('activities'),
 		route: Routes.CONTACTS_ACCOUNT,
 	},
@@ -31,11 +36,6 @@ const NAV_ITEMS = [
 		exact: true,
 		label: Liferay.Language.get('profile'),
 		route: Routes.CONTACTS_ACCOUNT_PROFILE,
-	},
-	{
-		exact: true,
-		label: Liferay.Language.get('overview'),
-		route: Routes.CONTACTS_ACCOUNT_OVERVIEW,
 	},
 ];
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
@@ -17,6 +17,9 @@ const Activities = lazy(
 const Profile = lazy(
 	() => import(/* webpackChunkName: "AccountProfile" */ './Profile')
 );
+const Overview = lazy(
+	() => import(/* webpackChunkName: "Overview" */ './Overview')
+);
 
 const NAV_ITEMS = [
 	{
@@ -28,6 +31,11 @@ const NAV_ITEMS = [
 		exact: true,
 		label: Liferay.Language.get('profile'),
 		route: Routes.CONTACTS_ACCOUNT_PROFILE,
+	},
+	{
+		exact: true,
+		label: Liferay.Language.get('overview'),
+		route: Routes.CONTACTS_ACCOUNT_OVERVIEW,
 	},
 ];
 
@@ -112,6 +120,12 @@ const AccountProfileRoutes = () => {
 							data={Activities}
 							exact
 							path={Routes.CONTACTS_ACCOUNT}
+						/>
+
+						<BundleRouter
+							data={Overview}
+							exact
+							path={Routes.CONTACTS_ACCOUNT_OVERVIEW}
 						/>
 
 						<RouteNotFound />

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/__tests__/ProfileRoutes.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/__tests__/ProfileRoutes.tsx
@@ -2,11 +2,12 @@ import mockStore from 'test/mock-store';
 import ProfileRoutes from '../ProfileRoutes';
 import React from 'react';
 import {ChannelContext} from 'shared/context/channel';
-import {cleanup, render, screen} from '@testing-library/react';
+import {cleanup, render, screen, within} from '@testing-library/react';
 import {createMemoryHistory} from 'history';
 import {mockChannelContext} from 'test/mock-channel-context';
 import {Provider} from 'react-redux';
 import {Router} from 'react-router-dom';
+import {Routes, toRoute} from 'shared/util/router';
 import {useRequest} from 'shared/hooks/useRequest';
 
 jest.unmock('react-dom');
@@ -41,12 +42,19 @@ jest.mock('../Activities', () => ({
 	default: () => <div data-testid="account-activities" />,
 }));
 
+jest.mock('../Overview', () => ({
+	__esModule: true,
+	default: () => <div data-testid="account-overview" />,
+}));
+
 jest.mock('../Profile', () => ({
 	__esModule: true,
 	default: () => <div data-testid="account-profile" />,
 }));
 
 const mockedUseRequest = useRequest as jest.Mock;
+
+const ROUTE_PARAMS = {channelId: '123', groupId: '23', id: 'acc-1'};
 
 const store = mockStore();
 
@@ -139,5 +147,49 @@ describe('AccountProfileRoutes', () => {
 
 		expect(screen.getAllByText('Acme Corp').length).toBeGreaterThan(0);
 		expect(screen.queryByText('Account Not Found')).not.toBeInTheDocument();
+	});
+
+	it('lists overview as the first tab in the account nav bar', () => {
+		mockedUseRequest.mockReturnValue({
+			data: {accountName: 'Acme Corp'},
+			error: false,
+			loading: false,
+		});
+
+		renderProfileRoutes();
+
+		const navTabs = within(screen.getByRole('navigation')).getAllByRole(
+			'link'
+		);
+
+		expect(navTabs.map((navTab) => navTab.textContent)).toEqual([
+			'Overview',
+			'Activities',
+			'Profile',
+		]);
+		expect(navTabs[0]).toHaveAttribute(
+			'href',
+			toRoute(Routes.CONTACTS_ACCOUNT_OVERVIEW, ROUTE_PARAMS)
+		);
+	});
+
+	it('renders the overview page on the overview route', async () => {
+		mockedUseRequest.mockReturnValue({
+			data: {accountName: 'Acme Corp'},
+			error: false,
+			loading: false,
+		});
+
+		renderProfileRoutes(
+			createMemoryHistory({
+				initialEntries: [
+					toRoute(Routes.CONTACTS_ACCOUNT_OVERVIEW, ROUTE_PARAMS),
+				],
+			})
+		);
+
+		expect(
+			await screen.findByTestId('account-overview')
+		).toBeInTheDocument();
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/router.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/router.ts
@@ -171,6 +171,8 @@ export const Routes = buildRoutes({
 											CONTACTS_ACCOUNT_INTEREST_DETAILS: `/interests/:interestId/:tabId(${INDIVIDUALS}|${PAGES})?`,
 											CONTACTS_ACCOUNT_INTERESTS:
 												'/interests',
+											CONTACTS_ACCOUNT_OVERVIEW:
+												'/overview',
 											CONTACTS_ACCOUNT_PROFILE:
 												'/profile',
 											CONTACTS_ACCOUNT_SEGMENTS: `/${SEGMENTS}`,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100043

## What Is Being Fixed

The account profile section had no Overview destination. There was no route, no page component, and no tab for it, so the account navigation bar led with Activities. This is the frontend groundwork the Overview dashboard will build on.

## How It Is Being Fixed

A `CONTACTS_ACCOUNT_OVERVIEW` entry is added to the account route map under `/overview`, and an `Overview` page component is wired into `AccountProfileRoutes` through `BundleRouter` with the same lazy loading the sibling pages use. Overview is registered as the first item in the account navigation bar so it becomes the landing tab ahead of Activities and Profile.

The `Overview` component is a placeholder for now and renders static text until the dashboard content lands. The `AccountProfileRoutes` suite covers the tab order, the Overview link target, and that the overview route resolves to the Overview page. That last assertion goes through a mocked `Overview` component rather than its rendered text, so replacing the placeholder will not break it.

## PR Check

**pr-check: PASS** — tested on `8fbe768d6f1e6b94e245f71d3c497a68272d132d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "8fbe768d6f1e6b94e245f71d3c497a68272d132d"} -->
