### PR TITLE
LPD-99939 Add endpoint to return account overview metrics

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -53,6 +53,7 @@ import com.liferay.osb.faro.engine.client.model.IndividualSegmentMembershipChang
 import com.liferay.osb.faro.engine.client.model.IndividualSegmentRealTimeMembership;
 import com.liferay.osb.faro.engine.client.model.IndividualTransformation;
 import com.liferay.osb.faro.engine.client.model.Interest;
+import com.liferay.osb.faro.engine.client.model.Metric;
 import com.liferay.osb.faro.engine.client.model.PageExperience;
 import com.liferay.osb.faro.engine.client.model.PageVisited;
 import com.liferay.osb.faro.engine.client.model.ProjectDataSourceCount;
@@ -238,6 +239,10 @@ public interface ContactsEngineClient {
 		FaroProject faroProject, String assetId, String assetTitle,
 		String assetType, Long channelId, String keywords, String rangeEnd,
 		Integer rangeKey, String rangeStart, int page, int pageSize);
+
+	public List<Metric> getAccountOverviewMetrics(
+			FaroProject faroProject, Long channelId, String id)
+		throws FaroEngineClientException;
 
 	public Results<Account> getAccounts(
 		FaroProject faroProject, String channelId, String filterString,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -64,6 +64,7 @@ import com.liferay.osb.faro.engine.client.model.IndividualSegmentMembershipChang
 import com.liferay.osb.faro.engine.client.model.IndividualSegmentRealTimeMembership;
 import com.liferay.osb.faro.engine.client.model.IndividualTransformation;
 import com.liferay.osb.faro.engine.client.model.Interest;
+import com.liferay.osb.faro.engine.client.model.Metric;
 import com.liferay.osb.faro.engine.client.model.PageExperience;
 import com.liferay.osb.faro.engine.client.model.PageVisited;
 import com.liferay.osb.faro.engine.client.model.PagedModel;
@@ -938,6 +939,24 @@ public class ContactsEngineClientImpl
 			uriVariables);
 
 		return pagedModel.getResults();
