### PR TITLE
LPD-101249 Remove the % change from Total Individuals and Accounts

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
@@ -53,9 +53,7 @@ const TotalAccounts = ({groupId}: {groupId: string}) => {
 					)}
 					loading={loading}
 					minHeight={160}
-					renderTrendLabel={renderTrendLabel}
 					title={Liferay.Language.get('total-accounts')}
-					trend={getMetric(AccountMetricType.Total)?.trend}
 					value={renderAccountValue(
 						getMetric(AccountMetricType.Total)
 					)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/__tests__/TotalAccounts.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/__tests__/TotalAccounts.tsx
@@ -11,41 +11,59 @@ jest.mock('react-router', () => ({
 	useParams: () => ({channelId: '456'}),
 }));
 
+const mockMetrics = () => {
+	const useRequest = require('shared/hooks/useRequest');
+
+	useRequest.useRequest = jest.fn(() => ({
+		data: [
+			{
+				metricType: AccountMetricType.Total,
+				trend: {
+					percentage: 50,
+					trendClassification: TrendClassification.Positive,
+				},
+				value: 15,
+			},
+			{
+				metricType: AccountMetricType.New,
+				trend: {
+					percentage: -30,
+					trendClassification: TrendClassification.Negative,
+				},
+				value: 10,
+			},
+			{
+				metricType: AccountMetricType.Active,
+				trend: {
+					percentage: 0,
+					trendClassification: TrendClassification.Neutral,
+				},
+				value: 1,
+			},
+		],
+	}));
+};
+
 describe('TotalAccounts', () => {
 	it('should render', () => {
-		const useRequest = require('shared/hooks/useRequest');
-		useRequest.useRequest = jest.fn(() => ({
-			data: [
-				{
-					metricType: AccountMetricType.Total,
-					trend: {
-						percentage: 50,
-						trendClassification: TrendClassification.Positive,
-					},
-					value: 15,
-				},
-				{
-					metricType: AccountMetricType.New,
-					trend: {
-						percentage: -30,
-						trendClassification: TrendClassification.Negative,
-					},
-					value: 10,
-				},
-				{
-					metricType: AccountMetricType.Active,
-					trend: {
-						percentage: 0,
-						trendClassification: TrendClassification.Neutral,
-					},
-					value: 1,
-				},
-			],
-		}));
+		mockMetrics();
 
 		const {container} = render(<TotalAccounts groupId="123" />);
 
 		expect(container).toMatchSnapshot();
+	});
+
+	it('should render the period-over-period trend only for the new and active accounts cards', () => {
+		mockMetrics();
+
+		const {getAllByText, queryByText} = render(
+			<TotalAccounts groupId="123" />
+		);
+
+		expect(getAllByText(/vs\. Previous 90 Days/)).toHaveLength(2);
+		expect(queryByText('50%')).toBeNull();
+		expect(getAllByText('30%')).toHaveLength(1);
+		expect(getAllByText('0%')).toHaveLength(1);
 	});
 
 	it("should load with empty values when there's no data", () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/__tests__/__snapshots__/TotalAccounts.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/__tests__/__snapshots__/TotalAccounts.tsx.snap
@@ -49,14 +49,9 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
-              <span
-                class="mr-1"
-                style="color: rgb(107, 108, 126);"
-              >
-                0%
-              </span>
-               vs. Previous 90 Days
+               
             </div>
           </div>
         </div>
@@ -106,6 +101,7 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
               <span
                 class="mr-1"
@@ -163,6 +159,7 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
               <span
                 class="mr-1"
@@ -229,23 +226,9 @@ exports[`TotalAccounts should render 1`] = `
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-caret-top-l"
-                role="presentation"
-                style="color: rgb(40, 125, 60);"
-              >
-                <use
-                  href="#caret-top-l"
-                />
-              </svg>
-              <span
-                class="mr-1"
-                style="color: rgb(40, 125, 60);"
-              >
-                50%
-              </span>
-               vs. Previous 90 Days
+               
             </div>
           </div>
         </div>
@@ -295,6 +278,7 @@ exports[`TotalAccounts should render 1`] = `
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
               <svg
                 class="lexicon-icon lexicon-icon-caret-bottom-l"
@@ -361,6 +345,7 @@ exports[`TotalAccounts should render 1`] = `
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
               <span
                 class="mr-1"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
@@ -113,14 +113,9 @@ exports[`List rendering should match the snapshot 1`] = `
                   </div>
                   <div
                     class="text-secondary"
+                    data-testid="metric-card-trend"
                   >
-                    <span
-                      class="mr-1"
-                      style="color: rgb(107, 108, 126);"
-                    >
-                      0%
-                    </span>
-                     vs. Previous 90 Days
+                     
                   </div>
                 </div>
               </div>
@@ -170,6 +165,7 @@ exports[`List rendering should match the snapshot 1`] = `
                   </div>
                   <div
                     class="text-secondary"
+                    data-testid="metric-card-trend"
                   >
                     <span
                       class="mr-1"
@@ -227,6 +223,7 @@ exports[`List rendering should match the snapshot 1`] = `
                   </div>
                   <div
                     class="text-secondary"
+                    data-testid="metric-card-trend"
                   >
                     <span
                       class="mr-1"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
@@ -16,7 +16,7 @@ const MostEngagedIndividuals: React.FC = () => {
 	return (
 		<Card minHeight={260} testId="most-engaged-individuals">
 			<Card.Title className="p-3">
-				<Text weight="semi-bold">
+				<Text size={5} weight="semi-bold">
 					{Liferay.Language.get(
 						'most-engaged-individuals'
 					).toUpperCase()}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
@@ -178,14 +178,9 @@ const IndividualsOverviewCDP = () => {
 									)}
 									loading={loading}
 									minHeight={198}
-									renderTrendLabel={renderTrendLabel}
 									title={Liferay.Language.get(
 										'total-individuals'
 									)}
-									trend={
-										data?.individualMetric
-											?.totalIndividualsMetric?.trend
-									}
 									value={renderIndividualsValue(
 										data?.individualMetric
 											?.totalIndividualsMetric?.value

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
@@ -113,6 +113,20 @@ describe('IndividualsOverviewCDP', () => {
 		expect(getByText('Anonymous Individuals')).toBeInTheDocument();
 	});
 
+	it('should render the period-over-period trend only for the known and anonymous individuals cards', () => {
+		(useQuery as jest.Mock).mockReturnValue({
+			data: mockedIndividualMetrics.data,
+			loading: false,
+		});
+
+		const {getAllByText, queryByText} = renderIndividualsOverviewCDP();
+
+		expect(getAllByText(/vs\. Last 30 Days/)).toHaveLength(2);
+		expect(queryByText('30.2%')).toBeNull();
+		expect(getAllByText('28.1%')).toHaveLength(1);
+		expect(getAllByText('11.1%')).toHaveLength(1);
+	});
+
 	it('should render a centered loader inside each metric card while metrics are loading', () => {
 		(useQuery as jest.Mock).mockReturnValue({
 			data: undefined,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
@@ -3,10 +3,10 @@ import classNames from 'classnames';
 import ClayIcon from '@clayui/icon';
 import Loading from 'shared/components/Loading';
 import React, {ReactNode} from 'react';
+import {formatPercent} from 'shared/util/numbers';
 import {getIcon, getStatsColor} from 'shared/util/metrics';
 import {isNil} from 'lodash';
 import {Text} from '@clayui/core';
-import {formatPercent} from 'shared/util/numbers';
 import {TrendClassification} from 'segment/types';
 
 interface IMetricCardTrend {
@@ -14,12 +14,18 @@ interface IMetricCardTrend {
 	trendClassification: TrendClassification;
 }
 
+/**
+ * Fills the trend row on cards without a trend so that it keeps its height,
+ * leaving the value aligned with the sibling cards that do render a trend.
+ */
+const TREND_PLACEHOLDER = '\u00A0';
+
 interface IMetricCardProps {
 	className?: string;
 	description: string;
 	loading?: boolean;
 	minHeight?: number;
-	renderTrendLabel: (percentageNode: ReactNode) => ReactNode;
+	renderTrendLabel?: (percentageNode: ReactNode) => ReactNode;
 	title: string;
 	trend?: IMetricCardTrend;
 	trendClassName?: string;
@@ -77,29 +83,38 @@ const MetricCard: React.FC<IMetricCardProps> = ({
 
 					<div
 						className={classNames('text-secondary', trendClassName)}
+						data-testid="metric-card-trend"
 					>
-						{!isNil(trend?.trendClassification) &&
-							trend?.trendClassification !==
-								TrendClassification.Neutral && (
-								<ClayIcon
-									style={{color: percentageColor}}
-									symbol={
-										getIcon(trend?.percentage ?? 0) ?? ''
-									}
-								/>
-							)}
+						{renderTrendLabel ? (
+							<>
+								{!isNil(trend?.trendClassification) &&
+									trend?.trendClassification !==
+										TrendClassification.Neutral && (
+										<ClayIcon
+											style={{color: percentageColor}}
+											symbol={
+												getIcon(
+													trend?.percentage ?? 0
+												) ?? ''
+											}
+										/>
+									)}
 
-						{renderTrendLabel(
-							<span
-								className="mr-1"
-								key="percentage"
-								style={{color: percentageColor}}
-							>
-								{formatPercent(
-									Math.abs(trend?.percentage ?? 0),
-									1
+								{renderTrendLabel(
+									<span
+										className="mr-1"
+										key="percentage"
+										style={{color: percentageColor}}
+									>
+										{formatPercent(
+											Math.abs(trend?.percentage ?? 0),
+											1
+										)}
+									</span>
 								)}
-							</span>
+							</>
+						) : (
+							TREND_PLACEHOLDER
 						)}
 					</div>
 				</div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
@@ -8,18 +8,12 @@ import {getIcon, getStatsColor} from 'shared/util/metrics';
 import {isNil} from 'lodash';
 import {Text} from '@clayui/core';
 import {TrendClassification} from 'segment/types';
+import {TREND_PLACEHOLDER} from '../util/constants';
 
 interface IMetricCardTrend {
 	percentage: number;
 	trendClassification: TrendClassification;
 }
-
-/**
- * Fills the trend row on cards without a trend so that it keeps its height,
- * leaving the value aligned with the sibling cards that do render a trend.
- */
-const TREND_PLACEHOLDER = '\u00A0';
-
 interface IMetricCardProps {
 	className?: string;
 	description: string;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/MetricCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/MetricCard.tsx
@@ -105,6 +105,37 @@ describe('MetricCard', () => {
 		).toBeNull();
 	});
 
+	it('should not render the trend when renderTrendLabel is omitted', () => {
+		const {container, getByText, queryByText} = render(
+			<MetricCard
+				description={defaultProps.description}
+				title={defaultProps.title}
+				trend={{
+					percentage: 10,
+					trendClassification: TrendClassification.Positive,
+				}}
+				value={defaultProps.value}
+			/>
+		);
+
+		expect(getByText('42')).toBeTruthy();
+		expect(queryByText('10%')).toBeNull();
+		expect(queryByText('vs last period')).toBeNull();
+		expect(container.querySelector('.lexicon-icon-caret-top-l')).toBeNull();
+	});
+
+	it('should keep the trend row height when renderTrendLabel is omitted so the value stays aligned', () => {
+		const {getByTestId} = render(
+			<MetricCard
+				description={defaultProps.description}
+				title={defaultProps.title}
+				value={defaultProps.value}
+			/>
+		);
+
+		expect(getByTestId('metric-card-trend').textContent).toBe('\u00A0');
+	});
+
 	it('should apply className and trendClassName', () => {
 		const {container} = render(
 			<MetricCard

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/MetricCard.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/MetricCard.tsx.snap
@@ -42,6 +42,7 @@ exports[`MetricCard should render 1`] = `
         </div>
         <div
           class="text-secondary"
+          data-testid="metric-card-trend"
         >
           <span
             class="mr-1"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/constants.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/constants.ts
@@ -493,6 +493,12 @@ export const TIME_RANGE_LABELS = {
 	[RangeKeyTimeRanges.Yesterday]: Liferay.Language.get('yesterday'),
 };
 
+/**
+ * Fills the trend row on cards without a trend so that it keeps its height,
+ * leaving the value aligned with the sibling cards that do render a trend.
+ */
+export const TREND_PLACEHOLDER = '\u00A0';
+
 export const TWO_DAYS = '172800000';
 
 const Constants: Window['faroConstants'] = window.faroConstants;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101249

## What Is Being Fixed

The Total Individuals and Total Accounts metric cards displayed a period-over-period % change beside their value. Both cards report a cumulative total, so comparing that total against the previous period produces a figure that does not reflect meaningful trend data and misleads the reader. The sibling cards on the same dashboards — Known Individuals, Anonymous Individuals, New Accounts, Active Accounts — measure activity within the period, so their trend remains valid and must keep displaying.

## How It Is Being Fixed

The shared `MetricCard` component drives every card on both dashboards, so the trend had to become opt-out rather than being torn out. Its `renderTrendLabel` prop is now optional, and omitting it suppresses the caret, the percentage, and the "vs. …" label. Only the Total Individuals and Total Accounts call sites drop the prop; every sibling card passes it unchanged and renders exactly as before.

Suppressing the row alone broke the layout. `Card.Body` is `justify-content-between`, which bottom-anchors the value group, so removing the trend let the value slide down one line while the neighbouring cards kept theirs. The trend row is therefore still rendered and holds a non-breaking space when there is no trend, reserving exactly one line of the inherited line-height so the value stays on the same baseline as its neighbours without relying on a hardcoded pixel value.

The GraphQL query and the accounts metrics API are untouched. The trend data is still fetched and still consumed by the sibling cards, so narrowing either would be churn with no benefit and would risk the neighbouring cards.

This branch also carries an unrelated one-line typography fix, setting an explicit text size on the Most Engaged Individuals card title.

## PR Check

**pr-check: PASS** — tested on `94944bb74a370e0700461b2f438eadf12785d391`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "94944bb74a370e0700461b2f438eadf12785d391"} -->
