### PR TITLE
LPD-100228 Add a configured status label to the sync entity list in MarketoCampaign

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/MarketoCampaignEntities.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/MarketoCampaignEntities.tsx
@@ -1,6 +1,7 @@
 import ClayIcon from '@clayui/icon';
 import ClayList from '@clayui/list';
 import ClaySticker from '@clayui/sticker';
+import Label from '@clayui/label';
 import React from 'react';
 import {ClayCheckbox} from '@clayui/form';
 import {sub} from 'shared/util/lang';
@@ -18,50 +19,74 @@ const MarketoCampaignEntities: React.FC<IMarketoCampaignEntitiesProps> = ({
 	enabledIndividuals,
 	individualsSyncedCount,
 	onIndividualsChange,
-}) => (
-	<div className="pt-1">
-		<ClayList className="mb-0">
-			<ClayList.Item flex>
-				<ClayList.ItemField>
-					<ClayCheckbox
-						checked={enabledIndividuals}
-						disabled={disabled}
-						onChange={onIndividualsChange}
-					/>
-				</ClayList.ItemField>
+}) => {
+	const configured =
+		typeof individualsSyncedCount === 'number' &&
+		individualsSyncedCount > 0;
 
-				<ClayList.ItemField>
-					<ClaySticker displayType="unstyled">
-						<ClayIcon className="text-secondary" symbol="users" />
-					</ClaySticker>
-				</ClayList.ItemField>
+	return (
+		<div className="pt-1">
+			<ClayList className="mb-0">
+				<ClayList.Item flex>
+					<ClayList.ItemField>
+						<ClayCheckbox
+							checked={enabledIndividuals}
+							disabled={disabled}
+							onChange={onIndividualsChange}
+						/>
+					</ClayList.ItemField>
 
-				<ClayList.ItemField
-					className="d-flex justify-content-center"
-					expand
-				>
-					<ClayList.ItemTitle>
-						{Liferay.Language.get('individuals')}
-					</ClayList.ItemTitle>
+					<ClayList.ItemField>
+						<ClaySticker displayType="unstyled">
+							<ClayIcon
+								className="text-secondary"
+								symbol="users"
+							/>
+						</ClaySticker>
+					</ClayList.ItemField>
 
-					<ClayList.ItemText>
-						{Liferay.Language.get(
-							'represents-fields-from-the-leads-and-companies-table-within-marketo'
-						)}
-					</ClayList.ItemText>
+					<ClayList.ItemField
+						className="d-flex justify-content-center"
+						expand
+					>
+						<ClayList.ItemTitle>
+							{Liferay.Language.get('individuals')}
+						</ClayList.ItemTitle>
 
-					{individualsSyncedCount !== undefined &&
-						individualsSyncedCount >= 0 && (
-							<ClayList.ItemText>
-								{sub(Liferay.Language.get('x-items-synced'), [
-									individualsSyncedCount,
-								])}
-							</ClayList.ItemText>
-						)}
-				</ClayList.ItemField>
-			</ClayList.Item>
-		</ClayList>
-	</div>
-);
+						<ClayList.ItemText>
+							{Liferay.Language.get(
+								'represents-fields-from-the-leads-and-companies-table-within-marketo'
+							)}
+						</ClayList.ItemText>
+
+						{individualsSyncedCount !== undefined &&
+							individualsSyncedCount >= 0 && (
+								<ClayList.ItemText>
+									{sub(
+										Liferay.Language.get('x-items-synced'),
+										[individualsSyncedCount]
+									)}
+								</ClayList.ItemText>
+							)}
+					</ClayList.ItemField>
+
+					<ClayList.ItemField className="justify-content-center">
+						<Label
+							displayType={configured ? 'success' : 'secondary'}
+						>
+							{configured
+								? Liferay.Language.get(
+										'configured'
+									).toUpperCase()
+								: Liferay.Language.get(
+										'unconfigured'
+									).toUpperCase()}
+						</Label>
+					</ClayList.ItemField>
+				</ClayList.Item>
+			</ClayList>
+		</div>
+	);
+};
 
 export default MarketoCampaignEntities;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/MarketoCampaignEntities.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/MarketoCampaignEntities.tsx
