### PR TITLE
LPD-101767 Remove the real time segments feature flag

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/List.tsx
@@ -46,7 +46,6 @@ import {
 	USER_NAME,
 } from 'shared/util/router';
 import {DateCell} from 'shared/components/table/cell-components';
-import {ENABLE_REAL_TIME_SEGMENTS} from 'shared/util/feature-flags';
 import {formatDateToTimeZone} from 'shared/util/date';
 import {
 	getDefaultSortOrder,
@@ -527,22 +526,20 @@ export const List: React.FC<IListProps> = ({
 										{Liferay.Language.get('batch-segment')}
 									</ClayDropDown.Item>
 
-									{ENABLE_REAL_TIME_SEGMENTS && (
-										<ClayDropDown.Item
-											data-testid="real-time-segment-dropdown-item"
-											href={setUriQueryValues(
-												{type: SegmentTypes.RealTime},
-												toRoute(
-													Routes.CONTACTS_SEGMENT_CREATE,
-													{channelId, groupId}
-												)
-											)}
-										>
-											{Liferay.Language.get(
-												'real-time-segment'
-											)}
-										</ClayDropDown.Item>
-									)}
+									<ClayDropDown.Item
+										data-testid="real-time-segment-dropdown-item"
+										href={setUriQueryValues(
+											{type: SegmentTypes.RealTime},
+											toRoute(
+												Routes.CONTACTS_SEGMENT_CREATE,
+												{channelId, groupId}
+											)
+										)}
+									>
+										{Liferay.Language.get(
+											'real-time-segment'
+										)}
+									</ClayDropDown.Item>
 								</ClayDropDown.Group>
 							</ClayDropDown>
 						</div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/__tests__/List.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/__tests__/List.jsx
@@ -17,13 +17,6 @@ import {waitForLoadingToBeRemoved} from 'test/helpers';
 
 jest.unmock('react-dom');
 
-jest.mock('shared/util/feature-flags', () => ({
-	...jest.requireActual('shared/util/feature-flags'),
-	ENABLE_REAL_TIME_SEGMENTS: false
-}));
-
-const featureFlags = jest.requireMock('shared/util/feature-flags');
-
 const MOCK_UNASSIGNED_SEGMENTS_CONTEXT = {
 	showUnassignedAlert: false,
 	unassignedSegments: [],
@@ -65,8 +58,6 @@ describe('List', () => {
 		jest.clearAllMocks();
 
 		jest.useFakeTimers();
-
-		featureFlags.ENABLE_REAL_TIME_SEGMENTS = true;
 	});
 
 	afterEach(() => {
@@ -164,32 +155,7 @@ describe('List', () => {
 		).not.toBeInTheDocument();
 	});
 
-	describe('when real time segments are disabled', () => {
-		beforeEach(() => {
-			featureFlags.ENABLE_REAL_TIME_SEGMENTS = false;
-		});
-
-		it('hides the real time segment option', async () => {
-			render(<DefaultComponent />);
-
-			await act(async () => {
-				jest.runAllTimers();
-			});
-
-			expect(
-				screen.getByTestId('account-batch-segment-dropdown-item')
-			).toBeInTheDocument();
-			expect(
-				screen.getByTestId('batch-segment-dropdown-item')
-			).toBeInTheDocument();
-
-			expect(
-				screen.queryByTestId('real-time-segment-dropdown-item')
-			).not.toBeInTheDocument();
-		});
-	});
-
-	it('shows the segment type dropdown when real time segments are enabled', async () => {
+	it('shows the segment type dropdown', async () => {
 		render(<DefaultComponent />);
 
 		await act(async () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/feature-flags.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/feature-flags.ts
@@ -20,8 +20,7 @@ export type FeatureFlagKey =
 	| 'ENABLE_BLOCKLIST_KEYWORDS'
 	| 'ENABLE_COMMERCE'
 	| 'ENABLE_DELETE_DATA_SOURCE_BUTTON'
-	| 'ENABLE_FORM_ABANDONMENT'
-	| 'ENABLE_REAL_TIME_SEGMENTS';
+	| 'ENABLE_FORM_ABANDONMENT';
 
 export interface FeatureFlagDefinition {
 	defaultValue: boolean;
@@ -34,7 +33,6 @@ export const FEATURE_FLAGS: FeatureFlagDefinition[] = [
 	{defaultValue: false, key: 'ENABLE_COMMERCE'},
 	{defaultValue: true, key: 'ENABLE_DELETE_DATA_SOURCE_BUTTON'},
 	{defaultValue: false, key: 'ENABLE_FORM_ABANDONMENT'},
-	{defaultValue: false, key: 'ENABLE_REAL_TIME_SEGMENTS'},
 ];
 
 const DEFAULTS = FEATURE_FLAGS.reduce(
@@ -107,8 +105,4 @@ export const ENABLE_DELETE_DATA_SOURCE_BUTTON = isFeatureFlagEnabled(
 
 export const ENABLE_FORM_ABANDONMENT = isFeatureFlagEnabled(
 	'ENABLE_FORM_ABANDONMENT'
-);
-
-export const ENABLE_REAL_TIME_SEGMENTS = isFeatureFlagEnabled(
-	'ENABLE_REAL_TIME_SEGMENTS'
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101767

## What Is Being Fixed

Real time segments are no longer behind development, so the `ENABLE_REAL_TIME_SEGMENTS` feature flag that gated the option had nothing left to gate. Keeping it meant the segment list still hid the real time segment entry unless the flag was turned on, and the flag registry carried a key nobody needs to flip.

## How It Is Being Fixed

The flag is removed end to end. The real time segment dropdown item in the segment list now renders unconditionally, and `ENABLE_REAL_TIME_SEGMENTS` is dropped from the `FeatureFlagKey` union, from the `FEATURE_FLAGS` registry, and from the exported constants in `shared/util/feature-flags`. The test that asserted the option stays hidden while the flag is off describes a state that can no longer exist, so it goes away along with the `jest.mock` wiring that forced the flag per test; the remaining case is renamed to drop the flag from its name.

## Why Are There No Tests?

This PR removes a feature flag whose behavior is now unconditional. The existing `List` test suite already covers the dropdown option; the only test change is deleting the now-impossible flag-disabled case.

## PR Check

**pr-check: PASS** — tested on `14007c9f7e5ac2e715d94c38a2603402fbd313c4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "14007c9f7e5ac2e715d94c38a2603402fbd313c4"} -->
