### PR TITLE
LPD-99939 Add account overview metrics endpoint

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -53,6 +53,7 @@ import com.liferay.osb.faro.engine.client.model.IndividualSegmentMembershipChang
 import com.liferay.osb.faro.engine.client.model.IndividualSegmentRealTimeMembership;
 import com.liferay.osb.faro.engine.client.model.IndividualTransformation;
 import com.liferay.osb.faro.engine.client.model.Interest;
+import com.liferay.osb.faro.engine.client.model.Metric;
 import com.liferay.osb.faro.engine.client.model.PageExperience;
 import com.liferay.osb.faro.engine.client.model.PageVisited;
 import com.liferay.osb.faro.engine.client.model.ProjectDataSourceCount;
@@ -238,6 +239,10 @@ public interface ContactsEngineClient {
 		FaroProject faroProject, String assetId, String assetTitle,
 		String assetType, Long channelId, String keywords, String rangeEnd,
 		Integer rangeKey, String rangeStart, int page, int pageSize);
+
+	public List<Metric> getAccountOverviewMetrics(
+			FaroProject faroProject, Long channelId, String id)
+		throws FaroEngineClientException;
 
 	public Results<Account> getAccounts(
 		FaroProject faroProject, String channelId, String filterString,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -64,6 +64,7 @@ import com.liferay.osb.faro.engine.client.model.IndividualSegmentMembershipChang
 import com.liferay.osb.faro.engine.client.model.IndividualSegmentRealTimeMembership;
 import com.liferay.osb.faro.engine.client.model.IndividualTransformation;
 import com.liferay.osb.faro.engine.client.model.Interest;
+import com.liferay.osb.faro.engine.client.model.Metric;
 import com.liferay.osb.faro.engine.client.model.PageExperience;
 import com.liferay.osb.faro.engine.client.model.PageVisited;
 import com.liferay.osb.faro.engine.client.model.PagedModel;
@@ -938,6 +939,24 @@ public class ContactsEngineClientImpl
 			uriVariables);
 
 		return pagedModel.getResults();
