### PR TITLE
LPD-100364 Remove the ENABLE_ACCOUNT_OVERVIEW feature flag

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
@@ -8,7 +8,6 @@ import React, {lazy, Suspense, useContext} from 'react';
 import RouteNotFound from 'shared/components/RouteNotFound';
 import {ACCOUNTS, Routes, toRoute} from 'shared/util/router';
 import {ChannelContext} from 'shared/context/channel';
-import {ENABLE_ACCOUNT_OVERVIEW} from 'shared/util/feature-flags';
 import {Redirect, Switch, useParams} from 'react-router-dom';
 import {useRequest} from 'shared/hooks/useRequest';
 
@@ -22,16 +21,12 @@ const Overview = lazy(
 	() => import(/* webpackChunkName: "Overview" */ './Overview')
 );
 
-const getNavItems = () => [
-	...(ENABLE_ACCOUNT_OVERVIEW
-		? [
-				{
-					exact: true,
-					label: Liferay.Language.get('overview'),
-					route: Routes.CONTACTS_ACCOUNT_OVERVIEW,
-				},
-			]
-		: []),
+const NAV_ITEMS = [
+	{
+		exact: true,
+		label: Liferay.Language.get('overview'),
+		route: Routes.CONTACTS_ACCOUNT_OVERVIEW,
+	},
 	{
 		exact: true,
 		label: Liferay.Language.get('activities'),
@@ -105,7 +100,7 @@ const AccountProfileRoutes = () => {
 				</BasePage.Row>
 
 				<BasePage.Header.NavBar
-					items={getNavItems()}
+					items={NAV_ITEMS}
 					routeParams={{channelId, groupId, id}}
 				/>
 			</BasePage.Header>
@@ -116,16 +111,11 @@ const AccountProfileRoutes = () => {
 						<Redirect
 							exact
 							from={Routes.CONTACTS_ACCOUNT}
-							to={toRoute(
-								ENABLE_ACCOUNT_OVERVIEW
-									? Routes.CONTACTS_ACCOUNT_OVERVIEW
-									: Routes.CONTACTS_ACCOUNT_ACTIVITIES,
-								{
-									channelId: channelId!,
-									groupId: groupId!,
-									id: id!,
-								}
-							)}
+							to={toRoute(Routes.CONTACTS_ACCOUNT_OVERVIEW, {
+								channelId: channelId!,
+								groupId: groupId!,
+								id: id!,
+							})}
 						/>
 
 						<BundleRouter
@@ -142,14 +132,12 @@ const AccountProfileRoutes = () => {
 							path={Routes.CONTACTS_ACCOUNT_ACTIVITIES}
 						/>
 
-						{ENABLE_ACCOUNT_OVERVIEW && (
-							<BundleRouter
-								componentProps={{account: data}}
-								data={Overview}
-								exact
-								path={Routes.CONTACTS_ACCOUNT_OVERVIEW}
-							/>
-						)}
+						<BundleRouter
+							componentProps={{account: data}}
+							data={Overview}
+							exact
+							path={Routes.CONTACTS_ACCOUNT_OVERVIEW}
+						/>
 
 						<RouteNotFound />
 					</Switch>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/__tests__/ProfileRoutes.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/__tests__/ProfileRoutes.tsx
@@ -28,11 +28,6 @@ jest.mock('shared/util/breadcrumbs', () => ({
 	})),
 }));
 
-jest.mock('shared/util/feature-flags', () => ({
-	...jest.requireActual('shared/util/feature-flags'),
-	ENABLE_ACCOUNT_OVERVIEW: true,
-}));
-
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'),
 	useParams: () => ({
@@ -59,8 +54,6 @@ jest.mock('../Profile', () => ({
 	default: () => <div data-testid="account-profile" />,
 }));
 
-const featureFlags = jest.requireMock('shared/util/feature-flags');
-
 const mockedUseRequest = useRequest as jest.Mock;
 
 const ROUTE_PARAMS = {channelId: '123', groupId: '23', id: 'acc-1'};
@@ -85,8 +78,6 @@ const renderProfileRoutes = (
 describe('AccountProfileRoutes', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
-
-		featureFlags.ENABLE_ACCOUNT_OVERVIEW = true;
 	});
 
 	afterEach(cleanup);
@@ -266,68 +257,5 @@ describe('AccountProfileRoutes', () => {
 		expect(
 			await screen.findByTestId('account-overview')
 		).toBeInTheDocument();
-	});
-
-	describe('when the account overview flag is disabled', () => {
-		beforeEach(() => {
-			featureFlags.ENABLE_ACCOUNT_OVERVIEW = false;
-
-			mockedUseRequest.mockReturnValue({
-				data: {accountName: 'Acme Corp'},
-				error: false,
-				loading: false,
-			});
-		});
-
-		it('omits overview from the account nav bar', () => {
-			renderProfileRoutes();
-
-			const navTabs = within(screen.getByRole('navigation')).getAllByRole(
-				'link'
-			);
-
-			expect(navTabs.map((navTab) => navTab.textContent)).toEqual([
-				'Activities',
-				'Profile',
-			]);
-		});
-
-		it('does not route to the overview page', async () => {
-			const history = createMemoryHistory({
-				initialEntries: [
-					toRoute(Routes.CONTACTS_ACCOUNT_OVERVIEW, ROUTE_PARAMS),
-				],
-			});
-
-			renderProfileRoutes(history);
-
-			await waitFor(() =>
-				expect(history.location.state).toEqual({notFoundError: true})
-			);
-
-			expect(
-				screen.queryByTestId('account-overview')
-			).not.toBeInTheDocument();
-		});
-
-		it('lands on activities when opening an account', async () => {
-			const history = createMemoryHistory({
-				initialEntries: [
-					toRoute(Routes.CONTACTS_ACCOUNT, ROUTE_PARAMS),
-				],
-			});
-
-			renderProfileRoutes(history);
-
-			await waitFor(() =>
-				expect(history.location.pathname).toBe(
-					toRoute(Routes.CONTACTS_ACCOUNT_ACTIVITIES, ROUTE_PARAMS)
-				)
-			);
-
-			expect(
-				await screen.findByTestId('account-activities')
-			).toBeInTheDocument();
-		});
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/feature-flags.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/feature-flags.ts
@@ -16,7 +16,6 @@
 export const FEATURE_FLAGS_STORAGE_KEY = 'faro:feature-flags';
 
 export type FeatureFlagKey =
-	| 'ENABLE_ACCOUNT_OVERVIEW'
 	| 'ENABLE_ASSET_CARD'
 	| 'ENABLE_BLOCKLIST_KEYWORDS'
 	| 'ENABLE_COMMERCE'
@@ -30,7 +29,6 @@ export interface FeatureFlagDefinition {
 }
 
 export const FEATURE_FLAGS: FeatureFlagDefinition[] = [
-	{defaultValue: false, key: 'ENABLE_ACCOUNT_OVERVIEW'},
 	{defaultValue: false, key: 'ENABLE_ASSET_CARD'},
 	{defaultValue: false, key: 'ENABLE_BLOCKLIST_KEYWORDS'},
 	{defaultValue: false, key: 'ENABLE_COMMERCE'},
@@ -94,10 +92,6 @@ export function setFeatureFlag(key: FeatureFlagKey, value: boolean): void {
  * and read just like the former `constants.ts` booleans. Changing a flag in the
  * panel requires a reload because these are evaluated only once, on import.
  */
-
-export const ENABLE_ACCOUNT_OVERVIEW = isFeatureFlagEnabled(
-	'ENABLE_ACCOUNT_OVERVIEW'
-);
 
 export const ENABLE_ASSET_CARD = isFeatureFlagEnabled('ENABLE_ASSET_CARD');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100364

## What Is Being Fixed

The account Overview page shipped behind the `ENABLE_ACCOUNT_OVERVIEW` feature flag, which defaulted to off. Now that the page is ready, the flag only adds branching: the nav item, the default redirect target, and the Overview route each had to be assembled conditionally, and the flag is evaluated once at import time, so toggling it required a reload.

Master also currently fails two osb-faro-web specs. `Overview` throws `TypeError: Expected "id" to be defined` while the account id is transiently missing, because `MostEngagedIndividuals` builds the account profile route unconditionally, and `IndividualsDataSet` still asserts the outdated `First-Time` label.

## How It Is Being Fixed

The flag and its `FeatureFlagKey` entry are removed, so `NAV_ITEMS` becomes a plain constant, `CONTACTS_ACCOUNT` redirects straight to the Overview route, and the Overview `BundleRouter` renders unconditionally. The tests covering the flag-off path in `ProfileRoutes` go away with it.

The carried LPD-101439 commit repairs the two failing specs. The "view all" footer link in `MostEngagedIndividuals` renders only once the `id` param is present, matching how the rest of the Overview tolerates the transient missing-id state, and the individuals data set test catches up with the reworded first-time label.

## PR Check

**pr-check: PASS** — tested on `29579527c2473597eb83d05e7fed28e884d3698b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| JavaScript Unit Tests | PASS |

Workspace Build ran as `./gradlew build -x :modules:osb-faro-web:osbYarnTest`; the excluded Jest task is covered by the JavaScript Unit Tests row, which ran the module's full suite (708 suites, 3987 tests, 0 failures).

<!-- pr-check {"result": "success", "sha": "29579527c2473597eb83d05e7fed28e884d3698b"} -->
