### PR TITLE
LPD-96997 Add upgrade step for FaroDataSourceUsage table

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-service/bnd.bnd
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-service/bnd.bnd
@@ -37,6 +37,6 @@ Import-Package:\
 	com.liferay.portal.kernel.uuid;version="[6.0.0,9999.0.0)",\
 	\
 	*
-Liferay-Require-SchemaVersion: 21.0.0
+Liferay-Require-SchemaVersion: 22.0.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-service/src/main/java/com/liferay/osb/faro/internal/upgrade/registry/FaroServiceUpgradeStepRegistrator.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-service/src/main/java/com/liferay/osb/faro/internal/upgrade/registry/FaroServiceUpgradeStepRegistrator.java
@@ -167,6 +167,18 @@ public class FaroServiceUpgradeStepRegistrator
 			UpgradeProcessFactory.runSQL(
 				"update OSBFaro_FaroProject set dataSourceConnected = " +
 					"[$TRUE$]"));
+
+		registry.register(
+			"21.0.0", "22.0.0",
+			UpgradeProcessFactory.runSQL(
+				StringBundler.concat(
+					"create table OSBFaro_FaroDataSourceUsage (mvccVersion ",
+					"LONG default 0 not null, faroDataSourceUsageId LONG not ",
+					"null primary key, companyId LONG, userId LONG, ",
+					"createTime LONG, modifiedTime LONG, billableEventsCount ",
+					"LONG, dataSourceId LONG, dataSourceName VARCHAR(75) ",
+					"null, dataSourceStatus VARCHAR(75) null, faroProjectId ",
+					"LONG, knownIndividualsCount LONG, usageTime LONG)")));
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96997

## What Is Being Fixed

The `FaroDataSourceUsage` Service Builder entity (added for the Data Source Usage Metrics feature) had `dataSourceStatus`/`dataSourceName` columns in its `service.xml` from the start, but no matching Service Builder upgrade step registering its `CREATE TABLE` DDL. Since `osb-faro-service` is already deployed everywhere, Service Builder does not retroactively diff `service.xml` against an existing schema — any environment where the module was previously deployed would never actually get the table created, eventually failing with a SQL error once `FaroDataSourceUsageLocalService` is queried.

## How It Is Being Fixed

Adds a new upgrade step (`"21.0.0" → "22.0.0"`) to `FaroServiceUpgradeStepRegistrator`, following this module's established convention for brand-new tables (mirroring the `OSBFaro_FaroChannel`/`OSBFaro_FaroPreferences` precedent), running the `CREATE TABLE OSBFaro_FaroDataSourceUsage` DDL with fields ordered to match `service.xml` exactly (PK, then audit fields, then other fields). `bnd.bnd`'s `Liferay-Require-SchemaVersion` is bumped to `22.0.0` to match.

## Why Are There No Tests?

Tests for this data flow live on the asah side, not on faro; this matches the existing convention for this class of code in this module.

## PR Check

**pr-check: PASS** — tested on `25a7c4539e58319d9c8916fec2ea6e3376635c55`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Baseline | PASS |
| Workspace Build | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "25a7c4539e58319d9c8916fec2ea6e3376635c55"} -->