@@ -1,0 +1,42 @@
+jest.unmock('react-dom');
+
+import MarketoCampaignEntities from '../MarketoCampaignEntities';
+import React from 'react';
+import {render} from '@testing-library/react';
+
+describe('MarketoCampaignEntities', () => {
+	it('renders the Configured label when the synced count is greater than zero', () => {
+		const {getByText} = render(
+			<MarketoCampaignEntities
+				enabledIndividuals
+				individualsSyncedCount={5}
+				onIndividualsChange={jest.fn()}
+			/>
+		);
+
+		expect(getByText('CONFIGURED')).toBeTruthy();
+	});
+
+	it('renders the Unconfigured label when the synced count is zero', () => {
+		const {getByText} = render(
+			<MarketoCampaignEntities
+				enabledIndividuals
+				individualsSyncedCount={0}
+				onIndividualsChange={jest.fn()}
+			/>
+		);
+
+		expect(getByText('UNCONFIGURED')).toBeTruthy();
+	});
+
+	it('renders the Unconfigured label when no synced count is provided', () => {
+		const {getByText} = render(
+			<MarketoCampaignEntities
+				enabledIndividuals={false}
+				onIndividualsChange={jest.fn()}
+			/>
+		);
+
+		expect(getByText('UNCONFIGURED')).toBeTruthy();
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
@@ -1366,6 +1366,19 @@ exports[`MarketoCampaignOverview should render the connected data source with th
                             20 Items Synced
                           </p>
                         </div>
+                        <div
+                          class="justify-content-center autofit-col"
+                        >
+                          <span
+                            class="label label-success"
+                          >
+                            <span
+                              class="label-item label-item-expand"
+                            >
+                              CONFIGURED
+                            </span>
+                          </span>
+                        </div>
                       </li>
                     </ul>
                   </div>
@@ -2344,6 +2357,19 @@ exports[`MarketoCampaignOverview should render the reconnect view when the data 
                           >
                             20 Items Synced
                           </p>
+                        </div>
+                        <div
+                          class="justify-content-center autofit-col"
+                        >
+                          <span
+                            class="label label-success"
+                          >
+                            <span
+                              class="label-item label-item-expand"
+                            >
+                              CONFIGURED
+                            </span>
+                          </span>
                         </div>
                       </li>
                     </ul>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100228

## What Is Being Fixed

The Marketo campaign data source settings listed the Individuals sync entity without any indication of whether it had been configured. The equivalent third-party connector screen already shows a status label per entity, so the Marketo screen was inconsistent with it and gave no at-a-glance signal of configuration state.

## How It Is Being Fixed

MarketoCampaignEntities now derives a configured flag from the synced count and renders the same success/secondary Clay label used by ConnectorEntities, in uppercase. The component gained a block body to hold that flag, which shifted the surrounding JSX one indentation level. A unit test covers both label states, including the unconfigured case that the overview snapshots do not exercise.

## PR Check

**pr-check: PASS** — tested on `621520fb913109303e0e092d40b0d44be3b28e1e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| JavaScript Unit Tests | PASS |

Workspace Build ran scoped to `:modules:osb-faro-web:build` after the full workspace build exceeded the time bound. JavaScript Unit Tests ran the reduced fallback scope `src/main/js/settings/components/marketo` after the full `yarn test` exceeded the time bound; the scoped Gradle build separately exercised the module's full Jest suite (693 suites, 3766 tests, 587 snapshots passed).

<!-- pr-check {"result": "success", "sha": "621520fb913109303e0e092d40b0d44be3b28e1e"} -->
