### PR TITLE
LPD-99030 Point the accounts segment filter at the search endpoint

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/AccountsDataSet.tsx
@@ -180,7 +180,7 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 						type: 'selection',
 					},
 					{
-						apiURL: `/o/faro/contacts/${groupId}/individual_segment?channelId=${channelId}`,
+						apiURL: `/o/faro/contacts/${groupId}/individual_segment/search?channelId=${channelId}`,
 						entityFieldType: 'string',
 						id: 'segmentId',
 						itemKey: 'id',

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/AccountsDataSet.tsx
@@ -379,7 +379,7 @@ describe('AccountsDataSet', () => {
 		const segmentFilter = lastFilters?.find((f) => f.id === 'segmentId');
 
 		expect(segmentFilter?.apiURL).toBe(
-			'/o/faro/contacts/23/individual_segment?channelId=123'
+			'/o/faro/contacts/23/individual_segment/search?channelId=123'
 		);
 	});
 


### PR DESCRIPTION
## Summary
- The Accounts table's segment filter dropdown called the bare `individual_segment` list endpoint, which returns `{items, total}`
- The generic FDS `SelectionFilter` component's infinite-scroll pagination relies on `response.totalCount`, a field only present on the `FaroFDSResultsDisplay` shape returned by `individual_segment/search`
- With `totalCount` undefined, the load-more condition never triggered, so only the first page of segments ever loaded — unlike the global segment filter, which uses a different fetch path entirely
- Points the filter's `apiURL` at `individual_segment/search` and fixes the corresponding test assertion, which already asserted the intended (but wrong) URL

## Test plan
- [x] Existing Jest suite for `AccountsDataSet.tsx` passes (21/21)
- [x] `tsc --noEmit` shows no new errors
- [x] `format.mjs --check` clean