### PR TITLE
LPD-101439 Move most engaged individuals above the engagement summary

### DIFF
--- a/cloud/helm/default/templates/liferayenvironment.yaml
+++ b/cloud/helm/default/templates/liferayenvironment.yaml
@@ -10,6 +10,9 @@ spec:
     activationCodeSecretRef:
         key: {{ .Values.license.activationCodeSecretKey }}
         name: {{ .Values.license.activationCodeSecretName | default (printf "%s-activation" (include "liferay.name" .)) }}
+    {{- if not .Values.autoscaling.enabled }}
+    desiredReplicas: {{ .Values.replicaCount }}
+    {{- end }}
     marketplaceVolume:
         enabled: {{ .Values.marketplace.enabled }}
         size: {{ .Values.marketplace.size }}

--- a/cloud/helm/default/tests/marketplace_test.yaml
+++ b/cloud/helm/default/tests/marketplace_test.yaml
@@ -29,6 +29,7 @@ tests:
                         activationCodeSecretRef:
                             key: activationCode
                             name: liferay-default-activation
+                        desiredReplicas: 1
                         marketplaceVolume:
                             enabled: true
                             size: 10Gi
@@ -39,6 +40,21 @@ tests:
         set:
             marketplace.enabled: true
             marketplace.storageClassName: nfs-sc
+        template: templates/liferayenvironment.yaml
+    -   asserts:
+            -   equal:
+                    path: spec.desiredReplicas
+                    value: 3
+        it: Sets desiredReplicas from the configured replica count
+        set:
+            replicaCount: 3
+        template: templates/liferayenvironment.yaml
+    -   asserts:
+            -   notExists:
+                    path: spec.desiredReplicas
+        it: Omits desiredReplicas when autoscaling manages the replica count
+        set:
+            autoscaling.enabled: true
         template: templates/liferayenvironment.yaml
     -   asserts:
             -   equal:

--- a/cloud/helm/dxp-operator/crds/licensing.liferay.com_liferayenvironments.yaml
+++ b/cloud/helm/dxp-operator/crds/licensing.liferay.com_liferayenvironments.yaml
@@ -28,6 +28,12 @@ spec:
         -   jsonPath: .status.license.validUntil
             name: Valid-Until
             type: string
+        -   jsonPath: .spec.desiredReplicas
+            name: Desired
+            type: integer
+        -   jsonPath: .status.effectiveReplicas
+            name: Effective
+            type: integer
         -   jsonPath: .status.phase
             name: Phase
             priority: 1
@@ -73,6 +79,9 @@ spec:
                                 -   key
                                 -   name
                                 type: object
+                            desiredReplicas:
+                                format: int32
+                                type: integer
                             dxpVersion:
                                 type: string
                             environmentName:
@@ -172,6 +181,9 @@ spec:
                                 x-kubernetes-list-map-keys:
                                 -   type
                                 x-kubernetes-list-type: map
+                            effectiveReplicas:
+                                format: int32
+                                type: integer
                             environmentId:
                                 type: string
                             license:

--- a/cloud/helm/dxp-operator/templates/rbac.yaml
+++ b/cloud/helm/dxp-operator/templates/rbac.yaml
@@ -43,6 +43,8 @@ rules:
         verbs:
             -   get
             -   list
+            -   patch
+            -   update
             -   watch
     -   apiGroups:
             -   licensing.liferay.com

--- a/cloud/helm/dxp-operator/tests/rbac_test.yaml
+++ b/cloud/helm/dxp-operator/tests/rbac_test.yaml
@@ -136,6 +136,19 @@ tests:
                             -   update
                             -   watch
                     path: rules
+            -   contains:
+                    content:
+                        apiGroups:
+                            -   apps
+                        resources:
+                            -   statefulsets
+                        verbs:
+                            -   get
+                            -   list
+                            -   patch
+                            -   update
+                            -   watch
+                    path: rules
         documentSelector:
             path: kind
             value: ClusterRole

--- a/cloud/helm/platform-components/tests/applications_test.yaml
+++ b/cloud/helm/platform-components/tests/applications_test.yaml
@@ -1,0 +1,198 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: Operator Applications
+templates:
+    -   templates/application-ack-prometheusservice.yaml
+    -   templates/application-argo-workflows.yaml
+    -   templates/application-crossplane.yaml
+    -   templates/application-eck-operator.yaml
+    -   templates/application-envoy-gateway.yaml
+    -   templates/application-external-secrets.yaml
+    -   templates/application-keda.yaml
+    -   templates/pdb-envoy-proxy.yaml
+tests:
+    -   asserts:
+            -   equal:
+                    path: spec.source.helm.valuesObject.controller.resources.requests.cpu
+                    value: 15m
+                template: templates/application-argo-workflows.yaml
+            -   equal:
+                    path: spec.source.helm.valuesObject.controller.workflowDefaults.spec.securityContext.runAsUser
+                    value: 8737
+                template: templates/application-argo-workflows.yaml
+            -   equal:
+                    path: spec.source.helm.valuesObject.executor.image.tag
+                    value: v4.0.4-nonroot
+                template: templates/application-argo-workflows.yaml
+        it: Applies the Argo Workflows resources and nonroot hardening
+    -   asserts:
+            -   equal:
+                    path: spec.source.helm.valuesObject.resourcesCrossplane.limits.memory
+                    value: 2Gi
+                template: templates/application-crossplane.yaml
+            -   equal:
+                    path: spec.source.helm.valuesObject.securityContextCrossplane.readOnlyRootFilesystem
+                    value: true
+                template: templates/application-crossplane.yaml
+            -   equal:
+                    path: spec.syncPolicy.managedNamespaceMetadata.labels["pod-security.kubernetes.io/enforce"]
+                    value: restricted
+                template: templates/application-crossplane.yaml
+        it: Applies the Crossplane resources and restricted pod security
+    -   asserts:
+            -   equal:
+                    path: spec.source.helm.valuesObject.config.envoyGateway.extensionApis.enableBackend
+                    value: false
+                template: templates/application-envoy-gateway.yaml
+            -   equal:
+                    path: spec.source.helm.valuesObject.deployment.replicas
+                    value: 2
+                template: templates/application-envoy-gateway.yaml
+        it: Applies the Envoy Gateway replica and extension API settings
+    -   asserts:
+            -   equal:
+                    path: spec.source.helm.valuesObject.resources.limits.memory
+                    value: 512Mi
+                template: templates/application-external-secrets.yaml
+            -   equal:
+                    path: spec.source.helm.valuesObject.webhook.resources.limits.memory
+                    value: 256Mi
+                template: templates/application-external-secrets.yaml
+        it: Applies the External Secrets resources
+    -   asserts:
+            -   equal:
+                    path: metadata.labels["app.kubernetes.io/name"]
+                    value: crossplane
+                template: templates/application-crossplane.yaml
+            -   equal:
+                    path: metadata.labels["liferay.com/project"]
+                    value: liferay-cloud-native
+                template: templates/application-crossplane.yaml
+            -   notExists:
+                    path: metadata.labels["app.kubernetes.io/part-of"]
+                template: templates/application-crossplane.yaml
+        it: Applies the minimal common label set to the applications
+    -   asserts:
+            -   equal:
+                    path: metadata.namespace
+                    value: envoy-gateway-system
+                template: templates/pdb-envoy-proxy.yaml
+            -   equal:
+                    path: spec.maxUnavailable
+                    value: 1
+                template: templates/pdb-envoy-proxy.yaml
+        it: Creates the Envoy proxy PodDisruptionBudget
+    -   asserts:
+            -   equal:
+                    path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+                    value: "-100"
+                template: templates/application-external-secrets.yaml
+            -   equal:
+                    path: spec.source.helm.valuesObject.installCRDs
+                    value: true
+                template: templates/application-external-secrets.yaml
+        it: Installs External Secrets Operator with CRDs in the first wave
+    -   asserts:
+            -   equal:
+                    path: spec.source.helm.valuesObject.installCRDs
+                    value: true
+                template: templates/application-eck-operator.yaml
+            -   equal:
+                    path: spec.destination.namespace
+                    value: elastic-system
+                template: templates/application-eck-operator.yaml
+            -   equal:
+                    path: spec.syncPolicy.managedNamespaceMetadata.labels["pod-security.kubernetes.io/enforce"]
+                    value: restricted
+                template: templates/application-eck-operator.yaml
+        it: Installs the ECK operator with CRDs in the restricted elastic-system namespace
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+                template: templates/application-keda.yaml
+        it: Omits KEDA by default
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+                template: templates/application-ack-prometheusservice.yaml
+        it: Omits the ACK Prometheus service controller by default
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+                template: templates/application-ack-prometheusservice.yaml
+        it: Omits the ACK Prometheus service controller when observability is disabled
+        set:
+            operatorApplications.ackPrometheusService.enabled: true
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+                template: templates/pdb-envoy-proxy.yaml
+        it: Omits the Envoy proxy PodDisruptionBudget when the gateway is disabled
+        set:
+            operatorApplications.envoyGateway.enabled: false
+    -   asserts:
+            -   equal:
+                    path: spec.source.chart
+                    value: crossplane
+                template: templates/application-crossplane.yaml
+            -   equal:
+                    path: spec.source.repoURL
+                    value: https://charts.crossplane.io/stable
+                template: templates/application-crossplane.yaml
+            -   equal:
+                    path: spec.source.targetRevision
+                    value: 2.1.3
+                template: templates/application-crossplane.yaml
+        it: Points the Crossplane application at the upstream chart
+    -   asserts:
+            -   equal:
+                    path: spec.source.chart
+                    value: gateway-helm
+                template: templates/application-envoy-gateway.yaml
+            -   equal:
+                    path: spec.source.repoURL
+                    value: oci://docker.io/envoyproxy
+                template: templates/application-envoy-gateway.yaml
+        it: Points the Envoy Gateway application at the OCI registry
+    -   asserts:
+            -   hasDocuments:
+                    count: 1
+                template: templates/application-keda.yaml
+            -   equal:
+                    path: spec.source.helm.valuesObject.resources.operator.limits.memory
+                    value: 512Mi
+                template: templates/application-keda.yaml
+        it: Renders KEDA when enabled
+        set:
+            operatorApplications.keda.enabled: true
+    -   asserts:
+            -   equal:
+                    path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+                    value: "-95"
+                template: templates/application-ack-prometheusservice.yaml
+            -   equal:
+                    path: spec.destination.namespace
+                    value: ack-system
+                template: templates/application-ack-prometheusservice.yaml
+            -   equal:
+                    path: spec.source.chart
+                    value: prometheusservice-chart
+                template: templates/application-ack-prometheusservice.yaml
+            -   equal:
+                    path: spec.source.helm.valuesObject.aws.region
+                    value: us-west-2
+                template: templates/application-ack-prometheusservice.yaml
+            -   equal:
+                    path: spec.source.repoURL
+                    value: oci://public.ecr.aws/aws-controllers-k8s
+                template: templates/application-ack-prometheusservice.yaml
+        it: Renders the ACK Prometheus service controller when observability and the operator are enabled
+        set:
+            observability.enabled: true
+            operatorApplications:
+                ackPrometheusService:
+                    enabled: true
+                    values:
+                        aws:
+                            region: us-west-2

--- a/cloud/helm/platform-components/tests/applicationset_test.yaml
+++ b/cloud/helm/platform-components/tests/applicationset_test.yaml
@@ -1,0 +1,222 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: ApplicationSets and AppProjects
+templates:
+    -   templates/application-infrastructure-provider.yaml
+    -   templates/application-observability.yaml
+    -   templates/applicationset-infrastructure.yaml
+    -   templates/applicationset-liferay.yaml
+    -   templates/applicationset-resources.yaml
+    -   templates/appproject-application.yaml
+    -   templates/appproject-infrastructure.yaml
+tests:
+    -   asserts:
+            -   hasDocuments:
+                    count: 1
+                template: templates/application-infrastructure-provider.yaml
+            -   hasDocuments:
+                    count: 1
+                template: templates/appproject-infrastructure.yaml
+        it: Always renders the infrastructure AppProject and provider application
+    -   asserts:
+            -   equal:
+                    path: spec.template.metadata.name
+                    value: "{{path[1]}}-{{path[3]}}-infra"
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.template.spec.destination.namespace
+                    value: liferay-{{path[1]}}-{{path[3]}}
+                template: templates/applicationset-infrastructure.yaml
+            -   contains:
+                    content:
+                        name: environmentId
+                        value: "{{path[3]}}"
+                    path: spec.template.spec.sources[0].helm.parameters
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.template.metadata.name
+                    value: "{{path[1]}}-{{path[3]}}-app"
+                template: templates/applicationset-liferay.yaml
+            -   contains:
+                    content:
+                        name: liferay-default.network.gatewayName
+                        value: "{{path[1]}}-{{path[3]}}-gateway"
+                    path: spec.template.spec.sources[0].helm.parameters
+                template: templates/applicationset-liferay.yaml
+            -   equal:
+                    path: spec.template.metadata.name
+                    value: "{{path[1]}}-resources"
+                template: templates/applicationset-resources.yaml
+            -   equal:
+                    path: spec.template.spec.destination.namespace
+                    value: liferay-{{path[1]}}-resources
+                template: templates/applicationset-resources.yaml
+        it: Derives the application names and namespaces from the layout expressions
+        set:
+            gitops:
+                layout:
+                    environmentId: "{{path[3]}}"
+                    projectId: "{{path[1]}}"
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+            infrastructure:
+                chart: liferay-azure-infrastructure
+                repoURL: oci://example-registry/liferay-azure-infrastructure
+            liferay:
+                chart: liferay-azure
+                repoURL: oci://example-registry/liferay-azure
+    -   asserts:
+            -   equal:
+                    path: spec.template.spec.sources[0].helm.valueFiles
+                    value:
+                        -   $values/liferay/projects/{{path[2]}}/base/infrastructure.yaml
+                        -   $values/{{path}}/infrastructure.yaml
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.template.spec.sources[0].helm.valueFiles
+                    value:
+                        -   $values/liferay/projects/{{path[2]}}/base/liferay.yaml
+                        -   $values/{{path}}/liferay.yaml
+                template: templates/applicationset-liferay.yaml
+            -   equal:
+                    path: spec.template.spec.sources[0].helm.valueFiles
+                    value:
+                        -   $values/{{path}}/project.yaml
+                template: templates/applicationset-resources.yaml
+            -   equal:
+                    path: spec.sources[0].helm.valueFiles
+                    value:
+                        -   $values/liferay/system/infrastructure-provider.yaml
+                template: templates/application-infrastructure-provider.yaml
+            -   equal:
+                    path: spec.sources[0].helm.valueFiles
+                    value:
+                        -   $values/liferay/system/observability.yaml
+                template: templates/application-observability.yaml
+        it: Layers the values files from the base directory to the environment directory
+        set:
+            gitops:
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+            infrastructure:
+                chart: liferay-azure-infrastructure
+                repoURL: oci://example-registry/liferay-azure-infrastructure
+            liferay:
+                chart: liferay-azure
+                repoURL: oci://example-registry/liferay-azure
+            observability:
+                enabled: true
+    -   asserts:
+            -   contains:
+                    content:
+                        name: clusterIdentity.deploymentName
+                        value: liferay-test
+                    path: spec.sources[0].helm.parameters
+                template: templates/application-infrastructure-provider.yaml
+            -   equal:
+                    path: spec.destination.namespace
+                    value: crossplane-system
+                template: templates/application-infrastructure-provider.yaml
+            -   equal:
+                    path: spec.sources[1].ref
+                    value: values
+                template: templates/application-infrastructure-provider.yaml
+            -   equal:
+                    path: metadata.name
+                    value: liferay-infrastructure
+                template: templates/appproject-infrastructure.yaml
+        it: Passes the cluster identity to the infrastructure provider application
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            infrastructureProvider:
+                chart: liferay-azure-infrastructure-provider
+                repoURL: oci://example-registry/liferay-azure-infrastructure-provider
+    -   asserts:
+            -   hasDocuments:
+                    count: 1
+                template: templates/applicationset-infrastructure.yaml
+            -   hasDocuments:
+                    count: 1
+                template: templates/applicationset-liferay.yaml
+            -   hasDocuments:
+                    count: 1
+                template: templates/applicationset-resources.yaml
+            -   hasDocuments:
+                    count: 1
+                template: templates/appproject-application.yaml
+        it: Renders every ApplicationSet and the application AppProject by default
+    -   asserts:
+            -   contains:
+                    content: https://github.com/example/liferay-gitops.git
+                    path: spec.sourceRepos
+                template: templates/appproject-infrastructure.yaml
+            -   equal:
+                    path: metadata.name
+                    value: liferay-application
+                template: templates/appproject-application.yaml
+        it: Renders the AppProjects with the GitOps repository whitelisted
+        set:
+            gitops:
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+            infrastructure:
+                chart: liferay-azure-infrastructure
+                repoURL: oci://example-registry/liferay-azure-infrastructure
+            liferay:
+                chart: liferay-azure
+                repoURL: oci://example-registry/liferay-azure
+    -   asserts:
+            -   contains:
+                    content: oci://us-central1-docker.pkg.dev/external-assets-prd/liferay-helm-chart/observability
+                    path: spec.sourceRepos
+                template: templates/appproject-infrastructure.yaml
+            -   contains:
+                    content: oci://us-central1-docker.pkg.dev/external-assets-prd/liferay-helm-chart/observability/*
+                    path: spec.sourceRepos
+                template: templates/appproject-infrastructure.yaml
+            -   contains:
+                    content:
+                        namespace: observability
+                        server: https://kubernetes.default.svc
+                    path: spec.destinations
+                template: templates/appproject-infrastructure.yaml
+        it: Whitelists the observability repository and namespace on the infrastructure AppProject
+    -   asserts:
+            -   equal:
+                    path: spec.generators[0].git.repoURL
+                    value: https://github.com/example/liferay-gitops.git
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.template.spec.project
+                    value: liferay-infrastructure
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.template.spec.project
+                    value: liferay-application
+                template: templates/applicationset-liferay.yaml
+            -   equal:
+                    path: spec.template.spec.sources[1].ref
+                    value: values
+                template: templates/applicationset-liferay.yaml
+            -   contains:
+                    content:
+                        name: gateway.className
+                        value: liferay-gateway-class
+                    path: spec.template.spec.sources[0].helm.parameters
+                template: templates/applicationset-infrastructure.yaml
+        it: Wires the ApplicationSets to the GitOps values repository
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+                region: eastus
+            gitops:
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+            infrastructure:
+                chart: liferay-azure-infrastructure
+                repoURL: oci://example-registry/liferay-azure-infrastructure
+            liferay:
+                chart: liferay-azure
+                repoURL: oci://example-registry/liferay-azure

