### PR TITLE
LPD-100990 Report a view when a document is rendered in a fragment

### DIFF
--- a/modules/apps/analytics/analytics-client-js/src/plugins/documents-fragment.ts
+++ b/modules/apps/analytics/analytics-client-js/src/plugins/documents-fragment.ts
@@ -9,6 +9,7 @@ import {
 	isDownloadAction,
 	isImpressionAction,
 	isTrackable,
+	isViewAction,
 	transformAssetTypeToSelector,
 } from '../utils/assets';
 import {composeDisposers} from '../utils/disposers';
@@ -144,12 +145,24 @@ function trackDocumentImpression(analytics: Analytics) {
 }
 
 /**
+ * Sends the view event the first time a Document is visible inside the
+ * viewport.
+ */
+function trackDocumentViewed(analytics: Analytics) {
+	return trackDocument(analytics, {
+		eventId: AnalyticsType.EventId.DocumentPreviewed,
+		isTrackable: (element) => isTrackable(element) && isViewAction(element),
+	});
+}
+
+/**
  * Plugin function that registers listeners for Document events.
  */
 function documents(analytics: Analytics) {
 	return composeDisposers([
 		trackDocumentDownloaded(analytics),
 		trackDocumentImpression(analytics),
+		trackDocumentViewed(analytics),
 	]);
 }
 

--- a/modules/apps/analytics/analytics-client-js/test/plugins/documentsFragment.ts
+++ b/modules/apps/analytics/analytics-client-js/test/plugins/documentsFragment.ts
@@ -396,6 +396,10 @@ describe('Documents Plugin', () => {
 				action: AnalyticsTypes.ElementAction.Download,
 				eventId: AnalyticsTypes.EventId.DocumentImpressionMade,
 			},
+			{
+				action: AnalyticsTypes.ElementAction.View,
+				eventId: AnalyticsTypes.EventId.DocumentPreviewed,
+			},
 		].forEach(async (props) => {
 			it(`is fired ${props.eventId} when view a document with action ${props.action} and type: ${AnalyticsTypes.ElementType.FileEntry}`, async () => {
 				const element = createDocumentsElementWithAction(props.action);

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/util/AnalyticsAttributesUtil.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/util/AnalyticsAttributesUtil.java
@@ -18,6 +18,7 @@ import com.liferay.fragment.processor.FragmentEntryProcessorContext;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.field.type.HTMLInfoFieldType;
+import com.liferay.info.field.type.ImageInfoFieldType;
 import com.liferay.info.field.type.LongTextInfoFieldType;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemFieldValues;
@@ -155,6 +156,11 @@ public class AnalyticsAttributesUtil {
 
 		if (Objects.equals(
 				infoField.getInfoFieldType(), HTMLInfoFieldType.INSTANCE) ||
+			(Objects.equals(
+				infoField.getInfoFieldType(), ImageInfoFieldType.INSTANCE) &&
+			 Objects.equals(
+				 infoItemFieldMapped.getClassName(),
+				 FileEntry.class.getName())) ||
 			Objects.equals(
 				infoField.getInfoFieldType(), LongTextInfoFieldType.INSTANCE)) {
 

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/src/testIntegration/java/com/liferay/fragment/entry/processor/editable/test/EditableFragmentEntryProcessorTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/src/testIntegration/java/com/liferay/fragment/entry/processor/editable/test/EditableFragmentEntryProcessorTest.java
@@ -1027,6 +1027,41 @@ public class EditableFragmentEntryProcessorTest {
 	}
 
 	@Test
+	@TestInfo("LPD-100990")
+	public void testFragmentEntryProcessorEditableAssertAnalyticsAttributesWithMappedFileEntryImageInViewMode()
+		throws Exception {
+
+		FileEntry fileEntry = _addImageFileEntry(RandomTestUtil.randomString());
+
+		Element element = _getElement(
+			"data-lfr-editable-id", "image-square",
+			_getEditableFieldValues(
+				_portal.getClassNameId(FileEntry.class),
+				fileEntry.getFileEntryId(), "FileEntry_previewImage",
+				"fragment_entry_link_mapped_asset_field_image.json"),
+			"fragment_entry_image.html", LocaleUtil.US,
+			FragmentEntryLinkConstants.VIEW);
+
+		Assert.assertEquals(
+			AnalyticsAttributesUtil.ACTION_VIEW,
+			element.attr("data-analytics-asset-action"));
+		Assert.assertEquals(
+			"FileEntry_previewImage",
+			element.attr("data-analytics-asset-field"));
+		Assert.assertEquals(
+			String.valueOf(fileEntry.getFileEntryId()),
+			element.attr("data-analytics-asset-id"));
+		Assert.assertEquals(
+			fileEntry.getMimeType(),
+			element.attr("data-analytics-asset-mime-type"));
+		Assert.assertEquals(
+			fileEntry.getTitle(), element.attr("data-analytics-asset-title"));
+		Assert.assertEquals(
+			FileEntry.class.getName(),
+			element.attr("data-analytics-asset-type"));
+	}
+
+	@Test
 	public void testFragmentEntryProcessorEditableAssertAnalyticsAttributesWithMappedImageInViewMode()
 		throws Exception {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100990

## What Is Being Fixed

An image file mapped to an image fragment reported only an impression event, never a view, so a document rendered in full on a page was indistinguishable from a teaser. Two gaps caused it. On the server, the analytics asset action of a mapped image field was always `impression`: LPD-56329 removed the branch that flagged image elements as `view`, and LPD-64445 restored `view` only for long text and rich text fields. On the client, the documents fragment plugin had no listener for the `view` action, so even a correctly flagged element reported nothing at all.

## How It Is Being Fixed

`AnalyticsAttributesUtil` now reports the view action when the mapped field is an image and the mapped info item is a `FileEntry`, which is the case where the rendered image is the document itself. The info item filter keeps every other asset on the impression action, so mapping the small image of a web content still reports an impression of that web content rather than a view, which is the behavior LPD-56329 introduced.

The documents fragment plugin gains `trackDocumentViewed`, mirroring the impression and view pair the object entry plugin already has. It reports `documentPreviewed`, the event Analytics Cloud reads as the view of a document, and which until now only the display page of a document sent.

## PR Check

**pr-check: PASS** — tested on `734edb43f864910106998bae4a6f57dbc2f7245f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "734edb43f864910106998bae4a6f57dbc2f7245f"} -->
