### PR TITLE
LPD-100080 Fix the Marketo Campaign type label and name corruption

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/MarketoCampaignOverview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/MarketoCampaignOverview.tsx
@@ -225,7 +225,7 @@ const MarketoCampaignOverview: React.FC<IMarketoCampaignOverviewProps> = ({
 							<ClayInput
 								readOnly
 								type="text"
-								value={Liferay.Language.get('marketo')}
+								value={Liferay.Language.get('marketo-campaign')}
 							/>
 						</ClayInput.GroupItem>
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
@@ -452,7 +452,7 @@ exports[`MarketoCampaignOverview should render an error when the count requests 
                         class="form-control"
                         readonly=""
                         type="text"
-                        value="Marketo"
+                        value="Marketo Campaign"
                       />
                     </div>
                     <div
@@ -1187,7 +1187,7 @@ exports[`MarketoCampaignOverview should render the connected data source with th
                         class="form-control"
                         readonly=""
                         type="text"
-                        value="Marketo"
+                        value="Marketo Campaign"
                       />
                     </div>
                     <div
@@ -2223,7 +2223,7 @@ exports[`MarketoCampaignOverview should render the reconnect view when the data 
                         class="form-control"
                         readonly=""
                         type="text"
-                        value="Marketo"
+                        value="Marketo Campaign"
                       />
                     </div>
                     <div

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
@@ -167,12 +167,14 @@ const getAlertMessage = (
 	}
 };
 
-const typeFormatter = (type: DataSourceTypes): string => {
+export const typeFormatter = (type: DataSourceTypes): string => {
 	switch (type) {
 		case DataSourceTypes.Csv:
 			return Liferay.Language.get('.csv');
 		case DataSourceTypes.Liferay:
 			return Liferay.Language.get('liferay-portal');
+		case DataSourceTypes.MarketoCampaign:
+			return Liferay.Language.get('marketo-campaign');
 		case DataSourceTypes.Salesforce:
 			return Liferay.Language.get('salesforce');
 		default:

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/__tests__/DataSourceList.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/__tests__/DataSourceList.jsx
@@ -3,7 +3,8 @@ import {
 	AddDataSourceNav,
 	DataSourceName,
 	disableRow,
-	StatusRenderer
+	StatusRenderer,
+	typeFormatter
 } from '../DataSourceList';
 import {DataSourceStates, DataSourceTypes} from 'shared/util/constants';
 import {MemoryRouter} from 'react-router-dom';
@@ -27,6 +28,32 @@ describe('DataSourceList exports', () => {
 			expect(disableRow({state: DataSourceStates.Disconnected})).toBe(
 				false
 			);
+		});
+	});
+
+	describe('typeFormatter', () => {
+		it.each([
+			['.CSV', DataSourceTypes.Csv],
+			['Liferay Portal', DataSourceTypes.Liferay],
+			['Marketo Campaign', DataSourceTypes.MarketoCampaign],
+			['Salesforce', DataSourceTypes.Salesforce]
+		])('renders %s for standalone data sources', (label, providerType) => {
+			expect(typeFormatter(providerType)).toBe(label);
+		});
+
+		it.each([
+			['Demandbase', DataSourceTypes.Demandbase],
+			['HubSpot', DataSourceTypes.Hubspot],
+			['Marketo Event Stream', DataSourceTypes.MarketoEventStream]
+		])(
+			'renders %s for connectors registered in the 3rd-party connector framework',
+			(label, providerType) => {
+				expect(typeFormatter(providerType)).toBe(label);
+			}
+		);
+
+		it('renders an empty string when the providerType is unknown', () => {
+			expect(typeFormatter('NOT_A_REGISTERED_CONNECTOR')).toBe('');
 		});
 	});
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/__tests__/data-source-marketo.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/__tests__/data-source-marketo.js
@@ -82,6 +82,35 @@ describe('Marketo Data Source API', () => {
 		expect(config.body instanceof FormData).toBe(true);
 	});
 
+	it('should omit the name on an update that does not change it', () => {
+		fetch.mockReturnValue(
+			Promise.resolve(new Response('{}', {status: 200}))
+		);
+
+		updateMarketoCampaign({
+			channelsConfiguration: {channels: [], enableAllChannels: true},
+			groupId: '23',
+			id: '7',
+		});
+
+		const [, config] = fetch.mock.calls[0];
+
+		expect(config.body.has('name')).toBe(false);
+		expect(config.body.get('name')).not.toBe('undefined');
+	});
+
+	it('should send the name on an update that changes it', () => {
+		fetch.mockReturnValue(
+			Promise.resolve(new Response('{}', {status: 200}))
+		);
+
+		updateMarketoCampaign({groupId: '23', id: '7', name: 'Renamed'});
+
+		const [, config] = fetch.mock.calls[0];
+
+		expect(config.body.get('name')).toBe('Renamed');
+	});
+
 	it('should reject with the HTTP status on a failed update', async () => {
 		fetch.mockReturnValue(Promise.resolve(new Response('', {status: 401})));
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/data-source.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/data-source.js
@@ -1,4 +1,4 @@
-import sendRequest, {getFormData, stringifyValues} from 'shared/util/request';
+import sendRequest, {getFormData, getRequestData} from 'shared/util/request';
 import {
 	buildOrderByFields,
 	createOrderIOMap,
@@ -372,7 +372,7 @@ function sendMarketoCampaignRequest({data, method, path}) {
 
 	return window
 		.fetch(`/o/faro/${path}`, {
-			body: data ? getFormData(stringifyValues(data)) : undefined,
+			body: data ? getFormData(getRequestData(data)) : undefined,
 			method,
 		})
 		.then(async (response) => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/request.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/request.js
@@ -4,6 +4,7 @@ import 'whatwg-fetch';
 import request, {
 	addParams,
 	getFormData,
+	getRequestData,
 	getServiceError,
 	parseFromJSON,
 	serializeQueryString,
@@ -236,6 +237,32 @@ describe('request', () => {
 		);
 
 		return expect(request({})).rejects.toBeInstanceOf(SyntaxError);
+	});
+});
+
+describe('getRequestData', () => {
+	it('should omit undefined values so they are not sent as the string "undefined"', () => {
+		const data = getRequestData({
+			channelsConfiguration: {enableAllChannels: true},
+			name: undefined,
+		});
+
+		expect(data).not.toHaveProperty('name');
+		expect(data.channelsConfiguration).toBe(
+			JSON.stringify({enableAllChannels: true})
+		);
+	});
+
+	it('should keep values that are defined but falsy', () => {
+		const data = getRequestData({
+			enabled: false,
+			name: '',
+			total: 0,
+		});
+
+		expect(data.enabled).toBe(false);
+		expect(data.name).toBe('');
+		expect(data.total).toBe(0);
 	});
 });
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/request.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/request.js
@@ -65,9 +65,12 @@ export function stringifyValues(data) {
 }
 
 /**
- * Remove undefined values from object authData
+ * Serializes a request payload and drops every undefined value. Undefined keys
+ * must never reach `getFormData`: it coerces each value to a string, so an
+ * undefined field would be sent as the literal string "undefined" and
+ * overwrite the stored value.
  */
-function getAuthData(data) {
+export function getRequestData(data) {
 	return Object.entries({
 		...stringifyValues(data),
 	})
@@ -89,7 +92,7 @@ export default (request) => {
 
 	let requestURL = `${baseURL}/${path}`;
 
-	const authData = data && getAuthData(data);
+	const authData = data && getRequestData(data);
 
 	const config = {method};
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100080

## What Is Being Fixed

Two defects on Marketo Campaign data sources.

The Type column in the data source list rendered blank for Marketo Campaign sources, and the Data Source Type field on the overview page read "Marketo" — the label belonging to the separate Marketo Event Stream connector.

Assigning properties renamed the data source to "undefined". Clicking either radio button under Data Availability corrupted the stored name, and the page title updated to match on the refetch that follows.

## How It Is Being Fixed

MARKETO_CAMPAIGN is a standalone data source rather than an entry in the third-party connector registry, so the registry fallback in typeFormatter resolved to an empty string. It now has an explicit case alongside the other standalone types, and the overview page uses the marketo-campaign language key.

The name corruption came from the dedicated request wrapper for the Marketo Campaign endpoints, which skipped the undefined filtering that the shared sendRequest performs. Because getFormData coerces every value to a string, a payload omitting the name sent it as the literal string "undefined", and that value is neither null nor blank, so the Validator.isNotNull guard on the server accepted it and persisted it. The filtering helper is now exported as getRequestData and used by both request paths. This also covers the property toggle and the property selection modal, which sent the same nameless payload and corrupted the name silently, without a refetch to reveal it.

## PR Check

**pr-check: PASS** — tested on `739cbaf2f28db73bcd3a8dae70f9dfc90bb9e49e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "739cbaf2f28db73bcd3a8dae70f9dfc90bb9e49e"} -->
