### PR TITLE
LPD-101782 Render every page at full width

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-admin-web/src/main/resources/META-INF/resources/projects.jsp
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-admin-web/src/main/resources/META-INF/resources/projects.jsp
@@ -25,7 +25,7 @@ FaroAdminDisplayContext faroAdminDisplayContext = new FaroAdminDisplayContext(re
 		<liferay-util:include page="" servletContext="<%= application %>" />
 	</liferay-frontend:sidebar-panel>
 
-	<div class="container-fluid container-fluid-max-xl sidenav-content">
+	<div class="container-fluid sidenav-content">
 		<aui:form name="fm">
 			<liferay-ui:search-container
 				id="faro_admin"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_base_page.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_base_page.scss
@@ -53,7 +53,7 @@
 			bottom: 0;
 			height: 40px;
 			margin: auto;
-			padding: 0 48px;
+			padding: 0 $pagePadding;
 			position: absolute;
 			right: 0;
 			top: 0;
@@ -101,13 +101,14 @@
 
 	.fluid-body-root {
 		display: flex;
+		padding: 0 $pagePadding;
 
 		&.sidebar-opened .card-root {
-			max-width: calc(100% - 488px - 1rem);
+			max-width: calc(100% - 488px);
 		}
 
 		.card-root {
-			margin: 1rem;
+			margin: 1rem 0;
 			width: 100%;
 		}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_base_page.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_base_page.scss
@@ -15,8 +15,6 @@
 
 	.header-container,
 	.page-container {
-		margin: 0 auto;
-		max-width: $maxPageWidth + ($pagePadding * 2);
 		min-width: $minPageWidthContent;
 		padding: 0 $pagePadding;
 		position: relative;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_card.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_card.scss
@@ -3,6 +3,7 @@
 	box-shadow: none;
 	display: flex;
 	flex-direction: column;
+	overflow: hidden;
 
 	&:hover {
 		box-shadow: none;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_contributor_builder.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_contributor_builder.scss
@@ -82,19 +82,6 @@
 					position: relative;
 				}
 			}
-
-			@media (min-width: $maxPageWidth) {
-				.contributor-container .container-fluid {
-					padding-right: calc(
-						#{$criteriaSidebarWidth} - ((100% - #{$maxPageWidth}) /
-									2)
-					);
-
-					.content-wrapper {
-						padding-right: 32px;
-					}
-				}
-			}
 		}
 
 		.criteria-builder-section-sidebar {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_segment_editor.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_segment_editor.scss
@@ -26,14 +26,3 @@
 		display: none;
 	}
 }
-
-@media (max-width: $maxPageWidth + $sidebarOpenWidth) {
-	body.open .segments-root {
-		.contributor-builder-root.editing
-			.criteria-builder-section-main
-			.contributor-container
-			.container-fluid {
-			padding-right: $criteriaSidebarWidth;
-		}
-	}
-}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_settings.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_settings.scss
@@ -38,8 +38,6 @@
 	}
 
 	.section-main {
-		margin: 0 auto;
-		max-width: $maxPageWidth + ($pagePadding * 2);
 		min-width: $minPageWidthContent;
 		padding: 0 $pagePadding;
 		width: 100%;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_variables.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_variables.scss
@@ -52,7 +52,6 @@ $profileHeaderMargin: 16px;
 $sidebarClosedWidth: 80px;
 $sidebarOpenWidth: 232px;
 
-$maxPageWidth: 1280px;
 $minPageWidth: 992px;
 $minPageWidthContent: 640px;
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_variables.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_variables.scss
@@ -47,7 +47,7 @@ $maxGridItems: 4;
 $maxGridItemsMd: 3;
 $maxGridItemsSm: 2;
 $navbarHeight: 72px;
-$pagePadding: 48px;
+$pagePadding: 12px;
 $profileHeaderMargin: 16px;
 $sidebarClosedWidth: 80px;
 $sidebarOpenWidth: 232px;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
@@ -12,7 +12,7 @@ exports[`List rendering should match the snapshot 1`] = `
       class="header-root"
     >
       <div
-        class="mx-5"
+        class="header-container"
       >
         <div
           class="row-root align-items-center d-flex justify-content-between"
@@ -57,7 +57,7 @@ exports[`List rendering should match the snapshot 1`] = `
       class="sub-header-root"
     >
       <div
-        class="mx-5"
+        class="header-container"
       >
         <div
           class="d-flex justify-content-end w-100"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
@@ -361,7 +361,6 @@ const List = () => {
 						label: selectedChannel?.name,
 					}),
 				]}
