### PR TITLE
LPD-99030 Filter known individuals by segment in the Visitors tab

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownIndividualsListAssetQuery.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownIndividualsListAssetQuery.js
@@ -10,6 +10,7 @@ import {INDIVIDUALS_FRAGMENT} from 'shared/queries/fragments';
  */
 export default (queryName, metricName) => gql`
 		query KnownIndividualsListAssetQuery(
+			$accountId: String
 			$assetId: String!
 			$channelId: String
 			$devices: String
@@ -18,12 +19,14 @@ export default (queryName, metricName) => gql`
 			$rangeEnd: String
 			$rangeKey: Int
 			$rangeStart: String
+			$segmentId: String
 			$size: Int!
 			$start: Int!
 			$title: String
 			$touchpoint: String
 		) {
 			${queryName}(
+				accountId: $accountId
 				assetId: $assetId
 				canonicalUrl: $touchpoint
 				channelId: $channelId
@@ -32,6 +35,7 @@ export default (queryName, metricName) => gql`
 				rangeEnd: $rangeEnd
 				rangeKey: $rangeKey
 				rangeStart: $rangeStart
+				segmentId: $segmentId
 				title: $title
 			) {
 				${metricName} {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownIndividualsListTouchpointQuery.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownIndividualsListTouchpointQuery.js
@@ -10,6 +10,7 @@ import {INDIVIDUALS_FRAGMENT} from 'shared/queries/fragments';
  */
 export default (queryName, metricName) => gql`
 		query KnownIndividualsListTouchpointQuery(
+			$accountId: String
 			$channelId: String
 			$devices: String
 			$keywords: String
@@ -17,12 +18,14 @@ export default (queryName, metricName) => gql`
 			$rangeEnd: String
 			$rangeKey: Int
 			$rangeStart: String
+			$segmentId: String
 			$size: Int!
 			$start: Int!
 			$title: String
 			$touchpoint: String
 		) {
 			${queryName}(
+				accountId: $accountId
 				channelId: $channelId
 				canonicalUrl: $touchpoint
 				deviceType: $devices
@@ -30,6 +33,7 @@ export default (queryName, metricName) => gql`
 				rangeEnd: $rangeEnd
 				rangeKey: $rangeKey
 				rangeStart: $rangeStart
+				segmentId: $segmentId
 				title: $title
 			) {
 				${metricName} {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99030

## What Is Being Fixed

In the Visitors tab of the asset and page dashboards, the Known Individuals list ignored the segment (and account) filter, always showing the unfiltered set of individuals regardless of the segment selected in the dashboard's global filter.

## How It Is Being Fixed

The GraphQL query documents backing the list (`knownIndividualsListAssetQuery.js` and `knownIndividualsListTouchpointQuery.js`) never declared or forwarded `$accountId`/`$segmentId` to the underlying field. The client already computed and sent those variables in the request payload, but since the query text never referenced them, the analytics engine silently ignored them. This backports the fix already merged to master: declaring `$accountId`/`$segmentId` and passing them through to the query field, matching the working pattern used by `TouchpointsQuery.js`.

## Why Are There No Tests?

This is a straight cherry-pick of the master fix onto `faro-v5.0.x`; the master PR carries the rationale for the untested GraphQL query text (query documents in this module have no existing unit coverage pattern to extend).

## PR Check

**pr-check: SKIPPED** — this branch targets the `faro-v5.0.x` release branch, not `master`; the `pr-check` skill's rebase/diff preconditions are hardcoded to a `master` baseline and don't apply here. The change is an identical cherry-pick of the master fix, which was itself validated by `pr-check` (PASS).

<!-- pr-check {"reason": "targets faro-v5.0.x, not master; pr-check skill only supports a master baseline", "result": "skipped", "sha": "159c2d2d20c35914a007105ea7d1a5f11ae8a1a8"} -->
