### PR TITLE
LPD-100729 Limit property preselection to Demandbase data sources

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/AssignedPropertiesTable.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/AssignedPropertiesTable.tsx
@@ -11,6 +11,7 @@ import {ClayRadio, ClayRadioGroup, ClayToggle} from '@clayui/form';
 import {createOrderIOMap, NAME} from 'shared/util/pagination';
 import {DataSourceStatuses, Sizes} from 'shared/util/constants';
 import {fetchChannelDatasources} from 'shared/api/data-source';
+import {getChannelsAutoSelectFilter} from 'shared/util/data-sources';
 import {Link, useParams} from 'react-router-dom';
 import {modalTypes} from 'shared/actions/modals';
 import {Routes, toRoute} from 'shared/util/router';
@@ -305,6 +306,10 @@ const AssignedPropertiesTable = ({
 									disabled={!dataSourceActive}
 									onClick={() =>
 										open(modalTypes.SELECT_CHANNELS_MODAL, {
+											autoSelectFilter:
+												getChannelsAutoSelectFilter(
+													dataSource
+												),
 											groupId,
 											initialItems:
 												channelsConfigurationRef.current?.channels?.map(

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/__tests__/AssignedPropertiesTable.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/__tests__/AssignedPropertiesTable.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {AssignedPropertiesTable} from '../AssignedPropertiesTable';
+import {DataSourceStatuses, DataSourceTypes} from 'shared/util/constants';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {fromJS} from 'immutable';
+import {modalTypes} from 'shared/actions/modals';
+
+jest.unmock('react-dom');
+
+jest.mock('react-router-dom', () => ({
+	...jest.requireActual('react-router-dom'),
+	useParams: () => ({groupId: '23'}),
+}));
+
+jest.mock('shared/api/data-source', () => ({
+	fetchChannelDatasources: jest.fn(),
+}));
+
+jest.mock('shared/hoc/CrossPageSelect', () => ({
+	__esModule: true,
+	default: ({renderNav}: {renderNav?: () => React.ReactNode}) => (
+		<div>{renderNav?.()}</div>
+	),
+}));
+
+jest.mock('shared/hooks/useCurrentUser', () => ({
+	useCurrentUser: () => ({isAdmin: () => true}),
+}));
+
+jest.mock('shared/hooks/useQueryPagination', () => ({
+	useQueryPagination: () => ({
+		delta: 10,
+		orderIOMap: {},
+		page: 1,
+		query: '',
+	}),
+}));
+
+jest.mock('shared/hooks/useRequest', () => ({
+	useRequest: () => ({
+		data: {items: [], total: 0},
+		error: false,
+		refetch: jest.fn(),
+	}),
+}));
+
+const mockDataSource = (providerType: DataSourceTypes) => ({
+	id: '42',
+	provider: fromJS({}),
+	providerType,
+	status: DataSourceStatuses.Active,
+});
+
+const defaultProps = {
+	addAlert: jest.fn(),
+	close: jest.fn(),
+	handleUpdateDataSource: jest.fn(),
+	updateDataSourceFn: jest.fn(),
+};
+
+const openSelectChannelsModal = (
+	open: jest.Mock,
+	providerType: DataSourceTypes
+) => {
+	render(
+		<AssignedPropertiesTable
+			{...defaultProps}
+			dataSource={mockDataSource(providerType)}
+			open={open}
+		/>
+	);
+
+	fireEvent.click(screen.getByText(Liferay.Language.get('select-property')));
+
+	return open.mock.calls[0][1];
+};
+
+describe('AssignedPropertiesTable', () => {
+	it('should preselect the properties syncing a site for a Demandbase data source', () => {
+		const {autoSelectFilter} = openSelectChannelsModal(
+			jest.fn(),
+			DataSourceTypes.Demandbase
+		);
+
+		expect(autoSelectFilter({groupsCount: 3})).toBe(true);
+		expect(autoSelectFilter({groupsCount: 0})).toBe(false);
+	});
+
+	it('should not preselect any property for a non Demandbase data source', () => {
+		const open = jest.fn();
+
+		const modalProps = openSelectChannelsModal(
+			open,
+			DataSourceTypes.Liferay
+		);
+
+		expect(open).toHaveBeenCalledWith(
+			modalTypes.SELECT_CHANNELS_MODAL,
+			expect.anything()
+		);
+
+		expect(modalProps.autoSelectFilter).toBeUndefined();
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/salesforce/steps/AssignIndividualsDataToChannelsStep.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/salesforce/steps/AssignIndividualsDataToChannelsStep.tsx
@@ -8,6 +8,7 @@ import React, {useEffect, useState} from 'react';
 import {Alert, Modal} from 'shared/types';
 import {ClayCheckbox} from '@clayui/form';
 import {DataSource} from 'shared/util/records';
+import {getChannelsAutoSelectFilter} from 'shared/util/data-sources';
 import {modalTypes} from 'shared/actions/modals';
 import {Routes, toRoute} from 'shared/util/router';
 import {sub} from 'shared/util/lang';
@@ -151,6 +152,10 @@ const AssignIndividualsDataToPropertiesStep = ({
 								displayType="secondary"
 								onClick={() => {
 									open(modalTypes.SELECT_CHANNELS_MODAL, {
+										autoSelectFilter:
+											getChannelsAutoSelectFilter(
+												dataSource
+											),
 										groupId,
 										initialItems: selectedItems,
 										onClose: close,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/salesforce/steps/__tests__/AssignIndividualsDataToChannelsStep.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/salesforce/steps/__tests__/AssignIndividualsDataToChannelsStep.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import {AssignIndividualsDataToPropertiesStep} from '../AssignIndividualsDataToChannelsStep';
+import {DataSourceTypes} from 'shared/util/constants';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {modalTypes} from 'shared/actions/modals';
+
+jest.unmock('react-dom');
+
+const useWizardPageMock = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+	...jest.requireActual('react-router-dom'),
+	useHistory: () => ({push: jest.fn()}),
+	useParams: () => ({groupId: '23'}),
+}));
+
+jest.mock('settings/components/base-page/WizardPageContext', () => ({
+	useWizardPage: () => useWizardPageMock(),
+}));
+
+const mockDataSource = (providerType: DataSourceTypes) => ({
+	id: '42',
+	provider: {get: () => undefined},
+	providerType,
+});
+
+const defaultProps = {
+	addAlert: jest.fn(),
+	close: jest.fn(),
+	onPrev: jest.fn(),
+	onSubmit: jest.fn(),
+	updateDataSourceFn: jest.fn(),
+};
+
+const openSelectChannelsModal = (open: jest.Mock) => {
+	render(
+		<AssignIndividualsDataToPropertiesStep
+			{...(defaultProps as any)}
+			open={open}
+		/>
+	);
+
+	fireEvent.click(screen.getByText(Liferay.Language.get('select')));
+
+	return open.mock.calls[0][1];
+};
+
+describe('AssignIndividualsDataToPropertiesStep', () => {
+	it('should preselect the properties syncing a site for a Demandbase data source', () => {
+		useWizardPageMock.mockReturnValue({
+			dataSource: mockDataSource(DataSourceTypes.Demandbase),
+		});
+
+		const {autoSelectFilter} = openSelectChannelsModal(jest.fn());
+
+		expect(autoSelectFilter({groupsCount: 1})).toBe(true);
+		expect(autoSelectFilter({groupsCount: 0})).toBe(false);
+	});
+
+	it('should not preselect any property for a non Demandbase data source', () => {
+		useWizardPageMock.mockReturnValue({
+			dataSource: mockDataSource(DataSourceTypes.Salesforce),
+		});
+
+		const open = jest.fn();
+
+		const modalProps = openSelectChannelsModal(open);
+
+		expect(open).toHaveBeenCalledWith(
+			modalTypes.SELECT_CHANNELS_MODAL,
+			expect.anything()
+		);
+
+		expect(modalProps.autoSelectFilter).toBeUndefined();
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/modals/SelectChannelsModal.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/modals/SelectChannelsModal.tsx
@@ -17,7 +17,21 @@ import {
 } from 'shared/context/selection';
 import {useStatefulPagination} from 'shared/hooks/useStatefulPagination';
 
+export interface ISelectableChannel {
+	commerceChannelsCount: number;
+	groupsCount: number;
+	id: string;
+	name: string;
+}
+
 interface ISelectChannelsModalProps {
+
+	/**
+	 * Opt in preselection. When given, the channels matching it are selected
+	 * on the first page of results. The modal itself has no opinion on which
+	 * channels matter, so each caller decides whether to preselect anything.
+	 */
+	autoSelectFilter?: (channel: ISelectableChannel) => boolean;
 	groupId: string;
 	onClose: () => {};
 	onSelect: (channels: string[]) => {};
@@ -25,6 +39,7 @@ interface ISelectChannelsModalProps {
 }
 
 const SelectChannelsModal: React.FC<ISelectChannelsModalProps> = ({
+	autoSelectFilter,
 
 	/**
 	 * const {groupId} = useParams() doesn't work on Modals
@@ -79,20 +94,22 @@ const SelectChannelsModal: React.FC<ISelectChannelsModalProps> = ({
 	}, [initialItems]);
 
 	useEffect(() => {
-		if (data?.items && !hasAutoSelectedRef.current) {
-			hasAutoSelectedRef.current = true;
+		if (!autoSelectFilter || !data?.items || hasAutoSelectedRef.current) {
+			return;
+		}
 
-			const channelsWithSites = data.items.filter(
-				(item: {groupsCount: number; id: string}) =>
-					item.groupsCount > 0 && !initialItems.includes(item.id)
-			);
+		hasAutoSelectedRef.current = true;
 
-			if (channelsWithSites.length) {
-				selectionDispatch?.({
-					payload: {items: channelsWithSites},
-					type: 'add',
-				});
-			}
+		const autoSelectedChannels = data.items.filter(
+			(channel: ISelectableChannel) =>
+				autoSelectFilter(channel) && !initialItems.includes(channel.id)
+		);
+
+		if (autoSelectedChannels.length) {
+			selectionDispatch?.({
+				payload: {items: autoSelectedChannels},
+				type: 'add',
+			});
 		}
 	}, [data]);
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/modals/__tests__/SelectChannelsModal.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/modals/__tests__/SelectChannelsModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import SelectChannelsModal from '../SelectChannelsModal';
+import SelectChannelsModal, {ISelectableChannel} from '../SelectChannelsModal';
 import {fireEvent, render} from '@testing-library/react';
 import {useRequest} from 'shared/hooks/useRequest';
 
@@ -20,6 +20,8 @@ const mockChannels = [
 	{groupsCount: 1, id: 'channel-3', name: 'Another Channel With Sites'},
 ];
 
+const hasSyncedSites = (channel: ISelectableChannel) => channel.groupsCount > 0;
+
 const defaultProps = {
 	groupId: '23',
 	initialItems: [],
@@ -39,10 +41,26 @@ describe('SelectChannelsModal', () => {
 		});
 	});
 
-	it('should auto-select channels with synced sites on first data load', () => {
+	it('should not preselect any channel when no filter is given', () => {
 		const onSelect = jest.fn();
 
 		render(<SelectChannelsModal {...defaultProps} onSelect={onSelect} />);
+
+		fireEvent.click(submitButton());
+
+		expect(onSelect).not.toHaveBeenCalled();
+	});
+
+	it('should auto-select the channels matching the given filter on first data load', () => {
+		const onSelect = jest.fn();
+
+		render(
+			<SelectChannelsModal
+				{...defaultProps}
+				autoSelectFilter={hasSyncedSites}
+				onSelect={onSelect}
+			/>
+		);
 
 		fireEvent.click(submitButton());
 
@@ -51,10 +69,16 @@ describe('SelectChannelsModal', () => {
 		);
 	});
 
-	it('should not auto-select channels without synced sites', () => {
+	it('should not auto-select the channels rejected by the given filter', () => {
 		const onSelect = jest.fn();
 
-		render(<SelectChannelsModal {...defaultProps} onSelect={onSelect} />);
+		render(
+			<SelectChannelsModal
+				{...defaultProps}
+				autoSelectFilter={hasSyncedSites}
+				onSelect={onSelect}
+			/>
+		);
 
 		fireEvent.click(submitButton());
 
@@ -67,6 +91,7 @@ describe('SelectChannelsModal', () => {
 		render(
 			<SelectChannelsModal
 				{...defaultProps}
+				autoSelectFilter={hasSyncedSites}
 				initialItems={['channel-1']}
 				onSelect={onSelect}
 			/>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/data-sources.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/data-sources.js
@@ -3,6 +3,7 @@ import * as data from 'test/data';
 import {DataSource} from 'shared/util/records';
 import {
 	dataSourceRedirectFn,
+	getChannelsAutoSelectFilter,
 	getDataSourceDisplayObject,
 	getIdsFromConfiguration,
 	getServiceAlertConfig,
@@ -12,7 +13,11 @@ import {
 	validateUniqueName,
 	validContactsConfig,
 } from '../data-sources';
-import {DataSourceStates, DataSourceStatuses} from 'shared/util/constants';
+import {
+	DataSourceStates,
+	DataSourceStatuses,
+	DataSourceTypes,
+} from 'shared/util/constants';
 import {fromJS} from 'immutable';
 import {noop, range} from 'lodash';
 import {Routes, toRoute} from 'shared/util/router';
@@ -210,6 +215,30 @@ describe('data-sources', () => {
 			expect(getIdsFromConfiguration(mockMap, testKey)).toEqual(
 				expectedArray
 			);
+		});
+	});
+
+	describe('getChannelsAutoSelectFilter', () => {
+		it('should preselect the channels syncing a site for a Demandbase data source', () => {
+			const filter = getChannelsAutoSelectFilter({
+				providerType: DataSourceTypes.Demandbase,
+			});
+
+			expect(filter({groupsCount: 2})).toBe(true);
+			expect(filter({groupsCount: 0})).toBe(false);
+		});
+
+		it('should not preselect any channel for a non Demandbase data source', () => {
+			expect(
+				getChannelsAutoSelectFilter({
+					providerType: DataSourceTypes.Salesforce,
+				})
+			).toBeUndefined();
+		});
+
+		it('should not preselect any channel when there is no data source', () => {
+			expect(getChannelsAutoSelectFilter(null)).toBeUndefined();
+			expect(getChannelsAutoSelectFilter()).toBeUndefined();
 		});
 	});
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/data-sources.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/data-sources.tsx
@@ -198,6 +198,24 @@ export function validateUniqueName({
 }
 
 /**
+ * Get the preselection rule the select properties modal must apply for a
+ * DataSource. Demandbase only enriches individuals that browse a synced site,
+ * so the properties already syncing a site start out selected. Every other
+ * provider type starts with an empty selection, so no filter is returned.
+ * @param {DataSource} dataSource - The DataSource the properties are assigned to.
+ * @returns {function|undefined} - The filter to pass to the modal, when any.
+ */
+export function getChannelsAutoSelectFilter(
+	dataSource?: DataSource | null
+): ((channel: {groupsCount: number}) => boolean) | undefined {
+	if (dataSource?.providerType !== DataSourceTypes.Demandbase) {
+		return undefined;
+	}
+
+	return (channel) => channel.groupsCount > 0;
+}
+
+/**
  * Utility for getting the display object for a dataSource state in order
  * to display its status.
  */


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100729

## What Is Being Fixed

`SelectChannelsModal` preselected every property with at least one synced site whenever it opened. The modal is shared, so the rule fired for every caller and every data source type, even though it is only correct for Demandbase.

## How It Is Being Fixed

The modal now takes an optional `autoSelectFilter` predicate and preselects nothing when it is absent, so it holds no opinion about which properties matter. The Demandbase rule lives in a single helper, `getChannelsAutoSelectFilter`, alongside the existing `providerType` helpers in `shared/util/data-sources`: it returns the "has at least one synced site" predicate for a Demandbase data source and `undefined` for every other provider type. Both call sites — the setup wizard step and the assigned properties table on the data source page — pass the helper's result straight through, so neither repeats the enum comparison.

Preselection still covers only the first page of results. That limitation is unchanged from the original commit and is being discussed separately, since fixing it costs an extra request on the slower backend path and may be better addressed through the existing `enableAllChannels` option.

## PR Check

**pr-check: PASS** — tested on `24f86c241f4d1684ac1cf4d73ea2f577a2fda1af`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "24f86c241f4d1684ac1cf4d73ea2f577a2fda1af"} -->
