### PR TITLE
LPD-101053 Abbreviate metric card counts with toThousands

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/hoc/segment/InterestsCard.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/hoc/segment/InterestsCard.jsx
@@ -60,6 +60,7 @@ const TableWithData = withTableData(withData, {
 			sortable: false
 		}),
 		compositionListColumns.getRelativeMetricBar({
+			abbreviateCount: true,
 			label: Liferay.Language.get('segment-members'),
 			maxCount,
 			totalCount

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
@@ -26,7 +26,7 @@ import {mapEventMetricToActivityHistory} from 'shared/util/activities';
 import {mapListResultsToProps} from 'shared/util/mappers';
 import {SessionEntityTypes} from 'shared/util/constants';
 import {sub} from 'shared/util/lang';
-import {toLocale} from 'shared/util/numbers';
+import {toThousands} from 'shared/util/numbers';
 import {useParams} from 'react-router-dom';
 import {useQuery} from '@apollo/client';
 import {useSelectedPoint} from 'shared/hooks/useSelectedPoint';
@@ -203,11 +203,11 @@ const AccountActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 			chartTooltipRenderRows={({totalEvents, totalSessions}) => [
 				{
 					label: Liferay.Language.get('events'),
-					value: toLocale(totalEvents),
+					value: toThousands(totalEvents),
 				},
 				{
 					label: Liferay.Language.get('sessions'),
-					value: toLocale(totalSessions ?? 0),
+					value: toThousands(totalSessions ?? 0),
 				},
 			]}
 			chartView={chartView}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/hocs/EnrichedProfilesCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/hocs/EnrichedProfilesCard.tsx
@@ -7,7 +7,7 @@ import {DataSource} from 'shared/util/records';
 import {isFinite} from 'lodash';
 import {ReportContainer} from 'shared/components/download-report/DownloadPDFReport';
 import {sub} from 'shared/util/lang';
-import {toLocale} from 'shared/util/numbers';
+import {toThousands} from 'shared/util/numbers';
 import {useParams} from 'react-router-dom';
 import {validContactsConfig} from 'shared/util/data-sources';
 import {withRequest} from 'shared/hoc';
@@ -16,7 +16,7 @@ const EnrichedProfilesBody = ({count}: {count: number}) => (
 	<Card.Body className="d-flex flex-column">
 		<div className="total d-flex flex-grow-1 text-center justify-content-center align-items-center">
 			{sub(Liferay.Language.get('x-profiles'), [
-				isFinite(count) ? toLocale(count) : 0,
+				isFinite(count) ? toThousands(count) : 0,
 			])}
 		</div>
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/hocs/InterestsCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/hocs/InterestsCard.tsx
@@ -64,6 +64,7 @@ const InterestsCard: React.FC<React.HTMLAttributes<HTMLElement>> = () => {
 			sortable: false,
 		}),
 		compositionListColumns.getRelativeMetricBar({
+			abbreviateCount: true,
 			label: Liferay.Language.get('total-individuals'),
 			maxCount,
 			totalCount,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/components/OutputVersionsCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/components/OutputVersionsCard.tsx
@@ -28,7 +28,7 @@ import {
 import {OrderedMap} from 'immutable';
 import {OrderParams} from 'shared/util/records';
 import {sub} from 'shared/util/lang';
-import {toLocale} from 'shared/util/numbers';
+import {toThousands} from 'shared/util/numbers';
 import {withEmpty} from 'cerebro-shared/hocs/utils';
 import {
 	withError,
@@ -43,7 +43,7 @@ const getContextItemCount =
 		const contextItem = context.find(({key}) => key === contextItemKey);
 
 		if (contextItem) {
-			return toLocale(Number(contextItem.value));
+			return toThousands(Number(contextItem.value));
 		}
 
 		return '0';

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/components/TrainingItemsCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/components/TrainingItemsCard.tsx
@@ -12,7 +12,7 @@ import {EXCLUDE, Filter} from '../utils/utils';
 import {get} from 'lodash';
 import {Modal} from 'shared/types';
 import {sub} from 'shared/util/lang';
-import {toLocale} from 'shared/util/numbers';
+import {toThousands} from 'shared/util/numbers';
 import {useQuery} from '@apollo/client';
 
 const {
@@ -83,7 +83,7 @@ const TrainingItemsCard: React.FC<ITrainingItemsCardProps> = ({
 			return <Loading key="LOADING" />;
 		}
 
-		return toLocale(get(data, ['pageAssets', 'total'], 0));
+		return toThousands(get(data, ['pageAssets', 'total'], 0));
 	};
 
 	return (

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/TopPagesCardContent.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/TopPagesCardContent.tsx
@@ -9,7 +9,7 @@ import Table from 'shared/components/table';
 import URLConstants from 'shared/util/url-constants';
 import {ApolloError} from '@apollo/client';
 import {ENTRANCES_METRIC, EXIT_RATE_METRIC} from 'shared/util/pagination';
-import {formatPercentFromRatio} from 'shared/util/numbers';
+import {formatPercentFromRatio, toThousands} from 'shared/util/numbers';
 import {metricsListColumns} from 'shared/util/table-columns';
 import {NameCell} from 'shared/components/table/cell-components';
 import {OrderByDirections} from 'shared/util/constants';
@@ -68,13 +68,19 @@ const DEFAULT_METRIC_COLUMN = {
 
 export const TOP_PAGES_TABS = [
 	{
-		metricColumn: metricsListColumns.visitorsMetric,
+		metricColumn: {
+			...metricsListColumns.visitorsMetric,
+			dataFormatter: (data: number | string) => toThousands(Number(data)),
+		},
 		rowIdentifier: ROW_IDENTIFIER,
 		tabId: 'visitorsMetric',
 		title: Liferay.Language.get('visited-pages'),
 	},
 	{
-		metricColumn: metricsListColumns.entrancesMetric,
+		metricColumn: {
+			...metricsListColumns.entrancesMetric,
+			dataFormatter: (data: number | string) => toThousands(Number(data)),
+		},
 		rowIdentifier: ROW_IDENTIFIER,
 		tabId: ENTRANCES_METRIC,
 		title: Liferay.Language.get('entrance-pages'),

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/RelativeMetricBar.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/RelativeMetricBar.tsx
@@ -2,9 +2,10 @@ import MetricBar, {Sizes} from 'shared/components/MetricBar';
 import React, {FC} from 'react';
 import TextTruncate from 'shared/components/TextTruncate';
 import {round} from 'lodash';
-import {toLocale} from 'shared/util/numbers';
+import {toLocale, toThousands} from 'shared/util/numbers';
 
 interface IRelativeMetricBarProps extends React.HTMLAttributes<HTMLElement> {
+	abbreviateCount?: boolean;
 	data: {
 		count: number;
 		name: string;
@@ -17,6 +18,7 @@ interface IRelativeMetricBarProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 const RelativeMetricBar: FC<IRelativeMetricBarProps> = ({
+	abbreviateCount = false,
 	data: {count, name},
 	empty = false,
 	showName = false,
@@ -31,7 +33,11 @@ const RelativeMetricBar: FC<IRelativeMetricBarProps> = ({
 			<MetricBar percent={percent} size={Sizes.Lg}>
 				<TextTruncate className="title" title={displayName} />
 
-				{!empty && <span className="count">{toLocale(count)}</span>}
+				{!empty && (
+					<span className="count">
+						{abbreviateCount ? toThousands(count) : toLocale(count)}
+					</span>
+				)}
 			</MetricBar>
 		</td>
 	);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/table-columns.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/table-columns.tsx
@@ -477,6 +477,7 @@ export const compositionListColumns = {
 		title: true,
 	}),
 	getRelativeMetricBar: ({
+		abbreviateCount = false,
 		empty = false,
 		label,
 		maxCount,
@@ -484,6 +485,7 @@ export const compositionListColumns = {
 		sortable = false,
 		totalCount,
 	}: {
+		abbreviateCount?: boolean;
 		empty?: boolean;
 		label: React.ReactNode;
 		maxCount: number;
@@ -494,6 +496,7 @@ export const compositionListColumns = {
 		accessor: 'count',
 		cellRenderer: RelativeMetricBarCell,
 		cellRendererProps: {
+			abbreviateCount,
 			empty,
 			maxCount,
 			showName,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/components/AcquisitionsCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/components/AcquisitionsCard.tsx
@@ -40,6 +40,7 @@ const getColumnsFn = (acquisitionType: AcquisitionTypes) => {
 			tooltip: true,
 		}),
 		compositionListColumns.getRelativeMetricBar({
+			abbreviateCount: true,
 			label: Liferay.Language.get('sessions'),
 			maxCount,
 			totalCount,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/components/__tests__/__snapshots__/AcquisitionsCard.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/components/__tests__/__snapshots__/AcquisitionsCard.tsx.snap
@@ -207,7 +207,7 @@ exports[`AcquisitionsCard renders 1`] = `
                       <span
                         class="count"
                       >
-                        2,686
+                        2.6K
                       </span>
                     </div>
                   </div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/InterestsCard.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/InterestsCard.js
@@ -46,6 +46,7 @@ const TableWithData = withTableData(withData, {
 	),
 	getColumns: ({maxCount, totalCount}) => [
 		compositionListColumns.getRelativeMetricBar({
+			abbreviateCount: true,
 			label: `${Liferay.Language.get(
 				'interest-topics'
 			)} | ${Liferay.Language.get('sessions')}`,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/SearchTermsCard.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/SearchTermsCard.js
@@ -46,6 +46,7 @@ const TableWithData = withTableData(withData, {
 	),
 	getColumns: ({maxCount, totalCount}) => [
 		compositionListColumns.getRelativeMetricBar({
+			abbreviateCount: true,
 			label: `${Liferay.Language.get(
 				'search-query'
 			)} | ${Liferay.Language.get('searches')}`,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/VisitorsByTimeCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/VisitorsByTimeCard.tsx
@@ -21,7 +21,7 @@ import {
 } from './mappers/visitors-by-time-query';
 import {ReportContainer} from 'shared/components/download-report/DownloadPDFReport';
 import {sub} from 'shared/util/lang';
-import {toLocale} from 'shared/util/numbers';
+import {toThousands} from 'shared/util/numbers';
 import {withEmpty, withError, withLoading} from 'shared/hoc';
 
 export const formatHour = (hour: string) => {
@@ -66,7 +66,7 @@ export const renderTooltip = ({
 						{
 							align: Alignments.Center,
 							label: sub(Liferay.Language.get('x-visitors'), [
-								toLocale(value),
+								toThousands(value),
 							]) as string,
 						},
 					],


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101053

## What Is Being Fixed

Several dashboard metric cards (Enriched Profiles, Training Items, Output Versions, Activity Stream, Visitors by Time, Acquisitions, Search Terms, Interests, Top Pages) displayed counts as full grouped numbers (e.g. "19.332") instead of the abbreviated K/M/B form the rest of the app already uses for large counts.

## How It Is Being Fixed

Switched the affected small metric-card displays from `toLocale` to `toThousands`. For the shared `RelativeMetricBar` cell renderer, used by both small dashboard cards and full paginated report pages for Acquisitions/Search Terms/Interests, added an opt-in `abbreviateCount` prop defaulting to `false`, so only the card variants abbreviate — the full paginated pages keep exact values, where precision matters more.

## PR Check

**pr-check: PASS** — tested on `a6e1e0577528f2b25709cd3bb4143341d10b8603`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a6e1e0577528f2b25709cd3bb4143341d10b8603"} -->
