### PR TITLE
LPD-100935 Update the Analytics Cloud OAuth2 application URLs

### DIFF
--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
@@ -55,6 +55,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.HttpURLConnection;
+import java.net.URL;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -132,12 +133,24 @@ public class AnalyticsCloudClient {
 				"Unable to connect with Analytics Cloud");
 		}
 
+		JSONObject jsonObject = _decodeToken(connectionToken);
+
+		String url = jsonObject.getString("url");
+
+		_validateConnectionTokenURL(url);
+
 		OAuth2Application oAuth2Application =
 			_oAuth2ApplicationLocalService.
 				fetchOAuth2ApplicationByExternalReferenceCode(
 					"ANALYTICS-CLOUD", company.getCompanyId());
 
 		if (oAuth2Application == null) {
+			URL connectionTokenURL = new URL(url);
+
+			String homePageURL = StringBundler.concat(
+				connectionTokenURL.getProtocol(), "://",
+				connectionTokenURL.getAuthority());
+
 			oAuth2Application =
 				_oAuth2ApplicationLocalService.addOrUpdateOAuth2Application(
 					"ANALYTICS-CLOUD", user.getUserId(), user.getScreenName(),
@@ -151,16 +164,10 @@ public class AnalyticsCloudClient {
 					OAuth2SecureRandomGenerator.generateClientId(),
 					ClientProfile.HEADLESS_SERVER.id(),
 					OAuth2SecureRandomGenerator.generateClientSecret(), null,
-					null, "https://analytics.liferay.com", 0, null,
-					"Analytics Cloud", null,
-					Collections.singletonList(
-						"https://analytics.liferay.com/oauth/receive"),
+					null, homePageURL, 0, null, "Analytics Cloud", null,
+					Collections.singletonList(homePageURL + "/oauth/receive"),
 					false, false, this::_buildScopes, new ServiceContext());
 		}
-
-		JSONObject connectionTokenJSONObject = _decodeToken(connectionToken);
-
-		_validateConnectionTokenURL(connectionTokenJSONObject.getString("url"));
 
 		Http.Options options = new Http.Options();
 
@@ -169,8 +176,8 @@ public class AnalyticsCloudClient {
 		options.addPart(
 			"oAuthClientSecret", oAuth2Application.getClientSecret());
 		options.addPart("portalURL", company.getPortalURL(0));
-		options.addPart("token", connectionTokenJSONObject.getString("token"));
-		options.setLocation(connectionTokenJSONObject.getString("url"));
+		options.addPart("token", jsonObject.getString("token"));
+		options.setLocation(url);
 		options.setPost(true);
 
 		String content = _http.URLtoString(options);

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut-test/src/testIntegration/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/v2_0_0/test/OAuth2ApplicationAnalyticsCloudUpgradeProcessTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut-test/src/testIntegration/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/v2_0_0/test/OAuth2ApplicationAnalyticsCloudUpgradeProcessTest.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.shortcut.internal.upgrade.v2_0_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.constants.ClientProfile;
+import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Leslie Wong
+ */
+@RunWith(Arquillian.class)
+public class OAuth2ApplicationAnalyticsCloudUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testUpgrade() throws Exception {
+		User user = TestPropsValues.getUser();
+
+		_setUpOAuth2Application(user);
+
+		_runUpgrade();
+
+		OAuth2Application oAuth2Application =
+			_oAuth2ApplicationLocalService.
+				fetchOAuth2ApplicationByExternalReferenceCode(
+					"ANALYTICS-CLOUD", user.getCompanyId());
+
+		Assert.assertEquals(
+			"https://ldp.liferay.com", oAuth2Application.getHomePageURL());
+		Assert.assertEquals(
+			Arrays.asList(
+				"https://analytics.liferay.com/oauth/receive",
+				"https://ldp.liferay.com/oauth/receive"),
+			oAuth2Application.getRedirectURIsList());
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+	}
+
+	private void _setUpOAuth2Application(User user) throws Exception {
+		OAuth2Application oAuth2Application =
+			_oAuth2ApplicationLocalService.
+				fetchOAuth2ApplicationByExternalReferenceCode(
+					"ANALYTICS-CLOUD", user.getCompanyId());
+
+		if (oAuth2Application == null) {
+			_oAuth2ApplicationLocalService.addOrUpdateOAuth2Application(
+				"ANALYTICS-CLOUD", user.getUserId(), user.getScreenName(),
+				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
+				"client_secret_post", user.getUserId(),
+				OAuth2SecureRandomGenerator.generateClientId(),
+				ClientProfile.HEADLESS_SERVER.id(),
+				OAuth2SecureRandomGenerator.generateClientSecret(), null, null,
+				"https://analytics.liferay.com", 0, null, "Analytics Cloud",
+				null,
+				Collections.singletonList(
+					"https://analytics.liferay.com/oauth/receive"),
+				false, false,
+				builder -> {
+				},
+				new ServiceContext());
+
+			return;
+		}
+
+		oAuth2Application.setHomePageURL("https://analytics.liferay.com");
+		oAuth2Application.setRedirectURIsList(
+			Collections.singletonList(
+				"https://analytics.liferay.com/oauth/receive"));
+
+		_oAuth2ApplicationLocalService.updateOAuth2Application(
+			oAuth2Application);
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.oauth2.provider.shortcut.internal.upgrade.v2_0_0." +
+			"OAuth2ApplicationAnalyticsCloudUpgradeProcess";
+
+	@Inject
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.oauth2.provider.shortcut.internal.upgrade.registry.OAuth2ProviderShortcutUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudInitialRequestPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudInitialRequestPortalInstanceLifecycleListener.java
@@ -52,7 +52,7 @@ import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalSe
 import java.io.InputStream;
 
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -165,10 +165,10 @@ public class AnalyticsCloudInitialRequestPortalInstanceLifecycleListener
 				OAuth2SecureRandomGenerator.generateClientId(),
 				ClientProfile.HEADLESS_SERVER.id(),
 				OAuth2SecureRandomGenerator.generateClientSecret(), null, null,
-				"https://analytics.liferay.com", 0, null, _APPLICATION_NAME,
-				null,
-				Collections.singletonList(
-					"https://analytics.liferay.com/oauth/receive"),
+				"https://ldp.liferay.com", 0, null, _APPLICATION_NAME, null,
+				Arrays.asList(
+					"https://analytics.liferay.com/oauth/receive",
+					"https://ldp.liferay.com/oauth/receive"),
 				false, false, this::_buildScopes, new ServiceContext());
 
 		Class<?> clazz = getClass();

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/registry/OAuth2ProviderShortcutUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/registry/OAuth2ProviderShortcutUpgradeStepRegistrator.java
@@ -34,6 +34,12 @@ public class OAuth2ProviderShortcutUpgradeStepRegistrator
 				_companyLocalService, _oAuth2ApplicationLocalService,
 				_resourcePermissionLocalService, _roleLocalService,
 				_userLocalService));
