### PR TITLE
LPD-100223 Report the page unload event through pagehide

### DIFF
--- a/modules/apps/analytics/analytics-client-js/src/plugins/timing.ts
+++ b/modules/apps/analytics/analytics-client-js/src/plugins/timing.ts
@@ -6,7 +6,7 @@
 import Analytics from '../analytics';
 import {Analytics as AnalyticsType} from '../types';
 import {MARK_NAVIGATION_START, MARK_VIEW_DURATION} from '../utils/constants';
-import {getDuration} from '../utils/performance';
+import {createMark, getDuration} from '../utils/performance';
 
 /**
  * Sends page load information on the window load event
@@ -30,9 +30,9 @@ function onload(analytics: Analytics) {
 }
 
 /**
- * Sends view duration information on the window unload event
+ * Sends view duration information on the window pagehide event
  */
-function unload(analytics: Analytics) {
+function pagehide(analytics: Analytics) {
 	const navigationStartMark = window.performance.getEntriesByName(
 		MARK_NAVIGATION_START
 	);
@@ -56,6 +56,17 @@ function unload(analytics: Analytics) {
 }
 
 /**
+ * Restarts the view duration measurement when the page is restored from the
+ * back/forward cache, so that the next pagehide event reports the duration of
+ * the new view instead of the time the page spent frozen
+ */
+function pageshow(event: PageTransitionEvent) {
+	if (event.persisted) {
+		createMark(MARK_NAVIGATION_START);
+	}
+}
+
+/**
  * Plugin function that registers listeners against browser time events
  */
 function timing(analytics: Analytics) {
@@ -63,13 +74,15 @@ function timing(analytics: Analytics) {
 
 	window.addEventListener('load', onLoad);
 
-	const onUnload = unload.bind(null, analytics);
+	const onPageHide = pagehide.bind(null, analytics);
 
-	window.addEventListener('unload', onUnload);
+	window.addEventListener('pagehide', onPageHide);
+	window.addEventListener('pageshow', pageshow);
 
 	return () => {
 		window.removeEventListener('load', onLoad);
-		window.removeEventListener('unload', onUnload);
+		window.removeEventListener('pagehide', onPageHide);
+		window.removeEventListener('pageshow', pageshow);
 	};
 }
 

--- a/modules/apps/analytics/analytics-client-js/src/plugins/visibility.ts
+++ b/modules/apps/analytics/analytics-client-js/src/plugins/visibility.ts
@@ -75,10 +75,12 @@ function visibility(analytics: Analytics) {
 		const onVisibilityChange = handleVisibilityChange.bind(null, analytics);
 
 		window.addEventListener('beforeunload', enableTabEventHandle);
+		window.addEventListener('pageshow', pageShowHandle);
 		document.addEventListener(visibilityChange, onVisibilityChange);
 
 		return () => {
 			window.removeEventListener('beforeunload', enableTabEventHandle);
+			window.removeEventListener('pageshow', pageShowHandle);
 			document.removeEventListener(visibilityChange, onVisibilityChange);
 		};
 	}
@@ -86,6 +88,17 @@ function visibility(analytics: Analytics) {
 
 function enableTabEventHandle() {
 	enableTabEvent = false;
+}
+
+/**
+ * Leaving the page disables the tab events so that the visibility change it
+ * causes is not reported. A page restored from the back/forward cache is being
+ * viewed again, so the events must be enabled back.
+ */
+function pageShowHandle(event: PageTransitionEvent) {
+	if (event.persisted) {
+		enableTabEvent = true;
+	}
 }
 
 export {visibility};

--- a/modules/apps/analytics/analytics-client-js/test/helpers.ts
+++ b/modules/apps/analytics/analytics-client-js/test/helpers.ts
@@ -98,6 +98,44 @@ export function wait(msToWait: number) {
 }
 
 /**
+ * jsdom does not implement the User Timing API, which the timing plugin relies
+ * on to measure how long a page has been viewed. An unknown start mark resolves
+ * to the time origin, mirroring the legacy `navigationStart` timing attribute
+ * the plugin falls back to.
+ */
+export function mockUserTiming() {
+	const marks = new Map<string, number>();
+	const measures = new Map<string, number>();
+
+	Object.assign(global.performance, {
+		clearMarks(name: string) {
+			marks.delete(name);
+		},
+		getEntriesByName(name: string) {
+			if (marks.has(name)) {
+				return [{duration: 0, name, startTime: marks.get(name)}];
+			}
+
+			if (measures.has(name)) {
+				return [{duration: measures.get(name), name, startTime: 0}];
+			}
+
+			return [];
+		},
+		mark(name: string) {
+			marks.set(name, global.performance.now());
+		},
+		measure(name: string, startMark: string, endMark?: string) {
+			const endTime = endMark
+				? marks.get(endMark) || 0
+				: global.performance.now();
+
+			measures.set(name, endTime - (marks.get(startMark) || 0));
+		},
+	});
+}
+
+/**
  * Makes an element report a visible, in-viewport bounding box. Pass a partial
  * rect to override specific fields (e.g. to place it outside the viewport).
  */

--- a/modules/apps/analytics/analytics-client-js/test/plugins/timing.ts
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/timing.ts
@@ -8,7 +8,8 @@
 import fetchMock from 'fetch-mock';
 
 import AnalyticsClient from '../../src/analytics';
-import {INITIAL_ANALYTICS_CONFIG} from '../helpers';
+import {MARK_NAVIGATION_START} from '../../src/utils/constants';
+import {INITIAL_ANALYTICS_CONFIG, mockUserTiming} from '../helpers';
 
 const applicationId = 'Page';
 
@@ -23,6 +24,8 @@ describe('Timing Plugin', () => {
 			value: 'loading',
 			writable: false,
 		});
+
+		mockUserTiming();
 
 		fetchMock.mock('*', () => 200);
 
@@ -58,6 +61,66 @@ describe('Timing Plugin', () => {
 					}),
 				})
 			);
+		});
+	});
+
+	describe('pageUnloaded event', () => {
+		it('is fired on the window pagehide event with the view duration', () => {
+			window.dispatchEvent(new Event('pagehide'));
+
+			const events = Analytics.getEvents().filter(
+				({eventId}) => eventId === 'pageUnloaded'
+			);
+
+			expect(events.length).toBe(1);
+
+			expect(events[0]).toEqual(
+				expect.objectContaining({
+					applicationId,
+					eventId: 'pageUnloaded',
+					properties: expect.objectContaining({
+						viewDuration: expect.any(Number),
+					}),
+				})
+			);
+		});
+
+		it('is not fired on the deprecated window unload event', () => {
+			window.dispatchEvent(new Event('unload'));
+
+			const events = Analytics.getEvents().filter(
+				({eventId}) => eventId === 'pageUnloaded'
+			);
+
+			expect(events.length).toBe(0);
+		});
+	});
+
+	describe('back/forward cache', () => {
+		it('restarts the view duration when the page is restored', () => {
+			window.performance.clearMarks(MARK_NAVIGATION_START);
+
+			const event = new Event('pageshow');
+
+			Object.defineProperty(event, 'persisted', {value: true});
+
+			window.dispatchEvent(event);
+
+			expect(
+				window.performance.getEntriesByName(MARK_NAVIGATION_START)
+					.length
+			).toBe(1);
+		});
+
+		it('keeps the current measurement when the page is not restored', () => {
+			window.performance.clearMarks(MARK_NAVIGATION_START);
+
+			window.dispatchEvent(new Event('pageshow'));
+
+			expect(
+				window.performance.getEntriesByName(MARK_NAVIGATION_START)
+					.length
+			).toBe(0);
 		});
 	});
 });

