### PR TITLE
LPD-101439 Move most engaged individuals above the engagement summary

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/Overview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/Overview.tsx
@@ -154,8 +154,14 @@ const Overview: React.FC<IOverviewProps> = ({account}) => {
 				</ClayLayout.Col>
 			</ClayLayout.Row>
 
+			<ClayLayout.Row>
+				<ClayLayout.Col size={12}>
+					<MostEngagedIndividuals />
+				</ClayLayout.Col>
+			</ClayLayout.Row>
+
 			<SectionHeader
-				className="mb-3 mt-4"
+				className="mb-3 mt-2"
 				icon="display-content"
 				title={Liferay.Language.get('engagement-summary')}
 			/>
@@ -176,12 +182,6 @@ const Overview: React.FC<IOverviewProps> = ({account}) => {
 						account={account}
 						className="flex-grow-1"
 					/>
-				</ClayLayout.Col>
-			</ClayLayout.Row>
-
-			<ClayLayout.Row>
-				<ClayLayout.Col size={12}>
-					<MostEngagedIndividuals />
 				</ClayLayout.Col>
 			</ClayLayout.Row>
 		</BasePage.Context.Provider>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/AccountInfoBar.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/AccountInfoBar.tsx
@@ -44,7 +44,7 @@ const AccountInfoBar: React.FC<IAccountInfoBarProps> = ({
 		getAccountInfoDisplayValues({annualRevenue, lifecycleStage});
 
 	return (
-		<Card className="mb-3">
+		<Card className="mb-4">
 			<Card.Body className="align-items-center d-flex flex-row flex-wrap justify-content-between p-3">
 				<Text size={5} weight="semi-bold">
 					{accountName}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
@@ -32,7 +32,7 @@ const MostEngagedIndividuals: React.FC = () => {
 					<ClayLink
 						borderless
 						button
-						className="button-root"
+						className="button-root rounded-lg"
 						displayType="primary"
 						href={toRoute(Routes.CONTACTS_ACCOUNT_PROFILE, {
 							channelId,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101439

## What Is Being Fixed

The most engaged individuals section rendered at the very bottom of the account overview page, below the engagement summary, where it was easy to miss. The surrounding spacing and the view all button styling also needed polish.

## How It Is Being Fixed

The most engaged individuals row moves above the engagement summary section, whose header margin is tightened from mt-4 to mt-2 to match the new placement. The account info bar gains breathing room below it (mb-3 to mb-4), and the view all button gets rounded corners via the rounded-lg utility class.

## Why Are There No Tests?

The change is purely visual — CSS utility classes and component placement in the layout. There is no logic to test.

## PR Check

**pr-check: PASS** — tested on `31fdf2da2edd3b6be873915fd23d3f0ed0f6613c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "31fdf2da2edd3b6be873915fd23d3f0ed0f6613c"} -->
