### PR TITLE
LPD-99030 Filter lifecycle stage metrics by segment

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -224,7 +224,8 @@ public interface ContactsEngineClient {
 		throws FaroEngineClientException;
 
 	public List<AccountLifecycleStageMetric> getAccountLifecycleStageMetrics(
-			FaroProject faroProject, String country, String id, String industry)
+			FaroProject faroProject, String country, String id, String industry,
+			Long segmentId)
 		throws FaroEngineClientException;
 
 	public AccountLifecycleStatus getAccountLifecycleStatus(

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -842,7 +842,8 @@ public class ContactsEngineClientImpl
 
 	@Override
 	public List<AccountLifecycleStageMetric> getAccountLifecycleStageMetrics(
-			FaroProject faroProject, String country, String id, String industry)
+			FaroProject faroProject, String country, String id, String industry,
+			Long segmentId)
 		throws FaroEngineClientException {
 
 		Map<String, Object> uriVariables = getUriVariables(faroProject, id);
@@ -853,6 +854,10 @@ public class ContactsEngineClientImpl
 
 		if (Validator.isNotNull(industry)) {
 			uriVariables.put("industry", industry);
+		}
+
+		if (Validator.isNotNull(segmentId)) {
+			uriVariables.put("segmentId", segmentId);
 		}
 
 		return get(

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -400,11 +400,12 @@ public abstract class BaseMockContactsEngineClientImpl
 
 	@Override
 	public List<AccountLifecycleStageMetric> getAccountLifecycleStageMetrics(
-			FaroProject faroProject, String country, String id, String industry)
+			FaroProject faroProject, String country, String id, String industry,
+			Long segmentId)
 		throws FaroEngineClientException {
 
 		return contactsEngineClient.getAccountLifecycleStageMetrics(
-			faroProject, country, id, industry);
+			faroProject, country, id, industry, segmentId);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountLifecycleFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountLifecycleFaroController.java
@@ -104,12 +104,13 @@ public class AccountLifecycleFaroController extends BaseFaroController {
 	public List<AccountLifecycleStageMetric> getAccountLifecycleStageMetrics(
 			@PathParam("groupId") long groupId, @PathParam("id") String id,
 			@QueryParam("country") String country,
-			@QueryParam("industry") String industry)
+			@QueryParam("industry") String industry,
+			@QueryParam("segmentId") Long segmentId)
 		throws Exception {
 
 		return contactsEngineClient.getAccountLifecycleStageMetrics(
 			faroProjectLocalService.getFaroProjectByGroupId(groupId), country,
-			id, industry);
+			id, industry, segmentId);
 	}
 
 	@GET

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
@@ -153,6 +153,8 @@ const LifecycleStagesSection = () => {
 
 	const {groupId} = useParams();
 
+	const {segmentId} = useSegmentFilter();
+
 	const {
 		data: stagesData,
 		error: stagesError,
@@ -164,6 +166,7 @@ const LifecycleStagesSection = () => {
 			groupId,
 			industry: filters.industryFilter,
 			lifecycleId,
+			segmentId,
 		},
 	});
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/lifecycle.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/lifecycle.ts
@@ -153,6 +153,7 @@ interface IFetchLifecycleStages {
 	groupId?: string;
 	industry?: string;
 	lifecycleId: string;
+	segmentId?: string | null;
 }
 
 export async function fetchLifecycleStages({
@@ -160,11 +161,13 @@ export async function fetchLifecycleStages({
 	groupId,
 	industry,
 	lifecycleId,
+	segmentId,
 }: IFetchLifecycleStages) {
 	return sendRequest({
 		data: {
 			...(country && {country}),
 			...(industry && {industry}),
+			...(segmentId && {segmentId}),
 		},
 		method: 'GET',
 		path: `contacts/${groupId}/account-lifecycle/${lifecycleId}/stages`,


### PR DESCRIPTION
## Summary
- The lifecycle stages card (active counts, average stage durations, stage-conversion rates) now respects the selected segment, the same way it already respects country/industry and the same way the accounts list on this page already does.
- Threads `segmentId` end-to-end: `BaseLifecycle.tsx` → `fetchLifecycleStages` → `AccountLifecycleFaroController` → `ContactsEngineClient`/`ContactsEngineClientImpl` (real + mock) → the Analytics Cloud backend's `/{id}/stages` endpoint.
- Backport of #3801 to faro-v5.0.x.

## Test plan
- [x] TypeScript type-check clean
- [x] `jest` `BaseLifecycle` suite passes (17/17)
- [x] Java modules (`osb-faro-engine-client`, `osb-faro-mock-engine-client`, `osb-faro-web`) compile clean
- [x] Format checks clean