### PR TITLE
LPD-96997 Source segment counts from ProjectMetric and isolate failures

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -55,7 +55,7 @@ import com.liferay.osb.faro.engine.client.model.IndividualTransformation;
 import com.liferay.osb.faro.engine.client.model.Interest;
 import com.liferay.osb.faro.engine.client.model.PageExperience;
 import com.liferay.osb.faro.engine.client.model.PageVisited;
-import com.liferay.osb.faro.engine.client.model.ProjectDataSourceCount;
+import com.liferay.osb.faro.engine.client.model.ProjectMetric;
 import com.liferay.osb.faro.engine.client.model.ProjectUsageMetric;
 import com.liferay.osb.faro.engine.client.model.Provider;
 import com.liferay.osb.faro.engine.client.model.RealTimeMembershipMetric;
@@ -590,8 +590,7 @@ public interface ContactsEngineClient {
 
 	public PageVisited getPageVisited(FaroProject faroProject, String id);
 
-	public Results<ProjectDataSourceCount> getProjectDataSourceCounts(
-		FaroProject faroProject);
+	public Results<ProjectMetric> getProjectMetrics(FaroProject faroProject);
 
 	public Results<ProjectUsageMetric> getProjectUsageMetrics(
 		FaroProject faroProject, Date sinceDate);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -67,7 +67,7 @@ import com.liferay.osb.faro.engine.client.model.Interest;
 import com.liferay.osb.faro.engine.client.model.PageExperience;
 import com.liferay.osb.faro.engine.client.model.PageVisited;
 import com.liferay.osb.faro.engine.client.model.PagedModel;
-import com.liferay.osb.faro.engine.client.model.ProjectDataSourceCount;
+import com.liferay.osb.faro.engine.client.model.ProjectMetric;
 import com.liferay.osb.faro.engine.client.model.ProjectUsageMetric;
 import com.liferay.osb.faro.engine.client.model.Provider;
 import com.liferay.osb.faro.engine.client.model.RealTimeMembershipMetric;
@@ -3280,13 +3280,11 @@ public class ContactsEngineClientImpl
 	}
 
 	@Override