--- a/cloud/helm/platform-components/tests/argocd-networking_test.yaml
+++ b/cloud/helm/platform-components/tests/argocd-networking_test.yaml
@@ -1,0 +1,204 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: ArgoCD Gateway Networking
+templates:
+    -   templates/argocd-networking.yaml
+tests:
+    -   asserts:
+            -   hasDocuments:
+                    count: 4
+            -   documentIndex: 0
+                equal:
+                    path: metadata.namespace
+                    value: envoy-gateway-system
+            -   documentIndex: 0
+                equal:
+                    path: spec.provider.kubernetes.envoyDeployment.replicas
+                    value: 2
+            -   documentIndex: 0
+                isKind:
+                    of: EnvoyProxy
+            -   documentIndex: 0
+                notExists:
+                    path: spec.provider.kubernetes.envoyDeployment.pod
+            -   documentIndex: 0
+                notExists:
+                    path: spec.provider.kubernetes.envoyService
+            -   documentIndex: 1
+                equal:
+                    path: spec.gatewayClassName
+                    value: argocd-gateway-class
+            -   documentIndex: 1
+                equal:
+                    path: spec.listeners
+                    value:
+                        -   allowedRoutes:
+                                namespaces:
+                                    from: Same
+                            hostname: argocd.liferay.test
+                            name: http
+                            port: 80
+                            protocol: HTTP
+            -   documentIndex: 1
+                isKind:
+                    of: Gateway
+            -   documentIndex: 2
+                equal:
+                    path: spec.controllerName
+                    value: gateway.envoyproxy.io/gatewayclass-controller
+            -   documentIndex: 2
+                equal:
+                    path: spec.parametersRef.name
+                    value: argocd-gateway-proxy-config
+            -   documentIndex: 2
+                equal:
+                    path: spec.parametersRef.namespace
+                    value: envoy-gateway-system
+            -   documentIndex: 2
+                isKind:
+                    of: GatewayClass
+            -   documentIndex: 3
+                equal:
+                    path: metadata.name
+                    value: argocd-server-route
+            -   documentIndex: 3
+                equal:
+                    path: spec.parentRefs[0].sectionName
+                    value: http
+            -   documentIndex: 3
+                equal:
+                    path: spec.rules[0].backendRefs[0].name
+                    value: argocd-server
+            -   documentIndex: 3
+                equal:
+                    path: spec.rules[0].backendRefs[0].port
+                    value: 80
+            -   documentIndex: 3
+                isKind:
+                    of: HTTPRoute
+        it: Exposes ArgoCD over plain HTTP while the gateway terminates no TLS
+        set:
+            argocd:
+                gateway:
+                    enabled: true
+                    hostname: argocd.liferay.test
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: Omits the networking by default
+    -   asserts:
+            -   documentIndex: 0
+                equal:
+                    path: spec.provider.kubernetes.envoyDeployment.pod.annotations["prometheus.io/scrape"]
+                    value: "true"
+            -   documentIndex: 0
+                equal:
+                    path: spec.provider.kubernetes.envoyDeployment.replicas
+                    value: 3
+            -   documentIndex: 0
+                equal:
+                    path: spec.provider.kubernetes.envoyService.annotations["service.beta.kubernetes.io/azure-load-balancer-internal"]
+                    value: "true"
+        it: Passes the Envoy proxy overrides through to the proxy config
+        set:
+            argocd:
+                gateway:
+                    enabled: true
+                    envoyProxy:
+                        podAnnotations:
+                            prometheus.io/scrape: "true"
+                        replicas: 3
+                        serviceAnnotations:
+                            service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+                    hostname: argocd.liferay.test
+    -   asserts:
+            -   failedTemplate:
+                    errorPattern: argocd.gateway.hostname is required
+        it: Rejects an enabled gateway without a hostname
+        set:
+            argocd.gateway.enabled: true
+    -   asserts:
+            -   hasDocuments:
+                    count: 6
+            -   documentIndex: 0
+                equal:
+                    path: metadata.name
+                    value: argocd-server-tls
+            -   documentIndex: 0
+                equal:
+                    path: metadata.namespace
+                    value: argocd-system
+            -   documentIndex: 0
+                equal:
+                    path: spec.dataFrom[0].extract.decodingStrategy
+                    value: Auto
+            -   documentIndex: 0
+                equal:
+                    path: spec.dataFrom[0].extract.key
+                    value: liferay-certificates-argocd
+            -   documentIndex: 0
+                equal:
+                    path: spec.secretStoreRef.name
+                    value: liferay-test-secret-store
+            -   documentIndex: 0
+                equal:
+                    path: spec.target.template.type
+                    value: kubernetes.io/tls
+            -   documentIndex: 0
+                isKind:
+                    of: ExternalSecret
+            -   documentIndex: 2
+                equal:
+                    path: spec.listeners[1].hostname
+                    value: argocd.liferay.test
+            -   documentIndex: 2
+                equal:
+                    path: spec.listeners[1].name
+                    value: https
+            -   documentIndex: 2
+                equal:
+                    path: spec.listeners[1].port
+                    value: 443
+            -   documentIndex: 2
+                equal:
+                    path: spec.listeners[1].tls.certificateRefs[0].name
+                    value: argocd-server-tls
+            -   documentIndex: 2
+                equal:
+                    path: spec.listeners[1].tls.mode
+                    value: Terminate
+            -   documentIndex: 4
+                equal:
+                    path: metadata.name
+                    value: argocd-redirect-route
+            -   documentIndex: 4
+                equal:
+                    path: spec.parentRefs[0].sectionName
+                    value: http
+            -   documentIndex: 4
+                equal:
+                    path: spec.rules[0].filters[0].requestRedirect.scheme
+                    value: https
+            -   documentIndex: 4
+                equal:
+                    path: spec.rules[0].filters[0].requestRedirect.statusCode
+                    value: 301
+            -   documentIndex: 5
+                equal:
+                    path: metadata.name
+                    value: argocd-server-route
+            -   documentIndex: 5
+                equal:
+                    path: spec.parentRefs[0].sectionName
+                    value: https
+        it: Terminates TLS and redirects plain HTTP once a certificate is configured
+        set:
+            argocd:
+                gateway:
+                    enabled: true
+                    hostname: argocd.liferay.test
+                    tls:
+                        externalSecretKey: liferay-certificates-argocd
+            clusterIdentity:
+                deploymentName: liferay-test

--- a/cloud/helm/platform-components/tests/cluster-bootstrap_test.yaml
+++ b/cloud/helm/platform-components/tests/cluster-bootstrap_test.yaml
@@ -1,0 +1,79 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: Cluster Bootstrap DaemonSet
+templates:
+    -   templates/cluster-bootstrap.yaml
+tests:
+    -   asserts:
+            -   documentIndex: 0
+                equal:
+                    path: spec.template.spec.containers[0].image
+                    value: registry.k8s.io/pause:3.9
+            -   documentIndex: 0
+                equal:
+                    path: spec.template.spec.initContainers[0].image
+                    value: alpine:3
+            -   documentIndex: 0
+                equal:
+                    path: spec.template.spec.initContainers[0].securityContext.privileged
+                    value: true
+            -   documentIndex: 0
+                equal:
+                    path: spec.template.spec.initContainers[0].resources.requests.memory
+                    value: 8Mi
+            -   documentIndex: 0
+                matchRegex:
+                    path: spec.template.spec.initContainers[0].command[2]
+                    pattern: vm.max_map_count=1048576
+        it: Applies the sysctl script through a privileged init container
+    -   asserts:
+            -   documentIndex: 0
+                equal:
+                    path: metadata.labels["liferay.com/project"]
+                    value: liferay-cloud-native
+            -   documentIndex: 0
+                equal:
+                    path: metadata.labels["app.kubernetes.io/name"]
+                    value: cluster-bootstrap
+            -   documentIndex: 1
+                equal:
+                    path: metadata.labels["liferay.com/project"]
+                    value: liferay-cloud-native
+            -   documentIndex: 1
+                equal:
+                    path: metadata.labels["app.kubernetes.io/name"]
+                    value: cluster-bootstrap-system
+        it: Labels both resources with the platform labels
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: Omits the bootstrap when disabled
+        set:
+            clusterBootstrap.enabled: false
+    -   asserts:
+            -   hasDocuments:
+                    count: 2
+            -   documentIndex: 0
+                equal:
+                    path: metadata.namespace
+                    value: cluster-bootstrap-system
+            -   documentIndex: 0
+                equal:
+                    path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+                    value: "-110"
+            -   documentIndex: 0
+                isKind:
+                    of: DaemonSet
+            -   documentIndex: 1
+                equal:
+                    path: metadata.name
+                    value: cluster-bootstrap-system
+            -   documentIndex: 1
+                equal:
+                    path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+                    value: "-110"
+            -   documentIndex: 1
+                isKind:
+                    of: Namespace
+        it: Renders the bootstrap DaemonSet and its namespace by default

--- a/cloud/helm/platform-components/tests/cluster-secret-store_test.yaml
+++ b/cloud/helm/platform-components/tests/cluster-secret-store_test.yaml
@@ -1,0 +1,59 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: ClusterSecretStore
+templates:
+    -   templates/clustersecretstore.yaml
+tests:
+    -   asserts:
+            -   equal:
+                    path: metadata.name
+                    value: liferay-test-secret-store
+            -   equal:
+                    path: spec.provider.azurekv.authType
+                    value: WorkloadIdentity
+            -   equal:
+                    path: spec.provider.azurekv.vaultUrl
+                    value: https://liferay-test-vault.vault.azure.net
+            -   hasDocuments:
+                    count: 1
+            -   isKind:
+                    of: ClusterSecretStore
+        it: Derives the ClusterSecretStore name and renders the provider verbatim
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            clusterSecretStore:
+                enabled: true
+                provider:
+                    azurekv:
+                        authType: WorkloadIdentity
+                        serviceAccountRef:
+                            name: external-secrets
+                            namespace: external-secrets-system
+                        vaultUrl: https://liferay-test-vault.vault.azure.net
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: Omits the ClusterSecretStore by default
+    -   asserts:
+            -   hasDocuments:
+                    count: 1
+            -   isEmpty:
+                    path: spec.provider
+        it: Renders an empty provider when none is configured
+        set:
+            clusterSecretStore.enabled: true
+    -   asserts:
+            -   equal:
+                    path: spec.provider.gcpsm.projectID
+                    value: my-project
+            -   notExists:
+                    path: spec.provider.azurekv
+        it: Renders any External Secrets provider without interpretation
+        set:
+            clusterSecretStore:
+                enabled: true
+                provider:
+                    gcpsm:
+                        projectID: my-project

--- a/cloud/helm/platform-components/tests/crossplane-functions_test.yaml
+++ b/cloud/helm/platform-components/tests/crossplane-functions_test.yaml
@@ -1,0 +1,127 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: Crossplane Functions
+templates:
+    -   templates/crossplane-functions.yaml
+tests:
+    -   asserts:
+            -   hasDocuments:
+                    count: 10
+            -   documentIndex: 6
+                equal:
+                    path: spec.package
+                    value: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.9.0
+            -   documentIndex: 7
+                equal:
+                    path: spec.deploymentTemplate.spec.template.spec.containers[0].resources.limits.memory
+                    value: 256Mi
+        it: Appends additional cloud specific functions
+        set:
+            operatorApplications:
+                crossplane:
+                    functions:
+                        function-patch-and-transform:
+                            package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.9.0
+                            resources:
+                                limits:
+                                    memory: 256Mi
+                                requests:
+                                    cpu: 15m
+                                    memory: 128Mi
+    -   asserts:
+            -   documentIndex: 1
+                equal:
+                    path: spec.deploymentTemplate.spec.selector.matchLabels["pkg.crossplane.io/function"]
+                    value: function-auto-ready
+            -   documentIndex: 1
+                equal:
+                    path: spec.deploymentTemplate.spec.template.metadata.annotations["sidecar.opentelemetry.io/inject"]
+                    value: "false"
+            -   documentIndex: 1
+                equal:
+                    path: spec.deploymentTemplate.spec.template.spec.containers[0].resources.limits.memory
+                    value: 256Mi
+            -   documentIndex: 1
+                equal:
+                    path: spec.deploymentTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+                    value: true
+            -   documentIndex: 1
+                equal:
+                    path: spec.deploymentTemplate.spec.template.spec.containers[0].securityContext.runAsUser
+                    value: 65532
+            -   documentIndex: 1
+                equal:
+                    path: spec.deploymentTemplate.spec.template.spec.securityContext.runAsNonRoot
+                    value: true
+            -   documentIndex: 5
+                equal:
+                    path: spec.deploymentTemplate.spec.template.spec.containers[0].resources.limits.memory
+                    value: 512Mi
+        it: Hardens the function runtimes and disables OpenTelemetry injection
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: Omits the functions when Crossplane is disabled
+        set:
+            operatorApplications.crossplane.enabled: false
+    -   asserts:
+            -   hasDocuments:
+                    count: 8
+            -   documentIndex: 0
+                equal:
+                    path: metadata.name
+                    value: function-auto-ready
+            -   documentIndex: 0
+                equal:
+                    path: spec.package
+                    value: xpkg.upbound.io/upbound/function-auto-ready:v0.6.0
+            -   documentIndex: 0
+                equal:
+                    path: spec.runtimeConfigRef.name
+                    value: function-auto-ready-runtime-config
+            -   documentIndex: 0
+                isKind:
+                    of: Function
+            -   documentIndex: 1
+                equal:
+                    path: metadata.name
+                    value: function-auto-ready-runtime-config
+            -   documentIndex: 1
+                isKind:
+                    of: DeploymentRuntimeConfig
+            -   documentIndex: 2
+                equal:
+                    path: spec.package
+                    value: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.6.0
+            -   documentIndex: 3
+                equal:
+                    path: metadata.name
+                    value: function-environment-configs-runtime-config
+            -   documentIndex: 4
+                equal:
+                    path: spec.package
+                    value: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.11.3
+            -   documentIndex: 5
+                equal:
+                    path: metadata.name
+                    value: function-go-templating-runtime-config
+            -   documentIndex: 6
+                equal:
+                    path: spec.package
+                    value: xpkg.upbound.io/crossplane-contrib/function-tag-manager:v0.6.0
+            -   documentIndex: 7
+                equal:
+                    path: metadata.name
+                    value: function-tag-manager-runtime-config
+        it: Renders the default functions with runtime configs
+    -   asserts:
+            -   documentIndex: 0
+                equal:
+                    path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+                    value: "-90"
+            -   documentIndex: 0
+                equal:
+                    path: metadata.annotations["argocd.argoproj.io/sync-options"]
+                    value: SkipDryRunOnMissingResource=true
+        it: Syncs the functions after Crossplane and before the provider

