### PR TITLE
LPD-99030 Apply the segment filter to the audience report card

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/AudienceReport.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/AudienceReport.tsx
@@ -103,6 +103,7 @@ interface IAudienceReportProps<TRawData>
 	experienceId?: string | null;
 	filters: RawFilters;
 	rangeSelectors: RangeSelectors;
+	segmentId?: string | null;
 	Query: DocumentNode;
 	mapper: (data: TRawData) => TData;
 	name: Name;
@@ -114,6 +115,7 @@ function AudienceReport<TRawData>({
 	experienceId,
 	filters,
 	rangeSelectors,
+	segmentId,
 	...otherProps
 }: IAudienceReportProps<TRawData>) {
 	const {assetId, channelId, title, touchpoint} = useParams();
@@ -124,6 +126,7 @@ function AudienceReport<TRawData>({
 			touchpoint: getSafeTouchpoint(touchpoint as string),
 			...(accountId && {accountId}),
 			...(experienceId && {experienceId}),
+			...(segmentId && {segmentId}),
 			...(otherProps.name !== Name.ObjectEntry && {
 				channelId,
 				title: getSafeDecodedURIComponent(title as string),

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/AudienceReportBaseCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/AudienceReportBaseCard.tsx
@@ -21,7 +21,13 @@ function AudienceReportBaseCard({
 			minHeight={536}
 			reportContainer={ReportContainer.AudienceCard}
 		>
-			{({accountId, experienceId, filters, rangeSelectors}) => (
+			{({
+				accountId,
+				experienceId,
+				filters,
+				rangeSelectors,
+				segmentId,
+			}) => (
 				<Card.Body>
 					<AudienceReport
 						{...props}
@@ -35,6 +41,7 @@ function AudienceReportBaseCard({
 							name,
 						})}
 						rangeSelectors={rangeSelectors}
+						segmentId={segmentId}
 					/>
 				</Card.Body>
 			)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/queries.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/queries.ts
@@ -36,6 +36,7 @@ export const PageAudienceReportQuery = ({
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -49,6 +50,7 @@ export const PageAudienceReportQuery = ({
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			${metricName} {
@@ -76,6 +78,7 @@ export const AssetAudienceReportQuery = ({
 		$rangeEnd: String
 		$rangeKey: Int
 		$rangeStart: String
+		$segmentId: String
 		$title: String
 		$touchpoint: String
 	) {
@@ -89,6 +92,7 @@ export const AssetAudienceReportQuery = ({
 			rangeEnd: $rangeEnd
 			rangeKey: $rangeKey
 			rangeStart: $rangeStart
+			segmentId: $segmentId
 			title: $title
 		) {
 			assetId


### PR DESCRIPTION
## Summary
- The audience report card never received the account segment filter: `BaseCard` already exposes `segmentId` in its render-prop context, but `AudienceReportBaseCard` never read it, `AudienceReport` never forwarded it to the query, and the two GraphQL queries never declared a `$segmentId` variable.
- Threads `segmentId` through `AudienceReportBaseCard` → `AudienceReport` → `PageAudienceReportQuery`/`AssetAudienceReportQuery`, matching the existing `accountId`/`experienceId` pattern.

## Test plan
- [x] `jest` audience-report suite passes (3/3, snapshot unchanged)
- [x] `tsc --noEmit` clean
- [x] format check clean