### PR TITLE
LPD-101615 Temporarily disable Pendo in Analytics Cloud until a consent flow ships

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/App.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/App.tsx
@@ -93,7 +93,20 @@ const RoutesContainer = ({children}: {children: React.ReactNode}) => {
 	const {data: currentUser, loading} = useFetchCurrentUser(groupId);
 
 	useEffect(() => {
-		if (currentUser?.id && project?.corpProjectName) {
+
+		// LPD-101615: Pendo initialization is temporarily disabled because
+		// Analytics Cloud has no user consent flow yet. Tracking users
+		// without consent is not compliant with our own consent model (the
+		// DXP tracking script asks first) nor with consent regulations.
+		// Remove PENDO_TRACKING_ENABLED once the consent banner ships.
+
+		const PENDO_TRACKING_ENABLED = false;
+
+		if (
+			PENDO_TRACKING_ENABLED &&
+			currentUser?.id &&
+			project?.corpProjectName
+		) {
 			const pendo = new Pendo();
 
 			pendo.initialize({currentUser, project});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/App.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/App.tsx
@@ -93,20 +93,7 @@ const RoutesContainer = ({children}: {children: React.ReactNode}) => {
 	const {data: currentUser, loading} = useFetchCurrentUser(groupId);
 
 	useEffect(() => {
-
-		// LPD-101615: Pendo initialization is temporarily disabled because
-		// Analytics Cloud has no user consent flow yet. Tracking users
-		// without consent is not compliant with our own consent model (the
-		// DXP tracking script asks first) nor with consent regulations.
-		// Remove PENDO_TRACKING_ENABLED once the consent banner ships.
-
-		const PENDO_TRACKING_ENABLED = false;
-
-		if (
-			PENDO_TRACKING_ENABLED &&
-			currentUser?.id &&
-			project?.corpProjectName
-		) {
+		if (currentUser?.id && project?.corpProjectName) {
 			const pendo = new Pendo();
 
 			pendo.initialize({currentUser, project});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/pendo.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/pendo.ts
@@ -1,8 +1,22 @@
 import {FaroEnv} from './constants';
 import {Project, User} from './records';
 
+// LPD-101615: Pendo is temporarily disabled because Analytics Cloud has no
+// user consent flow yet. Tracking users without consent is not compliant
+// with our own consent model (the DXP tracking script asks first) nor with
+// consent regulations. The guard disables both the identify payload and the
+// pendo.js agent request (`script` is injected by external-scripts.js on
+// every page load, so it must return the inert stub too). Remove the
+// constant once the consent banner ships.
+
+const PENDO_TRACKING_ENABLED: boolean = false;
+
 export class Pendo {
 	initialize({currentUser, project}: {currentUser: User; project: Project}) {
+		if (!PENDO_TRACKING_ENABLED) {
+			return;
+		}
+
 		const data = {
 			account: {
 				...(project.corpProjectUuid && {
@@ -27,7 +41,7 @@ export class Pendo {
 	}
 
 	get script() {
-		if (FARO_ENV === FaroEnv.Production) {
+		if (PENDO_TRACKING_ENABLED && FARO_ENV === FaroEnv.Production) {
 			return `(function(apiKey){
 			(function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=o._q||[];
 				v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){


### PR DESCRIPTION
## What

Disables the Pendo initialization in the AC frontend behind a hardcoded `PENDO_TRACKING_ENABLED = false` constant, with a comment explaining why and when to remove it.

## Why

AC currently initializes Pendo **unconditionally** for every signed-in user in production: there is no consent banner, no consent cookie and no opt-out, and the identify payload includes full PII (email, full name, id, role). This is inconsistent with our own consent model (the DXP tracking script asks for consent first and only sends the email domain) and exposes us to consent regulations (GDPR and equivalents). See LPD-101615 for the full analysis.

## How this pairs with the consent banner PR

This is the **urgent stop-the-bleeding** option, intended to be mergeable in minutes. Its counterpart PR implements the proper consent banner and supersedes this change (it replaces this guard with the real consent gate). Two ways to proceed:

1. Merge this one now to stop untracked-consent collection immediately, review the banner PR calmly, and merge it later (it will need a trivial rebase).
2. Skip this one and merge the banner PR directly if the review is fast.

Jira: [LPD-101615](https://liferay.atlassian.net/browse/LPD-101615)