### PR TITLE
LPD-99794 | master [Faro] Add Lifecycle stage as segment criteria

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/constants/FieldMappingConstants.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/constants/FieldMappingConstants.java
@@ -52,6 +52,8 @@ public class FieldMappingConstants {
 
 	public static final String TYPE_NUMBER = "Number";
 
+	public static final String TYPE_SELECT_TEXT = "Select-Text";
+
 	public static final String TYPE_TEXT = "Text";
 
 	public static String getAccountFieldMappingLanguageKey(String fieldName) {
@@ -132,6 +134,8 @@ public class FieldMappingConstants {
 		).put(
 			"lastActivityDate", "last-activity-date"
 		).put(
+			"lifecycleStatus", "lifecycle-stage"
+		).put(
 			"numberOfEmployees", "number-of-employees"
 		).put(
 			"state", "state"
@@ -150,6 +154,8 @@ public class FieldMappingConstants {
 			new FieldMappingMap("industry", "industry", TYPE_TEXT),
 			new FieldMappingMap(
 				"lastActivityDate", "lastActivityDate", TYPE_DATE),
+			new FieldMappingMap(
+				"lifecycleStatus", "lifecycleStatus", TYPE_SELECT_TEXT),
 			new FieldMappingMap(
 				"numberOfEmployees", "numberOfEmployees", TYPE_NUMBER),
 			new FieldMappingMap("state", "state", TYPE_TEXT),

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/SchemaOrgUtil.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/util/SchemaOrgUtil.java
@@ -45,6 +45,11 @@ public class SchemaOrgUtil {
 			return FieldMappingConstants.TYPE_NUMBER;
 		}
 		else if (StringUtil.equalsIgnoreCase(
+					type, FieldMappingConstants.TYPE_SELECT_TEXT)) {
+
+			return FieldMappingConstants.TYPE_SELECT_TEXT;
+		}
+		else if (StringUtil.equalsIgnoreCase(
 					type, FieldMappingConstants.TYPE_TEXT)) {
 
 			return FieldMappingConstants.TYPE_TEXT;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
@@ -27,22 +27,24 @@ const MostEngagedIndividuals: React.FC = () => {
 				<IndividualsDataSet preview />
 			</Card.Body>
 
-			<Card.Footer className="d-flex justify-content-end">
-				<ClayLink
-					borderless
-					button
-					className="button-root"
-					displayType="primary"
-					href={toRoute(Routes.CONTACTS_ACCOUNT_PROFILE, {
-						channelId,
-						groupId,
-						id,
-					})}
-					small
-				>
-					{Liferay.Language.get('view-all')}
-				</ClayLink>
-			</Card.Footer>
+			{id && (
+				<Card.Footer className="d-flex justify-content-end">
+					<ClayLink
+						borderless
+						button
+						className="button-root"
+						displayType="primary"
+						href={toRoute(Routes.CONTACTS_ACCOUNT_PROFILE, {
+							channelId,
+							groupId,
+							id,
+						})}
+						small
+					>
+						{Liferay.Language.get('view-all')}
+					</ClayLink>
+				</Card.Footer>
+			)}
 		</Card>
 	);
 };

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/IndividualsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/IndividualsDataSet.tsx
@@ -222,7 +222,7 @@ describe('getVisitorType', () => {
 	});
 
 	it('should read a single session as a first time visitor', () => {
-		expect(getVisitorType(1).label).toBe('First-Time');
+		expect(getVisitorType(1).label).toBe('First Time');
 	});
 
 	it('should read more than one session as a returning visitor', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/display-components/AccountDisplay.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/display-components/AccountDisplay.tsx
@@ -1,3 +1,4 @@
+import LifecycleStageDisplay from './LifecycleStageDisplay';
 import React from 'react';
 import {CustomValue} from 'shared/util/records';
 import {
@@ -11,6 +12,7 @@ import {
 } from '../utils';
 import {IDisplayComponentProps} from '../types';
 import {isOfKnownType} from 'segment/segment-editor/dynamic/utils/utils';
+import {PropertyTypes} from 'segment/segment-editor/dynamic/utils/constants';
 
 const AccountDisplay: React.FC<IDisplayComponentProps> = ({
 	criterion,
@@ -21,7 +23,11 @@ const AccountDisplay: React.FC<IDisplayComponentProps> = ({
 
 	const {entityName, label, type} = property;
 
-	const operatorName = getOperator(valueIMap, 0);
+	const selectText = type === PropertyTypes.AccountSelectText;
+
+	const operatorName = selectText
+		? criterion.operatorName ?? ''
+		: getOperator(valueIMap, 0);
 	const value = getPropertyValue(valueIMap, 'value', 0);
 
 	const operatorKey = maybeFormatToKnownType(operatorName, value);
@@ -36,9 +42,12 @@ const AccountDisplay: React.FC<IDisplayComponentProps> = ({
 
 			<span>{operatorLabel}</span>
 
-			{!isOfKnownType(operatorKey) && (
-				<b>{maybeFormatValue(value, type, timeZoneId)}</b>
-			)}
+			{!isOfKnownType(operatorKey) &&
+				(selectText ? (
+					<LifecycleStageDisplay label={label} value={value} />
+				) : (
+					<b>{maybeFormatValue(value, type, timeZoneId)}</b>
+				))}
 		</>
 	);
 };

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/display-components/LifecycleStageDisplay.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/display-components/LifecycleStageDisplay.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {sub} from 'shared/util/lang';
+import {useLifecycleStageOptions} from 'shared/hooks/useLifecycleStageOptions';
+import {useParams} from 'react-router-dom';
+
+const LifecycleStageDisplay: React.FC<{label: string; value: string}> = ({
+	label,
+	value,
+}) => {
+	const {groupId} = useParams<{groupId: string}>();
+
+	const {loading, options} = useLifecycleStageOptions({groupId});
+
+	const option = options.find(({value: stageId}) => stageId === value);
+
+	if (option) {
+		return <b>{`'${option.label}'`}</b>;
+	}
+
+	if (loading) {
+		return null;
+	}
+
+	return (
+		<b className="undefined-entity">
+			{sub(Liferay.Language.get('undefined-x'), [label])}
+		</b>
+	);
+};
+
+export default LifecycleStageDisplay;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/display-components/__tests__/AccountDisplay.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/display-components/__tests__/AccountDisplay.jsx
@@ -1,14 +1,17 @@
+import * as API from 'shared/api';
 import * as data from 'test/data';
 import AccountDisplay from '../AccountDisplay';
 import React from 'react';
 import {
 	CustomFunctionOperators,
+	NotOperators,
 	PropertyTypes,
 	RelationalOperators
 } from 'segment/segment-editor/dynamic/utils/constants';
 import {List, Map} from 'immutable';
 import {Property} from 'shared/util/records';
-import {render} from '@testing-library/react';
+import {render, waitFor} from '@testing-library/react';
+import {StaticRouter} from 'react-router';
 
 jest.unmock('react-dom');
 
@@ -45,6 +48,146 @@ describe('AccountDisplay', () => {
 		);
 
 		expect(container).toMatchSnapshot();
+	});
+
+	it('renders the label of the lifecycle stage', async () => {
+		API.lifecycle.fetchAccountLifecycles.mockReturnValueOnce(
+			Promise.resolve([{id: '1'}])
+		);
+
+		API.lifecycle.fetchLifecycle.mockReturnValueOnce(
+			Promise.resolve({
+				stages: [{displayOrder: 1, id: '1002', stageType: 'ENGAGED'}]
+			})
+		);
+
+		const criterion = {
+			operatorName: CustomFunctionOperators.AccountsFilter,
+			propertyName: 'lifecycleStatus',
+			value: Map({
+				criterionGroup: Map({
+					items: List([
+						Map({
+							operatorName: RelationalOperators.EQ,
+							propertyName: 'lifecycleStatus',
+							value: '1002'
+						})
+					])
+				})
+			})
+		};
+
+		const property = data.getImmutableMock(Property, data.mockProperty, 1, {
+			entityName: 'Account',
+			label: 'Lifecycle Stage',
+			name: 'lifecycleStatus',
+			propertykey: 'account',
+			type: PropertyTypes.AccountSelectText
+		});
+
+		const {container} = render(
+			<StaticRouter>
+				<AccountDisplay criterion={criterion} property={property} />
+			</StaticRouter>
+		);
+
+		await waitFor(() => expect(container).toHaveTextContent("'Engaged'"));
+
+		expect(container).not.toHaveTextContent('1002');
+	});
+
+	it('renders the is not operator of a lifecycle stage criterion', async () => {
+		API.lifecycle.fetchAccountLifecycles.mockReturnValueOnce(
+			Promise.resolve([{id: '1'}])
+		);
+
+		API.lifecycle.fetchLifecycle.mockReturnValueOnce(
+			Promise.resolve({
+				stages: [{displayOrder: 1, id: '1002', stageType: 'ENGAGED'}]
+			})
+		);
+
+		const criterion = {
+			operatorName: NotOperators.NotAccountsFilter,
+			propertyName: 'lifecycleStatus',
+			value: Map({
+				criterionGroup: Map({
+					items: List([
+						Map({
+							operatorName: RelationalOperators.EQ,
+							propertyName: 'lifecycleStatus',
+							value: '1002'
+						})
+					])
+				})
+			})
+		};
+
+		const property = data.getImmutableMock(Property, data.mockProperty, 1, {
+			entityName: 'Account',
+			label: 'Lifecycle Stage',
+			name: 'lifecycleStatus',
+			propertykey: 'account',
+			type: PropertyTypes.AccountSelectText
+		});
+
+		const {container} = render(
+			<StaticRouter>
+				<AccountDisplay criterion={criterion} property={property} />
+			</StaticRouter>
+		);
+
+		await waitFor(() => expect(container).toHaveTextContent("'Engaged'"));
+
+		expect(container).toHaveTextContent('is not');
+	});
+
+	it('renders the undefined label when the lifecycle stage is gone', async () => {
+		API.lifecycle.fetchAccountLifecycles.mockReturnValueOnce(
+			Promise.resolve([{id: '1'}])
+		);
+
+		API.lifecycle.fetchLifecycle.mockReturnValueOnce(
+			Promise.resolve({
+				stages: [{displayOrder: 1, id: '1002', stageType: 'ENGAGED'}]
+			})
+		);
+
+		const criterion = {
+			operatorName: CustomFunctionOperators.AccountsFilter,
+			propertyName: 'lifecycleStatus',
+			value: Map({
+				criterionGroup: Map({
+					items: List([
+						Map({
+							operatorName: RelationalOperators.EQ,
+							propertyName: 'lifecycleStatus',
+							value: 'deleted-stage'
+						})
+					])
+				})
+			})
+		};
+
+		const property = data.getImmutableMock(Property, data.mockProperty, 1, {
+			entityName: 'Account',
+			label: 'Lifecycle Stage',
+			name: 'lifecycleStatus',
+			propertykey: 'account',
+			type: PropertyTypes.AccountSelectText
+		});
+
+		const {container} = render(
+			<StaticRouter>
+				<AccountDisplay criterion={criterion} property={property} />
+			</StaticRouter>
+		);
+
+		await waitFor(() =>
+			expect(container.querySelector('.undefined-entity')).toBeTruthy()
+		);
+
+		expect(container).not.toHaveTextContent('deleted-stage');
 	});
 
 	it('renders w/ a unknownType', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/utils.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/utils.ts
@@ -51,6 +51,7 @@ export function getOperatorLabel(
 		case PropertyTypes.SessionGeolocation:
 			supportedOperators = GEOLOCATION_OPTIONS;
 			break;
+		case PropertyTypes.AccountSelectText:
 		case PropertyTypes.Behavior:
 		case PropertyTypes.Boolean:
 		case PropertyTypes.Date:

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/AccountProfile.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/AccountProfile.tsx
@@ -2,12 +2,14 @@ import * as breadcrumbs from 'shared/util/breadcrumbs';
 import AccountsDataSet from 'shared/components/accounts-data-set/AccountsDataSet';
 import BasePage from 'shared/components/base-page';
 import CriteriaCard from 'segment/components/criteria-card';
+import EmbeddedAlertList from 'shared/components/EmbeddedAlertList';
 import React from 'react';
 import {CSVType} from 'shared/components/download-report/utils';
 import {DownloadStaticCSVReport} from 'shared/components/download-report/DownloadStaticCSVReport';
 import {ReferencedObjectsProvider} from 'segment/segment-editor/dynamic/context/referencedObjects';
 import {Routes, SEGMENTS, toRoute} from 'shared/util/router';
 import {SectionHeader} from 'shared/components/SectionHeader';
+import {getSegmentAlerts} from 'segment/utils/alerts';
 import {Segment} from 'shared/util/records';
 import {SegmentStates, SegmentTypes} from 'shared/util/constants';
 import {useChannelContext} from 'shared/context/channel';
@@ -28,6 +30,8 @@ const AccountProfile: React.FC<IAccountProfileProps> = ({
 	const {timeZoneId} = useTimeZone();
 
 	const {name} = segment;
+
+	const disabled = segment.state === SegmentStates.Disabled;
 
 	return (
 		<BasePage
@@ -81,7 +85,7 @@ const AccountProfile: React.FC<IAccountProfileProps> = ({
 			<BasePage.SubHeader>
 				<div className="d-flex justify-content-end w-100">
 					<DownloadStaticCSVReport
-						disabled={segment.state === SegmentStates.Disabled}
+						disabled={disabled}
 						segmentId={segment.id}
 						type={CSVType.Membership}
 						typeLang={Liferay.Language.get('segment-membership')}
@@ -89,7 +93,9 @@ const AccountProfile: React.FC<IAccountProfileProps> = ({
 				</div>
 			</BasePage.SubHeader>
 
-			<BasePage.Body>
+			<EmbeddedAlertList alerts={getSegmentAlerts(segment)} />
+
+			<BasePage.Body disabled={disabled}>
 				<SectionHeader
 					icon="analytics"
 					title={Liferay.Language.get('details')}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/ProfileRoutes.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/ProfileRoutes.jsx
@@ -16,11 +16,11 @@ import React, {
 	useState
 } from 'react';
 import RouteNotFound from 'shared/components/RouteNotFound';
-import {AlertTypes} from 'shared/components/Alert';
 import {ChannelContext} from 'shared/context/channel';
 import {CSVType} from 'shared/components/download-report/utils';
 import {DownloadStaticCSVReport} from 'shared/components/download-report/DownloadStaticCSVReport';
 import {getMatchedRoute, Routes, SEGMENTS, toRoute} from 'shared/util/router';
+import {getSegmentAlerts} from 'segment/utils/alerts';
 import {Segment} from 'shared/util/records';
 import {
 	SegmentCategories,
@@ -149,30 +149,6 @@ export const SegmentProfileRoutes = () => {
 
 	const checkDisabled = () => segment.state === SegmentStates.Disabled;
 
-	const getAlerts = () => {
-		if (segment.state === SegmentStates.InProgress) {
-			return [
-				{
-					alertType: AlertTypes.Info,
-					message: Liferay.Language.get(
-						'segment-data-is-processing-please-check-back-later'
-					),
-					stripe: true
-				}
-			];
-		} else if (checkDisabled()) {
-			return [
-				{
-					alertType: AlertTypes.Danger,
-					message: Liferay.Language.get(
-						'this-segment-is-disabled-because-some-criteria-has-been-affected-by-removal-of-a-data-source.-to-continue-using-this-segment-please-update-the-criteria'
-					),
-					stripe: true
-				}
-			];
-		}
-	};
-
 	const isBatch = segmentDetails.segmentType === SegmentTypes.Batch;
 
 	return (
@@ -268,7 +244,7 @@ export const SegmentProfileRoutes = () => {
 					</BasePage.SubHeader>
 				)}
 
-			<EmbeddedAlertList alerts={getAlerts()} />
+			<EmbeddedAlertList alerts={getSegmentAlerts(segment)} />
 
 			<BasePage.Body disabled={checkDisabled()}>
 				{segment.id ? (

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/__tests__/AccountProfile.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/__tests__/AccountProfile.tsx
@@ -8,7 +8,7 @@ import {mockChannelContext} from 'test/mock-channel-context';
 import {mockSegment} from 'test/data';
 import {Provider} from 'react-redux';
 import {Segment} from 'shared/util/records';
-import {SegmentCategories} from 'shared/util/constants';
+import {SegmentCategories, SegmentStates} from 'shared/util/constants';
 import {StaticRouter} from 'react-router';
 
 jest.unmock('react-dom');
@@ -91,6 +91,32 @@ describe('AccountProfile', () => {
 		expect(screen.getByRole('heading', {name: 'Seattle0'})).toBeTruthy();
 		expect(screen.getByText('Account Batch Segment')).toBeTruthy();
 		expect(screen.getByText('ERC: my-erc')).toBeTruthy();
+	});
+
+	it('should warn that the membership is still being processed', () => {
+		renderAccountProfile({state: SegmentStates.InProgress});
+
+		expect(
+			screen.getByText(
+				'Segment data is processing, please check back later.'
+			)
+		).toBeTruthy();
+	});
+
+	it('should warn that the segment is disabled', () => {
+		renderAccountProfile({state: SegmentStates.Disabled});
+
+		expect(
+			screen.getByText(
+				'This segment is disabled because some criteria has been affected by removal of a data source. To continue using this segment please update the criteria.'
+			)
+		).toBeTruthy();
+	});
+
+	it('should not show any alert when the segment is ready', () => {
+		const {container} = renderAccountProfile({state: SegmentStates.Ready});
+
+		expect(container.querySelector('.alert')).toBeNull();
 	});
 
 	it('should link to the segment editor', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-builder/CriteriaRow.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-builder/CriteriaRow.tsx
@@ -1,4 +1,5 @@
 import AccountInput from '../inputs/AccountInput';
+import AccountSelectInput from '../inputs/AccountSelectInput';
 import BehaviorInput from '../inputs/BehaviorInput';
 import BooleanInput from '../inputs/BooleanInput';
 import ClayIcon from '@clayui/icon';
@@ -459,6 +460,7 @@ class CriteriaRow extends React.Component<
 			[PropertyTypes.Boolean]: BooleanInput,
 			[PropertyTypes.Vocabulary]: VocabularyInput,
 			[PropertyTypes.AccountDate]: AccountInput,
+			[PropertyTypes.AccountSelectText]: AccountSelectInput,
 			[PropertyTypes.AccountNumber]: AccountInput,
 			[PropertyTypes.AccountText]: AccountInput,
 			[PropertyTypes.Date]: DateInput,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/CriteriaSidebarCollapse.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/CriteriaSidebarCollapse.tsx
@@ -92,6 +92,7 @@ export const getDefaultValue = (property: Property): any => {
 					],
 				},
 			]);
+		case PropertyTypes.AccountSelectText:
 		case PropertyTypes.AccountNumber:
 		case PropertyTypes.AccountText:
 		case PropertyTypes.OrganizationSelectText:

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/CriteriaSidebarItem.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/criteria-sidebar/CriteriaSidebarItem.tsx
@@ -12,6 +12,7 @@ const TYPE_ICON_MAP = {
 	[PropertyTypes.Behavior]: 'click',
 	[PropertyTypes.Boolean]: 'check',
 	[PropertyTypes.AccountDate]: 'date',
+	[PropertyTypes.AccountSelectText]: 'text',
 	[PropertyTypes.AccountNumber]: 'integer',
 	[PropertyTypes.AccountText]: 'text',
 	[PropertyTypes.Date]: 'date',
@@ -81,6 +82,7 @@ export const beginDrag = ({
 	}
 	else if (
 		[
+			PropertyTypes.AccountSelectText,
 			PropertyTypes.AccountNumber,
 			PropertyTypes.AccountText,
 			PropertyTypes.Duration,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/AccountSelectInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/AccountSelectInput.tsx
@@ -1,0 +1,63 @@
+import Form from 'shared/components/form';
+import React from 'react';
+import {getPropertyValue, setPropertyValue} from '../utils/custom-inputs';
+import {ISegmentEditorCustomInputBase} from '../utils/types';
+import {Option, Picker} from '@clayui/core';
+import {useLifecycleStageOptions} from 'shared/hooks/useLifecycleStageOptions';
+
+interface IAccountSelectProps extends ISegmentEditorCustomInputBase {
+	groupId: string;
+	operatorRenderer: React.ElementType;
+}
+
+const AccountSelectInput: React.FC<IAccountSelectProps> = ({
+	displayValue,
+	groupId,
+	onChange,
+	operatorRenderer: OperatorDropdown,
+	property,
+	value,
+}) => {
+	const {options} = useLifecycleStageOptions({groupId});
+
+	return (
+		<div className="account-select-input-root criteria-statement">
+			<Form.Group autoFit>
+				<Form.GroupItem className="entity-name" label shrink>
+					{property.entityName}
+				</Form.GroupItem>
+
+				<Form.GroupItem className="display-value" label shrink>
+					{displayValue}
+				</Form.GroupItem>
+
+				<OperatorDropdown />
+
+				<Form.GroupItem>
+					<Picker
+						disabled={options.length === 0}
+						items={options}
+						onSelectionChange={(stageId) =>
+							onChange({
+								valid: true,
+								value: setPropertyValue(
+									value,
+									'value',
+									0,
+									String(stageId)
+								),
+							})
+						}
+						selectedKey={getPropertyValue(value, 'value', 0)}
+					>
+						{({label, value}) => (
+							<Option key={value}>{label}</Option>
+						)}
+					</Picker>
+				</Form.GroupItem>
+			</Form.Group>
+		</div>
+	);
+};
+
+export default AccountSelectInput;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/__tests__/AccountSelectInput.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/__tests__/AccountSelectInput.jsx
@@ -1,0 +1,99 @@
+import * as API from 'shared/api';
+import AccountSelectInput from '../AccountSelectInput';
+import React from 'react';
+import {cleanup, fireEvent, render, waitFor} from '@testing-library/react';
+import {createCustomValueMap} from '../../utils/custom-inputs';
+import {Property} from 'shared/util/records';
+import {PropertyTypes} from '../../utils/constants';
+
+jest.unmock('react-dom');
+
+const mockValue = createCustomValueMap([
+	{key: 'criterionGroup', value: [{operatorName: 'eq', value: '1002'}]}
+]);
+
+const defaultProps = {
+	displayValue: 'Lifecycle Stage',
+	groupId: '123',
+	onChange: jest.fn(),
+	operatorRenderer: () => <div>{'is'}</div>,
+	property: new Property({
+		entityName: 'Account',
+		label: 'Lifecycle Stage',
+		name: 'lifecycleStatus',
+		type: PropertyTypes.AccountSelectText
+	}),
+	value: mockValue
+};
+
+const DefaultComponent = props => (
+	<AccountSelectInput {...defaultProps} {...props} />
+);
+
+describe('AccountSelectInput', () => {
+	afterEach(cleanup);
+
+	beforeEach(() => {
+		API.lifecycle.fetchAccountLifecycles.mockReturnValue(
+			Promise.resolve([{id: '1'}])
+		);
+
+		API.lifecycle.fetchLifecycle.mockReturnValue(
+			Promise.resolve({
+				stages: [
+					{displayOrder: 2, id: '1002', stageType: 'ENGAGED'},
+					{displayOrder: 1, id: '1001', stageType: 'AWARE'}
+				]
+			})
+		);
+	});
+
+	it('should render the entity, the property and the operator of the criterion', () => {
+		const {getAllByText, getByText} = render(<DefaultComponent />);
+
+		expect(getByText('Account')).toBeTruthy();
+		expect(getAllByText('Lifecycle Stage')[0]).toBeTruthy();
+		expect(getByText('is')).toBeTruthy();
+	});
+
+	it('should render the stage of the selected id', async () => {
+		const {getByText} = render(<DefaultComponent />);
+
+		await waitFor(() => expect(getByText('Engaged')).toBeTruthy());
+	});
+
+	it('should render the stages of the lifecycle sorted by display order', async () => {
+		const {getAllByRole, getByText} = render(<DefaultComponent />);
+
+		await waitFor(() => expect(getByText('Engaged')).toBeTruthy());
+
+		fireEvent.click(getByText('Engaged'));
+
+		const options = getAllByRole('option');
+
+		expect(options[0]).toHaveTextContent('Aware');
+		expect(options[1]).toHaveTextContent('Engaged');
+	});
+
+	it('should store the id of the selected stage', async () => {
+		const onChange = jest.fn();
+
+		const {getAllByRole, getByText} = render(
+			<DefaultComponent onChange={onChange} />
+		);
+
+		await waitFor(() => expect(getByText('Engaged')).toBeTruthy());
+
+		fireEvent.click(getByText('Engaged'));
+		fireEvent.click(getAllByRole('option')[0]);
+
+		expect(
+			onChange.mock.calls[0][0].value.getIn([
+				'criterionGroup',
+				'items',
+				0,
+				'value'
+			])
+		).toBe('1001');
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/__tests__/odata.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/__tests__/odata.js
@@ -712,6 +712,20 @@ describe('odata', () => {
 			testConversionToAndFrom(testQuery);
 		});
 
+		it('should be able to translate a query string with a lifecycle stage to map and back to string', () => {
+			const testQuery =
+				"(accounts.filter(filter='(lifecycleStatus eq ''1002'')'))";
+
+			testConversionToAndFrom(testQuery);
+		});
+
+		it('should be able to translate a query string without a lifecycle stage to map and back to string', () => {
+			const testQuery =
+				"((not accounts.filter(filter='(lifecycleStatus eq ''1002'')')))";
+
+			testConversionToAndFrom(testQuery);
+		});
+
 		it('should be able to translate a query string with "not accounts.filter" to map and back to string', () => {
 			const testQuery =
 				"((not accounts.filter(filter='(activityKey eq ''Page#pageViewed#348853654381438580'')')))";

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/constants.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/constants.ts
@@ -130,6 +130,7 @@ export enum RelationalOperators {
 export enum PropertyTypes {
 	AccountDate = 'account-date',
 	AccountNumber = 'account-number',
+	AccountSelectText = 'account-select-text',
 	AccountText = 'account-text',
 	Behavior = 'behavior',
 	Boolean = 'boolean',
@@ -199,6 +200,18 @@ export const SUPPORTED_OPERATORS_MAP = {
 			key: CustomFunctionOperators.AccountsFilter,
 			label: Liferay.Language.get('is').toLowerCase(),
 			name: CustomFunctionOperators.AccountsFilter,
+		},
+	],
+	[PropertyTypes.AccountSelectText]: [
+		{
+			key: CustomFunctionOperators.AccountsFilter,
+			label: Liferay.Language.get('is').toLowerCase(),
+			name: CustomFunctionOperators.AccountsFilter,
+		},
+		{
+			key: NotOperators.NotAccountsFilter,
+			label: Liferay.Language.get('is-not').toLowerCase(),
+			name: NotOperators.NotAccountsFilter,
 		},
 	],
 	[PropertyTypes.AccountText]: [
@@ -472,6 +485,10 @@ export const SUPPORTED_OPERATORS_MAP = {
 export const SUPPORTED_PROPERTY_TYPES_MAP = {
 	[PropertyTypes.AccountDate]: [CustomFunctionOperators.AccountsFilter],
 	[PropertyTypes.AccountNumber]: [CustomFunctionOperators.AccountsFilter],
+	[PropertyTypes.AccountSelectText]: [
+		CustomFunctionOperators.AccountsFilter,
+		NotOperators.NotAccountsFilter,
+	],
 	[PropertyTypes.AccountText]: [CustomFunctionOperators.AccountsFilter],
 	[PropertyTypes.Behavior]: [
 		CustomFunctionOperators.ActivitiesFilterByCount,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/properties/account-properties.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/properties/account-properties.ts
@@ -68,6 +68,11 @@ const ACCOUNT_PROPERTIES = List(
 			type: PropertyTypes.AccountDate,
 		},
 		{
+			label: Liferay.Language.get('lifecycle-stage'),
+			name: 'lifecycleStatus',
+			type: PropertyTypes.AccountSelectText,
+		},
+		{
 			label: Liferay.Language.get('number-of-employees'),
 			name: 'numberOfEmployees',
 			type: PropertyTypes.AccountNumber,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/utils/alerts.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/utils/alerts.ts
@@ -1,0 +1,31 @@
+import {AlertTypes} from 'shared/components/Alert';
+import {Segment} from 'shared/util/records';
+import {SegmentStates} from 'shared/util/constants';
+
+export const getSegmentAlerts = (segment: Segment) => {
+	if (segment.state === SegmentStates.InProgress) {
+		return [
+			{
+				alertType: AlertTypes.Info,
+				message: Liferay.Language.get(
+					'segment-data-is-processing-please-check-back-later'
+				),
+				stripe: true,
+			},
+		];
+	}
+
+	if (segment.state === SegmentStates.Disabled) {
+		return [
+			{
+				alertType: AlertTypes.Danger,
+				message: Liferay.Language.get(
+					'this-segment-is-disabled-because-some-criteria-has-been-affected-by-removal-of-a-data-source.-to-continue-using-this-segment-please-update-the-criteria'
+				),
+				stripe: true,
+			},
+		];
+	}
+
+	return [];
+};

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/__mocks__/index.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/__mocks__/index.js
@@ -16,6 +16,7 @@ import * as individuals from './individuals';
 import * as individualSegment from './individual-segment';
 import * as interests from './interests';
 import * as issue from './issue';
+import * as lifecycle from './lifecycle';
 import * as notifications from './notifications';
 import * as pagesVisited from './pages-visited';
 import * as preferences from './preferences';
@@ -43,6 +44,7 @@ export {
 	individualSegment,
 	interests,
 	issue,
+	lifecycle,
 	notifications,
 	pagesVisited,
 	preferences,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/__mocks__/lifecycle.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/__mocks__/lifecycle.ts
@@ -1,0 +1,3 @@
+export const fetchAccountLifecycles = jest.fn(() => Promise.resolve([]));
+
+export const fetchLifecycle = jest.fn(() => Promise.resolve({stages: []}));

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/__tests__/useLifecycleStageOptions.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/__tests__/useLifecycleStageOptions.jsx
@@ -1,0 +1,73 @@
+import * as API from 'shared/api';
+import {renderHook, waitFor} from '@testing-library/react';
+import {useLifecycleStageOptions} from 'shared/hooks/useLifecycleStageOptions';
+
+jest.unmock('react-dom');
+
+describe('useLifecycleStageOptions', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should return the stages of the lifecycle sorted by display order', async () => {
+		API.lifecycle.fetchAccountLifecycles.mockReturnValueOnce(
+			Promise.resolve([{id: '1'}])
+		);
+
+		API.lifecycle.fetchLifecycle.mockReturnValueOnce(
+			Promise.resolve({
+				stages: [
+					{displayOrder: 2, id: '1002', stageType: 'ENGAGED'},
+					{displayOrder: 1, id: '1001', stageType: 'AWARE'}
+				]
+			})
+		);
+
+		const {result} = renderHook(() =>
+			useLifecycleStageOptions({groupId: '123'})
+		);
+
+		await waitFor(() =>
+			expect(result.current.options).toEqual([
+				{label: 'Aware', value: '1001'},
+				{label: 'Engaged', value: '1002'}
+			])
+		);
+
+		expect(result.current.loading).toBe(false);
+	});
+
+	it('should return the stage type of an unknown stage', async () => {
+		API.lifecycle.fetchAccountLifecycles.mockReturnValueOnce(
+			Promise.resolve([{id: '1'}])
+		);
+
+		API.lifecycle.fetchLifecycle.mockReturnValueOnce(
+			Promise.resolve({
+				stages: [{displayOrder: 1, id: '1001', stageType: 'CONVERTED'}]
+			})
+		);
+
+		const {result} = renderHook(() =>
+			useLifecycleStageOptions({groupId: '123'})
+		);
+
+		await waitFor(() =>
+			expect(result.current.options).toEqual([
+				{label: 'CONVERTED', value: '1001'}
+			])
+		);
+	});
+
+	it('should return no options without a lifecycle', async () => {
+		const {result} = renderHook(() =>
+			useLifecycleStageOptions({groupId: '123'})
+		);
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.options).toEqual([]);
+
+		expect(API.lifecycle.fetchLifecycle).not.toHaveBeenCalled();
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/useLifecycleStageOptions.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/useLifecycleStageOptions.ts
@@ -1,0 +1,44 @@
+import * as API from 'shared/api';
+import {ILifecycleStage} from 'shared/api/lifecycle';
+import {
+	LifecycleStages,
+	lifecycleStagesLabelMap,
+} from 'contacts/pages/account/utils/constants';
+import {useRequest} from 'shared/hooks/useRequest';
+
+export const useLifecycleStageOptions = ({
+	groupId,
+}: {
+	groupId: string;
+}): {loading: boolean; options: {label: string; value: string}[]} => {
+	const {data: lifecycles, loading: lifecyclesLoading} = useRequest({
+		dataSourceFn: API.lifecycle.fetchAccountLifecycles,
+		variables: {groupId},
+	});
+
+	const lifecycle = lifecycles?.[0];
+
+	const {data: lifecycleDetail, loading: lifecycleDetailLoading} = useRequest(
+		{
+			dataSourceFn: API.lifecycle.fetchLifecycle,
+			skipRequest: !lifecycle,
+			variables: {groupId, lifecycleId: lifecycle?.id ?? ''},
+		}
+	);
+
+	const stages: ILifecycleStage[] = lifecycleDetail?.stages ?? [];
+
+	return {
+		loading:
+			lifecyclesLoading || (Boolean(lifecycle) && lifecycleDetailLoading),
+		options: stages
+			.slice()
+			.sort((a, b) => a.displayOrder - b.displayOrder)
+			.map(({id, stageType}) => ({
+				label:
+					lifecycleStagesLabelMap[stageType as LifecycleStages]
+						?.label ?? stageType,
+				value: id,
+			})),
+	};
+};


### PR DESCRIPTION
Motivation
----

https://liferay.atlassian.net/browse/LPD-99794

Proposed Solution
----

We add **Lifecycle Stage** as an Account attribute in the segment editor, available in both the Individual and the Account segment builders. It is served as an account field mapping, so the criteria sidebar picks it up like any other account field, and it follows the organization select criteria: the operators of the criterion are the ones of the filter, so "is not" reads as not having any account in that stage.

The criterion stores the id of the lifecycle stage, which is what the engine compares against, while the editor and the criteria card show the label of its stage type. If a lifecycle is deleted and created again its stage ids change, so a saved criterion may point to a stage that no longer exists: it then reads as an undefined attribute instead of showing the raw id.

Along the way we noticed that the account segment profile returns before the alerts of the segment profile are built, so neither the processing notice nor the disabled warning ever reached an account segment. We extracted those alerts and both profiles now read them from the same place.