--- a/cloud/helm/platform-components/tests/crossplane-provider-kubernetes-rbac_test.yaml
+++ b/cloud/helm/platform-components/tests/crossplane-provider-kubernetes-rbac_test.yaml
@@ -1,0 +1,74 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: Crossplane provider-kubernetes RBAC
+templates:
+    -   templates/crossplane-provider-kubernetes-rbac.yaml
+tests:
+    -   asserts:
+            -   documentIndex: 1
+                equal:
+                    path: subjects[0].name
+                    value: provider-kubernetes
+            -   documentIndex: 1
+                equal:
+                    path: subjects[0].namespace
+                    value: crossplane-system
+        it: Binds the provider-kubernetes service account in the Crossplane namespace
+    -   asserts:
+            -   documentIndex: 1
+                equal:
+                    path: subjects[0].namespace
+                    value: custom-system
+        it: Follows the Crossplane namespace override
+        set:
+            operatorApplications.crossplane.namespace: custom-system
+    -   asserts:
+            -   documentIndex: 0
+                equal:
+                    path: rules
+                    value:
+                        -   apiGroups: [""]
+                            resources: ["secrets", "serviceaccounts"]
+                            verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+                        -   apiGroups: [""]
+                            resources: ["namespaces"]
+                            verbs: ["get", "list"]
+                        -   apiGroups: ["elasticsearch.k8s.elastic.co"]
+                            resources: ["elasticsearches"]
+                            verbs: ["get", "list", "watch"]
+                        -   apiGroups: ["rbac.authorization.k8s.io"]
+                            resources: ["clusterroles"]
+                            verbs: ["bind", "get", "list", "watch"]
+                        -   apiGroups: ["rbac.authorization.k8s.io"]
+                            resources: ["rolebindings"]
+                            verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+        it: Grants exactly the rules every cloud needs and nothing more
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: Omits the RBAC when Crossplane is disabled
+        set:
+            operatorApplications.crossplane.enabled: false
+    -   asserts:
+            -   hasDocuments:
+                    count: 2
+            -   documentIndex: 0
+                equal:
+                    path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+                    value: "-100"
+            -   documentIndex: 0
+                equal:
+                    path: metadata.labels["rbac.crossplane.io/aggregate-to-crossplane"]
+                    value: "true"
+            -   documentIndex: 0
+                isKind:
+                    of: ClusterRole
+            -   documentIndex: 1
+                equal:
+                    path: roleRef.name
+                    value: crossplane-provider-kubernetes
+            -   documentIndex: 1
+                isKind:
+                    of: ClusterRoleBinding
+        it: Renders the aggregated role and its binding by default

--- a/cloud/helm/platform-components/tests/externalsecret-argocd-sso_test.yaml
+++ b/cloud/helm/platform-components/tests/externalsecret-argocd-sso_test.yaml
@@ -1,0 +1,53 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: ArgoCD SSO ExternalSecret
+templates:
+    -   templates/externalsecret-argocd-sso.yaml
+tests:
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: Omits the ExternalSecret by default
+    -   asserts:
+            -   equal:
+                    path: metadata.name
+                    value: customer-idp-saml
+            -   equal:
+                    path: metadata.namespace
+                    value: argocd-system
+            -   equal:
+                    path: spec.data[0].remoteRef.key
+                    value: liferay-credentials-argocd-sso
+            -   equal:
+                    path: spec.data[0].remoteRef.property
+                    value: caData
+            -   equal:
+                    path: spec.data[3].secretKey
+                    value: ssoURL
+            -   equal:
+                    path: spec.secretStoreRef.name
+                    value: liferay-test-secret-store
+            -   equal:
+                    path: spec.target.template.metadata.labels["app.kubernetes.io/part-of"]
+                    value: argocd
+            -   hasDocuments:
+                    count: 1
+            -   isKind:
+                    of: ExternalSecret
+        it: Pulls the SAML connector properties from the cluster secret store
+        set:
+            argocd:
+                sso:
+                    credentialsSecretKey: liferay-credentials-argocd-sso
+                    enabled: true
+            clusterIdentity:
+                deploymentName: liferay-test
+    -   asserts:
+            -   hasDocuments:
+                    count: 1
+            -   isEmpty:
+                    path: spec.data[0].remoteRef.key
+        it: Renders an empty credentials key when none is configured
+        set:
+            argocd.sso.enabled: true

--- a/cloud/helm/platform-components/tests/git-repository-secret_test.yaml
+++ b/cloud/helm/platform-components/tests/git-repository-secret_test.yaml
@@ -1,0 +1,281 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: Git Repository ExternalSecret
+templates:
+    -   templates/externalsecret-git-repository.yaml
+tests:
+    -   asserts:
+            -   equal:
+                    path: spec.data[0].remoteRef.property
+                    value: github_app_id
+            -   equal:
+                    path: spec.data[1].remoteRef.property
+                    value: github_app_installation_id
+            -   equal:
+                    path: spec.data[2].remoteRef.property
+                    value: github_app_private_key
+            -   equal:
+                    path: spec.target.template.data.githubAppID
+                    value: "{{ .github_app_id }}"
+            -   equal:
+                    path: spec.target.template.data.githubAppInstallationID
+                    value: "{{ .github_app_installation_id }}"
+            -   equal:
+                    path: spec.target.template.data.githubAppPrivateKey
+                    value: "{{ .github_app_private_key }}"
+            -   notExists:
+                    path: spec.target.template.data.password
+            -   notExists:
+                    path: spec.target.template.data.username
+        it: Derives a GitHub App credential when the method is github_app
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                repository:
+                    method: github_app
+                    url: https://github.com/example/liferay-gitops.git
+    -   asserts:
+            -   equal:
+                    path: metadata.name
+                    value: git-repo-gitops-credentials
+            -   equal:
+                    path: metadata.namespace
+                    value: argocd-system
+            -   equal:
+                    path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+                    value: "-85"
+            -   equal:
+                    path: spec.data[0].remoteRef.key
+                    value: liferay-credentials-gitops
+            -   equal:
+                    path: spec.data[0].remoteRef.property
+                    value: git_access_token
+            -   equal:
+                    path: spec.data[1].remoteRef.property
+                    value: git_machine_user_id
+            -   equal:
+                    path: spec.secretStoreRef.name
+                    value: liferay-test-secret-store
+            -   equal:
+                    path: spec.target.name
+                    value: git-repo-gitops-credentials
+            -   equal:
+                    path: spec.target.template.data.name
+                    value: git-repo-gitops
+            -   equal:
+                    path: spec.target.template.data.url
+                    value: https://github.com/example/liferay-gitops.git
+            -   equal:
+                    path: spec.target.template.metadata.labels["argocd.argoproj.io/secret-type"]
+                    value: repository
+            -   hasDocuments:
+                    count: 1
+            -   isKind:
+                    of: ExternalSecret
+        it: Derives an https credential for the main repository with the defaults
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+    -   asserts:
+            -   hasDocuments:
+                    count: 2
+            -   documentIndex: 1
+                equal:
+                    path: metadata.name
+                    value: git-repo-infrastructure-credentials
+            -   documentIndex: 1
+                equal:
+                    path: spec.data[0].remoteRef.key
+                    value: liferay-credentials-infrastructure
+            -   documentIndex: 1
+                equal:
+                    path: spec.data[0].secretKey
+                    value: ssh_private_key
+            -   documentIndex: 1
+                equal:
+                    path: spec.target.template.data.name
+                    value: git-repo-infrastructure
+            -   documentIndex: 1
+                equal:
+                    path: spec.target.template.data.url
+                    value: git@github.com:example/infrastructure-gitops.git
+        it: Derives the infrastructure repository credential
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                infrastructureRepository:
+                    credentialsSecretName: liferay-credentials-infrastructure
+                    method: ssh
+                    url: git@github.com:example/infrastructure-gitops.git
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+    -   asserts:
+            -   equal:
+                    path: spec.data[0].remoteRef.key
+                    value: my-credentials
+            -   equal:
+                    path: spec.data[0].remoteRef.property
+                    value: ssh_key
+            -   equal:
+                    path: spec.data[0].secretKey
+                    value: ssh_private_key
+            -   notExists:
+                    path: spec.target.template.data.username
+        it: Honors auth method and property overrides
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                repository:
+                    credentialsSecretName: my-credentials
+                    method: ssh
+                    sshPrivateKeyProperty: ssh_key
+                    url: git@github.com:example/liferay-gitops.git
+    -   asserts:
+            -   hasDocuments:
+                    count: 2
+            -   documentIndex: 1
+                equal:
+                    path: metadata.name
+                    value: infrastructure-credentials
+            -   documentIndex: 1
+                equal:
+                    path: spec.data[0].remoteRef.property
+                    value: deploy_key
+            -   documentIndex: 1
+                equal:
+                    path: spec.data[0].secretKey
+                    value: ssh_private_key
+        it: Honors the credential overrides on the infrastructure repository
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                infrastructureRepository:
+                    internalSecretName: infrastructure-credentials
+                    method: ssh
+                    sshPrivateKeyProperty: deploy_key
+                    url: git@github.com:example/infrastructure-gitops.git
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+    -   asserts:
+            -   equal:
+                    path: metadata.name
+                    value: gitops-credentials
+            -   equal:
+                    path: spec.data[0].remoteRef.property
+                    value: access_token
+            -   equal:
+                    path: spec.data[1].remoteRef.property
+                    value: machine_user
+            -   equal:
+                    path: spec.target.name
+                    value: gitops-credentials
+        it: Honors the credential overrides on the main repository
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                repository:
+                    internalSecretName: gitops-credentials
+                    tokenProperty: access_token
+                    url: https://github.com/example/liferay-gitops.git
+                    usernameProperty: machine_user
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: Omits the credentials by default
+    -   asserts:
+            -   hasDocuments:
+                    count: 2
+            -   documentIndex: 0
+                equal:
+                    path: metadata.name
+                    value: git-repo-gitops-credentials
+            -   documentIndex: 1
+                equal:
+                    path: metadata.name
+                    value: git-repo-infrastructure-credentials
+        it: Registers a credential per repository when the URLs match
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                infrastructureRepository:
+                    url: https://github.com/example/liferay-gitops.git
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+    -   asserts:
+            -   failedTemplate:
+                    errorPattern: Unsupported git repository auth method
+        it: Rejects an unknown auth method
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                repository:
+                    method: kerberos
+                    url: https://github.com/example/liferay-gitops.git
+    -   asserts:
+            -   hasDocuments:
+                    count: 1
+        it: Skips the derived infrastructure credential for a revision only override
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                infrastructureRepository:
+                    revision: release
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+    -   asserts:
+            -   equal:
+                    path: metadata.name
+                    value: git-repo-gitops-credentials
+            -   hasDocuments:
+                    count: 1
+        it: Skips the infrastructure credential for a public repository
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                infrastructureRepository:
+                    registerCredentials: false
+                    url: https://github.com/example/infrastructure-gitops.git
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+    -   asserts:
+            -   hasDocuments:
+                    count: 0
+        it: Skips the main repository credential when registration is disabled
+        set:
+            gitops:
+                repository:
+                    registerCredentials: false
+                    url: https://github.com/example/liferay-gitops.git
+    -   asserts:
+            -   hasDocuments:
+                    count: 2
+            -   documentIndex: 1
+                equal:
+                    path: spec.data[0].remoteRef.key
+                    value: liferay-credentials-gitops
+            -   documentIndex: 1
+                equal:
+                    path: spec.data[0].remoteRef.property
+                    value: git_access_token
+        it: Uses the default https credential values for the infrastructure repository
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                infrastructureRepository:
+                    url: https://github.com/example/infrastructure-gitops.git
+                repository:
+                    url: https://github.com/example/liferay-gitops.git

--- a/cloud/helm/platform-components/tests/git-source_test.yaml
+++ b/cloud/helm/platform-components/tests/git-source_test.yaml
@@ -1,0 +1,109 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: Git Chart Sources
+templates:
+    -   templates/application-infrastructure-provider.yaml
+    -   templates/application-observability.yaml
+    -   templates/applicationset-infrastructure.yaml
+    -   templates/applicationset-liferay.yaml
+    -   templates/applicationset-resources.yaml
+    -   templates/appproject-application.yaml
+    -   templates/appproject-infrastructure.yaml
+tests:
+    -   asserts:
+            -   equal:
+                    path: spec.template.spec.sources[0].path
+                    value: cloud/helm/azure
+                template: templates/applicationset-liferay.yaml
+            -   notExists:
+                    path: spec.template.spec.sources[0].chart
+                template: templates/applicationset-liferay.yaml
+            -   contains:
+                    content: https://github.com/myfork/liferay-portal
+                    path: spec.sourceRepos
+                template: templates/appproject-application.yaml
+        it: Sources the Liferay chart from a Git repository
+        set:
+            gitops:
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+            infrastructure:
+                chart: liferay-azure-infrastructure
+                repoURL: oci://example-registry/liferay-azure-infrastructure
+            liferay:
+                path: cloud/helm/azure
+                repoURL: https://github.com/myfork/liferay-portal
+                targetRevision: LCD-12345
+    -   asserts:
+            -   equal:
+                    path: spec.template.spec.sources[0].path
+                    value: cloud/helm/azure-infrastructure
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.template.spec.sources[0].repoURL
+                    value: https://github.com/myfork/liferay-portal
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.template.spec.sources[0].targetRevision
+                    value: LCD-12345
+                template: templates/applicationset-infrastructure.yaml
+            -   notExists:
+                    path: spec.template.spec.sources[0].chart
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.template.spec.sources[0].path
+                    value: cloud/helm/azure-infrastructure
+                template: templates/applicationset-resources.yaml
+            -   notExists:
+                    path: spec.template.spec.sources[0].chart
+                template: templates/applicationset-resources.yaml
+        it: Sources the infrastructure charts from a Git repository
+        set:
+            gitops:
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+            infrastructure:
+                path: cloud/helm/azure-infrastructure
+                repoURL: https://github.com/myfork/liferay-portal
+                targetRevision: LCD-12345
+            liferay:
+                chart: liferay-azure
+                repoURL: oci://example-registry/liferay-azure
+    -   asserts:
+            -   equal:
+                    path: spec.sources[0].path
+                    value: cloud/helm/azure-infrastructure-provider
+                template: templates/application-infrastructure-provider.yaml
+            -   notExists:
+                    path: spec.sources[0].chart
+                template: templates/application-infrastructure-provider.yaml
+            -   contains:
+                    content: https://github.com/myfork/liferay-portal
+                    path: spec.sourceRepos
+                template: templates/appproject-infrastructure.yaml
+        it: Sources the infrastructure provider chart from a Git repository
+        set:
+            infrastructureProvider:
+                path: cloud/helm/azure-infrastructure-provider
+                repoURL: https://github.com/myfork/liferay-portal
+                targetRevision: LCD-12345
+    -   asserts:
+            -   equal:
+                    path: spec.sources[0].path
+                    value: cloud/helm/observability
+                template: templates/application-observability.yaml
+            -   equal:
+                    path: spec.sources[0].targetRevision
+                    value: LCD-12345
+                template: templates/application-observability.yaml
+            -   notExists:
+                    path: spec.sources[0].chart
+                template: templates/application-observability.yaml
+        it: Sources the observability chart from a Git repository
+        set:
+            observability:
+                enabled: true
+                path: cloud/helm/observability
+                repoURL: https://github.com/myfork/liferay-portal
+                targetRevision: LCD-12345