+	}
+
+	@Override
+	public List<Metric> getAccountOverviewMetrics(
+			FaroProject faroProject, Long channelId, String id)
+		throws FaroEngineClientException {
+
+		Map<String, Object> uriVariables = getUriVariables(faroProject, id);
+
+		if (Validator.isNotNull(channelId)) {
+			uriVariables.put("channelId", channelId);
+		}
+
+		return get(
+			faroProject, Rels.ACCOUNT_OVERVIEW,
+			new ParameterizedTypeReference<List<Metric>>() {
+			},
+			uriVariables);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/Rels.java
@@ -37,6 +37,8 @@ public interface Rels {
 
 	public static final String ACCOUNT_NAMES = "account-names";
 
+	public static final String ACCOUNT_OVERVIEW = "account-overview";
+
 	public static final String ACCOUNTS = "accounts";
 
 	public static final String ACCOUNTS_DISTRIBUTION = "accounts-distribution";

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/BaseMockContactsEngineClientImpl.java
@@ -53,6 +53,7 @@ import com.liferay.osb.faro.engine.client.model.IndividualSegmentMembershipChang
 import com.liferay.osb.faro.engine.client.model.IndividualSegmentRealTimeMembership;
 import com.liferay.osb.faro.engine.client.model.IndividualTransformation;
 import com.liferay.osb.faro.engine.client.model.Interest;
+import com.liferay.osb.faro.engine.client.model.Metric;
 import com.liferay.osb.faro.engine.client.model.PageExperience;
 import com.liferay.osb.faro.engine.client.model.PageVisited;
 import com.liferay.osb.faro.engine.client.model.Provider;
@@ -432,6 +433,15 @@ public abstract class BaseMockContactsEngineClientImpl
 		return contactsEngineClient.getAccountNames(
 			faroProject, assetId, assetTitle, assetType, channelId, keywords,
 			rangeEnd, rangeKey, rangeStart, page, pageSize);
+	}
+
+	@Override
+	public List<Metric> getAccountOverviewMetrics(
+			FaroProject faroProject, Long channelId, String id)
+		throws FaroEngineClientException {
+
+		return contactsEngineClient.getAccountOverviewMetrics(
+			faroProject, channelId, id);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/build.gradle
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	testImplementation group: "com.liferay.portal", name: "release.dxp.api", version: "2026.q1.5"
 	testImplementation group: "junit", name: "junit", version: "4.13.1"
 	testImplementation group: "org.mockito", name: "mockito-core", version: "5.14.2"
+	testImplementation group: "org.skyscreamer", name: "jsonassert", version: "1.5.0"
 	testImplementation project(":modules:osb-faro-api")
 	testImplementation project(":modules:osb-faro-contacts-api")
 	testImplementation project(":modules:osb-faro-engine-client")

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroController.java
@@ -13,6 +13,7 @@ import com.liferay.osb.faro.engine.client.model.AccountLifecycleStatus;
 import com.liferay.osb.faro.engine.client.model.AccountMetric;
 import com.liferay.osb.faro.engine.client.model.AccountName;
 import com.liferay.osb.faro.engine.client.model.Individual;
+import com.liferay.osb.faro.engine.client.model.Metric;
 import com.liferay.osb.faro.engine.client.model.Results;
 import com.liferay.osb.faro.engine.client.util.OrderByField;
 import com.liferay.osb.faro.web.internal.constants.FaroConstants;
@@ -172,6 +173,19 @@ public class AccountFaroController extends BaseFaroController {
 				assetId, assetTitle, assetType, channelId, keywords, rangeEnd,
 				rangeKey, rangeStart, page, pageSize),
 			page, pageSize);
+	}
+
+	@GET
+	@Path("/{id}/overview")
+	@RolesAllowed(RoleConstants.SITE_MEMBER)
+	public List<Metric> getAccountOverviewMetrics(
+			@PathParam("groupId") long groupId, @PathParam("id") String id,
+			@QueryParam("channelId") Long channelId)
+		throws Exception {
+
+		return contactsEngineClient.getAccountOverviewMetrics(
+			faroProjectLocalService.getFaroProjectByGroupId(groupId), channelId,
+			id);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/mixin/MetricMixin.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/mixin/MetricMixin.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.web.internal.model.display.contacts.mixin;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * @author Leslie Wong
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class MetricMixin {
+}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/JSONUtil.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/JSONUtil.java
@@ -17,12 +17,14 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 
 import com.liferay.osb.faro.engine.client.model.Credentials;
 import com.liferay.osb.faro.engine.client.model.Interest;
+import com.liferay.osb.faro.engine.client.model.Metric;
 import com.liferay.osb.faro.engine.client.model.PageVisited;
 import com.liferay.osb.faro.engine.client.model.credentials.OAuth1Credentials;
 import com.liferay.osb.faro.engine.client.model.credentials.OAuth2Credentials;
 import com.liferay.osb.faro.engine.client.model.credentials.TokenCredentials;
 import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.BaseMixin;
 import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.CredentialsMixin;
+import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.MetricMixin;
 import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.OAuth1CredentialsMixin;
 import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.OAuth2CredentialsMixin;
 import com.liferay.osb.faro.web.internal.model.display.contacts.mixin.PageVisitMixin;
@@ -82,6 +84,7 @@ public class JSONUtil {
 		{
 			addMixIn(Credentials.class, CredentialsMixin.class);
 			addMixIn(Interest.class, BaseMixin.class);
+			addMixIn(Metric.class, MetricMixin.class);
 			addMixIn(OAuth1Credentials.class, OAuth1CredentialsMixin.class);
 			addMixIn(OAuth2Credentials.class, OAuth2CredentialsMixin.class);
 			addMixIn(PageVisited.class, PageVisitMixin.class);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroControllerTest.java
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.web.internal.controller.contacts;
+
+import com.liferay.osb.faro.engine.client.ContactsEngineClient;
+import com.liferay.osb.faro.engine.client.model.Metric;
+import com.liferay.osb.faro.model.FaroProject;
+import com.liferay.osb.faro.service.FaroProjectLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Leslie Wong
+ */
+public class AccountFaroControllerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		Mockito.when(
+			_faroProjectLocalService.getFaroProjectByGroupId(Mockito.anyLong())
+		).thenReturn(
+			_faroProject
+		);
+
+		ReflectionTestUtils.setField(
+			_accountFaroController, "contactsEngineClient",
+			_contactsEngineClient);
+		ReflectionTestUtils.setField(
+			_accountFaroController, "faroProjectLocalService",
+			_faroProjectLocalService);
+	}
+
+	@Test
+	public void testGetAccountOverviewMetrics() throws Exception {
+		long channelId = RandomTestUtil.randomLong();
+		String id = RandomTestUtil.randomString();
+		List<Metric> metrics = Collections.singletonList(new Metric());
+
+		Mockito.when(
+			_contactsEngineClient.getAccountOverviewMetrics(
+				_faroProject, channelId, id)
+		).thenReturn(
+			metrics
+		);
+
+		long groupId = RandomTestUtil.randomLong();
+
+		Assert.assertSame(
+			metrics,
+			_accountFaroController.getAccountOverviewMetrics(
+				groupId, id, channelId));
+
+		Mockito.verify(
+			_faroProjectLocalService
+		).getFaroProjectByGroupId(
+			groupId
+		);
+	}
+
+	private final AccountFaroController _accountFaroController =
+		new AccountFaroController();
+	private final ContactsEngineClient _contactsEngineClient = Mockito.mock(
+		ContactsEngineClient.class);
+	private final FaroProject _faroProject = Mockito.mock(FaroProject.class);
+	private final FaroProjectLocalService _faroProjectLocalService =
+		Mockito.mock(FaroProjectLocalService.class);
+
+}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/util/JSONUtilTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/util/JSONUtilTest.java
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.web.internal.util;
+
+import com.liferay.osb.faro.engine.client.model.Metric;
+import com.liferay.osb.faro.engine.client.model.Trend;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.math.BigDecimal;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+/**
+ * @author Leslie Wong
+ */
+public class JSONUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testWriteValueAsStringExcludesNullMetricFields()
+		throws Exception {
+
+		String metricType = RandomTestUtil.randomString();
+
+		Metric metric = new Metric();
+
+		metric.setMetricType(metricType);
+
+		JSONAssert.assertEquals(
+			com.liferay.portal.kernel.json.JSONUtil.put(
+				"metricType", metricType
+			).put(
+				"value", 0D
+			).toString(),
+			JSONUtil.writeValueAsString(metric), JSONCompareMode.STRICT);
+	}
+
+	@Test
+	public void testWriteValueAsStringIncludesNonnullMetricFields()
+		throws Exception {
+
+		String metricType = RandomTestUtil.randomString();
+		double previousValue = RandomTestUtil.randomDouble();
+		String previousValueKey = RandomTestUtil.randomString();
+
+		Metric metric = new Metric();
+
+		metric.setMetricType(metricType);
+		metric.setPreviousValue(previousValue);
+		metric.setPreviousValueKey(previousValueKey);
+
+		double percentage = RandomTestUtil.randomDouble();
+		String trendClassification = RandomTestUtil.randomString();
+
+		Trend trend = new Trend();
+
+		trend.setPercentage(BigDecimal.valueOf(percentage));
+		trend.setTrendClassification(trendClassification);
+
+		metric.setTrend(trend);
+
+		double value = RandomTestUtil.randomDouble();
+		String valueKey = RandomTestUtil.randomString();
+
+		metric.setValue(value);
+		metric.setValueKey(valueKey);
+
+		JSONAssert.assertEquals(
+			com.liferay.portal.kernel.json.JSONUtil.put(
+				"metricType", metricType
+			).put(
+				"previousValue", previousValue
+			).put(
+				"previousValueKey", previousValueKey
+			).put(
+				"trend",
+				com.liferay.portal.kernel.json.JSONUtil.put(
+					"percentage", percentage
+				).put(
+					"trendClassification", trendClassification
+				)
+			).put(
+				"value", value
+			).put(
+				"valueKey", valueKey
+			).toString(),
+			JSONUtil.writeValueAsString(metric), JSONCompareMode.STRICT);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99939

## What Is Being Fixed

Faro had no API for retrieving the overview metrics of a single account, so the account view could not display them. In addition, when the Analytics Cloud engine returns metrics without values for every field, the serialized response emitted explicit `null` entries (`previousValue`, `previousValueKey`, `trend`, `valueKey`) instead of omitting them.

## How It Is Being Fixed

A new `GET /contacts/{groupId}/accounts/{id}/overview` endpoint on `AccountFaroController` delegates to a new `ContactsEngineClient.getAccountOverviewMetrics` method, which calls the engine's `account-overview` rel and returns the metrics as `List<Metric>`. Null metric fields are omitted by registering a `MetricMixin` carrying `@JsonInclude(JsonInclude.Include.NON_NULL)` on the shared osb-faro-web `ObjectMapper`. A mixin is used instead of annotating `Metric` directly because `osb-faro-engine-client` and `osb-faro-web` each embed a private copy of Jackson, so an annotation on the model class resolves to a different annotation `Class` than the one the serializing Jackson looks up and is silently ignored; the mixin lives in the web bundle beside the Jackson instance that performs the serialization, following the module's existing mixin pattern in `JSONUtil`. Unit tests cover the controller delegation and the serialization contract in both directions (null fields omitted, non-null fields retained), asserting with JSONAssert in strict mode so a reintroduced null field fails the test.

## PR Check

**pr-check: PASS** — tested on `1ebc72d54247db2013bc31da9d775d14da3ef40d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Workspace Build | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "1ebc72d54247db2013bc31da9d775d14da3ef40d"} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