-				fluid
 				groupId={groupId!}
 			>
 				<BasePage.Header.TitleSection

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/BaseInterestDetails.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/BaseInterestDetails.tsx
@@ -219,6 +219,7 @@ const BaseInterestDetails: React.FC<IBaseInterestDetailsProps> = ({
 				<Card.Header>
 					<ClayNavigationBar
 						className="page-subnav"
+						fluidSize={false}
 						key="subnav"
 						triggerLabel="label"
 					>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/ProfileRoutes.tsx
@@ -78,7 +78,6 @@ const AccountProfileRoutes = () => {
 			documentTitle={`${accountName} - ${Liferay.Language.get(
 				'account'
 			)}`}
-			fluid
 		>
 			<BasePage.Header
 				breadcrumbs={[

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/variant-card/VariantCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/variant-card/VariantCard.tsx
@@ -33,6 +33,7 @@ export const VariantCard = ({
 					{Liferay.Language.get('variant-report')}
 				</Card.Title>
 				<ClayNavigationBar
+					fluidSize={false}
 					triggerLabel={
 						variantView === VariantView.Medians
 							? Liferay.Language.get('medians')

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/Distribution.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/Distribution.tsx
@@ -85,9 +85,9 @@ export const IndividualsDistribution: React.FC<
 			/>
 
 			<StatesRenderer.Success>
-				<div className="individuals-dashboard-distribution-root container-fluid">
+				<div className="individuals-dashboard-distribution-root">
 					<div className="row">
-						<div className="col-xl-12">
+						<div className="col">
 							<Distribution
 								contextOptions={[CONTEXT_OPTIONS[0]]}
 								distributionsKey={

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/__snapshots__/index.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/__snapshots__/index.jsx.snap
@@ -58,7 +58,7 @@ exports[`Individuals Dashboard renders 1`] = `
             class="navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
           >
             <div
-              class="container-fluid container-fluid-max-xl"
+              class="container-fluid"
             >
               <button
                 aria-expanded="false"
@@ -85,7 +85,7 @@ exports[`Individuals Dashboard renders 1`] = `
                 class="navbar-collapse collapse"
               >
                 <div
-                  class="container-fluid container-fluid-max-xl"
+                  class="container-fluid"
                 >
                   <ul
                     class="navbar-nav"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/InterestDetails.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/InterestDetails.jsx
@@ -113,6 +113,7 @@ export default class InterestDetails extends React.Component {
 					<Card.Header>
 						<ClayNavigationBar
 							className='page-subnav'
+							fluidSize={false}
 							triggerLabel='label'
 						>
 							{this.getNavigationItems().map(

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutes.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutes.jsx.snap
@@ -84,7 +84,7 @@ exports[`IndividualProfileRoutes should render 1`] = `
             class="navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
           >
             <div
-              class="container-fluid container-fluid-max-xl"
+              class="container-fluid"
             >
               <button
                 aria-expanded="false"
@@ -111,7 +111,7 @@ exports[`IndividualProfileRoutes should render 1`] = `
                 class="navbar-collapse collapse"
               >
                 <div
-                  class="container-fluid container-fluid-max-xl"
+                  class="container-fluid"
                 >
                   <ul
                     class="navbar-nav"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutesCDP.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/pages/__tests__/__snapshots__/ProfileRoutesCDP.jsx.snap
@@ -84,7 +84,7 @@ exports[`IndividualProfileRoutes should render 1`] = `
             class="navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
           >
             <div
-              class="container-fluid container-fluid-max-xl"
+              class="container-fluid"
             >
               <button
                 aria-expanded="false"
@@ -111,7 +111,7 @@ exports[`IndividualProfileRoutes should render 1`] = `
                 class="navbar-collapse collapse"
               >
                 <div
-                  class="container-fluid container-fluid-max-xl"
+                  class="container-fluid"
                 >
                   <ul
                     class="navbar-nav"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/LifecycleSettingsForm.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/LifecycleSettingsForm.tsx
@@ -47,7 +47,7 @@ const LifecycleSettingsForm: React.FC<ILifecycleSettingsFormProps> = ({
 			submitLabel={submitLabel}
 		/>
 
-		<div className="justify-self-center d-inline-block mt-5 mx-auto">
+		<div className="mt-5 mx-5">
 			<Card>
 				<Card.Body>
 					<Card.Title>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/Distribution.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/Distribution.jsx
@@ -8,9 +8,9 @@ import {fetchDistribution} from 'shared/actions/distributions';
 import {Sizes} from 'shared/util/constants';
 
 const SegmentDistribution = ({segment, ...otherProps}) => (
-	<div className='segment-distribution-root container-fluid'>
+	<div className='segment-distribution-root'>
 		<div className='row'>
-			<div className='col-xl-12'>
+			<div className='col'>
 				<Distribution
 					distributionsKey={segment.id}
 					knownIndividualCount={segment.knownIndividualCount}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/__tests__/__snapshots__/SegmentEditor.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/__tests__/__snapshots__/SegmentEditor.jsx.snap
@@ -198,7 +198,7 @@ exports[`SegmentEditor should render 1`] = `
             class="contributor-container"
           >
             <div
-              class="container-fluid container-fluid-max-xl"
+              class="container-fluid"
             >
               <div
                 class="content-wrapper"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/index.tsx
@@ -346,7 +346,7 @@ class SegmentEditor extends React.Component<ISegmentEditorProps> {
 
 										<div className="criteria-builder-section-main">
 											<div className="contributor-container">
-												<div className="container-fluid container-fluid-max-xl">
+												<div className="container-fluid">
 													<div className="content-wrapper">
 														<div className="segment-erc">
 															<Form.Group autoFit>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/apis/pages/AccessTokenList.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/apis/pages/AccessTokenList.tsx
@@ -99,7 +99,7 @@ const TokenList: React.FC<
 	);
 
 	return (
-		<div className="col-xl-8 pl-0">
+		<div>
 			{!!tokens.length && !hasActiveToken && !onCloseAlert && (
 				<Alerts
 					iconSymbol="warning-full"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/apis/pages/__tests__/__snapshots__/AccessTokenList.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/apis/pages/__tests__/__snapshots__/AccessTokenList.jsx.snap
@@ -412,9 +412,7 @@ exports[`AccessTokenList should render 1`] = `
             />
           </div>
           <div>
-            <div
-              class="col-xl-8 pl-0"
-            >
+            <div>
               <div
                 class="card card-root"
               >

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/pages/Overview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/pages/Overview.tsx
@@ -193,7 +193,7 @@ export const Overview: React.FC<IOverviewProps> = ({close, groupId, open}) => {
 			pageTitle={Liferay.Language.get('data-control-&-privacy')}
 		>
 			<div className="row">
-				<div className="col-xl-8">
+				<div className="col">
 					<Card>
 						<Card.Body>
 							<div className="container">

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/pages/__tests__/__snapshots__/Overview.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/pages/__tests__/__snapshots__/Overview.jsx.snap
@@ -327,7 +327,7 @@ exports[`Data Privacy Overview should render 1`] = `
               class="row"
             >
               <div
-                class="col-xl-8"
+                class="col"
               >
                 <div
                   class="card card-root"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/event-attributes/components/TabsCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/event-attributes/components/TabsCard.tsx
@@ -49,6 +49,7 @@ const TabsCard: React.FC<ITabsCardProps> = ({groupId}) => {
 		<Card key="cardContainer" pageDisplay>
 			<ClayNavigationBar
 				className="page-subnav mx-4 my-3"
+				fluidSize={false}
 				triggerLabel={activeLabel}
 			>
 				{NAV_ITEMS.map(({label, route}) => (

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/event-attributes/components/__tests__/__snapshots__/TabsCard.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/event-attributes/components/__tests__/__snapshots__/TabsCard.jsx.snap
@@ -9,7 +9,7 @@ exports[`TabsCard should render 1`] = `
       class="page-subnav mx-4 my-3 navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
     >
       <div
-        class="container-fluid container-fluid-max-xl"
+        class="container-fluid"
       >
         <button
           aria-expanded="false"
@@ -36,7 +36,7 @@ exports[`TabsCard should render 1`] = `
           class="navbar-collapse collapse"
         >
           <div
-            class="container-fluid container-fluid-max-xl"
+            class="container-fluid"
           >
             <ul
               class="navbar-nav"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/event-attributes/pages/__tests__/__snapshots__/EventAttribute.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/event-attributes/pages/__tests__/__snapshots__/EventAttribute.jsx.snap
@@ -350,7 +350,7 @@ exports[`EventAttributes should render 1`] = `
                 class="page-subnav mx-4 my-3 navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
               >
                 <div
-                  class="container-fluid container-fluid-max-xl"
+                  class="container-fluid"
                 >
                   <button
                     aria-expanded="false"
@@ -377,7 +377,7 @@ exports[`EventAttributes should render 1`] = `
                     class="navbar-collapse collapse"
                   >
                     <div
-                      class="container-fluid container-fluid-max-xl"
+                      class="container-fluid"
                     >
                       <ul
                         class="navbar-nav"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/events/components/TabsCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/events/components/TabsCard.tsx
@@ -47,7 +47,11 @@ const TabsCard: React.FC<ITabsCardProps> = ({groupId}) => {
 
 	return (
 		<Card key="cardContainer" pageDisplay>
-			<ClayNavigationBar className="my-3" triggerLabel={activeLabel}>
+			<ClayNavigationBar
+				className="my-3"
+				fluidSize={false}
+				triggerLabel={activeLabel}
+			>
 				{NAV_ITEMS.map(({label, route}) => (
 					<ClayNavigationBar.Item
 						active={matchedRoute === route}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/events/components/__tests__/__snapshots__/TabsCard.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/events/components/__tests__/__snapshots__/TabsCard.jsx.snap
@@ -9,7 +9,7 @@ exports[`TabsCard should render 1`] = `
       class="my-3 navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
     >
       <div
-        class="container-fluid container-fluid-max-xl"
+        class="container-fluid"
       >
         <button
           aria-expanded="false"
@@ -36,7 +36,7 @@ exports[`TabsCard should render 1`] = `
           class="navbar-collapse collapse"
         >
           <div
-            class="container-fluid container-fluid-max-xl"
+            class="container-fluid"
           >
             <ul
               class="navbar-nav"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/events/pages/__tests__/__snapshots__/Events.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/events/pages/__tests__/__snapshots__/Events.jsx.snap
@@ -350,7 +350,7 @@ exports[`Events should render 1`] = `
                 class="my-3 navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
               >
                 <div
-                  class="container-fluid container-fluid-max-xl"
+                  class="container-fluid"
                 >
                   <button
                     aria-expanded="false"
@@ -377,7 +377,7 @@ exports[`Events should render 1`] = `
                     class="navbar-collapse collapse"
                   >
                     <div
-                      class="container-fluid container-fluid-max-xl"
+                      class="container-fluid"
                     >
                       <ul
                         class="navbar-nav"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/pages/Overview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/pages/Overview.tsx
@@ -111,7 +111,7 @@ export const Overview: React.FC<IOverviewProps> = ({groupId}) => (
 		pageTitle={Liferay.Language.get('definitions')}
 	>
 		<div className="row">
-			<div className="col-xl-8">
+			<div className="col">
 				<Card>
 					<ClayList>
 						{items(DEVELOPER_MODE)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/Workspace.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/Workspace.tsx
@@ -95,7 +95,7 @@ export const Workspace: React.FC<IWorkspaceProps> = ({
 			pageTitle={Liferay.Language.get('workspace-settings')}
 		>
 			<AddWorkspaceForm
-				className="add-workspace-root col-lg-7 pl-0"
+				className="add-workspace-root"
 				disabled={!currentUser.isAdmin()}
 				editing
 				emailAddressDomains={emailAddressDomains}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/__tests__/__snapshots__/Workspace.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/__tests__/__snapshots__/Workspace.jsx.snap
@@ -321,7 +321,7 @@ exports[`Workspace Settting should render 1`] = `
           </div>
           <div>
             <div
-              class="add-workspace-form-root add-workspace-root col-lg-7 pl-0"
+              class="add-workspace-form-root add-workspace-root"
             >
               <div
                 class="sheet"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/user/__tests__/__snapshots__/index.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/user/__tests__/__snapshots__/index.jsx.snap
@@ -327,7 +327,7 @@ exports[`UserRoutes should render 1`] = `
                 class="page-subnav mx-4 my-3 navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
               >
                 <div
-                  class="container-fluid container-fluid-max-xl"
+                  class="container-fluid"
                 >
                   <button
                     aria-expanded="false"
@@ -354,7 +354,7 @@ exports[`UserRoutes should render 1`] = `
                     class="navbar-collapse collapse"
                   >
                     <div
-                      class="container-fluid container-fluid-max-xl"
+                      class="container-fluid"
                     >
                       <ul
                         class="navbar-nav"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/user/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/user/index.tsx
@@ -80,6 +80,7 @@ export const User = ({className}: {className?: string}) => {
 				{currentUser.isAdmin() && (
 					<ClayNavigationBar
 						className="page-subnav mx-4 my-3"
+						fluidSize={false}
 						triggerLabel={activeTriggerLabel}
 					>
 						{NAV_ITEMS.map(({label, route}) => (

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/CreateItemSimilarity.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/CreateItemSimilarity.tsx
@@ -31,7 +31,7 @@ const CreateItemSimilarity: React.FC<ICreateItemSimilarityProps> = ({
 			pageTitle={Liferay.Language.get('new-item-similarity-model')}
 		>
 			<div className="row">
-				<div className="col-xl-8">
+				<div className="col">
 					<RecommendationStepCard
 						cancelHref={toRoute(Routes.SETTINGS_RECOMMENDATIONS, {
 							groupId,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/Edit.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/Edit.tsx
@@ -35,7 +35,7 @@ const Edit: React.FC<IEditProps> = ({job, router}) => {
 			pageTitle={name}
 		>
 			<div className="row">
-				<div className="col-xl-8">
+				<div className="col">
 					<RecommendationStepCard
 						cancelHref={toRoute(
 							Routes.SETTINGS_RECOMMENDATION_MODEL_VIEW,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/View.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/View.tsx
@@ -82,7 +82,7 @@ const View: React.FC<IViewProps> = ({addAlert, close, history, job, open}) => {
 
 	return (
 		<div className="row">
-			<div className="col-xl-8">
+			<div className="col">
 				<BasePage
 					breadcrumbItems={[
 						getRecommendations({groupId}),

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/__tests__/__snapshots__/CreateItemSimilarity.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/__tests__/__snapshots__/CreateItemSimilarity.jsx.snap
@@ -347,7 +347,7 @@ exports[`Recommendations should render 1`] = `
               class="row"
             >
               <div
-                class="col-xl-8"
+                class="col"
               >
                 <div
                   class="card card-root recommendation-step-card-root"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/__tests__/__snapshots__/Edit.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/__tests__/__snapshots__/Edit.jsx.snap
@@ -347,7 +347,7 @@ exports[`Edit should render 1`] = `
               class="row"
             >
               <div
-                class="col-xl-8"
+                class="col"
               >
                 <div
                   class="card card-root recommendation-step-card-root"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/__tests__/__snapshots__/View.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/pages/__tests__/__snapshots__/View.jsx.snap
@@ -6,7 +6,7 @@ exports[`View should render 1`] = `
     class="row"
   >
     <div
-      class="col-xl-8"
+      class="col"
     >
       <div
         class="settings-root"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/base-page/Header.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/base-page/Header.tsx
@@ -266,7 +266,6 @@ const Actions: React.FC<IActionsProps> = ({actions = []}) => (
 
 interface IHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
 	breadcrumbs: IBreadcrumbArgs[];
-	fluid?: boolean;
 	groupId: string;
 }
 
@@ -276,30 +275,8 @@ const Header: React.FC<IHeaderProps> & {
 	Actions: typeof Actions;
 	Section: typeof Section;
 	TitleSection: typeof TitleSection;
-} = ({breadcrumbs, children, fluid, groupId}) => {
+} = ({breadcrumbs, children, groupId}) => {
 	const notificationResponse = useNotificationsAPI(groupId);
-
-	if (fluid) {
-		return (
-			<header className="header-root">
-				<div className="mx-5">
-					{breadcrumbs && (
-						<Row>
-							<Breadcrumbs items={breadcrumbs} />
-						</Row>
-					)}
-
-					{children}
-				</div>
-
-				<NotificationAlertList
-					{...notificationResponse}
-					groupId={groupId}
-					stripe
-				/>
-			</header>
-		);
-	}
 
 	return (
 		<header className="header-root">

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/base-page/Header.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/base-page/Header.tsx
@@ -46,7 +46,7 @@ const NavBar: React.FC<INavBarProps> = ({
 
 	return (
 		<div className="row">
-			<ClayNavigationBar triggerLabel={activeLabel}>
+			<ClayNavigationBar fluidSize={false} triggerLabel={activeLabel}>
 				{items.map(({deprecated, label, route}) => (
 					<ClayNavigationBar.Item
 						active={matchedRoute === route}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/base-page/SubHeader.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/base-page/SubHeader.tsx
@@ -14,7 +14,7 @@ const SubHeader: React.FC<ISubHeaderProps> = ({
 	if (fluid) {
 		return (
 			<div className={getCN('sub-header-root', className)}>
-				<div className="mx-5">{children}</div>
+				<div className="header-container">{children}</div>
 			</div>
 		);
 	}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/base-page/__tests__/__snapshots__/Header.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/base-page/__tests__/__snapshots__/Header.jsx.snap
@@ -9,7 +9,7 @@ exports[`BasePage.Header NavBar renders NavBar 1`] = `
       class="navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
     >
       <div
-        class="container-fluid container-fluid-max-xl"
+        class="container-fluid"
       >
         <button
           aria-expanded="false"
@@ -36,7 +36,7 @@ exports[`BasePage.Header NavBar renders NavBar 1`] = `
           class="navbar-collapse collapse"
         >
           <div
-            class="container-fluid container-fluid-max-xl"
+            class="container-fluid"
           >
             <ul
               class="navbar-nav"
@@ -71,7 +71,7 @@ exports[`BasePage.Header NavBar renders NavBar w/o routeQueries 1`] = `
       class="navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
     >
       <div
-        class="container-fluid container-fluid-max-xl"
+        class="container-fluid"
       >
         <button
           aria-expanded="false"
@@ -98,7 +98,7 @@ exports[`BasePage.Header NavBar renders NavBar w/o routeQueries 1`] = `
           class="navbar-collapse collapse"
         >
           <div
-            class="container-fluid container-fluid-max-xl"
+            class="container-fluid"
           >
             <ul
               class="navbar-nav"
@@ -133,7 +133,7 @@ exports[`BasePage.Header NavBar renders NavBar with deprecated label 1`] = `
       class="navbar navbar-collapse-relative navbar-expand-md navbar-underline navigation-bar navigation-bar-light"
     >
       <div
-        class="container-fluid container-fluid-max-xl"
+        class="container-fluid"
       >
         <button
           aria-expanded="false"
@@ -160,7 +160,7 @@ exports[`BasePage.Header NavBar renders NavBar with deprecated label 1`] = `
           class="navbar-collapse collapse"
         >
           <div
-            class="container-fluid container-fluid-max-xl"
+            class="container-fluid"
           >
             <ul
               class="navbar-nav"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/base-page/index.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/base-page/index.tsx
@@ -10,7 +10,6 @@ import SubHeader from './SubHeader';
 
 interface IBasePageProps extends React.HTMLAttributes<HTMLElement> {
 	documentTitle: string;
-	fluid?: boolean;
 }
 
 export const BasePage: React.FC<IBasePageProps> & {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101782

## What Is Being Fixed

Every page was capped at 1280px and centered, which left growing amounts of unused space on wide screens and did not match the portal, where administration pages span the full viewport. The page padding was also 48px, four times what the portal gives a fluid container.

## How It Is Being Fixed

The cap lived in three containers rather than in the individual views, so removing it there covers every page that builds on BasePage, plus Settings and the admin projects table. Clay caps navigation bars through the container it renders internally, so those now pass a fluid size instead. Removing the cap then exposed the constraints it had been hiding: settings pages wrapped their content in a fixed Bootstrap column, the distribution views nested a container inside the page container, and the lifecycle form sized itself to its contents. The page padding now matches the portal, and the fluid layout takes it from its container instead of setting its own margin, which is what left Assets at 16px while its own header sat at 48px. Cards also clip their children now, so a first child painting its own background no longer squares off their corners.

## Why Are There No Tests?

The existing snapshot suite covers the affected markup; eleven snapshots were updated to record the new classes, so the change is verified by the suite that already exists.

## PR Check

**pr-check: PASS** — tested on `9d05aba2236d6607bf8cfd3ee3b24e4e7e5cffcd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JSP Compile | PASS |
| Workspace Build | PASS |

`compileJSP` on `osb-faro-admin-web` reported `NO-SOURCE`, so it exercised nothing; the JSP change removes one CSS class from a `class` attribute.

<!-- pr-check {"result": "success", "sha": "9d05aba2236d6607bf8cfd3ee3b24e4e7e5cffcd"} -->