--- a/cloud/helm/platform-components/tests/infrastructure-git-repository_test.yaml
+++ b/cloud/helm/platform-components/tests/infrastructure-git-repository_test.yaml
@@ -1,0 +1,166 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: Infrastructure Git Repository
+templates:
+    -   templates/application-infrastructure-provider.yaml
+    -   templates/application-observability.yaml
+    -   templates/applicationset-infrastructure.yaml
+    -   templates/applicationset-liferay.yaml
+    -   templates/applicationset-resources.yaml
+    -   templates/appproject-application.yaml
+    -   templates/appproject-infrastructure.yaml
+    -   templates/externalsecret-git-repository.yaml
+tests:
+    -   asserts:
+            -   equal:
+                    path: spec.generators[0].git.repoURL
+                    value: https://github.com/example/liferay-gitops.git
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.generators[0].git.revision
+                    value: HEAD
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.generators[0].git.repoURL
+                    value: https://github.com/example/liferay-gitops.git
+                template: templates/applicationset-resources.yaml
+            -   equal:
+                    path: spec.sources[1].repoURL
+                    value: https://github.com/example/liferay-gitops.git
+                template: templates/application-infrastructure-provider.yaml
+        it: Falls back to the main Git repository by default
+        set:
+            gitops:
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+            infrastructure:
+                chart: liferay-azure-infrastructure
+                repoURL: oci://example-registry/liferay-azure-infrastructure
+            infrastructureProvider:
+                chart: liferay-azure-infrastructure-provider
+                repoURL: oci://example-registry/liferay-azure-infrastructure-provider
+            liferay:
+                chart: liferay-azure
+                repoURL: oci://example-registry/liferay-azure
+    -   asserts:
+            -   equal:
+                    path: spec.generators[0].git.repoURL
+                    value: https://github.com/example/infrastructure-gitops.git
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.generators[0].git.revision
+                    value: v1.2.3
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.generators[0].git.revision
+                    value: v1.2.3
+                template: templates/applicationset-liferay.yaml
+        it: Falls back to the main revision when only the URL is overridden
+        set:
+            gitops:
+                infrastructureRepository:
+                    url: https://github.com/example/infrastructure-gitops.git
+                repository:
+                    revision: v1.2.3
+                    url: https://github.com/example/liferay-gitops.git
+            infrastructure:
+                chart: liferay-azure-infrastructure
+                repoURL: oci://example-registry/liferay-azure-infrastructure
+            liferay:
+                chart: liferay-azure
+                repoURL: oci://example-registry/liferay-azure
+    -   asserts:
+            -   equal:
+                    path: spec.generators[0].git.repoURL
+                    value: https://github.com/example/liferay-gitops.git
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.generators[0].git.revision
+                    value: v1.2.3
+                template: templates/applicationset-infrastructure.yaml
+        it: Follows the pinned main revision when only one repository is configured
+        set:
+            gitops:
+                repository:
+                    revision: v1.2.3
+                    url: https://github.com/example/liferay-gitops.git
+            infrastructure:
+                chart: liferay-azure-infrastructure
+                repoURL: oci://example-registry/liferay-azure-infrastructure
+            liferay:
+                chart: liferay-azure
+                repoURL: oci://example-registry/liferay-azure
+    -   asserts:
+            -   equal:
+                    path: spec.generators[0].git.repoURL
+                    value: https://github.com/example/infrastructure-gitops.git
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.generators[0].git.revision
+                    value: infra-release
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.template.spec.sources[1].repoURL
+                    value: https://github.com/example/infrastructure-gitops.git
+                template: templates/applicationset-infrastructure.yaml
+            -   equal:
+                    path: spec.generators[0].git.repoURL
+                    value: https://github.com/example/infrastructure-gitops.git
+                template: templates/applicationset-resources.yaml
+            -   equal:
+                    path: spec.template.spec.sources[1].targetRevision
+                    value: infra-release
+                template: templates/applicationset-resources.yaml
+            -   equal:
+                    path: spec.sources[1].repoURL
+                    value: https://github.com/example/infrastructure-gitops.git
+                template: templates/application-infrastructure-provider.yaml
+            -   equal:
+                    path: spec.sources[1].repoURL
+                    value: https://github.com/example/infrastructure-gitops.git
+                template: templates/application-observability.yaml
+            -   contains:
+                    content: https://github.com/example/infrastructure-gitops.git
+                    path: spec.sourceRepos
+                template: templates/appproject-infrastructure.yaml
+            -   equal:
+                    path: spec.generators[0].git.repoURL
+                    value: https://github.com/example/liferay-gitops.git
+                template: templates/applicationset-liferay.yaml
+            -   contains:
+                    content: https://github.com/example/liferay-gitops.git
+                    path: spec.sourceRepos
+                template: templates/appproject-application.yaml
+            -   contains:
+                    content:
+                        name: centralHub.gitURL
+                        value: https://github.com/example/liferay-gitops.git
+                    path: spec.sources[0].helm.parameters
+                template: templates/application-observability.yaml
+            -   documentIndex: 1
+                equal:
+                    path: metadata.name
+                    value: git-repo-infrastructure-credentials
+                template: templates/externalsecret-git-repository.yaml
+        it: Splits the infrastructure sources from the application repository
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            gitops:
+                infrastructureRepository:
+                    revision: infra-release
+                    url: https://github.com/example/infrastructure-gitops.git
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+            infrastructure:
+                chart: liferay-azure-infrastructure
+                repoURL: oci://example-registry/liferay-azure-infrastructure
+            infrastructureProvider:
+                chart: liferay-azure-infrastructure-provider
+                repoURL: oci://example-registry/liferay-azure-infrastructure-provider
+            liferay:
+                chart: liferay-azure
+                repoURL: oci://example-registry/liferay-azure
+            observability:
+                enabled: true

--- a/cloud/helm/platform-components/tests/parameters_test.yaml
+++ b/cloud/helm/platform-components/tests/parameters_test.yaml
@@ -1,0 +1,179 @@
+release:
+    name: my-release
+    namespace: argocd-system
+suite: Passed Parameters
+templates:
+    -   templates/application-infrastructure-provider.yaml
+    -   templates/application-observability.yaml
+    -   templates/applicationset-infrastructure.yaml
+    -   templates/applicationset-liferay.yaml
+    -   templates/applicationset-resources.yaml
+tests:
+    -   asserts:
+            -   contains:
+                    content:
+                        name: clusterIdentity.deploymentName
+                        value: liferay-test
+                    path: spec.sources[0].helm.parameters
+                template: templates/application-infrastructure-provider.yaml
+            -   contains:
+                    content:
+                        name: aws.vpcId
+                        value: vpc-0123456789
+                    path: spec.sources[0].helm.parameters
+                template: templates/application-infrastructure-provider.yaml
+        it: Appends the passed parameters after the cluster identity
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            infrastructureProvider:
+                chart: liferay-aws-infrastructure-provider
+                parameters:
+                    -   name: aws.vpcId
+                        value: vpc-0123456789
+                repoURL: oci://example-registry/liferay-aws-infrastructure-provider
+    -   asserts:
+            -   contains:
+                    content:
+                        name: azure.subnetId
+                        value: /subscriptions/x
+                    path: spec.template.spec.sources[0].helm.parameters
+                template: templates/applicationset-infrastructure.yaml
+            -   contains:
+                    content:
+                        name: secretStoreName
+                        value: liferay-test-secret-store
+                    path: spec.template.spec.sources[0].helm.parameters
+                template: templates/applicationset-infrastructure.yaml
+            -   contains:
+                    content:
+                        name: azure.subnetId
+                        value: /subscriptions/x
+                    path: spec.template.spec.sources[0].helm.parameters
+                template: templates/applicationset-resources.yaml
+            -   contains:
+                    content:
+                        name: projectId
+                        value: "{{path[2]}}"
+                    path: spec.template.spec.sources[0].helm.parameters
+                template: templates/applicationset-resources.yaml
+        it: Appends the passed parameters to both applications rendering the infrastructure chart
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            infrastructure:
+                chart: liferay-azure-infrastructure
+                parameters:
+                    -   name: azure.subnetId
+                        value: /subscriptions/x
+                repoURL: oci://example-registry/liferay-azure-infrastructure
+    -   asserts:
+            -   contains:
+                    content:
+                        name: global.aws.accountId
+                        value: "123456789012"
+                    path: spec.template.spec.sources[0].helm.parameters
+                template: templates/applicationset-liferay.yaml
+            -   contains:
+                    content:
+                        name: liferay-default.environmentId
+                        value: "{{path[4]}}"
+                    path: spec.template.spec.sources[0].helm.parameters
+                template: templates/applicationset-liferay.yaml
+        it: Appends the passed parameters to the Liferay applications
+        set:
+            gitops:
+                repository:
+                    url: https://github.com/example/liferay-gitops.git
+            liferay:
+                chart: liferay-aws
+                parameters:
+                    -   name: global.aws.accountId
+                        value: "123456789012"
+                repoURL: oci://example-registry/liferay-aws
+    -   asserts:
+            -   contains:
+                    content:
+                        name: cloudProvider
+                        value: aws
+                    path: spec.sources[0].helm.parameters
+                template: templates/application-observability.yaml
+            -   contains:
+                    content:
+                        name: namespaceOverride
+                        value: observability
+                    path: spec.sources[0].helm.parameters
+                template: templates/application-observability.yaml
+        it: Appends the passed parameters to the observability application
+        set:
+            observability:
+                enabled: true
+                parameters:
+                    -   name: cloudProvider
+                        value: aws
+    -   asserts:
+            -   contains:
+                    content:
+                        name: centralHub.argocdURL
+                        value: https://argocd.liferay.test
+                    path: spec.sources[0].helm.parameters
+                template: templates/application-observability.yaml
+        it: Derives the observability ArgoCD URL from a TLS gateway
+        set:
+            argocd:
+                gateway:
+                    enabled: true
+                    hostname: argocd.liferay.test
+                    tls:
+                        externalSecretKey: liferay-certificates-argocd
+            observability:
+                enabled: true
+    -   asserts:
+            -   contains:
+                    content:
+                        name: centralHub.argocdURL
+                        value: http://argocd.liferay.test
+                    path: spec.sources[0].helm.parameters
+                template: templates/application-observability.yaml
+        it: Derives the observability ArgoCD URL from a plaintext gateway
+        set:
+            argocd:
+                gateway:
+                    enabled: true
+                    hostname: argocd.liferay.test
+            observability:
+                enabled: true
+    -   asserts:
+            -   equal:
+                    path: spec.sources[0].helm.parameters[0].name
+                    value: centralHub.gitURL
+                template: templates/application-observability.yaml
+        it: Omits the ArgoCD URL from the observability application when the gateway is disabled
+        set:
+            observability:
+                enabled: true
+    -   asserts:
+            -   contains:
+                    content:
+                        name: deploymentName
+                        value: liferay-test
+                    path: spec.sources[0].helm.parameters
+                template: templates/application-infrastructure-provider.yaml
+            -   contains:
+                    content:
+                        name: global.projectId
+                        value: "{{path[2]}}"
+                    path: spec.template.spec.sources[0].helm.parameters
+                template: templates/applicationset-liferay.yaml
+        it: Renders the applications when no parameters are passed
+        set:
+            clusterIdentity:
+                deploymentName: liferay-test
+            infrastructureProvider:
+                chart: liferay-aws-infrastructure-provider
+                parameters: null
+                repoURL: oci://example-registry/liferay-aws-infrastructure-provider
+            liferay:
+                chart: liferay-aws
+                parameters: null
+                repoURL: oci://example-registry/liferay-aws

--- a/cloud/helm/platform/tests/application_test.yaml
+++ b/cloud/helm/platform/tests/application_test.yaml
@@ -1,0 +1,126 @@
+release:
+    name: liferay-platform
+    namespace: argocd-system
+suite: Root Application
+templates:
+    -   templates/application-liferay-platform.yaml
+tests:
+    -   asserts:
+            -   equal:
+                    path: spec.sources[0].helm.valuesObject.clusterIdentity.deploymentName
+                    value: liferay-test
+            -   equal:
+                    path: spec.sources[0].helm.valuesObject.clusterSecretStore.enabled
+                    value: true
+            -   equal:
+                    path: spec.sources[0].helm.valuesObject.clusterSecretStore.provider.azurekv.vaultUrl
+                    value: https://liferay-test-vault.vault.azure.net
+            -   equal:
+                    path: spec.sources[0].helm.valuesObject.gitops.repository.url
+                    value: https://github.com/example/liferay-gitops.git
+            -   equal:
+                    path: spec.sources[0].helm.valuesObject.operatorApplications.externalSecrets.values.serviceAccount.annotations["azure.workload.identity/client-id"]
+                    value: external-secrets-client-id
+        it: Forwards the platform components values verbatim
+        set:
+            platformComponents:
+                values:
+                    clusterIdentity:
+                        deploymentName: liferay-test
+                    clusterSecretStore:
+                        enabled: true
+                        provider:
+                            azurekv:
+                                vaultUrl: https://liferay-test-vault.vault.azure.net
+                    gitops:
+                        repository:
+                            url: https://github.com/example/liferay-gitops.git
+                    operatorApplications:
+                        externalSecrets:
+                            values:
+                                serviceAccount:
+                                    annotations:
+                                        azure.workload.identity/client-id: external-secrets-client-id
+    -   asserts:
+            -   notExists:
+                    path: spec.sources[0].helm
+        it: Omits the Helm values when none are provided
+    -   asserts:
+            -   equal:
+                    path: spec.sources[0].targetRevision
+                    value: 0.2.0
+        it: Pins the platform components chart to the requested version
+        set:
+            platformComponents.targetRevision: 0.2.0
+    -   asserts:
+            -   equal:
+                    path: metadata.namespace
+                    value: other-system
+            -   equal:
+                    path: spec.destination.namespace
+                    value: other-system
+        it: Places the application in the release namespace
+        release:
+            namespace: other-system
+    -   asserts:
+            -   equal:
+                    path: metadata.finalizers
+                    value:
+                        -   resources-finalizer.argocd.argoproj.io
+            -   equal:
+                    path: metadata.labels["app.kubernetes.io/name"]
+                    value: liferay-platform
+            -   equal:
+                    path: metadata.labels["liferay.com/project"]
+                    value: liferay-cloud-native
+            -   equal:
+                    path: metadata.name
+                    value: liferay-platform
+            -   equal:
+                    path: metadata.namespace
+                    value: argocd-system
+            -   equal:
+                    path: spec.destination.namespace
+                    value: argocd-system
+            -   equal:
+                    path: spec.destination.server
+                    value: https://kubernetes.default.svc
+            -   equal:
+                    path: spec.project
+                    value: default
+            -   equal:
+                    path: spec.sources[0].path
+                    value: .
+            -   equal:
+                    path: spec.sources[0].repoURL
+                    value: oci://us-central1-docker.pkg.dev/external-assets-prd/liferay-helm-chart/liferay-platform-components
+            -   equal:
+                    path: spec.sources[0].targetRevision
+                    value: 0.1.0
+            -   equal:
+                    path: spec.syncPolicy.automated.prune
+                    value: true
+            -   equal:
+                    path: spec.syncPolicy.automated.selfHeal
+                    value: true
+            -   equal:
+                    path: spec.syncPolicy.retry.backoff.duration
+                    value: 30s
+            -   equal:
+                    path: spec.syncPolicy.retry.backoff.factor
+                    value: 2
+            -   equal:
+                    path: spec.syncPolicy.retry.backoff.maxDuration
+                    value: 10m
+            -   equal:
+                    path: spec.syncPolicy.retry.limit
+                    value: 10
+            -   equal:
+                    path: spec.syncPolicy.syncOptions
+                    value:
+                        -   CreateNamespace=true
+            -   hasDocuments:
+                    count: 1
+            -   isKind:
+                    of: Application
+        it: Renders the root application by default

