### PR TITLE
LPD-99030 Filter dashboards, the segment picker, and accounts-listing views by segment

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/blog/hocs/DevicesCard.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/blog/hocs/DevicesCard.js
@@ -16,6 +16,7 @@ const BROWSER_DEVICE_QUERY = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -29,6 +30,7 @@ const BROWSER_DEVICE_QUERY = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			assetId

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/blog/hocs/LocationsCard.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/blog/hocs/LocationsCard.js
@@ -18,6 +18,7 @@ const GEOLOCATION_QUERY = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -31,6 +32,7 @@ const GEOLOCATION_QUERY = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			assetId

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/blog/pages/__tests__/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/blog/pages/__tests__/index.tsx
@@ -1,0 +1,128 @@
+import Blog from '../index';
+import mockStore from 'test/mock-store';
+import React from 'react';
+import {getMatchedRoute, Routes} from 'shared/util/router';
+import {MemoryRouter} from 'react-router-dom';
+import {Provider} from 'react-redux';
+import {render, screen} from '@testing-library/react';
+import {useLDPEnabled} from 'shared/hooks/useLDPEnabled';
+
+jest.unmock('react-dom');
+
+jest.mock('shared/components/download-report/DownloadCSVReport', () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+jest.mock('shared/components/download-report/DownloadPDFReport', () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+jest.mock('shared/components/Loading', () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+jest.mock('shared/components/RouteNotFound', () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+jest.mock('route-middleware/BundleRouter', () => ({
+	__esModule: true,
+	default: () => null,
+}));
+
+jest.mock('shared/components/AccountDropdown', () => ({
+	__esModule: true,
+	default: () => <div data-testid="account-dropdown" />,
+}));
+
+jest.mock('shared/components/SegmentDropdown', () => ({
+	__esModule: true,
+	default: ({
+		assetId,
+		assetType,
+		initialSegmentId,
+		initialSegmentName,
+	}: {
+		assetId?: string;
+		assetType?: string;
+		initialSegmentId?: string;
+		initialSegmentName?: string;
+	}) => (
+		<div
+			data-asset-id={assetId}
+			data-asset-type={assetType}
+			data-initial-segment-id={initialSegmentId}
+			data-initial-segment-name={initialSegmentName}
+			data-testid="segment-dropdown"
+		/>
+	),
+}));
+
+jest.mock('shared/context/channel', () => ({
+	useChannelContext: () => ({selectedChannel: {name: 'test channel'}}),
+}));
+
+jest.mock('shared/context/dataSources', () => ({
+	useDataSources: () => ({empty: false}),
+}));
+
+jest.mock('shared/hooks/useQueryRangeSelectors', () => ({
+	useQueryRangeSelectors: () => ({rangeKey: '30'}),
+}));
+
+jest.mock('shared/hooks/useLDPEnabled', () => ({
+	useLDPEnabled: jest.fn(),
+}));
+
+jest.mock('shared/util/router', () => {
+	const actual = jest.requireActual('shared/util/router');
+
+	return {
+		...actual,
+		getMatchedRoute: jest.fn(() => actual.Routes.ASSETS_BLOGS_OVERVIEW),
+	};
+});
+
+const ROUTER = {
+	className: '',
+	params: {
+		assetId: 'asset-1',
+		channelId: '1',
+		groupId: '2',
+		title: 'my blog',
+		touchpoint: 'http://example.com/web/site/blog',
+		type: 'Blog',
+	},
+	query: {},
+};
+
+describe('Blog', () => {
+	beforeEach(() => {
+		(useLDPEnabled as jest.Mock).mockReturnValue(true);
+	});
+
+	it('shows an unscoped segment filter on the accounts route', () => {
+		(getMatchedRoute as jest.Mock).mockReturnValue(
+			Routes.ASSETS_BLOGS_ACCOUNTS
+		);
+
+		render(
+			<Provider store={mockStore()}>
+				<MemoryRouter>
+					<Blog className="" router={ROUTER as any} />
+				</MemoryRouter>
+			</Provider>
+		);
+
+		expect(screen.getByTestId('segment-dropdown')).not.toHaveAttribute(
+			'data-asset-id'
+		);
+		expect(screen.getByTestId('segment-dropdown')).not.toHaveAttribute(
+			'data-asset-type'
+		);
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/blog/pages/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/blog/pages/index.tsx
@@ -166,6 +166,16 @@ const Blog: React.FC<{
 				</BasePage.SubHeader>
 			)}
 
+			{getMatchedRoute(NAV_ITEMS) === Routes.ASSETS_BLOGS_ACCOUNTS && (
+				<BasePage.SubHeader>
+					<SegmentDropdown
+						initialSegmentId={segmentId}
+						initialSegmentName={segmentName}
+						onFilterChange={setSegment}
+					/>
+				</BasePage.SubHeader>
+			)}
+
 			{getMatchedRoute(NAV_ITEMS) ===
 				Routes.ASSETS_BLOGS_KNOWN_INDIVIDUALS && (
 				<BasePage.SubHeader>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/blog/pages/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/blog/pages/index.tsx
@@ -138,6 +138,7 @@ const Blog: React.FC<{
 					{LDPEnabled && (
 						<AccountDropdown
 							assetType="blog"
+							className="mr-3"
 							initialAccountId={accountId}
 							initialAccountName={accountName}
 							onFilterChange={setAccount}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/components/AssetAppearsOnCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/components/AssetAppearsOnCard.tsx
@@ -71,7 +71,7 @@ export const AssetAppearsOnCard: React.FC<IAssetAppearsOnCardProps> = ({
 		minHeight={536}
 		reportContainer={ReportContainer.AssetAppearsOnCard}
 	>
-		{({accountId, rangeSelectors}) => (
+		{({accountId, rangeSelectors, segmentId}) => (
 			<AssetAppearsOnStateRenderer
 				accessors={accessors}
 				accountId={accountId}
@@ -79,6 +79,7 @@ export const AssetAppearsOnCard: React.FC<IAssetAppearsOnCardProps> = ({
 				emptyStateLink={emptyStateLink}
 				emptyStateText={emptyStateText}
 				rangeSelectors={rangeSelectors}
+				segmentId={segmentId}
 			/>
 		)}
 	</BaseCard>
@@ -91,6 +92,7 @@ const AssetAppearsOnStateRenderer = ({
 	emptyStateLink,
 	emptyStateText,
 	rangeSelectors,
+	segmentId,
 }: any) => {
 	const {assetId, channelId, title} = useParams();
 	const [pagination, setPagination] = useState({
@@ -108,6 +110,7 @@ const AssetAppearsOnStateRenderer = ({
 				assetType === AssetTypes.ObjectEntry
 					? 'OBJECT_ENTRY'
 					: assetType.toUpperCase(),
+			segmentId,
 			selectedMetrics: accessors,
 			...(assetType !== AssetTypes.ObjectEntry && {
 				channelId,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/hocs/DevicesCard.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/hocs/DevicesCard.ts
@@ -23,6 +23,7 @@ const BROWSER_DEVICE_QUERY = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -36,6 +37,7 @@ const BROWSER_DEVICE_QUERY = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			assetId

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/hocs/LocationsCard.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/hocs/LocationsCard.ts
@@ -25,6 +25,7 @@ const GEOLOCATION_QUERY = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -38,6 +39,7 @@ const GEOLOCATION_QUERY = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			assetId

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/hocs/VisitorsListCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/hocs/VisitorsListCard.tsx
@@ -22,7 +22,6 @@ import {
 	createOrderIOMap,
 	DOWNLOADS_METRIC,
 	NAME,
-	VIEWS_METRIC,
 } from 'shared/util/pagination';
 import {graphql} from '@apollo/client/react/hoc';
 import {RangeSelectors} from 'shared/types';
@@ -31,10 +30,10 @@ import {Sizes} from 'shared/util/constants';
 
 const withAccountsData = () =>
 	graphql(
-		knownAccountsListAssetQuery('document', VIEWS_METRIC),
+		knownAccountsListAssetQuery('document', DOWNLOADS_METRIC),
 		getMetricsMapper((result) => ({
-			items: result.document.viewsMetric.accounts.accountNames,
-			total: result.document.viewsMetric.accounts.total,
+			items: result.document.downloadsMetric.accounts.accountNames,
+			total: result.document.downloadsMetric.accounts.total,
 		}))
 	);
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/hocs/VisitorsListCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/hocs/VisitorsListCard.tsx
@@ -18,11 +18,7 @@ import {
 	withQueryPagination,
 	withQueryRangeSelectors,
 } from 'shared/hoc';
-import {
-	createOrderIOMap,
-	DOWNLOADS_METRIC,
-	NAME,
-} from 'shared/util/pagination';
+import {createOrderIOMap, DOWNLOADS_METRIC, NAME} from 'shared/util/pagination';
 import {graphql} from '@apollo/client/react/hoc';
 import {RangeSelectors} from 'shared/types';
 import {Routes} from 'shared/util/router';

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/pages/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/pages/index.tsx
@@ -174,6 +174,17 @@ const DocumentAndMedia: React.FC<{
 			)}
 
 			{getMatchedRoute(NAV_ITEMS) ===
+				Routes.ASSETS_DOCUMENTS_AND_MEDIA_ACCOUNTS && (
+				<BasePage.SubHeader>
+					<SegmentDropdown
+						initialSegmentId={segmentId}
+						initialSegmentName={segmentName}
+						onFilterChange={setSegment}
+					/>
+				</BasePage.SubHeader>
+			)}
+
+			{getMatchedRoute(NAV_ITEMS) ===
 				Routes.ASSETS_DOCUMENTS_AND_MEDIA_KNOWN_INDIVIDUALS && (
 				<BasePage.SubHeader>
 					<div className="d-flex justify-content-end w-100">

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/pages/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/document-and-media/pages/index.tsx
@@ -145,6 +145,7 @@ const DocumentAndMedia: React.FC<{
 					{LDPEnabled && (
 						<AccountDropdown
 							assetType="document"
+							className="mr-3"
 							initialAccountId={accountId}
 							initialAccountName={accountName}
 							onFilterChange={setAccount}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/hocs/DevicesCard.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/hocs/DevicesCard.js
@@ -16,6 +16,7 @@ const BROWSER_DEVICE = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -29,6 +30,7 @@ const BROWSER_DEVICE = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			submissionsMetric {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/hocs/FormAbandonmentCard.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/hocs/FormAbandonmentCard.jsx
@@ -38,7 +38,14 @@ const FormAbandonmentCard = ({className, label, legacyDropdownRangeKey}) => (
 		legacyDropdownRangeKey={legacyDropdownRangeKey}
 		minHeight={536}
 	>
-		{({accountId, filters, interval, rangeSelectors, router}) => (
+		{({
+			accountId,
+			filters,
+			interval,
+			rangeSelectors,
+			router,
+			segmentId
+		}) => (
 			<Card.Body>
 				<FormAbandonmentWithData
 					accountId={accountId}
@@ -46,6 +53,7 @@ const FormAbandonmentCard = ({className, label, legacyDropdownRangeKey}) => (
 					interval={interval}
 					rangeSelectors={rangeSelectors}
 					router={router}
+					segmentId={segmentId}
 				/>
 			</Card.Body>
 		)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/hocs/LocationsCard.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/hocs/LocationsCard.js
@@ -18,6 +18,7 @@ const GEOLOCATION_QUERY = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -31,6 +32,7 @@ const GEOLOCATION_QUERY = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			submissionsMetric {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/hocs/mappers/__tests__/form-abandonment-query.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/hocs/mappers/__tests__/form-abandonment-query.js
@@ -242,4 +242,27 @@ describe('FormAbandonmentQuery mapper', () => {
 			},
 		});
 	});
+
+	it('should include segmentId in the options when provided', () => {
+		const options = mapPropsToOptions({
+			filters: {},
+			rangeSelectors: {rangeKey: '7'},
+			router,
+			segmentId: 'segment-100',
+		});
+
+		expect(options).toEqual({
+			variables: {
+				assetId: 'formId',
+				devices: 'Any',
+				location: 'Any',
+				rangeEnd: null,
+				rangeKey: 7,
+				rangeStart: null,
+				segmentId: 'segment-100',
+				title: 'Liferay',
+				touchpoint: null,
+			},
+		});
+	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/hocs/mappers/form-abandonment-query.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/hocs/mappers/form-abandonment-query.jsx
@@ -126,7 +126,16 @@ const mapPropsToOptions = ({
 	filters,
 	interval,
 	rangeSelectors,
-	router: {params}
-}) => getVariables({accountId, filters, interval, params, rangeSelectors});
+	router: {params},
+	segmentId
+}) =>
+	getVariables({
+		accountId,
+		filters,
+		interval,
+		params,
+		rangeSelectors,
+		segmentId
+	});
 
 export {mapPropsToOptions, mapResultToProps};

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/pages/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/pages/index.tsx
@@ -170,6 +170,16 @@ const Form: React.FC<{
 				</BasePage.SubHeader>
 			)}
 
+			{getMatchedRoute(NAV_ITEMS) === Routes.ASSETS_FORMS_ACCOUNTS && (
+				<BasePage.SubHeader>
+					<SegmentDropdown
+						initialSegmentId={segmentId}
+						initialSegmentName={segmentName}
+						onFilterChange={setSegment}
+					/>
+				</BasePage.SubHeader>
+			)}
+
 			{getMatchedRoute(NAV_ITEMS) ===
 				Routes.ASSETS_FORMS_KNOWN_INDIVIDUALS && (
 				<BasePage.SubHeader>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/pages/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/form/pages/index.tsx
@@ -142,6 +142,7 @@ const Form: React.FC<{
 					{LDPEnabled && (
 						<AccountDropdown
 							assetType="form"
+							className="mr-3"
 							initialAccountId={accountId}
 							initialAccountName={accountName}
 							onFilterChange={setAccount}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/object-entry/hocs/DevicesCard.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/object-entry/hocs/DevicesCard.js
@@ -15,6 +15,7 @@ const BROWSER_DEVICE_QUERY = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$touchpoint: String
 	) {
 		objectEntry(
@@ -26,6 +27,7 @@ const BROWSER_DEVICE_QUERY = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 		) {
 			assetId
 			viewsMetric {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/object-entry/hocs/LocationsCard.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/object-entry/hocs/LocationsCard.js
@@ -17,6 +17,7 @@ const GEOLOCATION_QUERY = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$touchpoint: String
 	) {
 		objectEntry(
@@ -28,6 +29,7 @@ const GEOLOCATION_QUERY = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 		) {
 			assetId
 			viewsMetric {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/object-entry/pages/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/object-entry/pages/index.tsx
@@ -170,6 +170,17 @@ const ObjectEntry: React.FC<{
 				</BasePage.SubHeader>
 			)}
 
+			{getMatchedRoute(NAV_ITEMS) ===
+				Routes.ASSETS_OBJECT_ENTRY_ACCOUNTS && (
+				<BasePage.SubHeader>
+					<SegmentDropdown
+						initialSegmentId={segmentId}
+						initialSegmentName={segmentName}
+						onFilterChange={setSegment}
+					/>
+				</BasePage.SubHeader>
+			)}
+
 			<BasePage.Context.Provider
 				value={{
 					accountId,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/object-entry/pages/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/object-entry/pages/index.tsx
@@ -142,6 +142,7 @@ const ObjectEntry: React.FC<{
 					{LDPEnabled && (
 						<AccountDropdown
 							assetType="objectEntry"
+							className="mr-3"
 							initialAccountId={accountId}
 							initialAccountName={accountName}
 							onFilterChange={setAccount}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/web-content/hocs/DevicesCard.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/web-content/hocs/DevicesCard.ts
@@ -22,6 +22,7 @@ const BROWSER_DEVICE_QUERY = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -35,6 +36,7 @@ const BROWSER_DEVICE_QUERY = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			assetId

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/web-content/hocs/LocationsCard.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/web-content/hocs/LocationsCard.ts
@@ -24,6 +24,7 @@ const GEOLOCATION_QUERY = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -37,6 +38,7 @@ const GEOLOCATION_QUERY = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			assetId

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/web-content/pages/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/web-content/pages/index.tsx
@@ -172,6 +172,17 @@ const WebContent: React.FC<{
 			)}
 
 			{getMatchedRoute(NAV_ITEMS) ===
+				Routes.ASSETS_WEB_CONTENT_ACCOUNTS && (
+				<BasePage.SubHeader>
+					<SegmentDropdown
+						initialSegmentId={segmentId}
+						initialSegmentName={segmentName}
+						onFilterChange={setSegment}
+					/>
+				</BasePage.SubHeader>
+			)}
+
+			{getMatchedRoute(NAV_ITEMS) ===
 				Routes.ASSETS_WEB_CONTENT_KNOWN_INDIVIDUALS && (
 				<BasePage.SubHeader>
 					<div className="d-flex justify-content-end w-100">

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/web-content/pages/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/web-content/pages/index.tsx
@@ -143,6 +143,7 @@ const WebContent: React.FC<{
 					{LDPEnabled && (
 						<AccountDropdown
 							assetType="journal"
+							className="mr-3"
 							initialAccountId={accountId}
 							initialAccountName={accountName}
 							onFilterChange={setAccount}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/cerebro-shared/hocs/LocationsCard.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/cerebro-shared/hocs/LocationsCard.jsx
@@ -68,7 +68,15 @@ const withLocationsCard = (
 			minHeight={536}
 			reportContainer={reportContainer}
 		>
-			{({accountId, experienceId, filters, interval, rangeSelectors, router}) => (
+			{({
+				accountId,
+				experienceId,
+				filters,
+				interval,
+				rangeSelectors,
+				router,
+				segmentId
+			}) => (
 				<Card.Body>
 					<LocationsGeoMap
 						accountId={accountId}
@@ -78,6 +86,7 @@ const withLocationsCard = (
 						metricLabel={metricLabel}
 						rangeSelectors={rangeSelectors}
 						router={router}
+						segmentId={segmentId}
 					/>
 				</Card.Body>
 			)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/cerebro-shared/hocs/mappers/__tests__/devices.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/cerebro-shared/hocs/mappers/__tests__/devices.js
@@ -259,6 +259,37 @@ describe('Shared HOCs Mappers - Devices', () => {
 		});
 	});
 
+	it('should include segmentId in the request variables when provided', () => {
+		const mapper = getDevicesMapper(
+			(result) => result.form.submissionsMetric
+		);
+
+		const optionsResult = mapper.options({
+			router: {
+				params: {},
+			},
+			segmentId: 'segment-100',
+		});
+
+		expect(optionsResult.variables).toMatchObject({
+			segmentId: 'segment-100',
+		});
+	});
+
+	it('should not include segmentId in the request variables when not provided', () => {
+		const mapper = getDevicesMapper(
+			(result) => result.form.submissionsMetric
+		);
+
+		const optionsResult = mapper.options({
+			router: {
+				params: {},
+			},
+		});
+
+		expect(optionsResult.variables).not.toHaveProperty('segmentId');
+	});
+
 	it('should map devices information in correct order', () => {
 		const mapper = getDevicesMapper(
 			(result) => result.form.submissionsMetric

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/cerebro-shared/hocs/mappers/__tests__/locations.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/cerebro-shared/hocs/mappers/__tests__/locations.js
@@ -179,6 +179,40 @@ describe('Shared HOCs Mappers - Locations', () => {
 		});
 	});
 
+	it('should include segmentId in the request variables when provided', () => {
+		const mapper = getLocationsMapper(
+			(result) => result.form.submissionsMetric
+		);
+
+		const optionsResult = mapper.options({
+			filters: {
+				location: ['Any'],
+			},
+			rangeSelectors: {rangeKey: '0'},
+			router: {
+				params: {
+					assetId: ASSET_ID,
+					touchpoint: TOUCHPOINT,
+				},
+			},
+			segmentId: 'segment-100',
+		});
+
+		expect(optionsResult).toEqual({
+			variables: {
+				assetId: 'formId',
+				devices: 'Any',
+				location: 'Any',
+				rangeEnd: null,
+				rangeKey: 0,
+				rangeStart: null,
+				segmentId: 'segment-100',
+				title: '',
+				touchpoint: null,
+			},
+		});
+	});
+
 	it('should map locations information with region Brazil', () => {
 		const mapper = getLocationsMapper(
 			(result) => result.form.submissionsMetric
@@ -384,6 +418,40 @@ describe('Shared HOCs Mappers - Locations Countries', () => {
 				rangeEnd: null,
 				rangeKey: 0,
 				rangeStart: null,
+				title: '',
+				touchpoint: null,
+			},
+		});
+	});
+
+	it('should include segmentId in the countries request variables when provided', () => {
+		const mapper = getLocationsMapperCountries(
+			(result) => result.form.submissionsMetric
+		);
+
+		const optionsResult = mapper.options({
+			filters: {
+				location: ['Any'],
+			},
+			rangeSelectors: {rangeKey: '0'},
+			router: {
+				params: {
+					assetId: ASSET_ID,
+					touchpoint: TOUCHPOINT,
+				},
+			},
+			segmentId: 'segment-100',
+		});
+
+		expect(optionsResult).toEqual({
+			variables: {
+				assetId: 'formId',
+				devices: 'Any',
+				location: 'Any',
+				rangeEnd: null,
+				rangeKey: 0,
+				rangeStart: null,
+				segmentId: 'segment-100',
 				title: '',
 				touchpoint: null,
 			},

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/cerebro-shared/hocs/mappers/devices.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/cerebro-shared/hocs/mappers/devices.js
@@ -109,6 +109,7 @@ const getDevicesMapper = (getMetric) => {
 		interval,
 		rangeSelectors,
 		router: {params},
+		segmentId,
 	}) =>
 		getVariables({
 			accountId,
@@ -117,6 +118,7 @@ const getDevicesMapper = (getMetric) => {
 			interval,
 			params,
 			rangeSelectors,
+			segmentId,
 		});
 
 	return {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/cerebro-shared/hocs/mappers/locations.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/cerebro-shared/hocs/mappers/locations.js
@@ -42,7 +42,16 @@ const getLocationsMapper = (getMetric) => {
 		interval,
 		rangeSelectors,
 		router: {params},
-	}) => getVariables({accountId, filters, interval, params, rangeSelectors});
+		segmentId,
+	}) =>
+		getVariables({
+			accountId,
+			filters,
+			interval,
+			params,
+			rangeSelectors,
+			segmentId,
+		});
 
 	return {
 		options: mapPropsToOptions,
@@ -80,6 +89,7 @@ const getLocationsMapperCountries = (getMetric) => {
 		interval,
 		rangeSelectors,
 		router: {params},
+		segmentId,
 	}) => {
 		const {variables} = getVariables({
 			accountId,
@@ -88,6 +98,7 @@ const getLocationsMapperCountries = (getMetric) => {
 			interval,
 			params,
 			rangeSelectors,
+			segmentId,
 		});
 
 		return {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
@@ -11,6 +11,7 @@ import Loading from 'shared/components/Loading';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
 import OverviewSection from '../components/OverviewSection';
 import React, {useContext} from 'react';
+import SegmentDropdown from 'shared/components/SegmentDropdown';
 import URLConstants from 'shared/util/url-constants';
 import {
 	AccountMetricType,
@@ -28,6 +29,7 @@ import {useCurrentUser} from 'shared/hooks/useCurrentUser';
 import {useDataSources} from 'shared/context/dataSources';
 import {useHistory, useParams} from 'react-router-dom';
 import {useRequest} from 'shared/hooks/useRequest';
+import {useSegmentFilter} from 'shared/hooks/useSegmentFilter';
 
 const LifecycleEmptyState = ({
 	authorized,
@@ -179,6 +181,8 @@ const LifecycleAccounts = () => {
 
 	const {channelId, groupId} = useParams();
 
+	const {segmentId, segmentName} = useSegmentFilter();
+
 	return (
 		<section>
 			<SectionHeader
@@ -194,6 +198,8 @@ const LifecycleAccounts = () => {
 				groupId={groupId!}
 				industryFilter={filters.industryFilter}
 				lifecycleStageFilter={filters.lifecycleStageFilter}
+				segmentFilter={segmentId}
+				segmentName={segmentName}
 				stageSelectionNonce={stageSelectionNonce}
 			/>
 		</section>
@@ -210,6 +216,8 @@ const BaseLifecycle = () => {
 
 	const {empty: noDataSources, loading: dataSourcesLoading} =
 		useDataSources();
+
+	const {segmentId, segmentName, setSegment} = useSegmentFilter();
 
 	const {data: lifecycles, loading: lifecyclesLoading} = useRequest({
 		dataSourceFn: API.lifecycle.fetchLifecycles,
@@ -378,11 +386,18 @@ const BaseLifecycle = () => {
 								/>
 
 								<FilterPicker
+									className="mr-3"
 									entityLabel={Liferay.Language.get(
 										'countries'
 									)}
 									fieldMappingFieldName="country"
 									filterKey="countryFilter"
+								/>
+
+								<SegmentDropdown
+									initialSegmentId={segmentId}
+									initialSegmentName={segmentName}
+									onFilterChange={setSegment}
 								/>
 							</div>
 						</div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/BaseLifecycle.tsx
@@ -74,6 +74,23 @@ jest.mock('shared/components/AccountsDataSet', () => ({
 	default: () => <div data-testid="accounts-dataset" />,
 }));
 
+jest.mock('shared/components/SegmentDropdown', () => ({
+	__esModule: true,
+	default: ({
+		initialSegmentId,
+		initialSegmentName,
+	}: {
+		initialSegmentId?: string;
+		initialSegmentName?: string;
+	}) => (
+		<div
+			data-initial-segment-id={initialSegmentId}
+			data-initial-segment-name={initialSegmentName}
+			data-testid="segment-dropdown"
+		/>
+	),
+}));
+
 const mockedUseCurrentUser = useCurrentUser as jest.Mock;
 const mockedUseDataSources = useDataSources as jest.Mock;
 const mockedUseRequest = useRequest as jest.Mock;
@@ -390,6 +407,7 @@ describe('BaseLifecycle', () => {
 			'data-entity-label',
 			'Countries'
 		);
+		expect(screen.getByTestId('segment-dropdown')).toBeInTheDocument();
 		expect(screen.queryByText('No Account Data Available')).toBeNull();
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -24,6 +24,8 @@ interface IAccountsDataSetProps {
 	groupId: string;
 	industryFilter?: string;
 	lifecycleStageFilter?: LifecycleStages;
+	segmentFilter?: string;
+	segmentName?: string;
 	stageSelectionNonce?: number;
 }
 
@@ -48,6 +50,8 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 	groupId,
 	industryFilter,
 	lifecycleStageFilter,
+	segmentFilter,
+	segmentName,
 	stageSelectionNonce,
 }) => {
 	const {data: lifecycleStageFieldValues} = useRequest({
@@ -175,12 +179,26 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 							buildSelectionPreloadedData(countryFilter),
 						type: 'selection',
 					},
+					{
+						apiURL: `/o/faro/contacts/${groupId}/individual_segment?channelId=${channelId}`,
+						entityFieldType: 'string',
+						id: 'segmentId',
+						itemKey: 'id',
+						itemLabel: 'name',
+						label: Liferay.Language.get('segment'),
+						preloadedData: buildSelectionPreloadedData(
+							segmentFilter,
+							segmentName
+						),
+						type: 'selection',
+					},
 				]}
 				id="accounts-list-dataset"
 				key={[
 					countryFilter,
 					industryFilter,
 					lifecycleStageFilter,
+					segmentFilter,
 					stageSelectionNonce,
 					lifecycleStages.length,
 				].join()}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -34,6 +34,7 @@ const mockStages = (items: typeof DEFAULT_STAGE_ITEMS | undefined) => {
 };
 
 type FakeFilter = {
+	apiURL?: string;
 	id: string;
 	items?: Array<{label: string; value: string}>;
 	preloadedData?: {
@@ -326,6 +327,81 @@ describe('AccountsDataSet', () => {
 		);
 
 		expect(activitiesCountFilter).toBeUndefined();
+	});
+
+	it('should not append segmentFilter as a query param on the apiURL', () => {
+		render(
+			<AccountsDataSet
+				apiURL="fake-url"
+				channelId="123"
+				groupId="23"
+				segmentFilter="segment-100"
+			/>
+		);
+
+		expect(lastApiURL).toBe('fake-url');
+	});
+
+	it('should leave the segment filter without preloadedData when no segmentFilter prop is passed', () => {
+		render(
+			<AccountsDataSet apiURL="fake-url" channelId="123" groupId="23" />
+		);
+
+		const segmentFilter = lastFilters?.find((f) => f.id === 'segmentId');
+
+		expect(segmentFilter?.preloadedData).toBeUndefined();
+	});
+
+	it('should preload the segment filter with the segment name when segmentFilter and segmentName props are provided', () => {
+		render(
+			<AccountsDataSet
+				apiURL="fake-url"
+				channelId="123"
+				groupId="23"
+				segmentFilter="segment-100"
+				segmentName="VIP Customers"
+			/>
+		);
+
+		const segmentFilter = lastFilters?.find((f) => f.id === 'segmentId');
+
+		expect(segmentFilter?.preloadedData).toEqual({
+			exclude: false,
+			selectedItems: [
+				{label: 'VIP Customers', value: 'segment-100'},
+			],
+		});
+	});
+
+	it('should point the segment filter apiURL at the individual segment search endpoint', () => {
+		render(
+			<AccountsDataSet apiURL="fake-url" channelId="123" groupId="23" />
+		);
+
+		const segmentFilter = lastFilters?.find((f) => f.id === 'segmentId');
+
+		expect(segmentFilter?.apiURL).toBe(
+			'/o/faro/contacts/23/individual_segment?channelId=123'
+		);
+	});
+
+	it('should remount the FrontendDataSet when segmentFilter changes', () => {
+		const {rerender} = render(
+			<AccountsDataSet apiURL="fake-url" channelId="123" groupId="23" />
+		);
+
+		expect(mountCount).toBe(1);
+
+		rerender(
+			<AccountsDataSet
+				apiURL="fake-url"
+				channelId="123"
+				groupId="23"
+				segmentFilter="segment-100"
+			/>
+		);
+
+		expect(mountCount).toBe(2);
 	});
 
 	it('should remount the FrontendDataSet when stageSelectionNonce changes even if lifecycleStageFilter is unchanged', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -367,9 +367,7 @@ describe('AccountsDataSet', () => {
 
 		expect(segmentFilter?.preloadedData).toEqual({
 			exclude: false,
-			selectedItems: [
-				{label: 'VIP Customers', value: 'segment-100'},
-			],
+			selectedItems: [{label: 'VIP Customers', value: 'segment-100'}],
 		});
 	});
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/metric-card/queries.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/metric-card/queries.ts
@@ -201,6 +201,7 @@ export const PageMetricQuery = (metricName: string) => gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -214,6 +215,7 @@ export const PageMetricQuery = (metricName: string) => gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			${metricName} {
@@ -235,6 +237,7 @@ export const PageMetricTabsQuery = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -248,6 +251,7 @@ export const PageMetricTabsQuery = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			visitorsMetric {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hoc/DevicesCard.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hoc/DevicesCard.jsx
@@ -157,7 +157,8 @@ const withDevicesCard = (
 					filters,
 					interval,
 					rangeSelectors,
-					router
+					router,
+					segmentId
 				}) => (
 					<Card.Body>
 						<TabsWithDevices
@@ -178,6 +179,7 @@ const withDevicesCard = (
 							onChange={handleActiveTabChange}
 							rangeSelectors={rangeSelectors}
 							router={router}
+							segmentId={segmentId}
 						/>
 					</Card.Body>
 				)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AcquisitionsQuery.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AcquisitionsQuery.ts
@@ -20,6 +20,7 @@ export interface AcquisitionsQueryVariables extends SafeRangeSelectors {
 	accountId?: string | null;
 	activeTabId: string;
 	channelId?: string;
+	segmentId?: string | null;
 	size: number;
 	start: number;
 }
@@ -32,6 +33,7 @@ export default gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$size: Int!
 		$start: Int!
 	) {
@@ -42,6 +44,7 @@ export default gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			size: $size
 			start: $start
 		) {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AssetAppearsOnQuery.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AssetAppearsOnQuery.js
@@ -9,6 +9,7 @@ export default gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$selectedMetrics: [String]
 		$size: Int!
 		$start: Int!
@@ -22,6 +23,7 @@ export default gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			selectedMetrics: $selectedMetrics
 			size: $size
 			start: $start

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/FormMetricsQuery.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/FormMetricsQuery.js
@@ -16,6 +16,7 @@ export default gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -29,6 +30,7 @@ export default gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			abandonmentsMetric {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/ObjectEntryKnownAccountsListQuery.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/ObjectEntryKnownAccountsListQuery.ts
@@ -10,6 +10,7 @@ export default gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$size: Int!
 		$start: Int!
 		$touchpoint: String

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/SessionLocationsQuery.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/SessionLocationsQuery.js
@@ -8,6 +8,7 @@ export default gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 	) {
 		site(
 			accountId: $accountId
@@ -16,6 +17,7 @@ export default gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 		) {
 			sessionsMetric {
 				...geolocationFragment

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/SiteDevicesQuery.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/SiteDevicesQuery.js
@@ -8,6 +8,7 @@ export default gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 	) {
 		site(
 			accountId: $accountId
@@ -16,6 +17,7 @@ export default gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 		) {
 			sessionsMetric {
 				...browserFragment

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/SitesTopPagesQuery.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/SitesTopPagesQuery.ts
@@ -24,6 +24,7 @@ export interface SitesTopPagesQueryData {
 export interface SitesTopPagesQueryVariables extends SafeRangeSelectors {
 	accountId?: string | null;
 	channelId?: string;
+	segmentId?: string | null;
 	size: number;
 	sort: {
 		column: string;
@@ -39,6 +40,7 @@ export default gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$size: Int!
 		$sort: Sort!
 		$start: Int!
@@ -49,6 +51,7 @@ export default gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			size: $size
 			sort: $sort
 			start: $start

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/VisitorsByTimeQuery.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/VisitorsByTimeQuery.js
@@ -7,6 +7,7 @@ export default gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 	) {
 		siteVisitorHeatMap(
 			accountId: $accountId
@@ -14,6 +15,7 @@ export default gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 		) {
 			column: colDimension
 			row: rowDimension

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/fragments.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/fragments.js
@@ -2,7 +2,12 @@ import {gql} from '@apollo/client';
 
 export const ACCOUNTS_FRAGMENT = gql`
 	fragment accountsFragment on Metric {
-		accounts(keywords: $keywords, size: $size, start: $start) {
+		accounts(
+			keywords: $keywords
+			segmentId: $segmentId
+			size: $size
+			start: $start
+		) {
 			accountNames {
 				id
 				name

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownAccountsListAssetQuery.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownAccountsListAssetQuery.js
@@ -18,6 +18,7 @@ export default (queryName, metricName) => gql`
 			$rangeEnd: String
 			$rangeKey: Int
 			$rangeStart: String
+			$segmentId: String
 			$size: Int!
 			$start: Int!
 			$title: String

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownAccountsListTouchpointQuery.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownAccountsListTouchpointQuery.js
@@ -17,6 +17,7 @@ export default (queryName, metricName) => gql`
 			$rangeEnd: String
 			$rangeKey: Int
 			$rangeStart: String
+			$segmentId: String
 			$size: Int!
 			$start: Int!
 			$title: String

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/components/AcquisitionsCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/components/AcquisitionsCard.tsx
@@ -113,6 +113,7 @@ const AcquisitionsCardWithData: React.FC<IAcquisitionsCard> = ({
 		router: {
 			params: {channelId},
 		},
+		segmentId,
 	} = useContext(BasePage.Context);
 	const {data, error, loading} = useQuery<
 		AcquisitionsQueryData,
@@ -123,6 +124,7 @@ const AcquisitionsCardWithData: React.FC<IAcquisitionsCard> = ({
 			accountId,
 			activeTabId,
 			channelId,
+			segmentId,
 			size: 5,
 			start: 0,
 		},

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/components/TopPagesCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/components/TopPagesCard.tsx
@@ -58,6 +58,7 @@ const TopPagesCardWithData: React.FC<ITopPageCardWithData> = ({
 		router: {
 			params: {channelId},
 		},
+		segmentId,
 	} = useContext(BasePage.Context);
 	const {
 		data,
@@ -70,6 +71,7 @@ const TopPagesCardWithData: React.FC<ITopPageCardWithData> = ({
 				...getSafeRangeSelectors(rangeSelectors),
 				accountId,
 				channelId,
+				segmentId,
 				size: 5,
 				sort: {
 					column: activeTabId,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/VisitorsByTimeCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/VisitorsByTimeCard.tsx
@@ -115,7 +115,7 @@ const VisitorsByTimeCard: React.FC<IVisitorsByTimeCardProps> = ({
 	className,
 	label,
 }) => {
-	const {accountId, router} = useContext(
+	const {accountId, router, segmentId} = useContext(
 		BasePage.Context as React.Context<IBasePageContext>
 	);
 
@@ -135,6 +135,7 @@ const VisitorsByTimeCard: React.FC<IVisitorsByTimeCardProps> = ({
 						renderTooltip={renderTooltip}
 						router={router}
 						rowAxisFormatter={formatHour}
+						segmentId={segmentId}
 					/>
 				</Card.Body>
 			)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/mappers/__tests__/visitors-by-time-query.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/mappers/__tests__/visitors-by-time-query.js
@@ -38,4 +38,24 @@ describe('VisitorsByTimeQuery Mappers', () => {
 			})
 		);
 	});
+
+	it('should include segmentId in the options when provided', () => {
+		const mockProps = {
+			rangeSelectors: {rangeKey: '30'},
+			router: {params: {channelId: 123}},
+			segmentId: 'segment-100',
+		};
+
+		expect(mapPropsToOptions(mockProps)).toEqual(
+			expect.objectContaining({
+				variables: {
+					channelId: 123,
+					rangeEnd: null,
+					rangeKey: parseInt('30'),
+					rangeStart: null,
+					segmentId: 'segment-100',
+				},
+			})
+		);
+	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/mappers/visitors-by-time-query.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/mappers/visitors-by-time-query.ts
@@ -33,14 +33,17 @@ const mapPropsToOptions = ({
 	router: {
 		params: {channelId},
 	},
+	segmentId,
 }: {
 	accountId?: string | null;
 	rangeSelectors: RangeSelectors;
 	router: {params: {channelId: string}};
+	segmentId?: string | null;
 }) => ({
 	variables: {
 		accountId,
 		channelId,
+		segmentId,
 		...getSafeRangeSelectors(rangeSelectors),
 	},
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/hocs/DevicesCard.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/hocs/DevicesCard.js
@@ -16,6 +16,7 @@ const TouchpointDevicesQuery = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -29,6 +30,7 @@ const TouchpointDevicesQuery = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			viewsMetric {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/hocs/LocationsCard.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/hocs/LocationsCard.js
@@ -18,6 +18,7 @@ const TouchpointLocationsQuery = gql`
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -31,6 +32,7 @@ const TouchpointLocationsQuery = gql`
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			viewsMetric {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/pages/TouchpointRoutes.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/pages/TouchpointRoutes.jsx
@@ -211,6 +211,12 @@ function TouchpointRoutes({className, router}) {
 				</BasePage.SubHeader>
 			)}
 
+			{matchedRoute === Routes.SITES_TOUCHPOINTS_ACCOUNTS && (
+				<BasePage.SubHeader>
+					{segmentDropdown}
+				</BasePage.SubHeader>
+			)}
+
 			{matchedRoute === Routes.SITES_TOUCHPOINTS_KNOWN_INDIVIDUALS && (
 				<BasePage.SubHeader>
 					<div className='d-flex justify-content-end w-100'>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/pages/TouchpointRoutes.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/pages/TouchpointRoutes.jsx
@@ -91,7 +91,7 @@ function TouchpointRoutes({className, router}) {
 	const accountDropdown = LDPEnabled && (
 		<AccountDropdown
 			assetType='page'
-			className='mr-2'
+			className='mr-3'
 			initialAccountId={accountId}
 			initialAccountName={accountName}
 			onFilterChange={setAccount}
@@ -100,7 +100,7 @@ function TouchpointRoutes({className, router}) {
 
 	const segmentDropdown = LDPEnabled && (
 		<SegmentDropdown
-			className='mr-2'
+			className='mr-3'
 			initialSegmentId={segmentId}
 			initialSegmentName={segmentName}
 			onFilterChange={setSegment}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/pages/__tests__/TouchpointRoutes.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/touchpoints/pages/__tests__/TouchpointRoutes.jsx
@@ -502,6 +502,32 @@ describe('TouchpointRoutes', () => {
 		expect(screen.queryByTestId('segment-dropdown')).toBeNull();
 	});
 
+	it('shows the segment filter on the accounts route for LDP workspaces', () => {
+		getMatchedRoute.mockReturnValue(Routes.SITES_TOUCHPOINTS_ACCOUNTS);
+		useLDPEnabled.mockReturnValue(true);
+
+		const router = {
+			params: {
+				channelId: '1',
+				experienceId: '',
+				groupId: '2',
+				title: 'page',
+				touchpoint: 'http://example.com/web/site/home'
+			},
+			query: {}
+		};
+
+		render(
+			<Provider store={mockStore()}>
+				<MemoryRouter>
+					<TouchpointRoutes router={router} />
+				</MemoryRouter>
+			</Provider>
+		);
+
+		expect(screen.queryByTestId('segment-dropdown')).toBeTruthy();
+	});
+
 	it('shows the segment filter on the path route for LDP workspaces', () => {
 		getMatchedRoute.mockReturnValue(Routes.SITES_TOUCHPOINTS_PATH);
 		useLDPEnabled.mockReturnValue(true);


### PR DESCRIPTION
## Summary

Frontend counterpart to the osb-asah-backend PR for LPD-99030. Makes Account segments a fully functional filter everywhere Individual segments already were, and narrows the segment picker to segments relevant to the current context:

- Added the segment filter dropdown (`SegmentDropdown`) and `useSegmentFilter` hook, wired into Sites Overview, Pages List, and each asset dashboard.
- The Path tab and each asset dashboard's segment picker is scoped to the current page (`canonicalUrl`)/asset (`assetId`/`assetType`), narrowing the list to segments with an actually-interacting member.
- The Visitors-tab known-accounts list and Lifecycle's account list now accept and forward a `segmentId`, so selecting a segment actually filters the accounts shown for both Individual and Account segments.

Supersedes #3749 (closed, not merged).

## Test plan

- [x] Jest suites pass for all touched components/pages (`SegmentDropdown`, `TouchpointRoutes`, `AccountsDataSet`, `BaseLifecycle`, asset dashboard wrappers, `PagePathCard`)
- [x] `tsc --noEmit` clean on all touched files
- [ ] Manual verification against a real deployment (picker narrowing, segment filtering on dashboards, Visitors tab / Lifecycle accounts list)