### PR TITLE
LPD-99030 Filter known individuals by segment in the Visitors tab

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownIndividualsListAssetQuery.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownIndividualsListAssetQuery.js
@@ -10,6 +10,7 @@ import {INDIVIDUALS_FRAGMENT} from 'shared/queries/fragments';
  */
 export default (queryName, metricName) => gql`
 		query KnownIndividualsListAssetQuery(
+			$accountId: String
 			$assetId: String!
 			$channelId: String
 			$devices: String
@@ -18,12 +19,14 @@ export default (queryName, metricName) => gql`
 			$rangeEnd: String
 			$rangeKey: Int
 			$rangeStart: String
+			$segmentId: String
 			$size: Int!
 			$start: Int!
 			$title: String
 			$touchpoint: String
 		) {
 			${queryName}(
+				accountId: $accountId
 				assetId: $assetId
 				canonicalUrl: $touchpoint
 				channelId: $channelId
@@ -32,6 +35,7 @@ export default (queryName, metricName) => gql`
 				rangeEnd: $rangeEnd
 				rangeKey: $rangeKey
 				rangeStart: $rangeStart
+				segmentId: $segmentId
 				title: $title
 			) {
 				${metricName} {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownIndividualsListTouchpointQuery.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/knownIndividualsListTouchpointQuery.js
@@ -10,6 +10,7 @@ import {INDIVIDUALS_FRAGMENT} from 'shared/queries/fragments';
  */
 export default (queryName, metricName) => gql`
 		query KnownIndividualsListTouchpointQuery(
+			$accountId: String
 			$channelId: String
 			$devices: String
 			$keywords: String
@@ -17,12 +18,14 @@ export default (queryName, metricName) => gql`
 			$rangeEnd: String
 			$rangeKey: Int
 			$rangeStart: String
+			$segmentId: String
 			$size: Int!
 			$start: Int!
 			$title: String
 			$touchpoint: String
 		) {
 			${queryName}(
+				accountId: $accountId
 				channelId: $channelId
 				canonicalUrl: $touchpoint
 				deviceType: $devices
@@ -30,6 +33,7 @@ export default (queryName, metricName) => gql`
 				rangeEnd: $rangeEnd
 				rangeKey: $rangeKey
 				rangeStart: $rangeStart
+				segmentId: $segmentId
 				title: $title
 			) {
 				${metricName} {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99030

## What Is Being Fixed

In the Visitors tab of the asset and page dashboards, the Known Individuals list ignored the segment (and account) filter, always showing the unfiltered set of individuals regardless of the segment selected in the dashboard's global filter.

## How It Is Being Fixed

The GraphQL query documents backing the list (`knownIndividualsListAssetQuery.js` and `knownIndividualsListTouchpointQuery.js`) never declared or forwarded `$accountId`/`$segmentId` to the underlying field. The client already computed and sent those variables in the request payload, but since the query text never referenced them, the analytics engine silently ignored them. This declares `$accountId`/`$segmentId` and passes them through to the query field, matching the working pattern already used by `TouchpointsQuery.js`.

## Why Are There No Tests?

The query documents in this module have no existing unit test pattern to extend; coverage for the segment filter here would require an integration-level check against the external analytics engine, which is out of scope for this client-side query fix.

## PR Check

**pr-check: FAIL** — tested on `79ade572f522ad0f2f33ffd214e128997ca0637c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | FAIL |

The Workspace Build failure is `:modules:osb-faro-web:osbYarnTest`, specifically `Overview.tsx › metrics cards › should skip the request while the account id is missing`, throwing `TypeError: Expected "id" to be defined` from `path-to-regexp.ts` via `MostEngagedIndividuals.tsx`. This is unrelated to this change: verified by running the same test file against a clean `master` worktree (no changes applied), where it fails identically.

<!-- pr-check {"result": "failure", "sha": "79ade572f522ad0f2f33ffd214e128997ca0637c"} -->