+
+		registry.register(
+			"1.0.0", "2.0.0",
+			new com.liferay.oauth2.provider.shortcut.internal.upgrade.v2_0_0.
+				OAuth2ApplicationAnalyticsCloudUpgradeProcess(
+					_companyLocalService, _oAuth2ApplicationLocalService));
 	}
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/v2_0_0/OAuth2ApplicationAnalyticsCloudUpgradeProcess.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/v2_0_0/OAuth2ApplicationAnalyticsCloudUpgradeProcess.java
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.shortcut.internal.upgrade.v2_0_0;
+
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Leslie Wong
+ */
+public class OAuth2ApplicationAnalyticsCloudUpgradeProcess
+	extends UpgradeProcess {
+
+	public OAuth2ApplicationAnalyticsCloudUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		OAuth2ApplicationLocalService oAuth2ApplicationLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_oAuth2ApplicationLocalService = oAuth2ApplicationLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_companyLocalService.forEachCompanyId(
+			companyId -> _upgradeCompany(companyId));
+	}
+
+	private void _upgradeCompany(long companyId) {
+		OAuth2Application oAuth2Application =
+			_oAuth2ApplicationLocalService.
+				fetchOAuth2ApplicationByExternalReferenceCode(
+					"ANALYTICS-CLOUD", companyId);
+
+		if (oAuth2Application == null) {
+			return;
+		}
+
+		oAuth2Application.setHomePageURL("https://ldp.liferay.com");
+
+		List<String> redirectURIsList = new ArrayList<>(
+			oAuth2Application.getRedirectURIsList());
+
+		if (!redirectURIsList.contains(
+				"https://ldp.liferay.com/oauth/receive")) {
+
+			redirectURIsList.add("https://ldp.liferay.com/oauth/receive");
+
+			oAuth2Application.setRedirectURIsList(redirectURIsList);
+		}
+
+		_oAuth2ApplicationLocalService.updateOAuth2Application(
+			oAuth2Application);
+	}
+
+	private final CompanyLocalService _companyLocalService;
+	private final OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/test/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/v2_0_0/OAuth2ApplicationAnalyticsCloudUpgradeProcessTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/test/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/v2_0_0/OAuth2ApplicationAnalyticsCloudUpgradeProcessTest.java
@@ -1,0 +1,173 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.shortcut.internal.upgrade.v2_0_0;
+
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * @author Leslie Wong
+ */
+public class OAuth2ApplicationAnalyticsCloudUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		Mockito.doAnswer(
+			invocationOnMock -> {
+				UnsafeConsumer<Long, Exception> unsafeConsumer =
+					invocationOnMock.getArgument(0);
+
+				unsafeConsumer.accept(_COMPANY_ID);
+
+				return null;
+			}
+		).when(
+			_companyLocalService
+		).forEachCompanyId(
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testUpgradeAddsRedirectURI() throws Exception {
+		OAuth2Application oAuth2Application = _mockOAuth2Application(
+			Collections.singletonList(
+				"https://analytics.liferay.com/oauth/receive"));
+
+		_upgradeProcess.doUpgrade();
+
+		Mockito.verify(
+			oAuth2Application
+		).setHomePageURL(
+			"https://ldp.liferay.com"
+		);
+
+		ArgumentCaptor<List<String>> argumentCaptor = ArgumentCaptor.forClass(
+			List.class);
+
+		Mockito.verify(
+			oAuth2Application
+		).setRedirectURIsList(
+			argumentCaptor.capture()
+		);
+
+		Assert.assertEquals(
+			Arrays.asList(
+				"https://analytics.liferay.com/oauth/receive",
+				"https://ldp.liferay.com/oauth/receive"),
+			argumentCaptor.getValue());
+
+		Mockito.verify(
+			_oAuth2ApplicationLocalService
+		).updateOAuth2Application(
+			oAuth2Application
+		);
+	}
+
+	@Test
+	public void testUpgradeDoesNotDuplicateRedirectURI() throws Exception {
+		OAuth2Application oAuth2Application = _mockOAuth2Application(
+			Arrays.asList(
+				"https://analytics.liferay.com/oauth/receive",
+				"https://ldp.liferay.com/oauth/receive"));
+
+		_upgradeProcess.doUpgrade();
+
+		Mockito.verify(
+			oAuth2Application
+		).setHomePageURL(
+			"https://ldp.liferay.com"
+		);
+
+		Mockito.verify(
+			oAuth2Application, Mockito.never()
+		).setRedirectURIsList(
+			Mockito.anyList()
+		);
+
+		Mockito.verify(
+			_oAuth2ApplicationLocalService
+		).updateOAuth2Application(
+			oAuth2Application
+		);
+	}
+
+	@Test
+	public void testUpgradeSkipsCompanyWithoutOAuth2Application()
+		throws Exception {
+
+		Mockito.when(
+			_oAuth2ApplicationLocalService.
+				fetchOAuth2ApplicationByExternalReferenceCode(
+					"ANALYTICS-CLOUD", _COMPANY_ID)
+		).thenReturn(
+			null
+		);
+
+		_upgradeProcess.doUpgrade();
+
+		Mockito.verify(
+			_oAuth2ApplicationLocalService, Mockito.never()
+		).updateOAuth2Application(
+			Mockito.any()
+		);
+	}
+
+	private OAuth2Application _mockOAuth2Application(
+		List<String> redirectURIsList) {
+
+		OAuth2Application oAuth2Application = Mockito.mock(
+			OAuth2Application.class);
+
+		Mockito.when(
+			oAuth2Application.getRedirectURIsList()
+		).thenReturn(
+			redirectURIsList
+		);
+
+		Mockito.when(
+			_oAuth2ApplicationLocalService.
+				fetchOAuth2ApplicationByExternalReferenceCode(
+					"ANALYTICS-CLOUD", _COMPANY_ID)
+		).thenReturn(
+			oAuth2Application
+		);
+
+		return oAuth2Application;
+	}
+
+	private static final long _COMPANY_ID = 12345;
+
+	private final CompanyLocalService _companyLocalService = Mockito.mock(
+		CompanyLocalService.class);
+	private final OAuth2ApplicationLocalService _oAuth2ApplicationLocalService =
+		Mockito.mock(OAuth2ApplicationLocalService.class);
+	private final OAuth2ApplicationAnalyticsCloudUpgradeProcess
+		_upgradeProcess = new OAuth2ApplicationAnalyticsCloudUpgradeProcess(
+			_companyLocalService, _oAuth2ApplicationLocalService);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100935

## What Is Being Fixed

Analytics Cloud is adding support for the new ldp.liferay.com domain and transitioning its public URL from analytics.liferay.com to it, with the old domain remaining supported during the transition. The OAuth2 application that DXP registers for Analytics Cloud hardcodes the old domain as its home page URL and redirect URI in both creation sites (the portal instance lifecycle listener and the connect flow), and existing installations carry those values in their databases with no code path that ever updates them.

## How It Is Being Fixed

The connect flow now derives the application's home page URL and redirect URI from the origin of the URL embedded in the pasted connection token, which is already validated against the analytics.cloud.domain.allowed portal property, so a new registration reflects whichever workspace the customer actually connects to. The portal instance lifecycle listener, which runs before any connection exists and therefore has no configuration to read, now defaults the home page URL to the new domain and registers both the old and new redirect URIs, which is safe because redirectURIs is a list and inert under the CLIENT_CREDENTIALS and JWT_BEARER grants. A new upgrade process (1.0.0 to 2.0.0 in the oauth2-provider-shortcut registry) converges existing installations by finding each company's application through its ANALYTICS-CLOUD external reference code, updating the home page URL, and appending the new redirect URI idempotently. The upgrade process is covered by unit tests and an Arquillian integration test that seeds the old state and verifies the migrated values.

## PR Check

**pr-check: PASS** — tested on `632710e49bdddc05df70c17d9dc09d7562f5744a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "632710e49bdddc05df70c17d9dc09d7562f5744a"} -->
