### PR TITLE
LPD-99030 Add the missing dashboard filter snapshots

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/SegmentDropdown.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/SegmentDropdown.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SegmentDropdown should render with "All Segments" as the default value 1`] = `
+<div>
+  <div
+    class="dropdown"
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-label="Filter By Segments"
+      class="rounded-lg text-nowrap btn btn-sm btn-secondary"
+      role="combobox"
+      type="button"
+    >
+      <svg
+        class="lexicon-icon lexicon-icon-filter inline-item inline-item-before"
+        role="presentation"
+      >
+        <use
+          href="#filter"
+        />
+      </svg>
+      All Segments
+      <svg
+        class="lexicon-icon lexicon-icon-caret-bottom inline-item inline-item-after"
+        role="presentation"
+      >
+        <use
+          href="#caret-bottom"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/components/sankey/__tests__/__snapshots__/PagePathCard.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/components/sankey/__tests__/__snapshots__/PagePathCard.tsx.snap
@@ -998,6 +998,44 @@ exports[`PagePathCard should filter by the selected account 1`] = `
 </div>
 `;
 
+exports[`PagePathCard should filter by the selected segment 1`] = `
+<div>
+  <div
+    class="card card-root"
+    style="min-height: 600px;"
+  >
+    <div
+      class="card-header"
+    >
+      <div
+        class="card-title"
+      >
+        Path Analysis
+      </div>
+    </div>
+    <div>
+      <div
+        class="card-body d-flex align-items-center justify-content-center"
+      >
+        <div
+          class="error-display-root flex-grow-1 no-results-root flex-grow-1"
+        >
+          <div
+            class="no-results-content"
+          >
+            <div
+              class="h4 no-results-title"
+            >
+              An unexpected error occurred.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`PagePathCard should render 1`] = `
 <div>
   <div


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99030

## What Is Being Fixed

Two Jest snapshots are missing from the repository, both from the commit that added the segment filter to the Pages Dashboard.

The `SegmentDropdown` snapshot went missing when the dropdown moved from `sites/touchpoints/components` to `shared/components`: the component and its test moved along, but the snapshot stayed behind and was deleted with the old location. The `PagePathCard` one was never written at all, for the `should filter by the selected segment` case that the same commit added to its test.

In both cases the assertion has no baseline, so every developer who runs the suite writes the snapshot again in their own checkout, which leaves untracked files behind and makes the assertion verify nothing. On a continuous integration run both tests fail outright, because new snapshots are not written there.

## How It Is Being Fixed

Commit the two snapshots the tests expect. Both were regenerated from a clean checkout of `master` and match what the tests produce today, so the assertions have a baseline to compare against again. Each one was also checked with `--ci`, where the test fails without its snapshot and passes with it.

## Why Are There No Tests?

The change consists entirely of test artifacts: it restores the baselines of two existing tests that currently pass without asserting anything.

## PR Check

**pr-check: PASS** — tested on `6f043729145cc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "6f043729145cc18ae52f0b23ac0873cdec0abe5f"} -->
