### PR TITLE
LPD-101439 Render the view all link only when the account id is known

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
@@ -27,22 +27,24 @@ const MostEngagedIndividuals: React.FC = () => {
 				<IndividualsDataSet preview />
 			</Card.Body>
 
-			<Card.Footer className="d-flex justify-content-end">
-				<ClayLink
-					borderless
-					button
-					className="button-root"
-					displayType="primary"
-					href={toRoute(Routes.CONTACTS_ACCOUNT_PROFILE, {
-						channelId,
-						groupId,
-						id,
-					})}
-					small
-				>
-					{Liferay.Language.get('view-all')}
-				</ClayLink>
-			</Card.Footer>
+			{id && (
+				<Card.Footer className="d-flex justify-content-end">
+					<ClayLink
+						borderless
+						button
+						className="button-root"
+						displayType="primary"
+						href={toRoute(Routes.CONTACTS_ACCOUNT_PROFILE, {
+							channelId,
+							groupId,
+							id,
+						})}
+						small
+					>
+						{Liferay.Language.get('view-all')}
+					</ClayLink>
+				</Card.Footer>
+			)}
 		</Card>
 	);
 };

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/IndividualsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/IndividualsDataSet.tsx
@@ -222,7 +222,7 @@ describe('getVisitorType', () => {
 	});
 
 	it('should read a single session as a first time visitor', () => {
-		expect(getVisitorType(1).label).toBe('First-Time');
+		expect(getVisitorType(1).label).toBe('First Time');
 	});
 
 	it('should read more than one session as a returning visitor', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/MostEngagedIndividuals.tsx
@@ -1,6 +1,7 @@
 import MostEngagedIndividuals from '../MostEngagedIndividuals';
 import React from 'react';
 import {cleanup, render, screen} from '@testing-library/react';
+import {useParams} from 'react-router-dom';
 
 jest.unmock('react-dom');
 
@@ -13,11 +14,21 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'),
-	useParams: () => ({channelId: '456', groupId: '23', id: 'acc-1'}),
+	useParams: jest.fn(),
 }));
+
+const mockedUseParams = useParams as jest.Mock;
 
 describe('MostEngagedIndividuals', () => {
 	afterEach(cleanup);
+
+	beforeEach(() => {
+		mockedUseParams.mockReturnValue({
+			channelId: '456',
+			groupId: '23',
+			id: 'acc-1',
+		});
+	});
 
 	it('should render the card title', () => {
 		render(<MostEngagedIndividuals />);
@@ -42,5 +53,15 @@ describe('MostEngagedIndividuals', () => {
 		expect(
 			screen.getByRole('link', {name: 'View All'}).getAttribute('href')
 		).toContain('/contacts/accounts/acc-1/profile');
+	});
+
+	it('should render no link while the account id is missing', () => {
+		mockedUseParams.mockReturnValue({channelId: '456', groupId: '23'});
+
+		render(<MostEngagedIndividuals />);
+
+		expect(
+			screen.queryByRole('link', {name: 'View All'})
+		).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101439

## What Is Being Fixed

The account Overview test that skips the individual metrics request while the account id is missing crashed instead of passing: `MostEngagedIndividuals` built the account profile route with an undefined `id` param, so `path-to-regexp` threw `Expected "id" to be defined` and the whole render failed. The individuals data set test was also asserting the old "First-Time" label after the language key was wordsmithed to "First Time".

## How It Is Being Fixed

`MostEngagedIndividuals` now renders the View All link only once the `id` route param is present, matching how the rest of the overview already tolerates the transient missing-id state (`skipRequest: !id`). Its test suite gains a case asserting no link renders while the id is missing, and the individuals data set test catches up with the wordsmithed label.

## PR Check

**pr-check: PASS** — tested on `03fcce0b0072961863162e0577d1cb924dde2341`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "03fcce0b0072961863162e0577d1cb924dde2341"} -->
