### PR TITLE
LPD-100936 Avoid using hardcoded URLs where possible

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-login-web-fragment/src/main/resources/META-INF/resources/login.jsp
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-login-web-fragment/src/main/resources/META-INF/resources/login.jsp
@@ -69,7 +69,7 @@
 			<div class="secondary-info">
 				to continue to
 
-				<span>analytics.liferay.com</span>
+				<span><%= HtmlUtil.escape(themeDisplay.getServerName()) %></span>
 			</div>
 
 			<aui:form action="<%= loginURL %>" autocomplete='<%= PropsValues.COMPANY_SECURITY_LOGIN_FORM_AUTOCOMPLETE ? "on" : "off" %>' cssClass="sign-in-form" method="post" name="<%= formName %>" onSubmit="event.preventDefault();" validateOnBlur="<%= false %>">

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/DataSourceFaroController.java
@@ -170,8 +170,8 @@ public class DataSourceFaroController extends BaseFaroController {
 				faroProject,
 				OAuthUtil.getOAuth20Credentials(
 					"CLIENT_CREDENTIALS", portalURL, "",
-					"https://analytics.liferay.com/oauth/receive",
-					oAuthClientId, oAuthClientSecret, "LIFERAY"),
+					FaroPropsValues.FARO_URL + "/oauth/receive", oAuthClientId,
+					oAuthClientSecret, "LIFERAY"),
 				getUserId(), dataSourceName, portalURL, new LiferayProvider(),
 				null, DataSource.Status.ACTIVE.toString());
 
@@ -182,8 +182,8 @@ public class DataSourceFaroController extends BaseFaroController {
 				faroProject, dataSourceId,
 				OAuthUtil.getOAuth20Credentials(
 					"CLIENT_CREDENTIALS", portalURL, "",
-					"https://analytics.liferay.com/oauth/receive",
-					oAuthClientId, oAuthClientSecret, "LIFERAY"),
+					FaroPropsValues.FARO_URL + "/oauth/receive", oAuthClientId,
+					oAuthClientSecret, "LIFERAY"),
 				null, null, new LiferayProvider(),
 				DataSource.Status.ACTIVE.toString(), portalURL, getUserId());
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/useDownloadCSV.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/useDownloadCSV.ts
@@ -18,7 +18,7 @@ describe('useDownloadCSV', () => {
 		delete (window as {location?: Location}).location;
 
 		(window as {location: unknown}).location = new URL(
-			'https://analytics.liferay.com/workspace/liferay.com/420253908131944590'
+			'https://ldp.liferay.com/workspace/liferay.com/420253908131944590'
 		);
 	});
 
@@ -77,7 +77,7 @@ describe('useDownloadCSV', () => {
 
 	it('should include order by fields if field and sortOrder are present', () => {
 		(window as {location: unknown}).location = new URL(
-			'https://analytics.liferay.com/workspace/liferay.com/420253908131944590/?field=name&page=1&sortOrder=DESC'
+			'https://ldp.liferay.com/workspace/liferay.com/420253908131944590/?field=name&page=1&sortOrder=DESC'
 		);
 
 		const {result} = renderHook(() =>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/workspaces/SuccessDisplay.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/workspaces/SuccessDisplay.tsx
@@ -1,17 +1,17 @@
 import ClayLink from '@clayui/link';
+import Constants from 'shared/util/constants';
 import React from 'react';
 import Sheet from 'shared/components/Sheet';
 import URLConstants from 'shared/util/url-constants';
 import WorkspacesBasePage from 'shared/components/workspaces/BasePage';
 import {sub} from 'shared/util/lang';
 
+const {faroURL} = Constants;
+
 const SuccessDisplay = ({friendlyURL}: {friendlyURL: string}) => {
 	const link = (
-		<ClayLink
-			href={`https://analytics.liferay.com/workspace${friendlyURL}`}
-			key="link"
-		>
-			{`analytics.liferay.com/workspace${friendlyURL}`}
+		<ClayLink href={`${faroURL}/workspace${friendlyURL}`} key="link">
+			{`${faroURL}/workspace${friendlyURL}`}
 		</ClayLink>
 	);
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/SuccessDisplay.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/SuccessDisplay.jsx
@@ -2,7 +2,7 @@ import mockStore from 'test/mock-store';
 import React from 'react';
 import WorkspacesSuccessDisplay from '../SuccessDisplay';
 import {Provider} from 'react-redux';
-import {render} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 
 jest.unmock('react-dom');
 
@@ -15,5 +15,22 @@ describe('WorkspacesSuccessDisplay', () => {
 		);
 
 		expect(container).toMatchSnapshot();
+	});
+
+	it('should link to the workspace on the configured faroURL', () => {
+		render(
+			<Provider store={mockStore()}>
+				<WorkspacesSuccessDisplay friendlyURL='/fooFriendlyUrl' />
+			</Provider>
+		);
+
+		expect(
+			screen.getByRole('link', {
+				name: 'http://localhost:3000/workspace/fooFriendlyUrl',
+			})
+		).toHaveAttribute(
+			'href',
+			'http://localhost:3000/workspace/fooFriendlyUrl'
+		);
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/__snapshots__/SuccessDisplay.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/workspaces/__tests__/__snapshots__/SuccessDisplay.jsx.snap
@@ -115,9 +115,9 @@ exports[`WorkspacesSuccessDisplay should render 1`] = `
                 We will send you an email once it is ready to access at this URL: 
                 <a
                   class=""
-                  href="https://analytics.liferay.com/workspace/fooFriendlyUrl"
+                  href="http://localhost:3000/workspace/fooFriendlyUrl"
                 >
-                  analytics.liferay.com/workspace/fooFriendlyUrl
+                  http://localhost:3000/workspace/fooFriendlyUrl
                 </a>
               </p>
               <p>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100936

## What Is Being Fixed

Analytics Cloud is adding support for the new ldp.liferay.com domain and transitioning its public URL from analytics.liferay.com to it, with the old domain remaining supported during the transition. Three places in the product hardcode the old domain: the login page displays "to continue to analytics.liferay.com" as literal text, the workspace creation success page links to the workspace on the old domain, and the data source connect flow passes a hardcoded OAuth callback URL on the old domain. After the domain switch these would show and store stale URLs.

## How It Is Being Fixed

Each hardcoded reference is replaced with a value derived from configuration so the code follows whichever domain is configured. The login page renders the host of the current request. The workspace creation success page builds its link from the faroURL constant that the portal already exposes to the frontend from the FARO_URL environment variable, following the existing pattern in AddWorkspaceForm. The data source connect flow derives its OAuth callback URL from FaroPropsValues.FARO_URL; this argument is discarded by OAuthUtil.getOAuth20Credentials for the CLIENT_CREDENTIALS grant used here, so the change is behavior neutral today but stays correct if the flow changes. Test fixtures and the SuccessDisplay snapshot are updated accordingly, and a new explicit assertion pins the workspace link's text and href to the configured URL so a regression cannot be absorbed by a snapshot update.

## PR Check

**pr-check: PASS** — tested on `d14beeea37bf2f434915340b954d007ed1da1812`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| JSP Compile | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "d14beeea37bf2f434915340b954d007ed1da1812"} -->
