### PR TITLE
LPD-101245 | master [Faro] Add Account Lifecycle Status Filter to Account Dashboard

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
@@ -52,6 +52,11 @@ const List: React.FC<IListProps> = ({channelId, groupId}) => {
 		},
 	});
 
+	const {data: lifecycles, loading: lifecyclesLoading} = useRequest({
+		dataSourceFn: API.lifecycle.fetchLifecycles,
+		variables: {groupId},
+	});
+
 	useEffect(() => {
 		if (fieldCatalogError) {
 			dispatch(
@@ -152,10 +157,11 @@ const List: React.FC<IListProps> = ({channelId, groupId}) => {
 							title={Liferay.Language.get('accounts')}
 						/>
 
-						{fieldCatalogLoading ? (
+						{fieldCatalogLoading || lifecyclesLoading ? (
 							<Loading spacer />
 						) : (
 							<AccountsDataSet
+								accountLifecycleId={lifecycles?.[0]?.id}
 								apiURL={`/o/faro/contacts/${groupId}/account/search?channelId=${channelId}`}
 								channelId={channelId}
 								fieldCatalog={fieldCatalogData?.items}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/accounts-data-set/AccountsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/accounts-data-set/AccountsDataSet.tsx
@@ -151,9 +151,11 @@ const AccountsDataSet: React.FC<IAccountsDataSetProps> = ({
 					...(accountLifecycleId
 						? [
 								{
+									entityFieldType: 'string',
 									id: 'lifecycleStatus',
 									items: lifecycleStageItems,
 									label: Liferay.Language.get('status'),
+									multiple: true,
 									name: 'status',
 									preloadedData: buildSelectionPreloadedData(
 										preloadedLifecycleStage?.id,


### PR DESCRIPTION
Motivation
----

https://liferay.atlassian.net/browse/LPD-101223

Proposed Solution
----

The Accounts table already knew how to render a lifecycle stage filter, but it was only ever shown on the Lifecycles page, because that is the only place that passed an account lifecycle down to the data set. We now read the workspace lifecycle from the Accounts list as well, so account-based marketers can narrow the table down to the stages they care about.

We also let the filter take more than one stage at a time, matching the Industry and Country filters right next to it.

**pr-check: PASS** — tested on `439b0e44a31e9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| JavaScript Unit Tests | PASS |