### PR TITLE
LPD-100934 Redirect analytics domains to the new ldp domains

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-docker/cloud/configs/osgi/configs/com.liferay.redirect.internal.configuration.RedirectURLConfiguration.config
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-docker/cloud/configs/osgi/configs/com.liferay.redirect.internal.configuration.RedirectURLConfiguration.config
@@ -1,3 +1,3 @@
-allowedDomains=["localhost", "analytics.liferay.com", "analytics-internal.liferay.com", "analytics-stg.liferay.com"]
+allowedDomains=["localhost", "analytics.liferay.com", "analytics-internal.liferay.com", "analytics-stg.liferay.com", "ldp.liferay.com", "ldp-internal.liferay.com", "ldp-stg.liferay.com"]
 allowedIPs=["127.0.0.1", "SERVER_IP"]
 securityMode="domain"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-docker/cloud/portal-env.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-docker/cloud/portal-env.properties
@@ -1,8 +1,8 @@
 jdbc.default.driverClassName=org.mariadb.jdbc.Driver
 jdbc.default.url=jdbc:mariadb://database/lportal?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&useFastDateParsing=false
 jdbc.default.username=dxpcloud
-session.cookie.domain=analytics-stg.liferay.com
-web.server.host=analytics-stg.liferay.com
+session.cookie.domain=ldp-stg.liferay.com
+web.server.host=ldp-stg.liferay.com
 web.server.protocol=https
 jsonws.servlet.hosts.allowed=127.0.0.1,SERVER_IP
 webdav.servlet.hosts.allowed=127.0.0.1,SERVER_IP

--- a/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/configs/common/conf.d/liferay.conf
+++ b/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/configs/common/conf.d/liferay.conf
@@ -1,5 +1,15 @@
+set $redirect_host "";
+
 if ($host ~* ^analytics(-internal|-stg)?\.liferay\.com$) {
-    return 302 https://ldp$1.liferay.com$request_uri;
+    set $redirect_host "ldp$1.liferay.com";
+}
+
+if ($uri ~ ^/(api|endpoints|o)(/|$)) {
+    set $redirect_host "";
+}
+
+if ($redirect_host != "") {
+    return 302 https://$redirect_host$request_uri;
 }
 
 location / {

--- a/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/configs/common/conf.d/liferay.conf
+++ b/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/configs/common/conf.d/liferay.conf
@@ -1,3 +1,7 @@
+if ($host ~* ^analytics(-internal|-stg)?\.liferay\.com$) {
+    return 302 https://ldp$1.liferay.com$request_uri;
+}
+
 location / {
 
     fastcgi_read_timeout 60s;
@@ -27,7 +31,7 @@ location / {
 location = /robots.txt {
     add_header Content-Type text/plain;
 
-    if ($host ~* ^analytics-(internal|stg)\.liferay\.com$) {
+    if ($host ~* ^(analytics|ldp)-(internal|stg)\.liferay\.com$) {
         return 200 "User-Agent: *\nDisallow: /\n";
     }
 }

--- a/workspaces/liferay-osbfaro-workspace/modules/wedeploy/prd/LCP.json
+++ b/workspaces/liferay-osbfaro-workspace/modules/wedeploy/prd/LCP.json
@@ -5,7 +5,7 @@
 		"search"
 	],
 	"env": {
-		"FARO_URL": "https://analytics.liferay.com",
+		"FARO_URL": "https://ldp.liferay.com",
 		"ISSUES_EMAIL_ADDRESS": "ac-issues-trial@liferay.com",
 		"LCP_PROJECT_LIFERAY_CLUSTER_ENABLED": "true",
 		"OSB_API_PORT": 443,

--- a/workspaces/liferay-osbfaro-workspace/modules/wedeploy/prd/configs/portal-env.properties
+++ b/workspaces/liferay-osbfaro-workspace/modules/wedeploy/prd/configs/portal-env.properties
@@ -1,7 +1,7 @@
 javascript.single.page.application.enabled=false
 users.reminder.queries.enabled=false
 terms.of.use.required=false
-session.cookie.domain=analytics.liferay.com
+session.cookie.domain=ldp.liferay.com
 session.tracker.memory.enabled=false
 layout.user.private.layouts.enabled=false
 layout.user.public.layouts.enabled=false
@@ -23,7 +23,7 @@ search.container.page.delta.values=\
 com.liferay.portal.sharepoint.SharepointFilter=false
 com.liferay.portal.servlet.filters.strip.StripFilter=false
 com.liferay.portal.servlet.filters.i18n.I18nFilter=false
-web.server.host=analytics.liferay.com
+web.server.host=ldp.liferay.com
 web.server.protocol=https
 jsonws.servlet.hosts.allowed=127.0.0.1,SERVER_IP
 webdav.servlet.hosts.allowed=127.0.0.1,SERVER_IP
@@ -33,5 +33,5 @@ dl.file.entry.thumbnail.enabled=false
 portlet.css.enabled=false
 sites.control.panel.members.visible=false
 
-redirect.url.domains.allowed=analytics.liferay.com,localhost,SERVER_IP
+redirect.url.domains.allowed=ldp.liferay.com,analytics.liferay.com,localhost,SERVER_IP
 redirect.url.security.mode=domain


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100934

## What Is Being Fixed

Analytics Cloud is moving from the `analytics.liferay.com` domain family to `ldp.liferay.com`, but the old hostnames still served the application directly, so nothing steered traffic toward the new domain. The `/robots.txt` rule that keeps the nonproduction environments out of search indexes also matched only `analytics-internal` and `analytics-stg`, leaving the new `ldp` equivalents crawlable once they go live.

## How It Is Being Fixed

The webserver now returns a 302 from each analytics hostname to its `ldp` counterpart, preserving the request URI. A single regular expression covers `analytics`, `analytics-internal`, and `analytics-stg`, reusing the captured suffix to build the destination host rather than repeating the rule per environment.

Redirecting every request would break machine-to-machine traffic, since API clients are pinned to the old hostnames and do not necessarily follow redirects. Requests under `/api`, `/endpoints`, and `/o` therefore clear the redirect target and continue to be served on the analytics domains, while browser traffic moves to `ldp`.

The `/robots.txt` rule was widened to match both the `analytics-` and `ldp-` prefixes, so the internal and staging environments stay excluded from indexing on either domain.

## Why Are There No Tests?

This change is limited to the nginx webserver configuration, which has no automated test harness in the repository. The redirect behavior is verified manually against the deployed environments.

## PR Check

**pr-check: PASS** — tested on `6e8746938d7e6d52d60bda276845d92d39261f53`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "6e8746938d7e6d52d60bda276845d92d39261f53"} -->