--- a/cloud/operator/Tiltfile
+++ b/cloud/operator/Tiltfile
@@ -22,6 +22,7 @@ environment_names = [
 
 def environment_yaml(name):
 	namespace = "liferay-" + name
+	workload = name + "-liferay"
 
 	return "\n".join(
 	    [
@@ -41,13 +42,34 @@ def environment_yaml(name):
 	        "    activationCodeSecretRef:",
 	        "        key: activationCode",
 	        "        name: " + name + "-activation",
+	        "    desiredReplicas: 3",
 	        "    dxpVersion: 2026.q3.0",
 	        "    environmentName: \"" + name + "\"",
 	        "    marketplaceVolume:",
 	        "        size: 10Gi",
 	        "        storageClassName: local-path",
 	        "    workloadRef:",
-	        "        name: liferay-default",
+	        "        name: " + workload,
+	        "---",
+	        "apiVersion: apps/v1",
+	        "kind: StatefulSet",
+	        "metadata:",
+	        "    name: " + workload,
+	        "    namespace: " + namespace,
+	        "spec:",
+	        "    replicas: 3",
+	        "    selector:",
+	        "        matchLabels:",
+	        "            app: " + workload,
+	        "    serviceName: " + workload,
+	        "    template:",
+	        "        metadata:",
+	        "            labels:",
+	        "                app: " + workload,
+	        "        spec:",
+	        "            containers:",
+	        "                -   image: registry.k8s.io/pause:3.9",
+	        "                    name: liferay",
 	    ]
 	)
 
@@ -65,6 +87,7 @@ docker_build_with_restart(
 
 for name in environment_names:
 	namespace = "liferay-" + name
+	workload = name + "-liferay"
 
 	k8s_yaml(blob(environment_yaml(name)))
 
@@ -79,6 +102,12 @@ for name in environment_names:
 	        "liferay-dxp-operator",
 	        "operator-infra",
 	    ],
+	)
+
+	k8s_resource(
+	    labels=["environments"],
+	    resource_deps=[namespace],
+	    workload=workload,
 	)
 
 	cmd_button(

--- a/cloud/operator/resources/api/licensing/v1alpha1/liferayenvironment_types.go
+++ b/cloud/operator/resources/api/licensing/v1alpha1/liferayenvironment_types.go
@@ -28,6 +28,8 @@ type LicenseStatus struct {
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Activated")].status`,name="Activated",type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.license.maxClusterNodes`,name="Max",type=integer
 // +kubebuilder:printcolumn:JSONPath=`.status.license.validUntil`,name="Valid-Until",type=string
+// +kubebuilder:printcolumn:JSONPath=`.spec.desiredReplicas`,name="Desired",type=integer
+// +kubebuilder:printcolumn:JSONPath=`.status.effectiveReplicas`,name="Effective",type=integer
 // +kubebuilder:printcolumn:JSONPath=`.status.phase`,name="Phase",priority=1,type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.environmentId`,name="Environment-ID",priority=1,type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.activatedAt`,name="Activated-At",priority=1,type=date
@@ -54,6 +56,9 @@ type LiferayEnvironmentSpec struct {
 	ActivationCodeSecretRef SecretKeyRef `json:"activationCodeSecretRef"`
 
 	// +optional
+	DesiredReplicas *int32 `json:"desiredReplicas,omitempty"`
+
+	// +optional
 	DxpVersion string `json:"dxpVersion,omitempty"`
 
 	// +optional
@@ -74,6 +79,9 @@ type LiferayEnvironmentStatus struct {
 	// +listType=map
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// +optional
+	EffectiveReplicas *int32 `json:"effectiveReplicas,omitempty"`
 
 	// +optional
 	EnvironmentID string `json:"environmentId,omitempty"`

--- a/cloud/operator/resources/go.mod
+++ b/cloud/operator/resources/go.mod
@@ -4,6 +4,7 @@ go 1.24.4
 
 require (
 	github.com/caarlos0/env/v11 v11.3.1
+	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
 	sigs.k8s.io/controller-runtime v0.21.0
@@ -63,7 +64,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.33.1 // indirect
 	k8s.io/apiextensions-apiserver v0.33.0 // indirect
 	k8s.io/code-generator v0.33.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect

--- a/cloud/operator/resources/internal/controller/licensing/liferayenvironment_controller.go
+++ b/cloud/operator/resources/internal/controller/licensing/liferayenvironment_controller.go
@@ -21,6 +21,7 @@ import (
 	licensingv1alpha1 "github.com/liferay/liferay-portal/cloud/operator/api/licensing/v1alpha1"
 	license "github.com/liferay/liferay-portal/cloud/operator/internal/license"
 	provisioning "github.com/liferay/liferay-portal/cloud/operator/internal/provisioning"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	errors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
@@ -37,6 +38,7 @@ const (
 	conditionActivated             = "Activated"
 	conditionLicenseValid          = "LicenseValid"
 	conditionProvisioningReachable = "ProvisioningReachable"
+	conditionReplicasCountValid    = "ReplicasCountValid"
 	entitlementsSecretSuffix       = "-entitlements"
 	environmentLabel               = "licensing.liferay.com/environment"
 	identitySecretSuffix           = "-identity"
@@ -44,6 +46,7 @@ const (
 
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;patch;update;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;patch;update;watch
 func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) Reconcile(
 	context context.Context,
 	request controllerruntime.Request,
@@ -274,6 +277,12 @@ func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) Reconcile(
 		},
 	)
 
+	if error := liferayEnvironmentReconciler.enforceReplicaCeiling(
+		context, liferayEnvironment, entitlements.MaxClusterNodes,
+	); error != nil {
+		return controllerruntime.Result{}, error
+	}
+
 	liferayEnvironment.Status.Phase = "Ready"
 
 	return liferayEnvironmentReconciler.finishAfter(
@@ -301,6 +310,116 @@ func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) SetupWithManag
 	).Complete(
 		liferayEnvironmentReconciler,
 	)
+}
+
+func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) enforceReplicaCeiling(
+	context context.Context,
+	liferayEnvironment *licensingv1alpha1.LiferayEnvironment,
+	maxClusterNodes int32,
+) error {
+	logger := logf.FromContext(context)
+
+	if maxClusterNodes <= 0 {
+		liferayEnvironment.Status.EffectiveReplicas = nil
+
+		meta.SetStatusCondition(
+			&liferayEnvironment.Status.Conditions,
+			metav1.Condition{
+				Message: "The licensed maximum cluster node count is not yet known.",
+				Reason:  "MaxClusterNodesUnknown",
+				Status:  metav1.ConditionUnknown,
+				Type:    conditionReplicasCountValid,
+			},
+		)
+
+		return nil
+	}
+
+	statefulSet := &appsv1.StatefulSet{}
+
+	getError := liferayEnvironmentReconciler.Get(
+		context, types.NamespacedName{
+			Name:      liferayEnvironment.Spec.WorkloadRef.Name,
+			Namespace: liferayEnvironment.Namespace,
+		}, statefulSet)
+
+	if errors.IsNotFound(getError) {
+		logger.V(1).Info(
+			"Workload not found; skipping replica enforcement",
+			"workload", liferayEnvironment.Spec.WorkloadRef.Name,
+		)
+
+		liferayEnvironment.Status.EffectiveReplicas = nil
+
+		meta.SetStatusCondition(
+			&liferayEnvironment.Status.Conditions,
+			metav1.Condition{
+				Message: fmt.Sprintf(
+					"Workload StatefulSet %q was not found.",
+					liferayEnvironment.Spec.WorkloadRef.Name,
+				),
+				Reason: "WorkloadNotFound",
+				Status: metav1.ConditionUnknown,
+				Type:   conditionReplicasCountValid,
+			},
+		)
+
+		return nil
+	}
+
+	if getError != nil {
+		return getError
+	}
+
+	desiredReplicas := resolveDesiredReplicas(liferayEnvironment, statefulSet)
+
+	effectiveReplicas := min(desiredReplicas, maxClusterNodes)
+
+	if statefulSet.Spec.Replicas == nil || *statefulSet.Spec.Replicas != effectiveReplicas {
+		statefulSet.Spec.Replicas = &effectiveReplicas
+
+		if error := liferayEnvironmentReconciler.Update(context, statefulSet); error != nil {
+			return error
+		}
+
+		logger.Info(
+			"Enforced licensed replica ceiling",
+			"desiredReplicas", desiredReplicas,
+			"effectiveReplicas", effectiveReplicas,
+			"maxClusterNodes", maxClusterNodes,
+			"workload", statefulSet.Name,
+		)
+	}
+
+	liferayEnvironment.Status.EffectiveReplicas = &effectiveReplicas
+
+	if desiredReplicas > maxClusterNodes {
+		meta.SetStatusCondition(
+			&liferayEnvironment.Status.Conditions,
+			metav1.Condition{
+				Message: fmt.Sprintf(
+					"Requested %d replicas exceeds the licensed maximum of %d; capping to %d.",
+					desiredReplicas, maxClusterNodes, effectiveReplicas,
+				),
+				Reason: "ExceedsLicensedMaximum",
+				Status: metav1.ConditionFalse,
+				Type:   conditionReplicasCountValid,
+			},
+		)
+
+		return nil
+	}
+
+	meta.SetStatusCondition(
+		&liferayEnvironment.Status.Conditions,
+		metav1.Condition{
+			Reason: "WithinLicensedLimit",
+			Status: metav1.ConditionTrue,
+			Type:   conditionReplicasCountValid,
+		},
+	)
+
+	return nil
 }
 
 func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) ensureIdentity(
@@ -557,6 +676,21 @@ func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) readActivation
 	}
 
 	return string(code), nil
+}
+
+func resolveDesiredReplicas(
+	liferayEnvironment *licensingv1alpha1.LiferayEnvironment,
+	statefulSet *appsv1.StatefulSet,
+) int32 {
+	if liferayEnvironment.Spec.DesiredReplicas != nil {
+		return *liferayEnvironment.Spec.DesiredReplicas
+	}
+
+	if statefulSet.Spec.Replicas != nil {
+		return *statefulSet.Spec.Replicas
+	}
+
+	return 1
 }
 
 func (liferayEnvironmentReconciler *LiferayEnvironmentReconciler) resolveDxpVersion(

--- a/cloud/operator/resources/internal/controller/licensing/liferayenvironment_controller_test.go
+++ b/cloud/operator/resources/internal/controller/licensing/liferayenvironment_controller_test.go
@@ -1,0 +1,275 @@
+package licensing
+
+import (
+	"context"
+	"testing"
+
+	licensingv1alpha1 "github.com/liferay/liferay-portal/cloud/operator/api/licensing/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	meta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	types "k8s.io/apimachinery/pkg/types"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestEnforceReplicaCeiling(t *testing.T) {
+	testCases := map[string]struct {
+		desiredReplicas   *int32
+		expectedCondition metav1.ConditionStatus
+		expectedEffective *int32
+		expectedReason    string
+		expectedReplicas  *int32
+		maxClusterNodes   int32
+		workloadExists    bool
+		workloadReplicas  *int32
+	}{
+		"caps replicas above the licensed maximum": {
+			desiredReplicas:   pointerInt32(5),
+			expectedCondition: metav1.ConditionFalse,
+			expectedEffective: pointerInt32(3),
+			expectedReason:    "ExceedsLicensedMaximum",
+			expectedReplicas:  pointerInt32(3),
+			maxClusterNodes:   3,
+			workloadExists:    true,
+			workloadReplicas:  pointerInt32(5),
+		},
+		"caps the current replicas when desired is unset": {
+			desiredReplicas:   nil,
+			expectedCondition: metav1.ConditionFalse,
+			expectedEffective: pointerInt32(2),
+			expectedReason:    "ExceedsLicensedMaximum",
+			expectedReplicas:  pointerInt32(2),
+			maxClusterNodes:   2,
+			workloadExists:    true,
+			workloadReplicas:  pointerInt32(4),
+		},
+		"defaults to a single replica when neither desired nor current is set": {
+			desiredReplicas:   nil,
+			expectedCondition: metav1.ConditionTrue,
+			expectedEffective: pointerInt32(1),
+			expectedReason:    "WithinLicensedLimit",
+			expectedReplicas:  pointerInt32(1),
+			maxClusterNodes:   5,
+			workloadExists:    true,
+			workloadReplicas:  nil,
+		},
+		"reports when the workload does not exist": {
+			desiredReplicas:   pointerInt32(3),
+			expectedCondition: metav1.ConditionUnknown,
+			expectedEffective: nil,
+			expectedReason:    "WorkloadNotFound",
+			expectedReplicas:  nil,
+			maxClusterNodes:   3,
+			workloadExists:    false,
+			workloadReplicas:  nil,
+		},
+		"scales a running workload down to the ceiling": {
+			desiredReplicas:   pointerInt32(5),
+			expectedCondition: metav1.ConditionFalse,
+			expectedEffective: pointerInt32(3),
+			expectedReason:    "ExceedsLicensedMaximum",
+			expectedReplicas:  pointerInt32(3),
+			maxClusterNodes:   3,
+			workloadExists:    true,
+			workloadReplicas:  pointerInt32(5),
+		},
+		"skips enforcement when the ceiling is unknown": {
+			desiredReplicas:   pointerInt32(3),
+			expectedCondition: metav1.ConditionUnknown,
+			expectedEffective: nil,
+			expectedReason:    "MaxClusterNodesUnknown",
+			expectedReplicas:  pointerInt32(3),
+			maxClusterNodes:   0,
+			workloadExists:    true,
+			workloadReplicas:  pointerInt32(3),
+		},
+		"within the licensed limit": {
+			desiredReplicas:   pointerInt32(2),
+			expectedCondition: metav1.ConditionTrue,
+			expectedEffective: pointerInt32(2),
+			expectedReason:    "WithinLicensedLimit",
+			expectedReplicas:  pointerInt32(2),
+			maxClusterNodes:   3,
+			workloadExists:    true,
+			workloadReplicas:  pointerInt32(2),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			liferayEnvironment := &licensingv1alpha1.LiferayEnvironment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dev",
+					Namespace: "liferay-dev",
+				},
+				Spec: licensingv1alpha1.LiferayEnvironmentSpec{
+					DesiredReplicas: testCase.desiredReplicas,
+					WorkloadRef: licensingv1alpha1.WorkloadRef{
+						Name: "dev-liferay",
+					},
+				},
+			}
+
+			objects := []client.Object{}
+
+			if testCase.workloadExists {
+				objects = append(objects, &appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dev-liferay",
+						Namespace: "liferay-dev",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: testCase.workloadReplicas,
+					},
+				})
+			}
+
+			reconciler := &LiferayEnvironmentReconciler{
+				Client: newFakeClient(t, objects...),
+			}
+
+			if error := reconciler.enforceReplicaCeiling(
+				context.Background(), liferayEnvironment, testCase.maxClusterNodes,
+			); error != nil {
+				t.Fatalf("Unexpected error from enforceReplicaCeiling: %v", error)
+			}
+
+			assertReplicasEqual(
+				t, "status.effectiveReplicas",
+				testCase.expectedEffective,
+				liferayEnvironment.Status.EffectiveReplicas,
+			)
+
+			condition := meta.FindStatusCondition(
+				liferayEnvironment.Status.Conditions, conditionReplicasCountValid,
+			)
+
+			if condition == nil {
+				t.Fatalf("Expected a %s condition, got none", conditionReplicasCountValid)
+			}
+
+			if condition.Status != testCase.expectedCondition {
+				t.Errorf(
+					"Condition status = %q, want %q",
+					condition.Status, testCase.expectedCondition,
+				)
+			}
+
+			if condition.Reason != testCase.expectedReason {
+				t.Errorf(
+					"Condition reason = %q, want %q",
+					condition.Reason, testCase.expectedReason,
+				)
+			}
+
+			if !testCase.workloadExists {
+				return
+			}
+
+			statefulSet := &appsv1.StatefulSet{}
+
+			if error := reconciler.Get(
+				context.Background(), types.NamespacedName{
+					Name:      "dev-liferay",
+					Namespace: "liferay-dev",
+				}, statefulSet); error != nil {
+				t.Fatalf("Unable to read the workload: %v", error)
+			}
+
+			assertReplicasEqual(
+				t, "statefulSet.spec.replicas",
+				testCase.expectedReplicas, statefulSet.Spec.Replicas,
+			)
+		})
+	}
+}
+
+func TestResolveDesiredReplicas(t *testing.T) {
+	testCases := map[string]struct {
+		desiredReplicas  *int32
+		expected         int32
+		workloadReplicas *int32
+	}{
+		"defaults to one replica": {
+			desiredReplicas:  nil,
+			expected:         1,
+			workloadReplicas: nil,
+		},
+		"falls back to the running replica count": {
+			desiredReplicas:  nil,
+			expected:         2,
+			workloadReplicas: pointerInt32(2),
+		},
+		"prefers the operator intent": {
+			desiredReplicas:  pointerInt32(4),
+			expected:         4,
+			workloadReplicas: pointerInt32(2),
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			liferayEnvironment := &licensingv1alpha1.LiferayEnvironment{
+				Spec: licensingv1alpha1.LiferayEnvironmentSpec{
+					DesiredReplicas: testCase.desiredReplicas,
+				},
+			}
+
+			statefulSet := &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: testCase.workloadReplicas,
+				},
+			}
+
+			if actual := resolveDesiredReplicas(
+				liferayEnvironment, statefulSet,
+			); actual != testCase.expected {
+				t.Errorf("Unexpected resolveDesiredReplicas result: got %d, want %d", actual, testCase.expected)
+			}
+		})
+	}
+}
+
+func assertReplicasEqual(t *testing.T, field string, expected *int32, actual *int32) {
+	t.Helper()
+
+	if expected == nil {
+		if actual != nil {
+			t.Errorf("Unexpected %s: got %d, want nil", field, *actual)
+		}
+
+		return
+	}
+
+	if actual == nil {
+		t.Errorf("Unexpected %s: got nil, want %d", field, *expected)
+
+		return
+	}
+
+	if *actual != *expected {
+		t.Errorf("Unexpected %s: got %d, want %d", field, *actual, *expected)
+	}
+}
+
+func newFakeClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+
+	if error := appsv1.AddToScheme(scheme); error != nil {
+		t.Fatalf("Unable to register the apps/v1 scheme: %v", error)
+	}
+
+	if error := licensingv1alpha1.AddToScheme(scheme); error != nil {
+		t.Fatalf("Unable to register the licensing scheme: %v", error)
+	}
+
+	return fake.NewClientBuilder().WithObjects(objects...).WithScheme(scheme).Build()
+}
+
+func pointerInt32(value int32) *int32 {
+	return &value
+}

--- a/cloud/terraform/azure/aks/.terraform.lock.hcl
+++ b/cloud/terraform/azure/aks/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.81.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:olVprUWhmFTARlydw/r7VIx4fata2gy3zsAWfPGRrhg=",
+    "zh:0732e7b74264ddfa2b90ba69d01c283d3cbae9f72ed3e506c6ac92529fed7fd3",
+    "zh:12afb524e232fe4e3d6161927724af5dfa4831d71edd9c174917ca9b7377bfae",
+    "zh:169d619ae202c4145e02fb706fb7c3679445ab3e3ff722edbf89597517a8c92e",
+    "zh:6beb95a3ef2f2d9c76abaa48e5450e90686a3fb6a47f1cb0ff7c5e94b6960151",
+    "zh:705e075fb5ffc4bf66fd7cbabf1a65007a41621e80030a2c158a4c83b6046216",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a8d17fefe647040fcb9ee8821a4f09f395427c4fd49493489b9a93a9a1038e",
+    "zh:8cc3f900b3774c0ae37ae42365c4579a199cf9e5edf88e476fdf5ab1048f84ea",
+    "zh:dec373b9390fa95e257291acd018ed65a7d512b428645d35e22cdbe8b245a08b",
+    "zh:e60f1e9fb45df6defade2855ed6e68547409ea75d30655c556adb0c08579749b",
+    "zh:f901d12ec82f3f8b5880a27b5cbcd7bd0d97e60c9367a2d7ed82fdd1157b39ff",
+    "zh:facf68ea5bf0f2b8ba720e7fba5f86492e1d4c591100460bb91c3f79f391f4b6",
+  ]
+}

