### PR TITLE
LPD-100353 Fix User Management sidebar icon selector mismatch

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_settings.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_settings.scss
@@ -20,7 +20,7 @@
 		margin-right: 8px;
 		width: 16px;
 
-		.lexicon-icon-user-management {
+		.lexicon-icon-user_management {
 			font-size: 1.8rem;
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100353

## What Is Being Fixed

In the left navigation sidebar, under "Workspace Settings", the "User Management" icon rendered noticeably smaller than its sibling icons (APIs, Definitions, Data Control & Privacy, Data Sources, Properties, Subscription & Usage, Workspace). The `user_management` icon's source SVG is drawn on a 32x32 viewBox, roughly double the ~16x16-19 viewBoxes used by every other sidebar icon, so it renders visibly smaller once uniformly scaled into the same 1em icon box unless compensated for.

## How It Is Being Fixed

A dedicated CSS rule in `_settings.scss` was already meant to compensate for this icon's larger source artwork by bumping its font-size to 1.8rem, but the selector used a hyphenated class name (`.lexicon-icon-user-management`) while ClayIcon renders the class from the `user_management` symbol with an underscore (`lexicon-icon-user_management`). The mismatch meant the compensation rule never matched, so the icon kept the default 1rem size. Fixing the selector to use the underscore form restores the intended font-size override, bringing the icon back in line with its siblings.

## Why Are There No Tests?

This is a pure CSS selector fix (icon font-size). There is no unit/snapshot test that captures rendered icon size from CSS alone, and the module has no visual regression suite that would exercise this.

## PR Check

**pr-check: PASS** — tested on `0f43f38e7541db438cc2ffb8bab0eade2f061e45`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "0f43f38e7541db438cc2ffb8bab0eade2f061e45"} -->
