### PR TITLE
LPD-100362 Control property editing through an explicit editable prop

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
@@ -332,6 +332,7 @@ const ConnectorOverview: React.FC<IConnectorOverviewProps> = ({
 					close={close}
 					customColumns={config.columns ?? []}
 					dataSource={dataSource}
+					editable={currentUser.isAdmin()}
 					handleUpdateDataSource={handleUpdateDataSource}
 					loading={loading}
 					open={open}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/AssignedPropertiesTable.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/AssignedPropertiesTable.tsx
@@ -15,7 +15,6 @@ import {Link, useParams} from 'react-router-dom';
 import {modalTypes} from 'shared/actions/modals';
 import {Routes, toRoute} from 'shared/util/router';
 import {Text} from '@clayui/core';
-import {useCurrentUser} from 'shared/hooks/useCurrentUser';
 import {useQueryPagination} from 'shared/hooks/useQueryPagination';
 import {useRequest} from 'shared/hooks/useRequest';
 
@@ -29,6 +28,7 @@ interface IAssignedPropertiesTableProps {
 	close: (...args: any[]) => void;
 	customColumns?: any[];
 	dataSource: any;
+	editable: boolean;
 	handleUpdateDataSource: (...args: any[]) => void;
 	loading?: boolean;
 	open: (...args: any[]) => void;
@@ -40,6 +40,7 @@ const AssignedPropertiesTable = ({
 	close,
 	customColumns = [],
 	dataSource,
+	editable,
 	handleUpdateDataSource,
 	loading: initialLoading = false,
 	open,
@@ -47,8 +48,6 @@ const AssignedPropertiesTable = ({
 }: IAssignedPropertiesTableProps) => {
 	const [loading, setLoading] = useState(initialLoading);
 	const {groupId} = useParams();
-
-	const currentUser = useCurrentUser();
 
 	const {delta, orderIOMap, page, query} = useQueryPagination({
 		initialOrderIOMap: createOrderIOMap(NAME),
@@ -162,7 +161,7 @@ const AssignedPropertiesTable = ({
 					}}
 				>
 					<ClayRadio
-						disabled={!currentUser.isAdmin() || !dataSourceActive}
+						disabled={!editable || !dataSourceActive}
 						label={Liferay.Language.get(
 							'make-individual-data-from-this-data-source-available-in-all-properties,-including-those-not-yet-created'
 						)}
@@ -170,7 +169,7 @@ const AssignedPropertiesTable = ({
 					/>
 
 					<ClayRadio
-						disabled={!currentUser.isAdmin() || !dataSourceActive}
+						disabled={!editable || !dataSourceActive}
 						label={Liferay.Language.get('select-properties')}
 						value="custom"
 					/>
@@ -240,7 +239,7 @@ const AssignedPropertiesTable = ({
 									data={data}
 									disabled={
 										loading ||
-										!currentUser.isAdmin() ||
+										!editable ||
 										!dataSourceActive
 									}
 									key={`${data.channelId}-toggle`}
@@ -299,7 +298,7 @@ const AssignedPropertiesTable = ({
 					page={page}
 					query={query}
 					renderNav={() => {
-						if (currentUser.isAdmin()) {
+						if (editable) {
 							return (
 								<ClayButton
 									disabled={!dataSourceActive}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/__tests__/AssignedPropertiesTable.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/__tests__/AssignedPropertiesTable.tsx
@@ -1,0 +1,104 @@
+jest.unmock('react-dom');
+
+import * as data from 'test/data';
+import mockStore from 'test/mock-store';
+import React from 'react';
+import {AssignedPropertiesTable} from '../AssignedPropertiesTable';
+import {DataSource} from 'shared/util/records';
+import {DataSourceStatuses} from 'shared/util/constants';
+import {MemoryRouter, Route} from 'react-router-dom';
+import {Provider} from 'react-redux';
+import {render, screen} from '@testing-library/react';
+import {useRequest} from 'shared/hooks/useRequest';
+
+jest.mock('shared/hooks/useRequest', () => ({
+	useRequest: jest.fn(),
+}));
+
+const mockUseRequest = useRequest as jest.Mock;
+
+const WrappedComponent = ({
+	editable,
+	status = DataSourceStatuses.Active,
+}: {
+	editable: boolean;
+	status?: string;
+}) => (
+	<Provider store={mockStore()}>
+		<MemoryRouter
+			initialEntries={['/workspace/23/settings/data-source/test']}
+		>
+			<Route path="/workspace/:groupId/settings/data-source/:id">
+				<AssignedPropertiesTable
+					addAlert={jest.fn()}
+					close={jest.fn()}
+					dataSource={data.getImmutableMock(
+						DataSource,
+						(seed: number) => ({
+							...data.mockMarketoCampaignDataSource(seed),
+							status,
+						})
+					)}
+					editable={editable}
+					handleUpdateDataSource={jest.fn()}
+					open={jest.fn()}
+					updateDataSourceFn={jest.fn()}
+				/>
+			</Route>
+		</MemoryRouter>
+	</Provider>
+);
+
+const getRadios = () => ({
+	enableAllChannels: screen.getByLabelText(
+		'Make individual data from this data source available in all properties, including those not yet created.'
+	),
+	selectProperties: screen.getByLabelText('Select Properties'),
+});
+
+const querySelectPropertyButton = () =>
+	screen.queryByRole('button', {name: 'Select Property'});
+
+describe('AssignedPropertiesTable', () => {
+	beforeEach(() => {
+		mockUseRequest.mockReturnValue({
+			data: {items: [], total: 0},
+			loading: false,
+		});
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('allows editing the property selection and enabling all channels when editable is true', () => {
+		render(<WrappedComponent editable />);
+
+		const {enableAllChannels, selectProperties} = getRadios();
+
+		expect(enableAllChannels).toBeEnabled();
+		expect(selectProperties).toBeEnabled();
+		expect(querySelectPropertyButton()).toBeTruthy();
+	});
+
+	it('prevents editing the property selection and enabling all channels when editable is false', () => {
+		render(<WrappedComponent editable={false} />);
+
+		const {enableAllChannels, selectProperties} = getRadios();
+
+		expect(enableAllChannels).toBeDisabled();
+		expect(selectProperties).toBeDisabled();
+		expect(querySelectPropertyButton()).toBeNull();
+	});
+
+	it('prevents editing an inactive data source even when editable is true', () => {
+		render(
+			<WrappedComponent editable status={DataSourceStatuses.Inactive} />
+		);
+
+		const {enableAllChannels, selectProperties} = getRadios();
+
+		expect(enableAllChannels).toBeDisabled();
+		expect(selectProperties).toBeDisabled();
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/liferay/LiferayOverview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/liferay/LiferayOverview.tsx
@@ -340,6 +340,7 @@ const LiferayOverview: React.FC<ILiferayeOverviewProps> = ({
 						},
 					]}
 					dataSource={dataSource}
+					editable={currentUser.isAdmin()}
 					handleUpdateDataSource={handleUpdateDataSource}
 					open={open}
 					updateDataSourceFn={

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/MarketoCampaignOverview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/MarketoCampaignOverview.tsx
@@ -299,6 +299,7 @@ const MarketoCampaignOverview: React.FC<IMarketoCampaignOverviewProps> = ({
 					addAlert={addAlert}
 					close={close}
 					dataSource={dataSource}
+					editable={currentUser.isAdmin()}
 					handleUpdateDataSource={handleUpdateDataSource}
 					loading={loading}
 					open={open}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/salesforce/SalesforceOverview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/salesforce/SalesforceOverview.tsx
@@ -320,6 +320,7 @@ const SalesforceOverview: React.FC<ISalesforceOverviewProps> = ({
 					addAlert={addAlert}
 					close={close}
 					dataSource={dataSource}
+					editable={currentUser.isAdmin()}
 					handleUpdateDataSource={handleUpdateDataSource}
 					loading={loading}
 					open={open}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100362

## What Is Being Fixed

`AssignedPropertiesTable` decided on its own whether the property selection and the "enable all channels" option were editable. It called `useCurrentUser` internally and gated four controls on `isAdmin`. That put the permission decision inside a shared component rendered by four different data source overview pages, so no caller could influence it and the same rule was duplicated alongside each caller's own admin checks. A caller that needs to deny editing for any other reason has no way to express it, and a control added to the table later can silently ship ungated.

## How It Is Being Fixed

The table now takes a required `editable` boolean and gates every control on it: both data availability radios, the per property toggle, and the "Select Property" button. The internal `useCurrentUser` lookup is removed, so permission has a single source, the caller. All four callers (Marketo Campaign, Salesforce, Liferay and the third party connector overviews) pass `currentUser.isAdmin()`. The prop is required rather than optional so the compiler rejects a call site that forgets it, which is what keeps the rule from drifting again.

This is a refactor rather than a behavior change. Non admins were already blocked from the properties selection on all four pages, verified before and after, so nothing user visible changes here.

## PR Check

**pr-check: PASS** — tested on `b4aaf5236a4796454a3203e16707e7169a8c1fe6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "b4aaf5236a4796454a3203e16707e7169a8c1fe6"} -->
