### PR TITLE
LPD-100416 Add LDP custom domains for STG, internal, and production

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/LCP.json
+++ b/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/LCP.json
@@ -19,7 +19,8 @@
 				"certs": [
 					{
 						"customDomains": [
-							"analytics-internal.liferay.com"
+							"analytics-internal.liferay.com",
+							"ldp-internal.liferay.com"
 						]
 					}
 				],

--- a/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/LCP.json
+++ b/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/LCP.json
@@ -45,7 +45,8 @@
 				"certs": [
 					{
 						"customDomains": [
-							"analytics-stg.liferay.com"
+							"analytics-stg.liferay.com",
+							"ldp-stg.liferay.com"
 						]
 					}
 				],

--- a/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/LCP.json
+++ b/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/LCP.json
@@ -33,7 +33,8 @@
 				"certs": [
 					{
 						"customDomains": [
-							"analytics.liferay.com"
+							"analytics.liferay.com",
+							"ldp.liferay.com"
 						]
 					}
 				],


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100416
https://liferay.atlassian.net/browse/LPD-100417
https://liferay.atlassian.net/browse/LPD-100418

## What Is Being Fixed

The OSB Faro webserver only serves the `analytics*.liferay.com` custom domains, so the new `ldp*.liferay.com` domains cannot reach the STG, internal, and production environments.

## How It Is Being Fixed

Each environment's cert entry in `modules/wedeploy/common/webserver/LCP.json` gains an LDP custom domain alongside the existing analytics one: `ldp-stg.liferay.com` for STG (LPD-100416), `ldp-internal.liferay.com` for internal (LPD-100417), and `ldp.liferay.com` for production (LPD-100418).

## Why Are There No Tests?

The change is configuration only — it adds custom domain entries to the webserver's `LCP.json` with no code to exercise; domain routing is verified on the deployed environments.

## PR Check

**pr-check: PASS** — tested on `cd20363a6993724960738929a921c784eaa67639`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "cd20363a6993724960738929a921c784eaa67639"} -->
