### PR TITLE
LPD-100093 Grant site members read access to data sources

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
@@ -508,7 +508,7 @@ public class DataSourceFaroController extends BaseFaroController {
 
 	@GET
 	@Path("/{id}/channel-data-sources")
-	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
+	@RolesAllowed(RoleConstants.SITE_MEMBER)
 	public FaroResultsDisplay getChannelDataSourceFaroResultsDisplay(
 			@PathParam("groupId") long groupId, @PathParam("id") String id,
 			@QueryParam("enabled") Boolean enabled,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceMetricsFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceMetricsFaroController.java
@@ -29,7 +29,7 @@ public class DataSourceMetricsFaroController extends BaseFaroController {
 
 	@GET
 	@Path("/{dataSourceId}/accounts_count")
-	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
+	@RolesAllowed(RoleConstants.SITE_MEMBER)
 	public Long getAccountsCount(
 			@PathParam("groupId") long groupId,
 			@PathParam("dataSourceId") String dataSourceId)
@@ -44,7 +44,7 @@ public class DataSourceMetricsFaroController extends BaseFaroController {
 
 	@GET
 	@Path("/{dataSourceId}/events_count")
-	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
+	@RolesAllowed(RoleConstants.SITE_MEMBER)
 	public Long getEventsCount(
 			@PathParam("groupId") long groupId,
 			@PathParam("dataSourceId") String dataSourceId)
@@ -59,7 +59,7 @@ public class DataSourceMetricsFaroController extends BaseFaroController {
 
 	@GET
 	@Path("/{dataSourceId}/users_count")
-	@RolesAllowed(RoleConstants.SITE_ADMINISTRATOR)
+	@RolesAllowed(RoleConstants.SITE_MEMBER)
 	public Long getUsersCount(
 			@PathParam("groupId") long groupId,
 			@PathParam("dataSourceId") String dataSourceId)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100093

## What Is Being Fixed

The channel data source list and the account, event, and user count endpoints all required the site administrator role, so a site member could not read them. The views backed by those endpoints were therefore unavailable to anyone without the administrator role.

## How It Is Being Fixed

The `@RolesAllowed` constant on the four endpoints changes from `RoleConstants.SITE_ADMINISTRATOR` to `RoleConstants.SITE_MEMBER`. All four are read-only GET endpoints — one returns a data source listing, the other three return account, event, and user counts — so none of them expose configuration or permit mutation, and the site member role is sufficient to read them.

## Why Are There No Tests?

The new access level was verified manually against a local bundle by signing in as a site member and loading the views backed by these endpoints.

## PR Check

**pr-check: PASS** — tested on `d2b6ddccc2918afd30f4cc7e2d70ab61adb3a254`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "d2b6ddccc2918afd30f4cc7e2d70ab61adb3a254"} -->
