### PR TITLE
LPD-100882 Wait for the movement target before dropping a property

### DIFF
--- a/modules/test/playwright/pages/segments-web/SegmentEditorPage.ts
+++ b/modules/test/playwright/pages/segments-web/SegmentEditorPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {expandSection} from '../../utils/expandSection';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
@@ -33,6 +33,7 @@ export class SegmentEditorPage {
 	readonly page: Page;
 
 	readonly emptyDropzone: Locator;
+	readonly keyboardMovementTarget: Locator;
 	readonly loading: Locator;
 	readonly saveButton: Locator;
 
@@ -40,6 +41,9 @@ export class SegmentEditorPage {
 		this.page = page;
 
 		this.emptyDropzone = page.locator('.empty-drop-zone');
+		this.keyboardMovementTarget = page.locator(
+			'.drop-zone-indicator, .empty-drop-zone--target'
+		);
 		this.loading = page.locator('.sheet .loading-animation');
 		this.saveButton = page.getByText('Save');
 	}
@@ -112,6 +116,11 @@ export class SegmentEditorPage {
 
 		// Add property to desired dropzone
 
+		const criterionRows = this.page.locator(
+			`.criterion-row-root.drop-zone-${section}`
+		);
+		const criterionRowsCount = await criterionRows.count();
+
 		try {
 			await this.page.getByLabel(label, {exact: true}).press('Enter');
 		}
@@ -128,9 +137,14 @@ export class SegmentEditorPage {
 			}
 		}
 
+		// The drop is discarded unless the movement target is already set
+
+		await this.keyboardMovementTarget.first().waitFor({state: 'attached'});
+
 		await target.press('Enter');
 
-		await this.loading.waitFor();
+		await expect(criterionRows).toHaveCount(criterionRowsCount + 1);
+
 		await this.loading.waitFor({state: 'hidden'});
 
 		// Configure property


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100882

## What Is Being Fixed

The Playwright test `Can refresh the members count when conjunctions between conditions change` timed out after 90 seconds waiting for the members count spinner (`.sheet .loading-animation`) to become visible. The failure had nothing to do with conjunctions: it happened earlier, while the helper was still building the segment.

`SegmentEditorPage.addProperty` simulates a keyboard drag and drop with two Enter presses. The first one sets the keyboard movement source, which mounts `KeyboardMovementManager` and registers a document level keydown listener, and the manager resolves its movement target in a later render. The second Enter is handled by that listener, which dereferences the target with a non-null assertion. When the second press lands before the target is committed, the handler has already called `preventDefault` and `stopPropagation` and then throws, so the drop is silently discarded: the criteria never change, `membersCountLoading` is never set, and the spinner the helper waits for never appears.

## How It Is Being Fixed

Wait for the movement target to be highlighted before dropping. Both markup variants require a non-null `movementTarget`, since an empty section renders `.empty-drop-zone--target` and a populated one renders `.drop-zone-indicator`, so waiting for either one proves the manager is ready to accept the drop.

The transient spinner wait is also replaced with an assertion on the outcome: the helper now compares the criterion row count of the section before and after the drop. Waiting for a spinner to become visible is inherently racy, and it produced a 90 second timeout pointing at the members count instead of at the real cause. The wait for the spinner to be hidden stays, so the members count request still settles before the property is configured.

This was verified against DXP 7.4.13 Update 152, the release the failure was reported on. The target test passes 6 out of 6 runs and the full `segmentation.spec.ts` suite passes 44 of 50. The 6 remaining failures were checked against the unmodified helper: 3 fail identically without this change and the other 3 pass on a re-run, so none of them is caused by it. None of the six has a stack frame in `SegmentEditorPage`.

## PR Check

**pr-check: PASS** — tested on `c0c77f0f0a59abbfe4f15925bcb8fbb38309ac6b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Two validations matched the diff by path but could not be run. Per-Module Compile does not apply because `modules/test/playwright` is not a Gradle subproject, so `:test:playwright:deploy` does not exist. JavaScript Unit Tests does not apply because the module's `test` script is `playwright test`, an end to end runner that pr-check declares out of scope. The Playwright coverage was run manually instead, as described above.

<!-- pr-check {"result": "success", "sha": "c0c77f0f0a59abbfe4f15925bcb8fbb38309ac6b"} -->
