### PR TITLE
LPD-100307 Format the synced item counts with thousand separators

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorEntities.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorEntities.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import {ConnectorEntityDescriptor, ConnectorStatus} from './types';
 import {getEntityDisplay} from './getEntityDisplay';
 import {sub} from 'shared/util/lang';
+import {toLocale} from 'shared/util/numbers';
 
 interface IConnectorEntitiesProps {
 	connectorStatus?: ConnectorStatus;
@@ -44,7 +45,7 @@ const ConnectorEntities: React.FC<IConnectorEntitiesProps> = ({
 						{typeof count === 'number' && count >= 0 && (
 							<ClayList.ItemText>
 								{sub(Liferay.Language.get('x-items-synced'), [
-									count,
+									toLocale(count),
 								])}
 							</ClayList.ItemText>
 						)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorEntities.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/ConnectorEntities.tsx
@@ -29,6 +29,17 @@ describe('ConnectorEntities', () => {
 		expect(getByText(/42/)).toBeTruthy();
 	});
 
+	it('renders the synced count with comma separators when it is large', () => {
+		const {getByText} = render(
+			<ConnectorEntities
+				entities={[{entity: Entity.Accounts}]}
+				syncedCounts={{[Entity.Accounts]: 279089}}
+			/>
+		);
+
+		expect(getByText('279,089 Items Synced')).toBeTruthy();
+	});
+
 	it('renders the synced count when it is zero', () => {
 		const {getByText} = render(
 			<ConnectorEntities

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/MarketoCampaignEntities.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/MarketoCampaignEntities.tsx
@@ -4,6 +4,7 @@ import ClaySticker from '@clayui/sticker';
 import React from 'react';
 import {ClayCheckbox} from '@clayui/form';
 import {sub} from 'shared/util/lang';
+import {toLocale} from 'shared/util/numbers';
 
 interface IMarketoCampaignEntitiesProps {
 	disabled?: boolean;
@@ -54,7 +55,7 @@ const MarketoCampaignEntities: React.FC<IMarketoCampaignEntitiesProps> = ({
 						individualsSyncedCount >= 0 && (
 							<ClayList.ItemText>
 								{sub(Liferay.Language.get('x-items-synced'), [
-									individualsSyncedCount,
+									toLocale(individualsSyncedCount),
 								])}
 							</ClayList.ItemText>
 						)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/salesforce/SalesforceAccountsAndIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/salesforce/SalesforceAccountsAndIndividuals.tsx
@@ -4,6 +4,7 @@ import ClaySticker from '@clayui/sticker';
 import React from 'react';
 import {ClayCheckbox} from '@clayui/form';
 import {sub} from 'shared/util/lang';
+import {toLocale} from 'shared/util/numbers';
 
 interface ISalesforceAccountsAndIndividualsProps {
 	accountsSyncedCount?: number;
@@ -63,7 +64,7 @@ const SalesforceAccountsAndIndividuals: React.FC<
 						accountsSyncedCount >= 0 && (
 							<ClayList.ItemText>
 								{sub(Liferay.Language.get('x-items-synced'), [
-									accountsSyncedCount,
+									toLocale(accountsSyncedCount),
 								])}
 							</ClayList.ItemText>
 						)}
@@ -103,7 +104,7 @@ const SalesforceAccountsAndIndividuals: React.FC<
 						individualsSyncedCount >= 0 && (
 							<ClayList.ItemText>
 								{sub(Liferay.Language.get('x-items-synced'), [
-									individualsSyncedCount,
+									toLocale(individualsSyncedCount),
 								])}
 							</ClayList.ItemText>
 						)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/salesforce/__tests__/SalesforceAccountsAndIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/salesforce/__tests__/SalesforceAccountsAndIndividuals.tsx
@@ -1,0 +1,51 @@
+jest.unmock('react-dom');
+
+import React from 'react';
+import SalesforceAccountsAndIndividuals from '../SalesforceAccountsAndIndividuals';
+import {render} from '@testing-library/react';
+
+describe('SalesforceAccountsAndIndividuals', () => {
+	it('renders the synced counts with comma separators when they are large', () => {
+		const {getByText} = render(
+			<SalesforceAccountsAndIndividuals
+				accountsSyncedCount={73085}
+				enabledAccounts
+				enabledIndividuals
+				individualsSyncedCount={279089}
+				onAccountsChange={jest.fn()}
+				onIndividualsChange={jest.fn()}
+			/>
+		);
+
+		expect(getByText('73,085 Items Synced')).toBeTruthy();
+		expect(getByText('279,089 Items Synced')).toBeTruthy();
+	});
+
+	it('renders the synced counts when they are zero', () => {
+		const {getAllByText} = render(
+			<SalesforceAccountsAndIndividuals
+				accountsSyncedCount={0}
+				enabledAccounts
+				enabledIndividuals
+				individualsSyncedCount={0}
+				onAccountsChange={jest.fn()}
+				onIndividualsChange={jest.fn()}
+			/>
+		);
+
+		expect(getAllByText('0 Items Synced')).toHaveLength(2);
+	});
+
+	it('hides the synced counts when no values are provided', () => {
+		const {queryByText} = render(
+			<SalesforceAccountsAndIndividuals
+				enabledAccounts
+				enabledIndividuals
+				onAccountsChange={jest.fn()}
+				onIndividualsChange={jest.fn()}
+			/>
+		);
+
+		expect(queryByText(/Items Synced/i)).toBeNull();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100307

## What Is Being Fixed

The Synced Data panel of a data source printed the item counts exactly as they arrived from the connector, so large values were rendered as 73085 and 279089 instead of 73,085 and 279,089. Counts of that size are hard to read at a glance, and the panel was inconsistent with the DXP connector, which already formats its metrics.

## How It Is Being Fixed

The DXP connector routes every count through toLocale from shared/util/numbers, so the Salesforce, Marketo, and third party connector panels now do the same. All three render the same x-items-synced key from the same list widget, so fixing only the Salesforce one would have left the identical defect in the other two. The formatting follows the browser locale, which is what toLocale already does everywhere else in the application.

The Salesforce panel had no test of its own, so this adds one covering the formatted counts, the zero case, and the absence of a count. The existing third party connector test gains the large count case.

## PR Check

**pr-check: PASS** — tested on `41153ffb4fc988f45f89797677f7b977697a4248`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "41153ffb4fc988f45f89797677f7b977697a4248"} -->