--- a/modules/apps/analytics/analytics-client-js/test/plugins/visibility.ts
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/visibility.ts
@@ -8,7 +8,7 @@
 import fetchMock from 'fetch-mock';
 
 import AnalyticsClient from '../../src/analytics';
-import {INITIAL_ANALYTICS_CONFIG} from '../helpers';
+import {INITIAL_ANALYTICS_CONFIG, mockUserTiming} from '../helpers';
 
 const applicationId = 'Page';
 
@@ -23,6 +23,8 @@ describe('Visibility Plugin', () => {
 			value: 'loading',
 			writable: false,
 		});
+
+		mockUserTiming();
 
 		fetchMock.mock('*', () => 200);
 
@@ -81,6 +83,47 @@ describe('Visibility Plugin', () => {
 					eventId: 'tabFocused',
 				})
 			);
+		});
+	});
+
+	describe('back/forward cache', () => {
+		beforeEach(() => {
+			Object.defineProperty(document, 'hidden', {
+				configurable: true,
+				value: true,
+			});
+
+			// Leaving the page disables the tab events
+
+			window.dispatchEvent(new Event('beforeunload'));
+		});
+
+		it('reports the tab events again when the page is restored', () => {
+			const event = new Event('pageshow');
+
+			Object.defineProperty(event, 'persisted', {value: true});
+
+			window.dispatchEvent(event);
+
+			document.dispatchEvent(new Event('visibilitychange'));
+
+			const events = Analytics.getEvents().filter(
+				({eventId}) => eventId === 'tabBlurred'
+			);
+
+			expect(events.length).toBe(1);
+		});
+
+		it('keeps the tab events disabled when the page is not restored', () => {
+			window.dispatchEvent(new Event('pageshow'));
+
+			document.dispatchEvent(new Event('visibilitychange'));
+
+			const events = Analytics.getEvents().filter(
+				({eventId}) => eventId === 'tabBlurred'
+			);
+
+			expect(events.length).toBe(0);
 		});
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100223

## What Is Being Fixed

The SDK reported the `pageUnloaded` event from a `window.addEventListener('unload', ...)` handler. Chrome is deprecating the unload event through a staged rollout — 60% of page loads as of Chrome 151 (July 28, 2026), reaching 100% with Chrome 154 (September 22, 2026) — and on affected page loads it refuses the listener registration, logging `[Violation] Permissions policy violation: unload is not allowed in this document`. The handler never runs, so the event and its `viewDuration` property are never queued.

Since `viewDuration` is only ever emitted on `pageUnloaded`, the loss propagates to the pipelines that consume it: interest and keyword extraction, the Interest Score job, and the Recommendations training-data check. Metrics computed from event timestamps are unaffected. With SPA navigation enabled the dxp plugin still emits the event on `beforeNavigate`, limiting the loss to the last page of each visit; with SPA disabled the event is lost entirely.

The listener was also a back/forward cache blocker, so every page with Analytics Cloud enabled was ineligible for bfcache on desktop Chrome.

Reported by a customer in LRHC-154109 (DXP 2025.Q2.10 hotfix-49).

## How It Is Being Fixed

The timing plugin now listens for `pagehide`, which fires in every case `unload` did plus when the page enters the back/forward cache, and which Chrome documents as the migration path.

Because the `unload` listener was itself what kept pages out of the bfcache, removing it makes restores possible and introduces two cases that could not happen before. First, a restored page would measure `viewDuration` from the original navigation start, counting the time it spent frozen — so the plugin now recreates the navigation start mark on `pageshow` when the page was persisted, and each viewing period is reported with its own duration. The event is still sent when the page enters the cache rather than suppressed, since a page can be evicted and never restored, and losing the event outright is worse than reporting two viewing periods. Second, the visibility plugin disables its tab events on `beforeunload` so that the visibility change caused by leaving the page is not reported, and that module-level flag was never reset — a restored page would have had `tabBlurred` and `tabFocused` dead for the rest of its life. It is now re-enabled on a persisted `pageshow`.

The tests cover both plugins, including that the event is no longer reported on the deprecated `unload` event. They need a User Timing mock because jsdom implements none of `performance.mark`, `measure`, `clearMarks`, or `getEntriesByName`; it lives in `test/helpers.ts` rather than `test/setup.ts` because the forms test ships its own stub guarded on those methods being absent and depends on it to forge `focusDuration`.

## PR Check

**pr-check: PASS** — tested on `91b7bbb6ccbf410fe108edcb235e9196d54a6f1e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

Run from a worktree, where the canonical commands need adjusting: `modules/node_modules` is symlinked to the main checkout, so `ant format-source-current-branch` fails in `:yarnInstall` and `node-scripts test` roots at the main checkout. Source Format ran node-scripts' `formatSourceFiles` (the same prettier, eslint, and stylelint pipeline) over the five changed files; JavaScript Unit Tests ran the module's full suite against a worktree-rooted jest config (29 suites, 254 tests); Per-Module Compile ran the module's own `build:custom` plus `tsc --noEmit`, the module being TypeScript-only with no Java.

<!-- pr-check {"result": "success", "sha": "91b7bbb6ccbf410fe108edcb235e9196d54a6f1e"} -->

Resent from interaminense/liferay-portal#549