-	public Results<ProjectDataSourceCount> getProjectDataSourceCounts(
-		FaroProject faroProject) {
-
-		PagedModel<?, ProjectDataSourceCount> pagedModel = get(
-			faroProject, Rels.PROJECTS_DATA_SOURCE_COUNTS,
+	public Results<ProjectMetric> getProjectMetrics(FaroProject faroProject) {
+		PagedModel<?, ProjectMetric> pagedModel = get(
+			faroProject, Rels.PROJECTS_METRICS,
 			new ParameterizedTypeReference
-				<EntityModelPagedModel<ProjectDataSourceCount>>() {
+				<EntityModelPagedModel<ProjectMetric>>() {
 			},
 			getUriVariables(faroProject));
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/ProjectMetric.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/ProjectMetric.java
@@ -13,7 +13,12 @@ import java.util.Map;
 /**
  * @author Caio Pinheiro
  */
-public class ProjectDataSourceCount {
+public class ProjectMetric {
+
+	@JsonProperty("batchSegmentsCount")
+	public long getBatchSegmentsCount() {
+		return _batchSegmentsCount;
+	}
 
 	@JsonProperty("connectorsConnected")
 	public long getConnectorsConnected() {
@@ -34,6 +39,15 @@ public class ProjectDataSourceCount {
 		return _projectId;
 	}
 
+	@JsonProperty("realTimeSegmentsCount")
+	public long getRealTimeSegmentsCount() {
+		return _realTimeSegmentsCount;
+	}
+
+	public void setBatchSegmentsCount(long batchSegmentsCount) {
+		_batchSegmentsCount = batchSegmentsCount;
+	}
+
 	public void setConnectorsConnected(long connectorsConnected) {
 		_connectorsConnected = connectorsConnected;
 	}
@@ -50,9 +64,15 @@ public class ProjectDataSourceCount {
 		_projectId = projectId;
 	}
 
+	public void setRealTimeSegmentsCount(long realTimeSegmentsCount) {
+		_realTimeSegmentsCount = realTimeSegmentsCount;
+	}
+
+	private long _batchSegmentsCount;
 	private long _connectorsConnected;
 	private long _dataSourcesConnected;
 	private Map<String, Object> _embeddedResources = new HashMap<>();
 	private String _projectId;
+	private long _realTimeSegmentsCount;
 
 }

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
@@ -275,11 +275,10 @@ public interface Rels {
 
 	public static final String PROJECT_USAGE_METRICS = "project-usage-metrics";
 
-	public static final String PROJECTS_DATA_SOURCE_COUNTS =
-		"projects-data-source-counts";
-
 	public static final String PROJECTS_LAST_SEEN_DATE =
 		"projects-last-seen-date";
+
+	public static final String PROJECTS_METRICS = "projects-metrics";
 
 	public static final String REPORTS_EXPORT_CSV_COUNT =
 		"reports-export-csv-count";

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/MockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/MockContactsEngineClientImpl.java
@@ -12,7 +12,7 @@ import com.liferay.osb.faro.engine.client.model.ApiUsageMetric;
 import com.liferay.osb.faro.engine.client.model.DataSourceUsageMetric;
 import com.liferay.osb.faro.engine.client.model.Field;
 import com.liferay.osb.faro.engine.client.model.Individual;
-import com.liferay.osb.faro.engine.client.model.ProjectDataSourceCount;
+import com.liferay.osb.faro.engine.client.model.ProjectMetric;
 import com.liferay.osb.faro.engine.client.model.ProjectUsageMetric;
 import com.liferay.osb.faro.engine.client.model.Results;
 import com.liferay.osb.faro.engine.client.util.FilterBuilder;
@@ -167,10 +167,8 @@ public class MockContactsEngineClientImpl
 	}
 
 	@Override
-	public Results<ProjectDataSourceCount> getProjectDataSourceCounts(
-		FaroProject faroProject) {
-
-		return contactsEngineClient.getProjectDataSourceCounts(faroProject);
+	public Results<ProjectMetric> getProjectMetrics(FaroProject faroProject) {
+		return contactsEngineClient.getProjectMetrics(faroProject);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/helper/ProjectUsageHelper.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/helper/ProjectUsageHelper.java
@@ -11,8 +11,7 @@ import com.liferay.osb.faro.constants.FaroProjectConstants;
 import com.liferay.osb.faro.engine.client.ContactsEngineClient;
 import com.liferay.osb.faro.engine.client.model.ApiUsage;
 import com.liferay.osb.faro.engine.client.model.ApiUsageMetric;
-import com.liferay.osb.faro.engine.client.model.IndividualSegment;
-import com.liferay.osb.faro.engine.client.model.ProjectDataSourceCount;
+import com.liferay.osb.faro.engine.client.model.ProjectMetric;
 import com.liferay.osb.faro.engine.client.model.Results;
 import com.liferay.osb.faro.model.FaroDataSourceUsage;
 import com.liferay.osb.faro.model.FaroProject;
@@ -24,6 +23,8 @@ import com.liferay.osb.faro.web.internal.model.display.contacts.DataSourceUsage;
 import com.liferay.osb.faro.web.internal.model.display.contacts.DataSourceUsageMetric;
 import com.liferay.osb.faro.web.internal.model.display.contacts.DataSourceUsageMetricDisplay;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -67,17 +68,24 @@ public class ProjectUsageHelper {
 
 		Date endDate = _parseUTCDate(endDateString);
 
-		Map<String, Map<String, ProjectDataSourceCount>>
-			projectDataSourceCountsMap = _getProjectDataSourceCountsMap(
-				faroProjects);
+		Map<String, Map<String, ProjectMetric>> projectMetricsMap =
+			_getProjectMetricsMap(faroProjects);
 
 		Date startDate = _parseUTCDate(startDateString);
 
 		for (FaroProject faroProject : faroProjects) {
-			dataSourceUsageMetricDisplays.add(
-				_getDataSourceUsageMetricDisplay(
-					apiUsageMetricsMap, endDate, faroProject,
-					projectDataSourceCountsMap, startDate));
+			try {
+				dataSourceUsageMetricDisplays.add(
+					_getDataSourceUsageMetricDisplay(
+						apiUsageMetricsMap, endDate, faroProject,
+						projectMetricsMap, startDate));
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to build data source usage metric display for " +
+						"Faro project " + faroProject.getFaroProjectId(),
+					exception);
+			}
 		}
 
 		return Page.of(
@@ -112,13 +120,21 @@ public class ProjectUsageHelper {
 
 			Map<String, ApiUsageMetric> apiUsageMetricMap = new HashMap<>();
 
-			Results<ApiUsageMetric> results =
-				_contactsEngineClient.getApiUsageMetrics(
-					faroProject, endDateString, startDateString);
+			try {
+				Results<ApiUsageMetric> results =
+					_contactsEngineClient.getApiUsageMetrics(
+						faroProject, endDateString, startDateString);
 
-			for (ApiUsageMetric apiUsageMetric : results.getItems()) {
-				apiUsageMetricMap.put(
-					apiUsageMetric.getProjectId(), apiUsageMetric);
+				for (ApiUsageMetric apiUsageMetric : results.getItems()) {
+					apiUsageMetricMap.put(
+						apiUsageMetric.getProjectId(), apiUsageMetric);
+				}
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to fetch API usage metrics for project " +
+						faroProject.getProjectId(),
+					exception);
 			}
 
 			apiUsageMetricsMap.put(serverLocation, apiUsageMetricMap);
@@ -130,8 +146,7 @@ public class ProjectUsageHelper {
 	private DataSourceUsageMetricDisplay _getDataSourceUsageMetricDisplay(
 			Map<String, Map<String, ApiUsageMetric>> apiUsageMetricsMap,
 			Date endDate, FaroProject faroProject,
-			Map<String, Map<String, ProjectDataSourceCount>>
-				projectDataSourceCountsMap,
+			Map<String, Map<String, ProjectMetric>> projectMetricsMap,
 			Date startDate)
 		throws Exception {
 
@@ -151,20 +166,22 @@ public class ProjectUsageHelper {
 			}
 		}
 
-		Map<String, Long> map = _getIndividualSegmentsMap(faroProject);
-
-		long dataSourcesCount = 0;
+		long batchSegmentsCount = 0;
 		long connectorsCount = 0;
+		long dataSourcesCount = 0;
+		long realTimeSegmentsCount = 0;
 
-		Map<String, ProjectDataSourceCount> projectDataSourceCountMap =
-			projectDataSourceCountsMap.get(faroProject.getServerLocation());
+		Map<String, ProjectMetric> projectMetricMap = projectMetricsMap.get(
+			faroProject.getServerLocation());
 
-		ProjectDataSourceCount projectDataSourceCount =
-			projectDataSourceCountMap.get(faroProject.getProjectId());
+		ProjectMetric projectMetric = projectMetricMap.get(
+			faroProject.getProjectId());
 
-		if (projectDataSourceCount != null) {
-			dataSourcesCount = projectDataSourceCount.getDataSourcesConnected();
-			connectorsCount = projectDataSourceCount.getConnectorsConnected();
+		if (projectMetric != null) {
+			batchSegmentsCount = projectMetric.getBatchSegmentsCount();
+			connectorsCount = projectMetric.getConnectorsConnected();
+			dataSourcesCount = projectMetric.getDataSourcesConnected();
+			realTimeSegmentsCount = projectMetric.getRealTimeSegmentsCount();
 		}
 
 		List<DataSourceUsage> dataSourceUsages = new ArrayList<>();
@@ -208,9 +225,8 @@ public class ProjectUsageHelper {
 		}
 
 		return new DataSourceUsageMetricDisplay(
-			apiUsageMetricDisplays,
-			map.getOrDefault(IndividualSegment.Type.BATCH.name(), 0L),
-			dataSourcesCount, connectorsCount, faroProject.getCorpProjectName(),
+			apiUsageMetricDisplays, batchSegmentsCount, dataSourcesCount,
+			connectorsCount, faroProject.getCorpProjectName(),
 			faroProject.getCorpProjectUuid(), dataSourceUsages,
 			DateUtil.formatDate(
 				new Date(faroProject.getLastAccessTime()),
@@ -219,59 +235,44 @@ public class ProjectUsageHelper {
 				faroProject.getLastAnniversaryDate(), DateUtil.PATTERN_DATE),
 			!StringUtil.equals(
 				faroProject.getState(), FaroProjectConstants.STATE_READY),
-			map.getOrDefault(IndividualSegment.Type.REAL_TIME.name(), 0L),
-			faroProject.getWeDeployKey());
+			realTimeSegmentsCount, faroProject.getWeDeployKey());
 	}
 
-	private Map<String, Long> _getIndividualSegmentsMap(
-		FaroProject faroProject) {
+	private Map<String, Map<String, ProjectMetric>> _getProjectMetricsMap(
+		List<FaroProject> faroProjects) {
 
-		Map<String, Long> map = new HashMap<>();
-
-		Results<IndividualSegment> results =
-			_contactsEngineClient.getIndividualSegments(
-				faroProject, null, null, null, null, null, null, null, null,
-				IndividualSegment.Status.ACTIVE.name(), 1, 10000, null);
-
-		for (IndividualSegment individualSegment : results.getItems()) {
-			map.merge(individualSegment.getSegmentType(), 1L, Long::sum);
-		}
-
-		return map;
-	}
-
-	private Map<String, Map<String, ProjectDataSourceCount>>
-		_getProjectDataSourceCountsMap(List<FaroProject> faroProjects) {
-
-		Map<String, Map<String, ProjectDataSourceCount>>
-			projectDataSourceCountsMap = new HashMap<>();
+		Map<String, Map<String, ProjectMetric>> projectMetricsMap =
+			new HashMap<>();
 
 		for (FaroProject faroProject : faroProjects) {
 			String serverLocation = faroProject.getServerLocation();
 
-			if (projectDataSourceCountsMap.containsKey(serverLocation)) {
+			if (projectMetricsMap.containsKey(serverLocation)) {
 				continue;
 			}
 
-			Map<String, ProjectDataSourceCount> projectDataSourceCountMap =
-				new HashMap<>();
+			Map<String, ProjectMetric> projectMetricMap = new HashMap<>();
 
-			Results<ProjectDataSourceCount> results =
-				_contactsEngineClient.getProjectDataSourceCounts(faroProject);
+			try {
+				Results<ProjectMetric> results =
+					_contactsEngineClient.getProjectMetrics(faroProject);
 
-			for (ProjectDataSourceCount projectDataSourceCount :
-					results.getItems()) {
-
-				projectDataSourceCountMap.put(
-					projectDataSourceCount.getProjectId(),
-					projectDataSourceCount);
+				for (ProjectMetric projectMetric : results.getItems()) {
+					projectMetricMap.put(
+						projectMetric.getProjectId(), projectMetric);
+				}
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to fetch project metrics for project " +
+						faroProject.getProjectId(),
+					exception);
 			}
 
-			projectDataSourceCountsMap.put(
-				serverLocation, projectDataSourceCountMap);
+			projectMetricsMap.put(serverLocation, projectMetricMap);
 		}
 
-		return projectDataSourceCountsMap;
+		return projectMetricsMap;
 	}
 
 	private Date _parseUTCDate(String dateString) {
@@ -287,6 +288,9 @@ public class ProjectUsageHelper {
 
 		return Date.from(zonedDateTime.toInstant());
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ProjectUsageHelper.class);
 
 	private static final DateTimeFormatter _dateTimeFormatter =
 		DateTimeFormatter.ofPattern(DateUtil.PATTERN_DATE);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96997

## What Is Being Fixed

Per-project batch and real-time segment counts were computed by fetching every active individual segment for a project (paged up to 10000 items) and counting them client-side by type. This was expensive and capped at 10000 segments. Additionally, a failure fetching API usage metrics, data source counts, or individual segments for any single project aborted the entire data source usage metric listing for all projects.

## How It Is Being Fixed

The engine client now exposes a single `getProjectMetrics` endpoint backed by a renamed `ProjectMetric` model (formerly `ProjectDataSourceCount`), which returns `batchSegmentsCount` and `realTimeSegmentsCount` alongside the existing connector and data source counts. `ProjectUsageHelper` reads segment counts directly from this endpoint instead of deriving them from the individual segments list, removing that computation entirely. Each per-project and per-server-location fetch is now wrapped in a try/catch that logs and skips the failing entry, so one project's failure no longer breaks the listing for the rest.

## Why Are There No Tests?

Tests for this behavior live in the asah repo; the faro codebase doesn't typically carry test coverage for this kind of change.

## PR Check

**pr-check: PASS** — tested on `34bbd68db816bf72de6c34bf3e31f7b582c3c268`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "34bbd68db816bf72de6c34bf3e31f7b582c3c268"} -->