+	}
+
+	@Override
+	public List<Metric> getAccountOverviewMetrics(
+			FaroProject faroProject, Long channelId, String id)
+		throws FaroEngineClientException {
+
+		Map<String, Object> uriVariables = getUriVariables(faroProject, id);
+
+		if (Validator.isNotNull(channelId)) {
+			uriVariables.put("channelId", channelId);
+		}
+
+		return get(
+			faroProject, Rels.ACCOUNT_OVERVIEW,
+			new ParameterizedTypeReference<List<Metric>>() {
+			},
+			uriVariables);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
@@ -37,6 +37,8 @@ public interface Rels {
 
 	public static final String ACCOUNT_NAMES = "account-names";
 
+	public static final String ACCOUNT_OVERVIEW = "account-overview";
+
 	public static final String ACCOUNTS = "accounts";
 
 	public static final String ACCOUNTS_DISTRIBUTION = "accounts-distribution";

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -53,6 +53,7 @@ import com.liferay.osb.faro.engine.client.model.IndividualSegmentMembershipChang
 import com.liferay.osb.faro.engine.client.model.IndividualSegmentRealTimeMembership;
 import com.liferay.osb.faro.engine.client.model.IndividualTransformation;
 import com.liferay.osb.faro.engine.client.model.Interest;
+import com.liferay.osb.faro.engine.client.model.Metric;
 import com.liferay.osb.faro.engine.client.model.PageExperience;
 import com.liferay.osb.faro.engine.client.model.PageVisited;
 import com.liferay.osb.faro.engine.client.model.Provider;
@@ -432,6 +433,15 @@ public abstract class BaseMockContactsEngineClientImpl
 		return contactsEngineClient.getAccountNames(
 			faroProject, assetId, assetTitle, assetType, channelId, keywords,
 			rangeEnd, rangeKey, rangeStart, page, pageSize);
+	}
+
+	@Override
+	public List<Metric> getAccountOverviewMetrics(
+			FaroProject faroProject, Long channelId, String id)
+		throws FaroEngineClientException {
+
+		return contactsEngineClient.getAccountOverviewMetrics(
+			faroProject, channelId, id);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroController.java
@@ -13,6 +13,7 @@ import com.liferay.osb.faro.engine.client.model.AccountLifecycleStatus;
 import com.liferay.osb.faro.engine.client.model.AccountMetric;
 import com.liferay.osb.faro.engine.client.model.AccountName;
 import com.liferay.osb.faro.engine.client.model.Individual;
+import com.liferay.osb.faro.engine.client.model.Metric;
 import com.liferay.osb.faro.engine.client.model.Results;
 import com.liferay.osb.faro.engine.client.util.OrderByField;
 import com.liferay.osb.faro.web.internal.constants.FaroConstants;
@@ -172,6 +173,19 @@ public class AccountFaroController extends BaseFaroController {
 				assetId, assetTitle, assetType, channelId, keywords, rangeEnd,
 				rangeKey, rangeStart, page, pageSize),
 			page, pageSize);
+	}
+
+	@GET
+	@Path("/{id}/overview")
+	@RolesAllowed(RoleConstants.SITE_MEMBER)
+	public List<Metric> getAccountOverviewMetrics(
+			@PathParam("groupId") long groupId, @PathParam("id") String id,
+			@QueryParam("channelId") Long channelId)
+		throws Exception {
+
+		return contactsEngineClient.getAccountOverviewMetrics(
+			faroProjectLocalService.getFaroProjectByGroupId(groupId), channelId,
+			id);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/mixin/MetricMixin.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/mixin/MetricMixin.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.web.internal.model.display.contacts.mixin;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * @author Leslie Wong
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class MetricMixin {
+}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/JSONUtil.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/JSONUtil.java
@@ -17,12 +17,14 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 
 import com.liferay.osb.faro.engine.client.model.Credentials;
 import com.liferay.osb.faro.engine.client.model.Interest;
+import com.liferay.osb.faro.engine.client.model.Metric;
 import com.liferay.osb.faro.engine.client.model.PageVisited;
 import com.liferay.osb.faro.engine.client.model.credentials.OAuth1Credentials;
 import com.liferay.osb.faro.engine.client.model.credentials.OAuth2Credentials;
 import com.liferay.osb.faro.engine.client.model.credentials.TokenCredentials;
 import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.BaseMixin;
 import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.CredentialsMixin;
+import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.MetricMixin;
 import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.OAuth1CredentialsMixin;
 import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.OAuth2CredentialsMixin;
 import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.PageVisitMixin;
@@ -82,6 +84,7 @@ public class JSONUtil {
 		{
 			addMixIn(Credentials.class, CredentialsMixin.class);
 			addMixIn(Interest.class, BaseMixin.class);
+			addMixIn(Metric.class, MetricMixin.class);
 			addMixIn(OAuth1Credentials.class, OAuth1CredentialsMixin.class);
 			addMixIn(OAuth2Credentials.class, OAuth2CredentialsMixin.class);
 			addMixIn(PageVisited.class, PageVisitMixin.class);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroControllerTest.java
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.web.internal.controller.contacts;
+
+import com.liferay.osb.faro.engine.client.ContactsEngineClient;
+import com.liferay.osb.faro.engine.client.model.Metric;
+import com.liferay.osb.faro.model.FaroProject;
+import com.liferay.osb.faro.service.FaroProjectLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Leslie Wong
+ */
+public class AccountFaroControllerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		Mockito.when(
+			_faroProjectLocalService.getFaroProjectByGroupId(Mockito.anyLong())
+		).thenReturn(
+			_faroProject
+		);
+
+		ReflectionTestUtils.setField(
+			_accountFaroController, "contactsEngineClient",
+			_contactsEngineClient);
+		ReflectionTestUtils.setField(
+			_accountFaroController, "faroProjectLocalService",
+			_faroProjectLocalService);
+	}
+
+	@Test
+	public void testGetAccountOverviewMetrics() throws Exception {
+		long channelId = RandomTestUtil.randomLong();
+		String id = RandomTestUtil.randomString();
+		List<Metric> metrics = Collections.singletonList(new Metric());
+
+		Mockito.when(
+			_contactsEngineClient.getAccountOverviewMetrics(
+				_faroProject, channelId, id)
+		).thenReturn(
+			metrics
+		);
+
+		long groupId = RandomTestUtil.randomLong();
+
+		Assert.assertSame(
+			metrics,
+			_accountFaroController.getAccountOverviewMetrics(
+				groupId, id, channelId));
+
+		Mockito.verify(
+			_faroProjectLocalService
+		).getFaroProjectByGroupId(
+			groupId
+		);
+	}
+
+	private final AccountFaroController _accountFaroController =
+		new AccountFaroController();
+	private final ContactsEngineClient _contactsEngineClient = Mockito.mock(
+		ContactsEngineClient.class);
+	private final FaroProject _faroProject = Mockito.mock(FaroProject.class);
+	private final FaroProjectLocalService _faroProjectLocalService =
+		Mockito.mock(FaroProjectLocalService.class);
+
+}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/util/JSONUtilTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/util/JSONUtilTest.java
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.web.internal.util;
+
+import com.liferay.osb.faro.engine.client.model.Metric;
+import com.liferay.osb.faro.engine.client.model.Trend;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.math.BigDecimal;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Leslie Wong
+ */
+public class JSONUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testWriteValueAsStringExcludesNullMetricFields()
+		throws Exception {
+
+		Metric metric = new Metric();
+
+		metric.setMetricType("anonymousIndividualsCount");
+
+		Assert.assertEquals(
+			"{\"metricType\":\"anonymousIndividualsCount\",\"value\":0.0}",
+			JSONUtil.writeValueAsString(metric));
+	}
+
+	@Test
+	public void testWriteValueAsStringIncludesNonnullMetricFields()
+		throws Exception {
+
+		Metric metric = new Metric();
+
+		metric.setMetricType("knownIndividualsCount");
+		metric.setPreviousValue(10D);
+		metric.setPreviousValueKey("previousKey");
+
+		Trend trend = new Trend();
+
+		trend.setPercentage(new BigDecimal("12.5"));
+		trend.setTrendClassification("POSITIVE");
+
+		metric.setTrend(trend);
+
+		metric.setValue(20D);
+		metric.setValueKey("key");
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"{\"metricType\":\"knownIndividualsCount\",",
+				"\"previousValue\":10.0,\"previousValueKey\":\"previousKey\",",
+				"\"trend\":{\"percentage\":12.5,",
+				"\"trendClassification\":\"POSITIVE\"},\"value\":20.0,",
+				"\"valueKey\":\"key\"}"),
+			JSONUtil.writeValueAsString(metric));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99939

## What Is Being Fixed

The contacts engine exposes per-account overview metrics through its `account-overview` endpoint, but osb-faro-web had no way to retrieve them, so the UI could not show overview metrics for a single account. Additionally, `Metric` fields with no value would serialize as explicit `null` entries in the JSON response.

## How It Is Being Fixed

A new `getAccountOverviewMetrics` method is added to `ContactsEngineClient`, calling the engine's `account-overview` rel with the account ID and an optional channel ID, with the mock engine client delegating as usual. The controller exposes it as `GET /{id}/overview` on `AccountFaroController`, restricted to site members like the sibling endpoints. `Metric` serialization registers a `@JsonInclude(NON_NULL)` mixin in `JSONUtil`'s object mapper, which serializes the new endpoint's responses, so unset metric fields are omitted instead of rendered as null. Unit tests cover the controller delegation and both serialization behaviors.

## PR Check

**pr-check: PASS** — tested on `8b6d20cbaeb2ea2616064d151d18a162fa19d55b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "8b6d20cbaeb2ea2616064d151d18a162fa19d55b"} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
