### PR TITLE
LPD-100348 Fix the lowercase connector status label

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorEntities.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorEntities.tsx
@@ -55,9 +55,9 @@ const ConnectorEntities: React.FC<IConnectorEntitiesProps> = ({
 						<Label
 							displayType={configured ? 'success' : 'secondary'}
 						>
-							{Liferay.Language.get(
-								configured ? 'configured' : 'unconfigured'
-							)}
+							{configured
+								? Liferay.Language.get('configured')
+								: Liferay.Language.get('unconfigured')}
 						</Label>
 					</ClayList.ItemField>
 				</ClayList.Item>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/MarketoCampaignEntities.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/MarketoCampaignEntities.tsx
@@ -76,12 +76,8 @@ const MarketoCampaignEntities: React.FC<IMarketoCampaignEntitiesProps> = ({
 							displayType={configured ? 'success' : 'secondary'}
 						>
 							{configured
-								? Liferay.Language.get(
-										'configured'
-									).toUpperCase()
-								: Liferay.Language.get(
-										'unconfigured'
-									).toUpperCase()}
+								? Liferay.Language.get('configured')
+								: Liferay.Language.get('unconfigured')}
 						</Label>
 					</ClayList.ItemField>
 				</ClayList.Item>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/MarketoCampaignEntities.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/MarketoCampaignEntities.tsx
@@ -14,7 +14,7 @@ describe('MarketoCampaignEntities', () => {
 			/>
 		);
 
-		expect(getByText('CONFIGURED')).toBeTruthy();
+		expect(getByText('Configured')).toBeTruthy();
 	});
 
 	it('renders the Unconfigured label when the synced count is zero', () => {
@@ -26,7 +26,7 @@ describe('MarketoCampaignEntities', () => {
 			/>
 		);
 
-		expect(getByText('UNCONFIGURED')).toBeTruthy();
+		expect(getByText('Unconfigured')).toBeTruthy();
 	});
 
 	it('renders the Unconfigured label when no synced count is provided', () => {
@@ -37,6 +37,6 @@ describe('MarketoCampaignEntities', () => {
 			/>
 		);
 
-		expect(getByText('UNCONFIGURED')).toBeTruthy();
+		expect(getByText('Unconfigured')).toBeTruthy();
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/marketo/__tests__/__snapshots__/MarketoCampaignOverview.jsx.snap
@@ -1375,7 +1375,7 @@ exports[`MarketoCampaignOverview should render the connected data source with th
                             <span
                               class="label-item label-item-expand"
                             >
-                              CONFIGURED
+                              Configured
                             </span>
                           </span>
                         </div>
@@ -2367,7 +2367,7 @@ exports[`MarketoCampaignOverview should render the reconnect view when the data 
                             <span
                               class="label-item label-item-expand"
                             >
-                              CONFIGURED
+                              Configured
                             </span>
                           </span>
                         </div>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100348

## What Is Being Fixed

The status badges in the Available Data panel of the 3rd party connector page rendered their untranslated language keys, so the labels appeared as lowercase `configured` and `unconfigured` instead of the translated text, even though the keys were defined correctly in Language.properties.

The equivalent Marketo panel rendered the same badges in all caps, so the two panels disagreed on casing.

## How It Is Being Fixed

ConnectorEntities passed a ternary as the argument of Liferay.Language.get, and in that form the key was not resolved, leaving the raw key rendered in the UI. Moving the ternary out so each branch calls Liferay.Language.get with a literal key restores the translated text.

MarketoCampaignEntities already passed literal keys but uppercased the result, so dropping that call brings it in line with the connector panel. The existing assertions and snapshots covering both label states were retargeted to the corrected casing.

## PR Check

**pr-check: PASS** — tested on `1c3d89816e5d4e14dcc8e621de4b564a8f9d00ee`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "1c3d89816e5d4e14dcc8e621de4b564a8f9d00ee"} -->
