### PR TITLE
[On Hold] LPD-100576 Resolve locale from the account's language preference

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/commerce/components/CommerceMetricCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/commerce/components/CommerceMetricCard.tsx
@@ -12,7 +12,7 @@ import {RangeSelectors, SafeRangeSelectors} from 'shared/types';
 import {sub} from 'shared/util/lang';
 import {toRounded} from 'shared/util/numbers';
 import {Trend} from 'commerce/utils/types';
-import {useCurrentUser} from 'shared/hooks/useCurrentUser';
+import {useLocale} from 'shared/hooks/useLocale';
 import {useParams} from 'react-router-dom';
 
 import {useQueryRangeSelectors} from 'shared/hooks/useQueryRangeSelectors';
@@ -85,7 +85,7 @@ function CommerceMetricCard<TGraphQlData>({
 			},
 		}
 	);
-	const currentUser = useCurrentUser();
+	const locale = useLocale();
 
 	const result = data ? mapper(data) : [];
 
@@ -110,11 +110,7 @@ function CommerceMetricCard<TGraphQlData>({
 							loading={loading}
 						>
 							<h1 className="commerce-card-currency font-size-lg-3x font-weight-semibold mb-2">
-								{formatCurrency(
-									currencyCode,
-									currentUser.languageId,
-									value
-								)}
+								{formatCurrency(currencyCode, locale, value)}
 							</h1>
 
 							<div className="d-flex align-items-center mb-2">
@@ -176,7 +172,7 @@ function formatCurrency(
 	locale: string,
 	value: string
 ): string {
-	return new Intl.NumberFormat(locale.replace('_', '-'), {
+	return new Intl.NumberFormat(locale, {
 		currency: currencyCode,
 		style: 'currency',
 	}).format(parseFloat(value));

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/TimeZoneAlert.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/TimeZoneAlert.tsx
@@ -2,7 +2,7 @@ import Alert, {AlertTypes} from 'shared/components/Alert';
 import React from 'react';
 import {applyTimeZone} from 'shared/util/date';
 import {sub} from 'shared/util/lang';
-import {useCurrentUser} from 'shared/hooks/useCurrentUser';
+import {useLanguageId} from 'shared/hooks/useLocale';
 import {useTimeZone} from 'shared/hooks/useTimeZone';
 
 const TIME_ZONE_COUNTRY_REGEX = /\([^)]+.*/;
@@ -19,7 +19,7 @@ const TimeZoneAlert: React.FC<ITimeZoneAlertProps> = ({
 	stripe,
 }) => {
 	const {displayTimeZone, timeZoneId} = useTimeZone();
-	const currentUser = useCurrentUser();
+	const languageId = useLanguageId();
 
 	return (
 		<Alert
@@ -38,7 +38,7 @@ const TimeZoneAlert: React.FC<ITimeZoneAlertProps> = ({
 					applyTimeZone(
 						modifiedTime,
 						timeZoneId,
-						currentUser.languageId
+						languageId
 					).fromNow(),
 				]
 			)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/__tests__/useLocale.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/__tests__/useLocale.tsx
@@ -1,0 +1,97 @@
+import * as data from 'test/data';
+import mockStore, {toRD} from 'test/mock-store';
+import React from 'react';
+import {act, renderHook} from '@testing-library/react';
+import {actionTypes} from 'shared/actions/users';
+import {DEFAULT_LANGUAGE_ID, DEFAULT_LOCALE} from 'shared/util/locale';
+import {fromJS} from 'immutable';
+import {LanguageIds} from 'shared/util/constants';
+import {Provider} from 'react-redux';
+import {useLanguageId, useLocale} from 'shared/hooks/useLocale';
+import {User} from 'shared/util/records';
+
+jest.unmock('react-dom');
+
+function buildInitialState(
+	currentUserId: string,
+	users: {[id: string]: string | null}
+) {
+	const usersState: Record<string, unknown> = {};
+
+	Object.keys(users).forEach((id) => {
+		usersState[id] = toRD(
+			new User(data.mockUser(Number(id), {languageId: users[id]}))
+		);
+	});
+
+	return fromJS({
+		currentUser: toRD(currentUserId),
+		users: usersState,
+	});
+}
+
+function renderWithStore<T>(
+	useHook: () => T,
+	store: ReturnType<typeof mockStore>
+) {
+	return renderHook(useHook, {
+		wrapper: ({children}) => <Provider store={store}>{children}</Provider>,
+	});
+}
+
+describe('useLocale', () => {
+	it('wires the current user languageId into resolveLocale', () => {
+		const store = mockStore(
+			buildInitialState('1', {1: LanguageIds.Portuguese})
+		);
+		const {result} = renderWithStore(useLocale, store);
+
+		expect(result.current).toBe('pt-BR');
+	});
+
+	it('falls back to the default locale when the current user has no languageId set', () => {
+		const store = mockStore(buildInitialState('1', {1: null}));
+		const {result} = renderWithStore(useLocale, store);
+
+		expect(result.current).toBe(DEFAULT_LOCALE);
+	});
+
+	it('re-renders with the new locale when the language preference changes, with no reload involved', () => {
+		const store = mockStore(
+			buildInitialState('1', {
+				1: LanguageIds.English,
+				2: LanguageIds.Portuguese,
+			})
+		);
+		const {result} = renderWithStore(useLocale, store);
+
+		expect(result.current).toBe('en-US');
+
+		act(() => {
+			store.dispatch({
+				payload: {result: '2'},
+				type: actionTypes.FETCH_CURRENT_USER_SUCCESS,
+			});
+		});
+
+		expect(result.current).toBe('pt-BR');
+	});
+});
+
+describe('useLanguageId', () => {
+	it('wires the current user languageId into resolveLanguageId', () => {
+		const store = mockStore(
+			buildInitialState('1', {1: LanguageIds.Portuguese})
+		);
+		const {result} = renderWithStore(useLanguageId, store);
+
+		expect(result.current).toBe(LanguageIds.Portuguese);
+	});
+
+	it('falls back to the default language id when the current user has no languageId set', () => {
+		const store = mockStore(buildInitialState('1', {1: null}));
+		const {result} = renderWithStore(useLanguageId, store);
+
+		expect(result.current).toBe(DEFAULT_LANGUAGE_ID);
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/useCurrentUser.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/useCurrentUser.ts
@@ -36,6 +36,17 @@ export const useFetchCurrentUser = (initialGroupId: string = '0') => {
 };
 
 /**
+ * Reads the current user's languageId straight from state, without going
+ * through the useCurrentUser hook. Shared by getLocale (shared/util/locale)
+ * so both stay in sync with how the current user is found in the store.
+ */
+export const getCurrentUserLanguageId = (state: any): string | null => {
+	const currentUserId = state.getIn(['currentUser', 'data']);
+
+	return state.getIn(['users', currentUserId, 'data', 'languageId']);
+};
+
+/**
  * Get currentUser from redux store.
  */
 export const useCurrentUser = (): User => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/useLocale.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/useLocale.ts
@@ -1,0 +1,25 @@
+import {LanguageIds} from 'shared/util/constants';
+import {resolveLanguageId, resolveLocale} from 'shared/util/locale';
+import {useCurrentUser} from 'shared/hooks/useCurrentUser';
+
+/**
+ * Resolves the current user's locale from their account language
+ * preference. Backed by useCurrentUser, so it re-renders with the new
+ * value whenever the underlying Redux state changes.
+ */
+export const useLocale = (): string => {
+	const {languageId} = useCurrentUser();
+
+	return resolveLocale(languageId);
+};
+
+/**
+ * Same resolution as useLocale, but returns the portal languageId
+ * (e.g. `en_US`) instead of the BCP-47 locale. Use this for consumers
+ * that expect a LanguageIds value, such as `applyTimeZone`.
+ */
+export const useLanguageId = (): LanguageIds => {
+	const {languageId} = useCurrentUser();
+
+	return resolveLanguageId(languageId);
+};

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/locale.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/locale.ts
@@ -1,0 +1,98 @@
+jest.mock('shared/store', () => ({
+	__esModule: true,
+	default: {
+		getState: jest.fn(),
+	},
+}));
+
+import {
+	DEFAULT_LANGUAGE_ID,
+	DEFAULT_LOCALE,
+	getLocale,
+	resolveLanguageId,
+	resolveLocale,
+} from '../locale';
+import {fromJS} from 'immutable';
+import {LanguageIds} from 'shared/util/constants';
+import store from 'shared/store';
+
+describe('resolveLanguageId', () => {
+	it.each([
+		LanguageIds.English,
+		LanguageIds.Japanese,
+		LanguageIds.Portuguese,
+		LanguageIds.Spanish,
+	])('keeps %s unchanged', (languageId) => {
+		expect(resolveLanguageId(languageId)).toBe(languageId);
+	});
+
+	it.each([null, undefined, '', 'de_DE', 'not-a-real-language'])(
+		'falls back to the default language id for %p',
+		(languageId) => {
+			expect(resolveLanguageId(languageId)).toBe(DEFAULT_LANGUAGE_ID);
+		}
+	);
+});
+
+describe('resolveLocale', () => {
+	it.each([
+		[LanguageIds.English, 'en-US'],
+		[LanguageIds.Japanese, 'ja-JP'],
+		[LanguageIds.Portuguese, 'pt-BR'],
+		[LanguageIds.Spanish, 'es-ES'],
+	])('resolves %s to %s', (languageId, locale) => {
+		expect(resolveLocale(languageId)).toBe(locale);
+	});
+
+	it.each([null, undefined, '', 'de_DE', 'not-a-real-language'])(
+		'falls back to the default locale for %p',
+		(languageId) => {
+			expect(resolveLocale(languageId)).toBe(DEFAULT_LOCALE);
+		}
+	);
+});
+
+describe('getLocale', () => {
+	const mockGetState = store.getState as jest.Mock;
+
+	afterEach(() => {
+		mockGetState.mockReset();
+	});
+
+	function mockState({
+		currentUserId = '23',
+		languageId,
+	}: {
+		currentUserId?: string;
+		languageId?: string | null;
+	}) {
+		return fromJS({
+			currentUser: {data: currentUserId},
+			users: {
+				[currentUserId]: {
+					data: {languageId},
+				},
+			},
+		});
+	}
+
+	it('resolves the locale from the current user languageId', () => {
+		mockGetState.mockReturnValue(
+			mockState({languageId: LanguageIds.Portuguese})
+		);
+
+		expect(getLocale()).toBe('pt-BR');
+	});
+
+	it('falls back to the default locale when the current user has no languageId set', () => {
+		mockGetState.mockReturnValue(mockState({languageId: null}));
+
+		expect(getLocale()).toBe(DEFAULT_LOCALE);
+	});
+
+	it('falls back to the default locale when the current user has an unsupported languageId', () => {
+		mockGetState.mockReturnValue(mockState({languageId: 'de_DE'}));
+
+		expect(getLocale()).toBe(DEFAULT_LOCALE);
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/locale.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/locale.ts
@@ -1,0 +1,40 @@
+import {getCurrentUserLanguageId} from 'shared/hooks/useCurrentUser';
+import {LanguageIds} from 'shared/util/constants';
+import store from 'shared/store';
+
+export const DEFAULT_LANGUAGE_ID = LanguageIds.English;
+
+export const SUPPORTED_LOCALES: Record<LanguageIds, string> = {
+	[LanguageIds.English]: 'en-US',
+	[LanguageIds.Japanese]: 'ja-JP',
+	[LanguageIds.Portuguese]: 'pt-BR',
+	[LanguageIds.Spanish]: 'es-ES',
+};
+
+export const DEFAULT_LOCALE = SUPPORTED_LOCALES[DEFAULT_LANGUAGE_ID];
+
+/**
+ * Clamps a portal languageId to one of the 4 languages the product
+ * ships, falling back to DEFAULT_LANGUAGE_ID when it is missing or not
+ * one of them. Use this when the consumer needs the portal languageId
+ * itself (e.g. `applyTimeZone`'s moment-locale mapping); prefer
+ * `resolveLocale`/`getLocale`/`useLocale` for Intl-style formatting.
+ */
+export function resolveLanguageId(languageId?: string | null): LanguageIds {
+	return languageId && SUPPORTED_LOCALES[languageId as LanguageIds]
+		? (languageId as LanguageIds)
+		: DEFAULT_LANGUAGE_ID;
+}
+
+export function resolveLocale(languageId?: string | null): string {
+	return SUPPORTED_LOCALES[resolveLanguageId(languageId)];
+}
+
+/**
+ * Reads the current user's language preference straight from the Redux
+ * store. Use this outside React components (module scope, PDF export);
+ * components should prefer the `useLocale` hook instead.
+ */
+export function getLocale(): string {
+	return resolveLocale(getCurrentUserLanguageId(store.getState()));
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100576

## What Is Being Fixed

The app has no single, reliable way to resolve the current user's locale for date/number formatting. `currentUser.languageId` was read directly and inconsistently at only two call sites (`TimeZoneAlert`, `CommerceMetricCard`), with no fallback — a user without a language preference set could crash `CommerceMetricCard` (`null.replace(...)`). This is the first step of a larger effort to make dates and numbers throughout the product locale-aware.

## How It Is Being Fixed

Added `shared/util/locale.ts` (`resolveLocale`/`resolveLanguageId`, pure and testable, falling back to `en-US`/`en_US` when the account has no language set or an unsupported one) and `shared/hooks/useLocale.ts` (`useLocale`/`useLanguageId`, reactive via the existing `useCurrentUser` hook). Migrated the two existing direct consumers, `TimeZoneAlert` and `CommerceMetricCard`, onto the new hooks, removing the now-unnecessary `.replace('_', '-')` normalization in `CommerceMetricCard`. Also extracted a small reusable selector (`getCurrentUserLanguageId`) in `useCurrentUser.ts` so the non-hook `getLocale()` (for use outside React, e.g. future export code) shares the exact same Redux traversal instead of reimplementing it.

## PR Check

**pr-check: PASS** — tested on `f7de7be1bc9c837f222b8a135223e677473701b7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "f7de7be1bc9c837f222b8a135223e677473701b7"} -->