--- a/cloud/terraform/azure/platform/.terraform.lock.hcl
+++ b/cloud/terraform/azure/platform/.terraform.lock.hcl
@@ -1,0 +1,82 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.81.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:olVprUWhmFTARlydw/r7VIx4fata2gy3zsAWfPGRrhg=",
+    "zh:0732e7b74264ddfa2b90ba69d01c283d3cbae9f72ed3e506c6ac92529fed7fd3",
+    "zh:12afb524e232fe4e3d6161927724af5dfa4831d71edd9c174917ca9b7377bfae",
+    "zh:169d619ae202c4145e02fb706fb7c3679445ab3e3ff722edbf89597517a8c92e",
+    "zh:6beb95a3ef2f2d9c76abaa48e5450e90686a3fb6a47f1cb0ff7c5e94b6960151",
+    "zh:705e075fb5ffc4bf66fd7cbabf1a65007a41621e80030a2c158a4c83b6046216",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79a8d17fefe647040fcb9ee8821a4f09f395427c4fd49493489b9a93a9a1038e",
+    "zh:8cc3f900b3774c0ae37ae42365c4579a199cf9e5edf88e476fdf5ab1048f84ea",
+    "zh:dec373b9390fa95e257291acd018ed65a7d512b428645d35e22cdbe8b245a08b",
+    "zh:e60f1e9fb45df6defade2855ed6e68547409ea75d30655c556adb0c08579749b",
+    "zh:f901d12ec82f3f8b5880a27b5cbcd7bd0d97e60c9367a2d7ed82fdd1157b39ff",
+    "zh:facf68ea5bf0f2b8ba720e7fba5f86492e1d4c591100460bb91c3f79f391f4b6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "3.1.2"
+  constraints = "~> 3.1.1"
+  hashes = [
+    "h1:lIuknMfM7+QTzPWs8VBocstZF0B3TpEMIj/bw+dLAOs=",
+    "zh:1086b24b20d94afc331eb38c52b70848899fd0efaed46d9f4646180b96e9dffd",
+    "zh:28bebd04f8d0c44291dc961597c89de5be1e62153191b8b466dbbfb254c696aa",
+    "zh:49a7dd287c2c80621ba0c25834b1afac88c45d47ad3a24cd0aed634d78b1bbd4",
+    "zh:574e146b128be51cd4d9ee66cb8352eac82c7e3be2dbf53a51516ca701bb8b7c",
+    "zh:68285c8987affaa635c9590a0cefe238ba277e12532b64cb2d7ffec570ade064",
+    "zh:6ce12b5eb8f1d9aa61c4d336905e0186f9ea82c8767169533be5b206e4bd33f4",
+    "zh:83b7743951c989732f191cb429549296bca6faecffed492094bef92bec5c9dcb",
+    "zh:84fe2d11907b4e9d0c536d8b50bb63ad4056f60a73c4b734d5de7435784e53a7",
+    "zh:c8a25498bfbde4916f178d6880d9ee56ed9ceb88bef4842cd47360faadbb3dfb",
+    "zh:dfad553c09b36a7df68c3622c78b835669e69aaf954735802e85375a8df01dff",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fd6f36da732f442e421d2b90ed3925a1c9ad0992c380a61fe7681d90b34aa5f3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "3.1.0"
+  constraints = "~> 3.1.0"
+  hashes = [
+    "h1:oodIAuFMikXNmEtil5MQgP4dfSctUBYQiGJfjbsF3NY=",
+    "zh:0215c5c60be62028c09a2f22458e89cda3ef5830a632299f1d401eb3538874b0",
+    "zh:09ebb9f442431e278a310a9423f32caf467cb4b3cad3fe59573ca71fa7b14e20",
+    "zh:0c4e5912f83bb35846ae0a9ae54fc320706ee61894cd21cc6b4181b1c5a2fa5c",
+    "zh:1678c982853ad461e65ccb5e79d585e13ed109dd47dab2a66d3a7a304faeef65",
+    "zh:1c050a5c15e330457a9c18caacf61a923c59d663e13f2962e4b32f04fef523a0",
+    "zh:2c55bcec83be58ec132c7cb0a1ac644758b800d794fdc636d53a0eada0358a3a",
+    "zh:a062bb0aa316c08d8460c66a5d68da71da40de5d3bc3b31abcf3a1a9a19650f1",
+    "zh:a26fdea0afaa9b247c73c0b42843ca51ba7db0ac2571f9d3d50dcabd20ca1b98",
+    "zh:c872c9385a78d502bf5823d61cd3bb0f9a0585030e025eb12585c83451beeaa1",
+    "zh:f180879af931182beee4c8c0d9dab62b81d86f17ddcbe3786ef4c7cec9163a4e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f70f5789264069e0eef06f9b5d5fde955ef7206f7d446d1ce51a4c37a3f3e02f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.8.1"
+  hashes = [
+    "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/cloud/terraform/azure/platform/tests/platform.tftest.hcl
+++ b/cloud/terraform/azure/platform/tests/platform.tftest.hcl
@@ -1,0 +1,192 @@
+mock_provider "azurerm" {
+	mock_data "azurerm_key_vault" {
+		defaults={
+			id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/liferay-test/providers/Microsoft.KeyVault/vaults/liferay-test-vault"
+		}
+	}
+	mock_data "azurerm_resource_group" {
+		defaults={
+			id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/liferay-test"
+		}
+	}
+	mock_resource "azurerm_user_assigned_identity" {
+		defaults={
+			id="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/liferay-test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/liferay-test-identity"
+		}
+	}
+}
+override_module {
+	target=module.argocd
+}
+run "should_assemble_the_cluster_identity" {
+	assert {
+		condition=join(",", keys(local.cluster_identity)) == "crossplaneDataClientId,crossplaneIamClientId,deploymentName,oidcIssuerUrl,region,resourceGroupName,subscriptionId,tenantId"
+		error_message="The cluster identity must carry exactly the keys the infrastructure provider consumes"
+	}
+	assert {
+		condition=local.cluster_identity.deploymentName == "liferay-test"
+		error_message="The cluster identity must carry the deployment name"
+	}
+	assert {
+		condition=local.cluster_identity.region == "eastus"
+		error_message="The cluster identity must carry the deployment region"
+	}
+	command=plan
+}
+run "should_default_to_the_azure_key_vault_secret_store" {
+	assert {
+		condition=join(",", keys(local.cluster_secret_store_provider)) == "azurekv"
+		error_message="The secret store provider must default to Azure Key Vault"
+	}
+	assert {
+		condition=local.cluster_secret_store_provider.azurekv.authType == "WorkloadIdentity"
+		error_message="The default Azure Key Vault provider must authenticate through workload identity"
+	}
+	assert {
+		condition=local.cluster_secret_store_provider.azurekv.serviceAccountRef.name == "external-secrets" && local.cluster_secret_store_provider.azurekv.serviceAccountRef.namespace == "external-secrets-system"
+		error_message="The default Azure Key Vault provider must reference the External Secrets service account"
+	}
+	assert {
+		condition=local.cluster_secret_store_provider.azurekv.vaultUrl == data.azurerm_key_vault.liferay[0].vault_uri
+		error_message="The default Azure Key Vault provider must point at the deployment vault"
+	}
+	command=plan
+}
+run "should_derive_azure_resource_names_from_the_deployment_name" {
+	assert {
+		condition=data.azurerm_kubernetes_cluster.aks.name == "liferay-test-aks"
+		error_message="The AKS cluster lookup must derive its name from the deployment name"
+	}
+	assert {
+		condition=data.azurerm_key_vault.liferay[0].name == "liferay-test-vault"
+		error_message="The Key Vault lookup must derive its name from the deployment name with the -vault suffix"
+	}
+	assert {
+		condition=data.azurerm_key_vault.liferay[0].resource_group_name == "liferay-test"
+		error_message="The resource group lookup must derive its name from the deployment name"
+	}
+	assert {
+		condition=azurerm_user_assigned_identity.crossplane_data.name == "liferay-test-crossplane-data"
+		error_message="The Crossplane data identity must derive its name from the deployment name"
+	}
+	assert {
+		condition=azurerm_user_assigned_identity.crossplane_iam.name == "liferay-test-crossplane-iam"
+		error_message="The Crossplane IAM identity must derive its name from the deployment name"
+	}
+	assert {
+		condition=azurerm_user_assigned_identity.external_secrets.name == "liferay-test-external-secrets"
+		error_message="The External Secrets identity must derive its name from the deployment name"
+	}
+	command=plan
+}
+run "should_inject_an_external_secret_store_provider" {
+	assert {
+		condition=local.cluster_secret_store_provider.vault.server == "https://vault.example.com:8200"
+		error_message="A configured external secret store provider must flow to the platform module verbatim"
+	}
+	assert {
+		condition=!contains(keys(local.cluster_secret_store_provider), "azurekv")
+		error_message="An external secret store provider must replace the default Azure Key Vault provider"
+	}
+	assert {
+		condition=length(data.azurerm_key_vault.liferay) == 0
+		error_message="An external secret store provider must skip the Key Vault lookup"
+	}
+	assert {
+		condition=length(azurerm_role_assignment.external_secrets_vault) == 0
+		error_message="An external secret store provider must skip the Key Vault role assignment"
+	}
+	command=plan
+	variables {
+		cluster_secret_store_provider_hcl={
+			vault={
+				server="https://vault.example.com:8200"
+			}
+		}
+	}
+}
+run "should_reject_a_deployment_name_the_vault_name_cannot_absorb" {
+	command=plan
+	expect_failures=[
+		var.deployment_name,
+	]
+	variables {
+		deployment_name="liferay-test-overflowing"
+	}
+}
+run "should_wire_the_platform_identities" {
+	assert {
+		condition=azurerm_federated_identity_credential.crossplane_data.subject == "system:serviceaccount:crossplane-system:crossplane-data"
+		error_message="The Crossplane data federated credential must pin the provider service account subject"
+	}
+	assert {
+		condition=azurerm_federated_identity_credential.crossplane_iam.subject == "system:serviceaccount:crossplane-system:crossplane-iam"
+		error_message="The Crossplane IAM federated credential must pin the provider service account subject"
+	}
+	assert {
+		condition=azurerm_federated_identity_credential.external_secrets.subject == "system:serviceaccount:external-secrets-system:external-secrets"
+		error_message="The External Secrets federated credential subject must match the secret store service account reference"
+	}
+	assert {
+		condition=azurerm_federated_identity_credential.external_secrets.issuer == data.azurerm_kubernetes_cluster.aks.oidc_issuer_url
+		error_message="The federated credentials must trust the cluster OIDC issuer"
+	}
+	assert {
+		condition=local.cluster_identity.crossplaneDataClientId == azurerm_user_assigned_identity.crossplane_data.client_id
+		error_message="The cluster identity must carry the Crossplane data identity client ID"
+	}
+	assert {
+		condition=local.cluster_identity.crossplaneIamClientId == azurerm_user_assigned_identity.crossplane_iam.client_id
+		error_message="The cluster identity must carry the Crossplane IAM identity client ID"
+	}
+	assert {
+		condition=output.external_secrets_client_id == azurerm_user_assigned_identity.external_secrets.client_id
+		error_message="The External Secrets client ID must be published so the bootstrap can annotate the service account"
+	}
+	assert {
+		condition=output.cluster_identity == local.cluster_identity
+		error_message="The cluster identity must be published for the bootstrap to place under clusterIdentity"
+	}
+	assert {
+		condition=output.cluster_secret_store_provider == local.cluster_secret_store_provider
+		error_message="The secret store provider must be published for the bootstrap to place under clusterSecretStore.provider"
+	}
+	assert {
+		condition=azurerm_role_assignment.crossplane_data_contributor.role_definition_name == "Contributor"
+		error_message="The Crossplane data identity must hold Contributor on the resource group"
+	}
+	assert {
+		condition=azurerm_role_assignment.crossplane_iam_managed_identity_contributor.role_definition_name == "Managed Identity Contributor"
+		error_message="The Crossplane IAM identity must hold Managed Identity Contributor on the resource group"
+	}
+	assert {
+		condition=azurerm_role_assignment.crossplane_iam_rbac_administrator.role_definition_name == "Role Based Access Control Administrator"
+		error_message="The Crossplane IAM identity must hold Role Based Access Control Administrator on the resource group"
+	}
+	assert {
+		condition=data.azurerm_role_definition.key_vault_crypto_service_encryption_user.name == "Key Vault Crypto Service Encryption User" && data.azurerm_role_definition.storage_blob_data_contributor.name == "Storage Blob Data Contributor"
+		error_message="The grantable role allowlist must resolve the intended built in roles by name"
+	}
+	assert {
+		condition=strcontains(azurerm_role_assignment.crossplane_iam_rbac_administrator.condition, basename(data.azurerm_role_definition.key_vault_crypto_service_encryption_user.role_definition_id)) && strcontains(azurerm_role_assignment.crossplane_iam_rbac_administrator.condition, basename(data.azurerm_role_definition.storage_blob_data_contributor.role_definition_id))
+		error_message="The role assignment condition must restrict grantable roles to the allowlist"
+	}
+	assert {
+		condition=strcontains(azurerm_role_assignment.crossplane_iam_rbac_administrator.condition, "@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId]") && strcontains(azurerm_role_assignment.crossplane_iam_rbac_administrator.condition, "@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId]")
+		error_message="The condition must constrain the write and delete actions through their respective attribute sources"
+	}
+	assert {
+		condition=strcontains(azurerm_role_assignment.crossplane_iam_rbac_administrator.condition, "'ServicePrincipal'")
+		error_message="The condition must restrict grants to service principals"
+	}
+	assert {
+		condition=length(azurerm_role_assignment.external_secrets_vault) == 1 && azurerm_role_assignment.external_secrets_vault[0].role_definition_name == "Key Vault Secrets User"
+		error_message="The External Secrets identity must hold Key Vault Secrets User on the deployment vault"
+	}
+	command=apply
+}
+variables {
+	argocd_helm_chart_version="10.1.3"
+	deployment_name="liferay-test"
+	region="eastus"
+}

--- a/cloud/terraform/gcp/gitops/platform/.terraform.lock.hcl
+++ b/cloud/terraform/gcp/gitops/platform/.terraform.lock.hcl
@@ -1,0 +1,84 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:faTJQOetP9/RYuHwA3r2SWnuYoyzQNm4tUWZrZggcgY=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "3.2.0"
+  constraints = "~> 3.1"
+  hashes = [
+    "h1:CTWVDQxyq1cQJR/9RJSkXii/gz5zMjxszSw9LmptDh4=",
+    "zh:2f1d55bf4e6a9c2629dfd3b162a05632f2e251bf6083d8613f38af3d51cea553",
+    "zh:33b378f15d39c2050a9272f6d5e8437f162972c93244af6df6de54ba2b0a416c",
+    "zh:501d7e7b3d42f5b40a6e5e979d5a6a4d67eba0fb37d786e2c3d7186e742dd557",
+    "zh:52e430da694bad4a06d049aa574d4a7a2b4e11c47d7bab637131068cc1160593",
+    "zh:77fb8ecaa27f4218177917bb3865551b058b92193408fa20366c45a529f0ac94",
+    "zh:b114d6ea5ab4486dc26b83cd595f0af820b3d66d0d1cf81975dfe7baa84419e2",
+    "zh:b6729f6f32fab90945e3cb4ba0268b73262dad0d14c1d71514ac767bac644595",
+    "zh:b9ff1756e698e1d3bdb0c2605ee31794f15d8275e2f8817a2bf66f3272ed9362",
+    "zh:be4791496afea715783f0efb65d21c99d3dc84ddb94ba4868f3afee2d50e71ef",
+    "zh:c8f66bd76991d7521a805cce3000a5226b1b18baf1d6b63a03d38e09208a564b",
+    "zh:e2bdd80b8956307f7307f90ffab0e91169bb83babeb540c712239dbc5c09916f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fcda8394edc50d2a2132534edf8655cb25dc76f55937e859b9ffb5f787430f37",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.36.0"
+  constraints = "~> 2.36.0"
+  hashes = [
+    "h1:vdY0sxo7ahwuz/y7flXTE04tSwn0Zhxyg6n62aTmAHI=",
+    "zh:07f38fcb7578984a3e2c8cf0397c880f6b3eb2a722a120a08a634a607ea495ca",
+    "zh:1adde61769c50dbb799d8bf8bfd5c8c504a37017dfd06c7820f82bcf44ca0d39",
+    "zh:39707f23ab58fd0e686967c0f973c0f5a39c14d6ccfc757f97c345fdd0cd4624",
+    "zh:4cc3dc2b5d06cc22d1c734f7162b0a8fdc61990ff9efb64e59412d65a7ccc92a",
+    "zh:8382dcb82ba7303715b5e67939e07dd1c8ecddbe01d12f39b82b2b7d7357e1d9",
+    "zh:88e8e4f90034186b8bfdea1b8d394621cbc46a064ff2418027e6dba6807d5227",
+    "zh:a6276a75ad170f76d88263fdb5f9558998bf3a3f7650d7bd3387b396410e59f3",
+    "zh:bc816c7e0606e5df98a0c7634b240bb0c8100c3107b8b17b554af702edc6a0c5",
+    "zh:cb2f31d58f37020e840af52755c18afd1f09a833c4903ac59270ab440fab57b7",
+    "zh:ee0d103b8d0089fb1918311683110b4492a9346f0471b136af46d3b019576b22",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f688b9ec761721e401f6859c19c083e3be20a650426f4747cd359cdc079d212a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/cloud/terraform/gcp/gitops/resources/.terraform.lock.hcl
+++ b/cloud/terraform/gcp/gitops/resources/.terraform.lock.hcl
@@ -1,0 +1,63 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:faTJQOetP9/RYuHwA3r2SWnuYoyzQNm4tUWZrZggcgY=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "3.2.0"
+  constraints = "~> 3.1"
+  hashes = [
+    "h1:CTWVDQxyq1cQJR/9RJSkXii/gz5zMjxszSw9LmptDh4=",
+    "zh:2f1d55bf4e6a9c2629dfd3b162a05632f2e251bf6083d8613f38af3d51cea553",
+    "zh:33b378f15d39c2050a9272f6d5e8437f162972c93244af6df6de54ba2b0a416c",
+    "zh:501d7e7b3d42f5b40a6e5e979d5a6a4d67eba0fb37d786e2c3d7186e742dd557",
+    "zh:52e430da694bad4a06d049aa574d4a7a2b4e11c47d7bab637131068cc1160593",
+    "zh:77fb8ecaa27f4218177917bb3865551b058b92193408fa20366c45a529f0ac94",
+    "zh:b114d6ea5ab4486dc26b83cd595f0af820b3d66d0d1cf81975dfe7baa84419e2",
+    "zh:b6729f6f32fab90945e3cb4ba0268b73262dad0d14c1d71514ac767bac644595",
+    "zh:b9ff1756e698e1d3bdb0c2605ee31794f15d8275e2f8817a2bf66f3272ed9362",
+    "zh:be4791496afea715783f0efb65d21c99d3dc84ddb94ba4868f3afee2d50e71ef",
+    "zh:c8f66bd76991d7521a805cce3000a5226b1b18baf1d6b63a03d38e09208a564b",
+    "zh:e2bdd80b8956307f7307f90ffab0e91169bb83babeb540c712239dbc5c09916f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fcda8394edc50d2a2132534edf8655cb25dc76f55937e859b9ffb5f787430f37",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.36.0"
+  constraints = "~> 2.36.0"
+  hashes = [
+    "h1:vdY0sxo7ahwuz/y7flXTE04tSwn0Zhxyg6n62aTmAHI=",
+    "zh:07f38fcb7578984a3e2c8cf0397c880f6b3eb2a722a120a08a634a607ea495ca",
+    "zh:1adde61769c50dbb799d8bf8bfd5c8c504a37017dfd06c7820f82bcf44ca0d39",
+    "zh:39707f23ab58fd0e686967c0f973c0f5a39c14d6ccfc757f97c345fdd0cd4624",
+    "zh:4cc3dc2b5d06cc22d1c734f7162b0a8fdc61990ff9efb64e59412d65a7ccc92a",
+    "zh:8382dcb82ba7303715b5e67939e07dd1c8ecddbe01d12f39b82b2b7d7357e1d9",
+    "zh:88e8e4f90034186b8bfdea1b8d394621cbc46a064ff2418027e6dba6807d5227",
+    "zh:a6276a75ad170f76d88263fdb5f9558998bf3a3f7650d7bd3387b396410e59f3",
+    "zh:bc816c7e0606e5df98a0c7634b240bb0c8100c3107b8b17b554af702edc6a0c5",
+    "zh:cb2f31d58f37020e840af52755c18afd1f09a833c4903ac59270ab440fab57b7",
+    "zh:ee0d103b8d0089fb1918311683110b4492a9346f0471b136af46d3b019576b22",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f688b9ec761721e401f6859c19c083e3be20a650426f4747cd359cdc079d212a",
+  ]
+}

--- a/cloud/terraform/gcp/gke/.terraform.lock.hcl
+++ b/cloud/terraform/gcp/gke/.terraform.lock.hcl
@@ -1,0 +1,125 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.43.0"
+  constraints = "~> 7.0"
+  hashes = [
+    "h1:oiNYwWzxjToOWwGtc59+Sxoa/Xkwh8t8deJ7lBDimuk=",
+    "zh:0050abe670a076cfc110662ba3e9f8c25366a63df9389dfbe090b5dc5e73a4d2",
+    "zh:31769c27700334d11e652ddb2a0dfc9efd65df43dbc51a06afc04e10db645bbe",
+    "zh:33f7211886d44a31d9dc89fbe11f0d2e282da22b509ae25dcfb8c6533eeacff4",
+    "zh:3ee98b297ec00ad10b1080fddfddbe72c38dec00eece6d56e706fea1e871d648",
+    "zh:620683cba53b964a882a419c38d40ab4595459b44dc54b9ed18c5bb6b97fbceb",
+    "zh:7c118cc8ba4c245807b3cbcfd4f5bdb81b1afce83fa1528020208117f7c9518c",
+    "zh:8263f9aeab9c8bc661a8f6a4963e585ca0a86ed6662424d8f34923fd01c6de18",
+    "zh:d2ba502aa3da2dad62ae81dd32c97bc279c56a97b9ac3bb3f806303dc0af598d",
+    "zh:db37f9f900b801ffaad1b7194c4b89de9351879e753b752ca37e12f3e989691f",
+    "zh:eca80c71ef4a559b94a779365a8d8b91a33d7a805a27ca21c176720085c31d30",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fa91060bb31207fc91645e7de881fa61f106b9d0dfed2f444f158b9cd9420c58",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "7.43.0"
+  constraints = "~> 7.0"
+  hashes = [
+    "h1:X+bbst5TDxzGIQM+ZJf4pUGHT8ojyVlTVF66Ej24+E4=",
+    "zh:066d487c339ebbcb4fed9889af5849c3e69509639bf76343afc684ca9fa7ce9f",
+    "zh:11f72e6be5296fff41489a24acc3f68b3db2cdbb69260e1b79d1cd7ed54f40fe",
+    "zh:14eeb35909a37f8aaf36bad30b8c294c9fe7d9c54bc937990bf130d8fb141e68",
+    "zh:1d19b0e2fee8d5fd99cd3b6fb63ae6d1a27ceca449301ad4619e98807ef595be",
+    "zh:2b17780801a1f4b5efaa95a66b7410e1c88d34c36aea549af7fafb616688f966",
+    "zh:41e07102521298b1e7dac81363a863f44f9d66711c9c9e7bc5bde398d712949a",
+    "zh:588df429b0667a612bd1d7ee05bd703f53762879a66fc6f2494999f8e12143e6",
+    "zh:8a53b87c29ee0653b711d89b1dfb4993d41ff754e31d4d98267dea908ee46100",
+    "zh:8e53fc59171a73a5c5ff1a60e97e5143c3a652729550748506f0fa720c807bad",
+    "zh:962bede77af31c8359a1d6724c950659d7bbe19df738d44dee8096cf2bd52d3d",
+    "zh:c050e33e9a0e738b80b4d07f729a5be033a692857b47547c6a85430de6b90000",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "3.2.0"
+  constraints = "~> 3.1"
+  hashes = [
+    "h1:CTWVDQxyq1cQJR/9RJSkXii/gz5zMjxszSw9LmptDh4=",
+    "zh:2f1d55bf4e6a9c2629dfd3b162a05632f2e251bf6083d8613f38af3d51cea553",
+    "zh:33b378f15d39c2050a9272f6d5e8437f162972c93244af6df6de54ba2b0a416c",
+    "zh:501d7e7b3d42f5b40a6e5e979d5a6a4d67eba0fb37d786e2c3d7186e742dd557",
+    "zh:52e430da694bad4a06d049aa574d4a7a2b4e11c47d7bab637131068cc1160593",
+    "zh:77fb8ecaa27f4218177917bb3865551b058b92193408fa20366c45a529f0ac94",
+    "zh:b114d6ea5ab4486dc26b83cd595f0af820b3d66d0d1cf81975dfe7baa84419e2",
+    "zh:b6729f6f32fab90945e3cb4ba0268b73262dad0d14c1d71514ac767bac644595",
+    "zh:b9ff1756e698e1d3bdb0c2605ee31794f15d8275e2f8817a2bf66f3272ed9362",
+    "zh:be4791496afea715783f0efb65d21c99d3dc84ddb94ba4868f3afee2d50e71ef",
+    "zh:c8f66bd76991d7521a805cce3000a5226b1b18baf1d6b63a03d38e09208a564b",
+    "zh:e2bdd80b8956307f7307f90ffab0e91169bb83babeb540c712239dbc5c09916f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fcda8394edc50d2a2132534edf8655cb25dc76f55937e859b9ffb5f787430f37",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.36.0"
+  constraints = "~> 2.36.0"
+  hashes = [
+    "h1:vdY0sxo7ahwuz/y7flXTE04tSwn0Zhxyg6n62aTmAHI=",
+    "zh:07f38fcb7578984a3e2c8cf0397c880f6b3eb2a722a120a08a634a607ea495ca",
+    "zh:1adde61769c50dbb799d8bf8bfd5c8c504a37017dfd06c7820f82bcf44ca0d39",
+    "zh:39707f23ab58fd0e686967c0f973c0f5a39c14d6ccfc757f97c345fdd0cd4624",
+    "zh:4cc3dc2b5d06cc22d1c734f7162b0a8fdc61990ff9efb64e59412d65a7ccc92a",
+    "zh:8382dcb82ba7303715b5e67939e07dd1c8ecddbe01d12f39b82b2b7d7357e1d9",
+    "zh:88e8e4f90034186b8bfdea1b8d394621cbc46a064ff2418027e6dba6807d5227",
+    "zh:a6276a75ad170f76d88263fdb5f9558998bf3a3f7650d7bd3387b396410e59f3",
+    "zh:bc816c7e0606e5df98a0c7634b240bb0c8100c3107b8b17b554af702edc6a0c5",
+    "zh:cb2f31d58f37020e840af52755c18afd1f09a833c4903ac59270ab440fab57b7",
+    "zh:ee0d103b8d0089fb1918311683110b4492a9346f0471b136af46d3b019576b22",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f688b9ec761721e401f6859c19c083e3be20a650426f4747cd359cdc079d212a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:l+dm3lhmu4ys7GbvIldfn544olSPH0DOiYruuFSfQkY=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = "~> 0.12"
+  hashes = [
+    "h1:4EThC3ocCFiFPMZQSUvSGSxoJqBcGWxMcFYmL67uS7Y=",
+    "zh:12abfd6b800e4d7fa6db7310dec8ffd440b31993861ef188c7ed5260b3073937",
+    "zh:23005521e800bb19e1597bf755c5f70d675d30b685d4255001ed5fa47d9df3f1",
+    "zh:2fea249b582ae97cd1cc10385187ea50993bb47c28cc5df0305e57ceaabf0a10",
+    "zh:322018d3b987b7aad08697178029a2bb667bed699e88328f0c89c52a2fd41341",
+    "zh:32a08e98fce2d273cb9b2c89d6c54727cc9f0a32e15bfd896be4e02cc6b48f95",
+    "zh:3db89aabd0e619616bd4b0f8b373a7586dfe60feffcea12a84a0bdbc445714b3",
+    "zh:7488f56c81d742dc020f29063626c8f07ca188aa97be61e7307e8d62397020a2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7cb4067f2e7559b13f7562ef722f948950901eb37834873e98360ab28f66e9d7",
+    "zh:9d552c8345f61e1b7db8e725144981345f18ac1014d58d6f5ddf0928a195fffb",
+    "zh:a8e69fb6b97fc9d86fb19a9f4d42abe33c4a68e700b15387ce2e17d2b9934bed",
+    "zh:aeeb900eb8dd0f790c60ea5c0e0c8d42bd6e4a54f391681d4decca15b544394b",
+    "zh:c239c619101a8c95e1f14061eb973c57a8d15fa0e68878ced5bbd76858ee5b79",
+  ]
+}

--- a/cloud/terraform/modules/argocd/.terraform.lock.hcl
+++ b/cloud/terraform/modules/argocd/.terraform.lock.hcl
@@ -1,0 +1,62 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "3.1.2"
+  constraints = "~> 3.1.1"
+  hashes = [
+    "h1:lIuknMfM7+QTzPWs8VBocstZF0B3TpEMIj/bw+dLAOs=",
+    "zh:1086b24b20d94afc331eb38c52b70848899fd0efaed46d9f4646180b96e9dffd",
+    "zh:28bebd04f8d0c44291dc961597c89de5be1e62153191b8b466dbbfb254c696aa",
+    "zh:49a7dd287c2c80621ba0c25834b1afac88c45d47ad3a24cd0aed634d78b1bbd4",
+    "zh:574e146b128be51cd4d9ee66cb8352eac82c7e3be2dbf53a51516ca701bb8b7c",
+    "zh:68285c8987affaa635c9590a0cefe238ba277e12532b64cb2d7ffec570ade064",
+    "zh:6ce12b5eb8f1d9aa61c4d336905e0186f9ea82c8767169533be5b206e4bd33f4",
+    "zh:83b7743951c989732f191cb429549296bca6faecffed492094bef92bec5c9dcb",
+    "zh:84fe2d11907b4e9d0c536d8b50bb63ad4056f60a73c4b734d5de7435784e53a7",
+    "zh:c8a25498bfbde4916f178d6880d9ee56ed9ceb88bef4842cd47360faadbb3dfb",
+    "zh:dfad553c09b36a7df68c3622c78b835669e69aaf954735802e85375a8df01dff",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fd6f36da732f442e421d2b90ed3925a1c9ad0992c380a61fe7681d90b34aa5f3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "3.1.0"
+  constraints = "~> 3.1.0"
+  hashes = [
+    "h1:oodIAuFMikXNmEtil5MQgP4dfSctUBYQiGJfjbsF3NY=",
+    "zh:0215c5c60be62028c09a2f22458e89cda3ef5830a632299f1d401eb3538874b0",
+    "zh:09ebb9f442431e278a310a9423f32caf467cb4b3cad3fe59573ca71fa7b14e20",
+    "zh:0c4e5912f83bb35846ae0a9ae54fc320706ee61894cd21cc6b4181b1c5a2fa5c",
+    "zh:1678c982853ad461e65ccb5e79d585e13ed109dd47dab2a66d3a7a304faeef65",
+    "zh:1c050a5c15e330457a9c18caacf61a923c59d663e13f2962e4b32f04fef523a0",
+    "zh:2c55bcec83be58ec132c7cb0a1ac644758b800d794fdc636d53a0eada0358a3a",
+    "zh:a062bb0aa316c08d8460c66a5d68da71da40de5d3bc3b31abcf3a1a9a19650f1",
+    "zh:a26fdea0afaa9b247c73c0b42843ca51ba7db0ac2571f9d3d50dcabd20ca1b98",
+    "zh:c872c9385a78d502bf5823d61cd3bb0f9a0585030e025eb12585c83451beeaa1",
+    "zh:f180879af931182beee4c8c0d9dab62b81d86f17ddcbe3786ef4c7cec9163a4e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f70f5789264069e0eef06f9b5d5fde955ef7206f7d446d1ce51a4c37a3f3e02f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.8.1"
+  hashes = [
+    "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/cloud/terraform/modules/argocd/tests/argocd.tftest.hcl
+++ b/cloud/terraform/modules/argocd/tests/argocd.tftest.hcl
@@ -1,0 +1,109 @@
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+mock_provider "random" {}
+run "should_advertise_the_external_url_without_enabling_sso" {
+	assert {
+		condition=anytrue([for value in helm_release.argocd.values : try(yamldecode(value).configs.cm.url, null) == "http://argocd.liferay.test"])
+		error_message="The ArgoCD external URL must fall back to HTTP while the gateway terminates no TLS"
+	}
+	assert {
+		condition=alltrue([for value in helm_release.argocd.values : try(yamldecode(value).configs.cm["dex.config"], null) == null])
+		error_message="Publishing an external URL must not enable SSO on its own"
+	}
+	command=plan
+	variables {
+		argocd_external_access_config={
+			hostname="argocd.liferay.test"
+		}
+	}
+}
+run "should_append_the_additional_values_last" {
+	assert {
+		condition=element(helm_release.argocd.values, length(helm_release.argocd.values) - 1) == "controller:\n  replicas: 2\n"
+		error_message="The additional values must land last so callers override the module defaults"
+	}
+	command=plan
+	variables {
+		additional_values=[
+			"controller:\n  replicas: 2\n",
+		]
+	}
+}
+run "should_configure_the_dex_connector_when_sso_is_enabled" {
+	assert {
+		condition=anytrue([for value in helm_release.argocd.values : try(yamldecode(value).configs.cm["dex.config"], null) != null])
+		error_message="The ArgoCD release must configure the SAML connector once SSO is enabled"
+	}
+	assert {
+		condition=anytrue([for value in helm_release.argocd.values : try(yamldecode(yamldecode(value).configs.cm["dex.config"]).connectors[0].type, null) == "saml"])
+		error_message="The Dex connector must declare the SAML type"
+	}
+	assert {
+		condition=anytrue([for value in helm_release.argocd.values : try(yamldecode(value).configs.rbac["policy.default"], null) == "role:liferay-guest"])
+		error_message="Enabling SSO must install the Liferay RBAC policy alongside the connector"
+	}
+	assert {
+		condition=anytrue([for value in helm_release.argocd.values : try(yamldecode(value).configs.cm.url, null) == "https://argocd.liferay.test"])
+		error_message="Enabling SSO must still advertise the external URL Dex derives its issuer from"
+	}
+	command=plan
+	variables {
+		argocd_external_access_config={
+			hostname="argocd.liferay.test"
+			sso_enabled=true
+			tls_enabled=true
+		}
+	}
+}
+run "should_derive_a_tls_external_url" {
+	assert {
+		condition=anytrue([for value in helm_release.argocd.values : try(yamldecode(value).configs.cm.url, null) == "https://argocd.liferay.test"])
+		error_message="The ArgoCD external URL must use HTTPS once the gateway terminates TLS"
+	}
+	command=plan
+	variables {
+		argocd_external_access_config={
+			hostname="argocd.liferay.test"
+			tls_enabled=true
+		}
+	}
+}
+run "should_disable_admin_login_independently_of_external_access" {
+	assert {
+		condition=!yamldecode(helm_release.argocd.values[0]).configs.cm["admin.enabled"]
+		error_message="The admin login toggle must stand on its own, so hardening it does not require SSO"
+	}
+	command=plan
+	variables {
+		argocd_admin_login_enabled=false
+	}
+}
+run "should_enable_admin_login_by_default" {
+	assert {
+		condition=yamldecode(helm_release.argocd.values[0]).configs.cm["admin.enabled"]
+		error_message="The ArgoCD release must leave the built in admin login enabled by default"
+	}
+	command=plan
+}
+run "should_omit_the_external_url_and_the_dex_connector_by_default" {
+	assert {
+		condition=alltrue([for value in helm_release.argocd.values : try(yamldecode(value).configs.cm.url, null) == null])
+		error_message="The ArgoCD release must leave the external URL unset while no caller publishes one"
+	}
+	assert {
+		condition=alltrue([for value in helm_release.argocd.values : try(yamldecode(value).configs.cm["dex.config"], null) == null])
+		error_message="The ArgoCD release must omit the SAML connector while ArgoCD is not externally reachable"
+	}
+	command=plan
+}
+run "should_register_the_health_checks_under_the_infrastructure_api_group" {
+	assert {
+		condition=contains(keys(yamldecode(helm_release.argocd.values[0]).configs.cm), "resource.customizations.health.azure.liferay.com_LiferayInfrastructure")
+		error_message="The LiferayInfrastructure health check key must carry the caller's infrastructure API group"
+	}
+	command=plan
+}
+variables {
+	argocd_helm_chart_version="10.1.3"
+	infrastructure_api_group="azure.liferay.com"
+}

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -618,14 +618,12 @@ definition {
 			locator1 = "ObjectAdmin#TAB_LABEL_NAME",
 			value1 = ${tabName});
 
-		Click(
-			key_labelName = "Relationship",
-			locator1 = "ObjectAdmin#CLAY_GENERIC_BUTTON");
+		Click(locator1 = "ObjectAdmin#RELATIONSHIP_AUTOCOMPLETE");
 
 		if (isSet(relationshipsLabelName)) {
 			Click(
 				key_optionName = ${relationshipsLabelName},
-				locator1 = "ObjectAdmin#CLAY_GENERIC_DROPDOWN_ITEM");
+				locator1 = "ObjectAdmin#RELATIONSHIP_AUTOCOMPLETE_ITEM");
 		}
 
 		Click(

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectAdmin.macro
@@ -1283,7 +1283,7 @@ definition {
 					checkboxName = ${fieldName},
 					locator1 = "Checkbox#ANY_CHECKBOX");
 
-				PortletEntry.save();
+				ObjectCustomViews.clickSave();
 
 				SelectFrame(locator1 = "ObjectAction#IFRAME_SIDE_PANEL");
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectCustomViews.macro
@@ -222,7 +222,7 @@ definition {
 			locator1 = "FormViewBuilder#OBJECT_FIELD_BUTTON_DROPDOWN");
 
 		Type(
-			key_fieldName = "yyyy-mm-dd",
+			key_fieldName = "mm/dd/yyyy",
 			locator1 = "ObjectCustomViews#FROM_DATE_INPUT",
 			value1 = ${displayDate});
 

--- a/modules/apps/object/object-test/src/testFunctional/macros/ObjectNotifications.macro
+++ b/modules/apps/object/object-test/src/testFunctional/macros/ObjectNotifications.macro
@@ -95,7 +95,8 @@ definition {
 		}
 
 		Type(
-			locator1 = "CKEditor#BODY_FIELD_IFRAME",
+			key_fieldLabel = "Template",
+			locator1 = "CKEditor#BODY_FIELD_CONTENTEDITABLE_WEB_CONTENT_ARTICLE",
 			value1 = ${emailBody});
 	}
 
@@ -224,7 +225,8 @@ definition {
 
 		if (isSet(emailBody)) {
 			Type(
-				locator1 = "CKEditor#BODY_FIELD_IFRAME",
+				key_fieldLabel = "Template",
+				locator1 = "CKEditor#BODY_FIELD_CONTENTEDITABLE_WEB_CONTENT_ARTICLE",
 				value1 = ${emailBody});
 		}
 

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectAdmin.path
@@ -56,6 +56,16 @@
 		<td></td>
 	</tr>
 	<tr>
+		<td>RELATIONSHIP_AUTOCOMPLETE</td>
+		<td>//input[@id = 'relationshipAutocomplete']</td>
+		<td></td>
+	</tr>
+	<tr>
+		<td>RELATIONSHIP_AUTOCOMPLETE_ITEM</td>
+		<td>//div[contains(@class,'dropdown-menu-select')]//button[contains(@class,'dropdown-item') and contains(.,'${key_optionName}')]</td>
+		<td></td>
+	</tr>
+	<tr>
 		<td>SAVE_CUSTOM_OBJECT</td>
 		<td>//button[contains(text(),'Save')]</td>
 		<td></td>

--- a/modules/apps/object/object-test/src/testFunctional/paths/ObjectPortlet.path
+++ b/modules/apps/object/object-test/src/testFunctional/paths/ObjectPortlet.path
@@ -56,6 +56,11 @@
 		<td></td>
 	</tr>
 	<tr>
+		<td>ENTRY_RICH_TEXT_EDITABLE</td>
+		<td>//label[contains(.,'${key_fieldLabel}')]//following-sibling::div//div[contains(@class,'ck-editor__editable_inline') and @contenteditable = 'true' and contains(.,'${key_value}')]</td>
+		<td></td>
+	</tr>
+	<tr>
 		<td>ENTRY_STATUS</td>
 		<td>//*[text()='${key_entry}']/../following-sibling::td//*[text()='${key_status}']</td>
 		<td></td>

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -317,10 +317,10 @@ definition {
 		}
 
 		task ("Then it's possible to edit the field's value") {
-			AssertEditable(
+			AssertElementPresent(
 				key_fieldLabel = "Custom Field",
-				locator1 = "FormFields#RICH_TEXT_CONTENT",
-				value = "Entry Test");
+				key_value = "Entry Test",
+				locator1 = "ObjectPortlet#ENTRY_RICH_TEXT_EDITABLE");
 		}
 	}
 

--- a/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/ObjectFields.testcase
@@ -894,7 +894,7 @@ definition {
 
 			ObjectAdmin.clickFieldsSearchableSectionRadioOption(radioOption = "True");
 
-			CreateObject.saveObject();
+			ObjectAdmin.saveSidePanel();
 		}
 
 		task ("When viewing the added entry") {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
@@ -116,9 +116,7 @@ definition {
 
 	@summary = "Default summary"
 	macro startReindex(action = null) {
-		while ((IsElementNotPresent(locator1 = "SearchAdmin#EXECUTE_REINDEX_BUTTON")) && (maxIterations = "50")) {
-			TestUtils.hardRefresh();
-		}
+		TestUtils.hardRefresh();
 
 		Click(
 			key_action = ${action},

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1547,7 +1547,7 @@ definition {
 
 	@summary = "Default summary"
 	macro increaseDisplayDate(minuteIncrease = null) {
-		var displayDate = DateUtil.getDateOffsetByMinutes(${minuteIncrease}, "yyyy-MM-dd HH:mm", "UTC");
+		var displayDate = DateUtil.getDateOffsetByMinutes(${minuteIncrease}, "yyyy-MM-dd hh:mm a", "UTC");
 
 		WebContent.scheduleWCArticleWithPermissions(displayDate = ${displayDate});
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/development/tools/testinginfrastructure/block/macro/TestUtils.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/development/tools/testinginfrastructure/block/macro/TestUtils.macro
@@ -234,20 +234,17 @@ return element.textContent;
 
 	@summary = "Default summary"
 	macro hardRefresh() {
-		var mac = OSDetector.isApple();
+		var cdpParameters = MapUtil.newObjectHashMap();
 
-		if (${mac} == "true") {
-			Type.sendKeys(
-				locator1 = "//body",
-				value1 = "Shift + Command + r");
-		}
-		else {
-			Type.sendKeys(
-				locator1 = "//body",
-				value1 = "Ctrl + Shift + r");
-		}
+		ExecuteCDPCommand(
+			value1 = "Network.enable",
+			value2 = ${cdpParameters});
 
-		WaitForPageLoad();
+		ExecuteCDPCommand(
+			value1 = "Network.clearBrowserCache",
+			value2 = ${cdpParameters});
+
+		Refresh();
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboard.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboard.testcase
@@ -1894,7 +1894,7 @@ definition {
 
 			WebContentNavigator.gotoEditCP(webContentTitle = "WC Title");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-01-01 01:00");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-01-01 01:00 AM");
 		}
 
 		task ("Go to Content Dashboard and click on the title") {
@@ -3694,7 +3694,7 @@ definition {
 
 			WebContentNavigator.gotoEditCP(webContentTitle = "WC Title Scheduled");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:00");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:00 AM");
 		}
 
 		task ("Filter asset at Content Dashboard using status") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
@@ -1596,7 +1596,7 @@ definition {
 			webContentContent = "Web Content Content",
 			webContentTitle = "Web Content Title");
 
-		WebContent.scheduleWCArticleWithPermissions(displayDate = "01/01/2050");
+		WebContent.scheduleWCArticleWithPermissions(displayDate = "2050-01-01 01:00 AM");
 
 		Publications.publishPublication(
 			gotoPublicationsAdmin = "true",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
@@ -1113,7 +1113,7 @@ definition {
 				webContentContent = "Web Content Content",
 				webContentTitle = "Web Content Title");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:01");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:01 AM");
 		}
 
 		task ("Add a page with a Web Content Display widget and display the Web Content article in the Web Content Display widget") {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/Overview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/Overview.tsx
@@ -154,8 +154,14 @@ const Overview: React.FC<IOverviewProps> = ({account}) => {
 				</ClayLayout.Col>
 			</ClayLayout.Row>
 
+			<ClayLayout.Row>
+				<ClayLayout.Col size={12}>
+					<MostEngagedIndividuals />
+				</ClayLayout.Col>
+			</ClayLayout.Row>
+
 			<SectionHeader
-				className="mb-3 mt-4"
+				className="mb-3 mt-2"
 				icon="display-content"
 				title={Liferay.Language.get('engagement-summary')}
 			/>
@@ -176,12 +182,6 @@ const Overview: React.FC<IOverviewProps> = ({account}) => {
 						account={account}
 						className="flex-grow-1"
 					/>
-				</ClayLayout.Col>
-			</ClayLayout.Row>
-
-			<ClayLayout.Row>
-				<ClayLayout.Col size={12}>
-					<MostEngagedIndividuals />
 				</ClayLayout.Col>
 			</ClayLayout.Row>
 		</BasePage.Context.Provider>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/AccountInfoBar.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/AccountInfoBar.tsx
@@ -44,7 +44,7 @@ const AccountInfoBar: React.FC<IAccountInfoBarProps> = ({
 		getAccountInfoDisplayValues({annualRevenue, lifecycleStage});
 
 	return (
-		<Card className="mb-3">
+		<Card className="mb-4">
 			<Card.Body className="align-items-center d-flex flex-row flex-wrap justify-content-between p-3">
 				<Text size={5} weight="semi-bold">
 					{accountName}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
@@ -27,22 +27,24 @@ const MostEngagedIndividuals: React.FC = () => {
 				<IndividualsDataSet preview />
 			</Card.Body>
 
-			<Card.Footer className="d-flex justify-content-end">
-				<ClayLink
-					borderless
-					button
-					className="button-root"
-					displayType="primary"
-					href={toRoute(Routes.CONTACTS_ACCOUNT_PROFILE, {
-						channelId,
-						groupId,
-						id,
-					})}
-					small
-				>
-					{Liferay.Language.get('view-all')}
-				</ClayLink>
-			</Card.Footer>
+			{id && (
+				<Card.Footer className="d-flex justify-content-end">
+					<ClayLink
+						borderless
+						button
+						className="button-root"
+						displayType="primary"
+						href={toRoute(Routes.CONTACTS_ACCOUNT_PROFILE, {
+							channelId,
+							groupId,
+							id,
+						})}
+						small
+					>
+						{Liferay.Language.get('view-all')}
+					</ClayLink>
+				</Card.Footer>
+			)}
 		</Card>
 	);
 };

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
@@ -32,7 +32,7 @@ const MostEngagedIndividuals: React.FC = () => {
 					<ClayLink
 						borderless
 						button
-						className="button-root"
+						className="button-root rounded-lg"
 						displayType="primary"
 						href={toRoute(Routes.CONTACTS_ACCOUNT_PROFILE, {
 							channelId,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/IndividualsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/IndividualsDataSet.tsx
@@ -222,7 +222,7 @@ describe('getVisitorType', () => {
 	});
 
 	it('should read a single session as a first time visitor', () => {
-		expect(getVisitorType(1).label).toBe('First-Time');
+		expect(getVisitorType(1).label).toBe('First Time');
 	});
 
 	it('should read more than one session as a returning visitor', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/MostEngagedIndividuals.tsx
@@ -1,6 +1,7 @@
 import MostEngagedIndividuals from '../MostEngagedIndividuals';
 import React from 'react';
 import {cleanup, render, screen} from '@testing-library/react';
+import {useParams} from 'react-router-dom';
 
 jest.unmock('react-dom');
 
@@ -13,11 +14,21 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'),
-	useParams: () => ({channelId: '456', groupId: '23', id: 'acc-1'}),
+	useParams: jest.fn(),
 }));
+
+const mockedUseParams = useParams as jest.Mock;
 
 describe('MostEngagedIndividuals', () => {
 	afterEach(cleanup);
+
+	beforeEach(() => {
+		mockedUseParams.mockReturnValue({
+			channelId: '456',
+			groupId: '23',
+			id: 'acc-1',
+		});
+	});
 
 	it('should render the card title', () => {
 		render(<MostEngagedIndividuals />);
@@ -42,5 +53,15 @@ describe('MostEngagedIndividuals', () => {
 		expect(
 			screen.getByRole('link', {name: 'View All'}).getAttribute('href')
 		).toContain('/contacts/accounts/acc-1/profile');
+	});
+
+	it('should render no link while the account id is missing', () => {
+		mockedUseParams.mockReturnValue({channelId: '456', groupId: '23'});
+
+		render(<MostEngagedIndividuals />);
+
+		expect(
+			screen.queryByRole('link', {name: 'View All'})
+		).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101439

## What Is Being Fixed

The most engaged individuals section rendered at the very bottom of the account overview page, below the engagement summary, where it was easy to miss. The surrounding spacing and the view all button styling also needed polish.

## How It Is Being Fixed

The most engaged individuals row moves above the engagement summary section, whose header margin is tightened from mt-4 to mt-2 to match the new placement. The account info bar gains breathing room below it (mb-3 to mb-4), and the view all button gets rounded corners via the rounded-lg utility class.

## Why Are There No Tests?

The change is purely visual — CSS utility classes and component placement in the layout. There is no logic to test.

## PR Check

**pr-check: PASS** — tested on `31fdf2da2edd3b6be873915fd23d3f0ed0f6613c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "31fdf2da2edd3b6be873915fd23d3f0ed0f6613c"} -->
