### PR TITLE
LPD-100563 Add locale-aware date and time formatting

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/LifecycleStatus.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/LifecycleStatus.tsx
@@ -7,7 +7,7 @@ import ClaySticker from '@clayui/sticker';
 import MultiStepNav from '@clayui/multi-step-nav';
 import React from 'react';
 import StatesRenderer from 'shared/components/states-renderer/StatesRenderer';
-import {CUSTOM_DATE_FORMAT, formatUTCDate} from 'shared/util/date';
+import {formatUTCDate, getCustomDateFormat} from 'shared/util/date';
 import {
 	IAccountLifecycleStageStatus,
 	IAccountLifecycleStatus,
@@ -139,7 +139,7 @@ const LifecycleStatus: React.FC<LifecycleStatusProps> = ({className}) => {
 												stage.startDate
 													? formatUTCDate(
 															stage.startDate,
-															CUSTOM_DATE_FORMAT
+															getCustomDateFormat()
 														)
 													: undefined
 											}
@@ -206,7 +206,7 @@ const LifecycleStatus: React.FC<LifecycleStatusProps> = ({className}) => {
 											<Text color="secondary" size={3}>
 												{formatUTCDate(
 													activeStage.startDate,
-													CUSTOM_DATE_FORMAT
+													getCustomDateFormat()
 												)}
 											</Text>
 										)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/LifecycleStatus.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/LifecycleStatus.tsx
@@ -191,7 +191,7 @@ describe('LifecycleStatus', () => {
 			) as HTMLElement;
 
 			expect(
-				within(multistep).getByText('Jan 04, 2026')
+				within(multistep).getByText('Jan 4, 2026')
 			).toBeInTheDocument();
 			expect(
 				within(multistep).getByText('Jan 16, 2026')
@@ -379,10 +379,10 @@ describe('LifecycleStatus', () => {
 			) as HTMLElement;
 
 			expect(
-				within(multistep).getByText('Feb 01, 2026')
+				within(multistep).getByText('Feb 1, 2026')
 			).toBeInTheDocument();
 			expect(
-				within(multistep).getByText('Mar 01, 2026')
+				within(multistep).getByText('Mar 1, 2026')
 			).toBeInTheDocument();
 		});
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/event-analysis/utils/utils.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/event-analysis/utils/utils.ts
@@ -14,7 +14,11 @@ import {
 	ParsedBreakdownItem,
 } from './types';
 import {formatTime} from 'shared/util/time';
-import {formatUTCDate} from 'shared/util/date';
+import {
+	formatUTCDate,
+	getCustomDateFormat,
+	getMonthYearFormat,
+} from 'shared/util/date';
 import {OrderByDirections} from 'shared/util/constants';
 
 const DEFAULT_DATE_GROUPING = DateGroupings.Month;
@@ -141,7 +145,10 @@ const getDateDisplay = (
 ): [string, string] => {
 	const operatorLabel = DATE_OPERATOR_LABELS_MAP[operator];
 
-	const formattedStartDate = formatUTCDate(startDate as string, 'll');
+	const formattedStartDate = formatUTCDate(
+		startDate as string,
+		getCustomDateFormat()
+	);
 
 	const breakdownValue =
 		operator === Operators.Between
@@ -149,7 +156,7 @@ const getDateDisplay = (
 					'between'
 				)} ${formattedStartDate} ${operatorLabel} ${formatUTCDate(
 					endDate as string,
-					'll'
+					getCustomDateFormat()
 				)}`
 			: `${operatorLabel} ${formattedStartDate}`;
 
@@ -345,9 +352,9 @@ export const formatDateName = (
 ): string => {
 	switch (dateGrouping) {
 		case DateGroupings.Day:
-			return moment(name, 'YYYY-MM-DD').format('ll');
+			return moment(name, 'YYYY-MM-DD').format(getCustomDateFormat());
 		case DateGroupings.Month:
-			return moment(name, 'YYYY-MM').format('MMM YYYY');
+			return moment(name, 'YYYY-MM').format(getMonthYearFormat());
 		case DateGroupings.Year:
 		default:
 			return name;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/ComposedChart.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/ComposedChart.tsx
@@ -1,4 +1,4 @@
-import * as d3 from 'd3';
+import moment from 'moment';
 import React, {useState} from 'react';
 import {ANIMATION_DURATION, AXIS, getAxisTickText} from 'shared/util/recharts';
 import {
@@ -15,7 +15,7 @@ import {
 import {CHART_COLOR_NAMES} from 'shared/util/charts';
 import {CONTROL_COLOR} from '../util/constants';
 import {getAxisMeasuresFromData} from 'shared/util/charts';
-import {getDate} from 'shared/util/date';
+import {getDate, getDayMonthFormat} from 'shared/util/date';
 import {getShortIntervals} from 'experiments/util/experiments';
 
 const {stark: CHART_BLUE} = CHART_COLOR_NAMES;
@@ -76,7 +76,7 @@ export const ComposedChart = ({
 					dataKey="key"
 					interval="preserveStart"
 					tickFormatter={(date) =>
-						d3.utcFormat('%b %-d')(getDate(date))
+						moment.utc(getDate(date)).format(getDayMonthFormat())
 					}
 					tickLine={false}
 					ticks={customIntervals}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/SessionsCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/SessionsCard.tsx
@@ -1,4 +1,3 @@
-import * as d3 from 'd3';
 import Card from 'shared/components/Card';
 import ChartTooltip, {
 	Alignments,
@@ -7,11 +6,12 @@ import ChartTooltip, {
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import getCN from 'classnames';
+import moment from 'moment';
 import React, {useState} from 'react';
 import StatesRenderer from 'shared/components/states-renderer/StatesRenderer';
 import {ComposedChart} from './ComposedChart';
 import {getAxisFormatter} from 'shared/util/charts';
-import {getDate} from 'shared/util/date';
+import {getDate, getDayMonthFormat} from 'shared/util/date';
 import {Sizes} from 'shared/util/constants';
 import {toThousandsABTesting} from 'experiments/util/experiments';
 
@@ -25,9 +25,9 @@ const TotalSessionsTooltip = ({dataPoint}: {dataPoint: any[]}) => {
 		{
 			columns: [
 				{
-					label: d3.utcFormat('%b %-d')(
-						getDate(dataPoint[0].payload.key)
-					),
+					label: moment
+						.utc(getDate(dataPoint[0].payload.key))
+						.format(getDayMonthFormat()),
 					weight: Weights.Semibold,
 					width: 100,
 				},
@@ -69,7 +69,9 @@ const PerVariantTooltip = ({dataPoint}: {dataPoint: any[]}) => {
 		{
 			columns: [
 				{
-					label: d3.utcFormat('%b %-d')(getDate(control.payload.key)),
+					label: moment
+						.utc(getDate(control.payload.key))
+						.format(getDayMonthFormat()),
 					weight: Weights.Semibold,
 					width: 80,
 				},

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryCompletedCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryCompletedCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {
 	getMetricName,
 	mergedVariants,
@@ -56,7 +56,7 @@ export const SummaryCompletedCard: React.FC<{
 							{sub(Liferay.Language.get('started-x'), [
 								formatDateToTimeZone(
 									startedDate,
-									'll',
+									getCustomDateFormat(),
 									timeZoneId
 								),
 							])}
@@ -67,7 +67,7 @@ export const SummaryCompletedCard: React.FC<{
 								{sub(Liferay.Language.get('ended-x'), [
 									formatDateToTimeZone(
 										finishedDate,
-										'll',
+										getCustomDateFormat(),
 										timeZoneId
 									),
 								])}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryNoWinnerCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryNoWinnerCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {
 	getBestVariant,
 	getMetricName,
@@ -50,7 +50,11 @@ export const SummaryNoWinnerCard: React.FC<{
 			<SummaryBaseCard.Header
 				Description={() =>
 					sub(Liferay.Language.get('started-x'), [
-						formatDateToTimeZone(startedDate, 'll', timeZoneId),
+						formatDateToTimeZone(
+							startedDate,
+							getCustomDateFormat(),
+							timeZoneId
+						),
 					]) as any
 				}
 				title={Liferay.Language.get('no-clear-winner')}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryRunningCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryRunningCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {
 	getBestVariant,
 	getMetricName,
@@ -49,7 +49,11 @@ export const SummaryRunningCard: React.FC<{
 			<SummaryBaseCard.Header
 				Description={() =>
 					sub(Liferay.Language.get('started-x'), [
-						formatDateToTimeZone(startedDate, 'll', timeZoneId),
+						formatDateToTimeZone(
+							startedDate,
+							getCustomDateFormat(),
+							timeZoneId
+						),
 					]) as any
 				}
 				title={Liferay.Language.get('test-is-running')}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryTerminatedCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryTerminatedCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {
 	getBestVariant,
 	getMetricName,
@@ -76,7 +76,7 @@ export const SummaryTerminatedCard: React.FC<{
 							{sub(Liferay.Language.get('started-x'), [
 								formatDateToTimeZone(
 									startedDate,
-									'll',
+									getCustomDateFormat(),
 									timeZoneId
 								),
 							])}
@@ -87,7 +87,7 @@ export const SummaryTerminatedCard: React.FC<{
 								{sub(Liferay.Language.get('stopped-x'), [
 									formatDateToTimeZone(
 										finishedDate,
-										'll',
+										getCustomDateFormat(),
 										timeZoneId
 									),
 								])}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryWinnerCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/summary-card/SummaryWinnerCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {
 	getMetricName,
 	mergedVariants,
@@ -56,7 +56,11 @@ export const SummaryWinnerCard: React.FC<{
 			<SummaryBaseCard.Header
 				Description={() =>
 					sub(Liferay.Language.get('started-x'), [
-						formatDateToTimeZone(startedDate, 'll', timeZoneId),
+						formatDateToTimeZone(
+							startedDate,
+							getCustomDateFormat(),
+							timeZoneId
+						),
 					]) as any
 				}
 				title={Liferay.Language.get('winner-declared')}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/test-traffic/Tooltip.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/test-traffic/Tooltip.tsx
@@ -1,11 +1,11 @@
-import * as d3 from 'd3';
 import ChartTooltip, {
 	IChartTooltipProps,
 } from 'shared/components/chart-tooltip';
+import moment from 'moment';
 import React from 'react';
 import {Alignments, Weights} from 'shared/components/chart-tooltip';
 import {formatPercent} from 'shared/util/numbers';
-import {getDate as getDateUtil} from 'shared/util/date';
+import {getCustomDateFormat, getDate as getDateUtil} from 'shared/util/date';
 import {toThousandsABTesting} from 'experiments/util/experiments';
 
 const formatTooltip = (dataPoint: any[]): IChartTooltipProps => {
@@ -16,11 +16,9 @@ const formatTooltip = (dataPoint: any[]): IChartTooltipProps => {
 		{
 			columns: [
 				{
-					label: `${Liferay.Language.get(
-						'test-traffic'
-					)} | ${d3.utcFormat('%b %-d %Y')(
-						getDateUtil(control.payload.key)
-					)}`,
+					label: `${Liferay.Language.get('test-traffic')} | ${moment
+						.utc(getDateUtil(control.payload.key))
+						.format(getCustomDateFormat())}`,
 					weight: Weights.Semibold,
 					width: 180,
 				},

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/variant-card/per-day-chart/Tooltip.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/components/variant-card/per-day-chart/Tooltip.tsx
@@ -1,12 +1,12 @@
-import * as d3 from 'd3';
 import ChartTooltip, {
 	Alignments,
 	Weights,
 } from 'shared/components/chart-tooltip';
+import moment from 'moment';
 import React from 'react';
 import Trend from 'shared/components/Trend';
 import {Colors} from 'shared/util/charts';
-import {getDate as getDateUtil} from 'shared/util/date';
+import {getCustomDateFormat, getDate as getDateUtil} from 'shared/util/date';
 
 export const Tooltip = ({dataPoint}: {dataPoint: any[]}) => {
 	const control = dataPoint[0];
@@ -36,11 +36,9 @@ export const Tooltip = ({dataPoint}: {dataPoint: any[]}) => {
 		{
 			columns: [
 				{
-					label: `${Liferay.Language.get(
-						'variants'
-					)} | ${d3.utcFormat('%b %-d %Y')(
-						getDateUtil(control.payload.key)
-					)}`,
+					label: `${Liferay.Language.get('variants')} | ${moment
+						.utc(getDateUtil(control.payload.key))
+						.format(getCustomDateFormat())}`,
 					weight: Weights.Semibold,
 					width: 140,
 				},

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/hocs/columns.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/experiments/hocs/columns.js
@@ -3,7 +3,11 @@ import moment from 'moment';
 import momentTimezone from 'moment-timezone';
 import React from 'react';
 import TextTruncate from 'shared/components/TextTruncate';
-import {applyTimeZone, formatDateToTimeZone} from 'shared/util/date';
+import {
+	applyTimeZone,
+	formatDateToTimeZone,
+	getCustomDateFormat,
+} from 'shared/util/date';
 import {DateCell} from 'shared/components/table/cell-components';
 import {getSafeDecodedURIComponent} from 'shared/util/util';
 import {getStatusColor, getStatusName} from 'experiments/util/experiments';
@@ -77,7 +81,7 @@ export default (timeZoneId) => [
 		cellRenderer: DateCell,
 		cellRendererProps: {
 			dateFormatter: (date) =>
-				formatDateToTimeZone(date, 'll', timeZoneId),
+				formatDateToTimeZone(date, getCustomDateFormat(), timeZoneId),
 			datePath: 'createDate',
 		},
 		className: 'table-column-text-end',
@@ -97,7 +101,11 @@ export default (timeZoneId) => [
 					return momentTimezone()
 						.tz(timeZoneId)
 						.diff(timeZonedDate, 'day') > 0
-						? formatDateToTimeZone(modifiedDate, 'll', timeZoneId)
+						? formatDateToTimeZone(
+								modifiedDate,
+								getCustomDateFormat(),
+								timeZoneId
+							)
 						: moment.utc(modifiedDate).fromNow();
 				}
 			},

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/AccountMembership.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/AccountMembership.tsx
@@ -8,7 +8,7 @@ import {
 	DataDrivenConfig,
 	GeneralInfoSection,
 } from 'shared/components/GeneralInfoSection';
-import {formatUTCDate} from 'shared/util/date';
+import {formatUTCDate, getCustomDateFormat} from 'shared/util/date';
 import {Map} from 'immutable';
 import {Routes, toRoute} from 'shared/util/router';
 import {SectionHeader} from 'shared/components/SectionHeader';
@@ -96,7 +96,7 @@ const AccountMembership: React.FC<IAccountMembershipProps> = ({
 		}
 
 		if (dateKeys.includes(key)) {
-			return formatUTCDate(data, 'YYYY-MM-DD');
+			return formatUTCDate(data, getCustomDateFormat());
 		}
 
 		if (key === 'annualRevenue') {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/IndividualAllAttributesCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/IndividualAllAttributesCDP.tsx
@@ -10,7 +10,7 @@ import {
 	PropertyCell,
 	SourceCell,
 } from 'shared/components/table/cell-components';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {SectionHeader} from 'shared/components/SectionHeader';
 import {useQueryParams} from 'shared/hooks/useQueryParams';
 import {useRequest} from 'shared/hooks/useRequest';
@@ -33,7 +33,7 @@ export const detailsListCDPColumns = {
 		cellRenderer: DateCell,
 		cellRendererProps: {
 			dateFormatter: (date: string | number) =>
-				formatDateToTimeZone(date, 'll'),
+				formatDateToTimeZone(date, getCustomDateFormat()),
 			datePath: 'dateModified',
 		},
 		label: Liferay.Language.get('last-modified'),

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/IndividualAttributesCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/IndividualAttributesCDP.tsx
@@ -3,7 +3,7 @@ import {
 	DataDrivenConfig,
 	GeneralInfoSection,
 } from 'shared/components/GeneralInfoSection';
-import {formatUTCDate} from 'shared/util/date';
+import {formatUTCDate, getCustomDateFormat} from 'shared/util/date';
 import {SectionHeader} from 'shared/components/SectionHeader';
 
 interface IIndividualAttributesProps {
@@ -70,7 +70,7 @@ const IndividualAttributesCDP: React.FC<IIndividualAttributesProps> = ({
 			const birthDate = propertiesData?.get('birthDate');
 
 			return birthDate
-				? formatUTCDate(birthDate, 'YYYY-MM-DD')
+				? formatUTCDate(birthDate, getCustomDateFormat())
 				: undefined;
 		}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/AccountMembership.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/AccountMembership.tsx
@@ -50,8 +50,8 @@ describe('Account Membership', () => {
 		);
 
 		expect(getByText('2015')).toBeTruthy();
-		expect(getByText('2021-12-01')).toBeTruthy();
-		expect(getByText('2020-01-01')).toBeTruthy();
+		expect(getByText('Dec 1, 2021')).toBeTruthy();
+		expect(getByText('Jan 1, 2020')).toBeTruthy();
 	});
 
 	it('should display the fallback dash for missing account values', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/IndividualAttributesCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/IndividualAttributesCDP.tsx
@@ -48,7 +48,7 @@ describe('IndividualAttributesCDP', () => {
 			<IndividualAttributesCDP propertiesData={fromJS(mockProperties)} />
 		);
 
-		expect(getByText('2020-01-01')).toBeTruthy();
+		expect(getByText('Jan 1, 2020')).toBeTruthy();
 	});
 
 	it('should display the fallback dash for missing values', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/__snapshots__/AccountMembership.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/__snapshots__/AccountMembership.tsx.snap
@@ -327,7 +327,7 @@ exports[`Account Membership should render the snapshot 1`] = `
                     class="font-weight-semi-bold text-break text-dark"
                     style="word-break: break-all;"
                   >
-                    2021-12-01
+                    Dec 1, 2021
                   </span>
                 </div>
               </div>
@@ -353,7 +353,7 @@ exports[`Account Membership should render the snapshot 1`] = `
                     class="font-weight-semi-bold text-break text-dark"
                     style="word-break: break-all;"
                   >
-                    2020-01-01
+                    Jan 1, 2020
                   </span>
                 </div>
               </div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/__snapshots__/IndividualAttributesCDP.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/__snapshots__/IndividualAttributesCDP.tsx.snap
@@ -345,7 +345,7 @@ exports[`IndividualAttributesCDP should render 1`] = `
                     class="font-weight-semi-bold text-break text-dark"
                     style="word-break: break-all;"
                   >
-                    2020-01-01
+                    Jan 1, 2020
                   </span>
                 </div>
               </div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/StageConfigurationPanel.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/StageConfigurationPanel.tsx
@@ -3,6 +3,7 @@ import ClayDatePicker from '@clayui/date-picker';
 import ClayPopover from '@clayui/popover';
 import getCN from 'classnames';
 import Label from '@clayui/label';
+import moment from 'moment';
 import Panel from '@clayui/panel';
 import React, {useState} from 'react';
 import ClayForm, {ClayInput, ClayToggle} from '@clayui/form';
@@ -189,12 +190,14 @@ const StageConfigurationPanel: React.FC<IStageConfigurationPanelProps> = ({
 					expanded={dateExpanded}
 					max={maxDate.format(DEFAULT_DATE_FORMAT)}
 					min={minDate.format(DEFAULT_DATE_FORMAT)}
+					months={moment.months()}
 					onChange={(conditionValue) =>
 						onChange({...value, conditionValue})
 					}
 					onExpandedChange={setDateExpanded}
 					placeholder={Liferay.Language.get('yyyy-mm-dd')}
 					value={value.conditionValue ?? ''}
+					weekdaysShort={moment.weekdaysShort()}
 					years={{
 						end: maxDate.year(),
 						start: minDate.year(),

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/Growth.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/Growth.tsx
@@ -38,7 +38,7 @@ import {
 import {CHART_COLOR_NAMES} from 'shared/util/charts';
 import {createDateKeysIMap} from 'shared/util/intervals';
 import {DATE_CHANGED, NAME} from 'shared/util/pagination';
-import {formatUTCDateFromUnix} from 'shared/util/date';
+import {formatUTCDateFromUnix, getCustomDateFormat} from 'shared/util/date';
 import {formatXAxisDate, getIntervals} from 'shared/util/charts';
 import {get, isNil} from 'lodash';
 import {getNetChange} from 'shared/util/change';
@@ -194,7 +194,12 @@ export const SegmentGrowthChart: React.FC<ISegmentGrowthChartProps> = ({
 							{
 								label: sub(
 									Liferay.Language.get('as-of-x'),
-									[formatUTCDateFromUnix(modifiedDate, 'll')],
+									[
+										formatUTCDateFromUnix(
+											modifiedDate,
+											getCustomDateFormat()
+										),
+									],
 									false
 								) as string,
 								weight: Weights.Semibold,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/SegmentActivationCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/SegmentActivationCard.tsx
@@ -10,7 +10,7 @@ import React, {useEffect, useMemo, useState} from 'react';
 import {addAlert} from 'shared/actions/alerts';
 import {Alert} from 'shared/types';
 import {connect, ConnectedProps} from 'react-redux';
-import {formatUTCDateFromUnix} from 'shared/util/date';
+import {formatUTCDateFromUnix, getCustomDateFormat} from 'shared/util/date';
 import {Option, Picker, Text} from '@clayui/core';
 import {ReportContainer} from 'shared/components/download-report/DownloadPDFReport';
 import {
@@ -265,6 +265,7 @@ const ActivationConfigurationModal: React.FC<
 							SegmentActivationFrequencyTypes.Between && (
 							<DateInput
 								className="flex-fill"
+								displayFormat={getCustomDateFormat()}
 								limitEndDate={false}
 								maxRange={365}
 								onChange={(value) => {
@@ -364,8 +365,14 @@ const SegmentActivationCard: React.FC<
 				])
 			: sub(Liferay.Language.get('x-sync-will-run-from-x-to-x'), [
 					getScheduleLabel(scheduleType),
-					formatUTCDateFromUnix(scheduleStartDate, 'MMM DD, yyyy'),
-					formatUTCDateFromUnix(scheduleEndDate, 'MMM DD, yyyy'),
+					formatUTCDateFromUnix(
+						scheduleStartDate,
+						getCustomDateFormat()
+					),
+					formatUTCDateFromUnix(
+						scheduleEndDate,
+						getCustomDateFormat()
+					),
 				]);
 
 	return (

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/__tests__/utils.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/__tests__/utils.js
@@ -60,8 +60,8 @@ describe('utils', () => {
 			${'Test'}              | ${PropertyTypes.Text}               | ${'"Test"'}
 			${'true'}              | ${PropertyTypes.Boolean}            | ${'TRUE'}
 			${data.getTimestamp()} | ${PropertyTypes.Date}               | ${'2018-07-10'}
-			${data.getTimestamp()} | ${PropertyTypes.DateTime}           | ${'2018-07-10 23:01'}
-			${data.getTimestamp()} | ${PropertyTypes.SessionDateTime}    | ${'2018-07-10 23:01'}
+			${data.getTimestamp()} | ${PropertyTypes.DateTime}           | ${'Jul 10, 2018, 11:01 PM'}
+			${data.getTimestamp()} | ${PropertyTypes.SessionDateTime}    | ${'Jul 10, 2018, 11:01 PM'}
 			${123}                 | ${PropertyTypes.AccountNumber}      | ${123}
 			${1000}                | ${PropertyTypes.Duration}           | ${'00:00:01'}
 			${123}                 | ${PropertyTypes.Number}             | ${123}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/display-components/AttributeConjunctionDisplay.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/display-components/AttributeConjunctionDisplay.tsx
@@ -7,7 +7,7 @@ import {
 	ReferencedObjectsContext,
 } from 'segment/segment-editor/dynamic/context/referencedObjects';
 import {formatTime} from 'shared/util/time';
-import {formatUTCDate} from 'shared/util/date';
+import {formatUTCDate, getCustomDateFormat} from 'shared/util/date';
 import {FunctionalOperators} from 'segment/segment-editor/dynamic/utils/constants';
 import {
 	decodeAttributeId,
@@ -54,13 +54,13 @@ const AttributeConjunctionDisplay: React.FC<
 				if (FunctionalOperators.Between === operatorName) {
 					const {end, start} = value;
 
-					return `${formatUTCDate(start, 'll')} - ${formatUTCDate(
-						end,
-						'll'
-					)}`;
+					return `${formatUTCDate(
+						start,
+						getCustomDateFormat()
+					)} - ${formatUTCDate(end, getCustomDateFormat())}`;
 				}
 
-				return formatUTCDate(value, 'll');
+				return formatUTCDate(value, getCustomDateFormat());
 			case DataTypes.Duration:
 				return formatTime(value);
 			case DataTypes.Number:

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/display-components/__tests__/__snapshots__/OrganizationDisplay.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/display-components/__tests__/__snapshots__/OrganizationDisplay.jsx.snap
@@ -25,7 +25,7 @@ exports[`OrganizationDisplay renders as a Date Time criteria 1`] = `
     is
   </span>
   <b>
-    2020-02-11 22:16
+    Feb 11, 2020, 10:16 PM
   </b>
 </div>
 `;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/utils.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/criteria-card/utils.ts
@@ -1,10 +1,9 @@
 import moment from 'moment';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateTimeFormat} from 'shared/util/date';
 import {formatTime} from 'shared/util/time';
 import {
 	GEOLOCATION_OPTIONS,
 	INPUT_DATE_FORMAT,
-	INPUT_DISPLAY_DATE_TIME_FORMAT,
 	isKnown,
 	isUnknown,
 	PropertyTypes,
@@ -113,7 +112,7 @@ export function maybeFormatValue(
 		case PropertyTypes.SessionDateTime:
 			return formatDateToTimeZone(
 				value,
-				INPUT_DISPLAY_DATE_TIME_FORMAT,
+				getCustomDateTimeFormat(),
 				timeZoneId
 			);
 		case PropertyTypes.Duration:

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/List.tsx
@@ -47,7 +47,11 @@ import {
 } from 'shared/util/router';
 import {DateCell} from 'shared/components/table/cell-components';
 import {ENABLE_REAL_TIME_SEGMENTS} from 'shared/util/feature-flags';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {
+	formatDateToTimeZone,
+	getCustomDateFormat,
+	getCustomDateTimeFormat,
+} from 'shared/util/date';
 import {
 	getDefaultSortOrder,
 	NAME,
@@ -728,7 +732,11 @@ export const List: React.FC<IListProps> = ({
 									cellRendererProps: {
 										dateFormatter: (
 											date: string | number
-										) => formatDateToTimeZone(date, 'lll'),
+										) =>
+											formatDateToTimeZone(
+												date,
+												getCustomDateTimeFormat()
+											),
 										datePath: 'lastMembershipUpdateDate',
 									},
 									className: 'table-column-text-start',
@@ -749,7 +757,11 @@ export const List: React.FC<IListProps> = ({
 									cellRendererProps: {
 										dateFormatter: (
 											date: string | number
-										) => formatDateToTimeZone(date, 'll'),
+										) =>
+											formatDateToTimeZone(
+												date,
+												getCustomDateFormat()
+											),
 										datePath: 'dateModified',
 									},
 									className: 'table-column-text-start',

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/CustomDateInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/CustomDateInput.tsx
@@ -2,17 +2,14 @@ import DateInput from './DateInput';
 import Form from 'shared/components/form';
 import React from 'react';
 import {Criterion, ISegmentEditorCustomInputBase} from '../utils/types';
+import {getCustomDateFormat} from 'shared/util/date';
 import {
 	getCompleteDate,
 	getOperator,
 	setCompleteDate,
 	setOperator,
 } from '../utils/custom-inputs';
-import {
-	INPUT_DATE_FORMAT,
-	PropertyTypes,
-	SUPPORTED_OPERATORS_MAP,
-} from '../utils/constants';
+import {PropertyTypes, SUPPORTED_OPERATORS_MAP} from '../utils/constants';
 import {Option, Picker} from '@clayui/core';
 
 const DATE_OPERATORS = SUPPORTED_OPERATORS_MAP[PropertyTypes.Date];
@@ -69,7 +66,7 @@ export default class CustomDateInput extends React.Component<ISegmentEditorCusto
 		return (
 			<DateInput
 				{...otherProps}
-				displayFormat={INPUT_DATE_FORMAT}
+				displayFormat={getCustomDateFormat()}
 				onChange={this.handleDateChange}
 				operatorRenderer={this.renderOperatorDropdown}
 				value={getCompleteDate(value)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/DateTimeInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/DateTimeInput.tsx
@@ -1,12 +1,8 @@
 import DateInput from 'shared/components/DateInput';
 import Form from 'shared/components/form';
 import React from 'react';
-import {formatDateToTimeZone} from 'shared/util/date';
-import {
-	INPUT_DATE_TIME_FORMAT,
-	INPUT_DISPLAY_DATE_TIME_FORMAT,
-	PropertyTypes,
-} from '../utils/constants';
+import {formatDateToTimeZone, getCustomDateTimeFormat} from 'shared/util/date';
+import {INPUT_DATE_TIME_FORMAT, PropertyTypes} from '../utils/constants';
 import {ISegmentEditorInputBase} from '../utils/types';
 
 interface IDateTimeInputProps extends ISegmentEditorInputBase {
@@ -58,7 +54,7 @@ export default class DateTimeInput extends React.Component<IDateTimeInputProps> 
 					<Form.GroupItem>
 						<DateInput
 							className={className}
-							displayFormat={INPUT_DISPLAY_DATE_TIME_FORMAT}
+							displayFormat={getCustomDateTimeFormat()}
 							format={INPUT_DATE_TIME_FORMAT}
 							onDateInputChange={this.handleDateChange}
 							showTimeSelector

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/DatePickerInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/DatePickerInput.tsx
@@ -2,6 +2,7 @@ import DateInput from 'shared/components/DateInput';
 import DateRangeInput, {DateRange} from 'shared/components/DateRangeInput';
 import getCN from 'classnames';
 import React from 'react';
+import {getCustomDateFormat} from 'shared/util/date';
 
 interface IDatePickerInputProps {
 	isRange?: boolean;
@@ -29,6 +30,7 @@ const DatePickerInput: React.FC<IDatePickerInputProps> = ({
 			{isRange ? (
 				<DateRangeInput
 					className={classNames}
+					displayFormat={getCustomDateFormat()}
 					onBlur={onBlur}
 					onChange={onChange as (param: DateRange) => void}
 					value={value as DateRange}
@@ -36,6 +38,7 @@ const DatePickerInput: React.FC<IDatePickerInputProps> = ({
 			) : (
 				<DateInput
 					className={classNames}
+					displayFormat={getCustomDateFormat()}
 					onDateInputBlur={onBlur}
 					onDateInputChange={onChange}
 					readOnly

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/constants.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/constants.ts
@@ -64,7 +64,6 @@ export enum AccountTypes {
 
 export const INPUT_DATE_FORMAT = 'YYYY-MM-DD';
 export const INPUT_DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mmZ';
-export const INPUT_DISPLAY_DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm';
 
 /**
  * Constants for OData query.

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/apis/pages/AccessTokenList.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/apis/pages/AccessTokenList.tsx
@@ -19,7 +19,7 @@ import {ApisPath} from 'shared/util/url-constants';
 import {close, modalTypes, open} from 'shared/actions/modals';
 import {compose} from 'redux';
 import {connect, ConnectedProps} from 'react-redux';
-import {CUSTOM_DATE_FORMAT} from 'shared/util/date';
+import {getCustomDateFormat} from 'shared/util/date';
 import {ExpirationPeriod} from 'shared/util/constants';
 import {formatDateToTimeZone, getDateNow} from 'shared/util/date';
 import {RootState} from 'shared/store';
@@ -153,7 +153,7 @@ const TokenList: React.FC<
 									dataFormatter: (val: string) =>
 										formatDateToTimeZone(
 											val,
-											CUSTOM_DATE_FORMAT,
+											getCustomDateFormat(),
 											timeZoneId
 										),
 									label: Liferay.Language.get('date-created'),
@@ -180,7 +180,7 @@ const TokenList: React.FC<
 											<td>
 												{formatDateToTimeZone(
 													data.expirationDate,
-													CUSTOM_DATE_FORMAT,
+													getCustomDateFormat(),
 													timeZoneId
 												)}
 											</td>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/apis/pages/__tests__/__snapshots__/AccessTokenList.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/apis/pages/__tests__/__snapshots__/AccessTokenList.jsx.snap
@@ -64,7 +64,7 @@ exports[`AccessTokenList should display the "Generate Token" card  above the tab
             Jul 10, 2018
           </td>
           <td>
-            Jul 09, 2018
+            Jul 9, 2018
           </td>
           <td
             class="row-inline-actions"
@@ -495,7 +495,7 @@ exports[`AccessTokenList should render 1`] = `
                             Jul 10, 2018
                           </td>
                           <td>
-                            Aug 09, 2018
+                            Aug 9, 2018
                           </td>
                           <td
                             class="row-inline-actions"
@@ -619,7 +619,7 @@ exports[`AccessTokenList should show the generated token in a list and the "Gene
             Jul 10, 2018
           </td>
           <td>
-            Aug 09, 2018
+            Aug 9, 2018
           </td>
           <td
             class="row-inline-actions"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/channels/pages/ChannelList.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/channels/pages/ChannelList.tsx
@@ -23,7 +23,7 @@ import {close, modalTypes, open} from 'shared/actions/modals';
 import {compose} from 'shared/hoc';
 import {connect, ConnectedProps} from 'react-redux';
 import {CREATE_TIME, createOrderIOMap} from 'shared/util/pagination';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {FormikHelpers} from 'formik';
 import {getPluralMessage, sub} from 'shared/util/lang';
 import {IPagination} from 'shared/types';
@@ -495,7 +495,11 @@ const ChannelList: React.FC<IChannelListProps> = ({
 						{
 							accessor: 'createTime',
 							dataFormatter: (date: string | number) =>
-								formatDateToTimeZone(date, 'll', timeZoneId),
+								formatDateToTimeZone(
+									date,
+									getCustomDateFormat(),
+									timeZoneId
+								),
 							label: Liferay.Language.get('date-added'),
 						},
 					]}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/usage-overview/KnownIndividualsSession.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/usage-overview/KnownIndividualsSession.tsx
@@ -2,7 +2,7 @@ import moment from 'moment';
 import React from 'react';
 import {Colors} from 'shared/util/charts';
 import {CurrentUsage} from './CurrentUsage';
-import {CUSTOM_DATE_FORMAT, formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {STATUS_DISPLAY_MAP} from 'shared/util/subscriptions';
 import {sub} from 'shared/util/lang';
 import {Text} from '@clayui/core';
@@ -35,7 +35,7 @@ export const KnownIndividualsSession = ({
 						[
 							formatDateToTimeZone(
 								moment(currentPlan.startDate),
-								CUSTOM_DATE_FORMAT,
+								getCustomDateFormat(),
 								timeZoneId
 							),
 						]

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/usage-overview/PageViewsSession.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/components/usage-overview/PageViewsSession.tsx
@@ -2,7 +2,7 @@ import moment from 'moment';
 import React from 'react';
 import {Colors} from 'shared/util/charts';
 import {CurrentUsage} from './CurrentUsage';
-import {CUSTOM_DATE_FORMAT, formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {STATUS_DISPLAY_MAP} from 'shared/util/subscriptions';
 import {sub} from 'shared/util/lang';
 import {toLocale} from 'shared/util/numbers';
@@ -28,7 +28,7 @@ export const PageViewsSession = ({currentPlan}: IPageViewsSessionProps) => {
 					[
 						formatDateToTimeZone(
 							moment(currentPlan.startDate),
-							CUSTOM_DATE_FORMAT,
+							getCustomDateFormat(),
 							timeZoneId
 						),
 					]

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/hocs/RequestList.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/hocs/RequestList.tsx
@@ -22,7 +22,7 @@ import {
 	createOrderIOMap,
 	getGraphQLVariablesFromPagination,
 } from 'shared/util/pagination';
-import {CUSTOM_DATE_FORMAT} from 'shared/util/date';
+import {getCustomDateFormat} from 'shared/util/date';
 import {FilterByType, FilterInputType} from 'shared/types';
 import {formatDateToTimeZone} from 'shared/util/date';
 import {
@@ -353,7 +353,7 @@ const RequestList: React.FC<IRequestListProps> = ({
 						dataFormatter: (date: string) =>
 							formatDateToTimeZone(
 								date,
-								CUSTOM_DATE_FORMAT,
+								getCustomDateFormat(),
 								timeZoneId
 							),
 						label: Liferay.Language.get('requested-date'),

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/hocs/SuppressedUserList.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/hocs/SuppressedUserList.tsx
@@ -17,8 +17,7 @@ import {
 } from 'shared/hoc';
 import {connect, ConnectedProps} from 'react-redux';
 import {CREATE_DATE, createOrderIOMap} from 'shared/util/pagination';
-import {CUSTOM_DATE_FORMAT} from 'shared/util/date';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {
 	GDPRRequestStatuses,
 	GDPRRequestTypes,
@@ -139,13 +138,13 @@ const SuppressedListWithData = withBaseResults(withData, {
 		{
 			accessor: 'dataControlTaskCreateDate',
 			dataFormatter: (val: string) =>
-				formatDateToTimeZone(val, CUSTOM_DATE_FORMAT, timeZoneId),
+				formatDateToTimeZone(val, getCustomDateFormat(), timeZoneId),
 			label: Liferay.Language.get('requested-date'),
 		},
 		{
 			accessor: 'createDate',
 			dataFormatter: (val: string) =>
-				formatDateToTimeZone(val, CUSTOM_DATE_FORMAT, timeZoneId),
+				formatDateToTimeZone(val, getCustomDateFormat(), timeZoneId),
 			label: Liferay.Language.get('suppression-date'),
 		},
 	],

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/hocs/__tests__/__snapshots__/RequestList.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/hocs/__tests__/__snapshots__/RequestList.jsx.snap
@@ -366,7 +366,7 @@ exports[`RequestList should render 1`] = `
                 Delete
               </td>
               <td>
-                Oct 09, 2019
+                Oct 9, 2019
               </td>
               <td>
                 <div
@@ -419,7 +419,7 @@ exports[`RequestList should render 1`] = `
                 Unsuppress
               </td>
               <td>
-                Oct 09, 2019
+                Oct 9, 2019
               </td>
               <td>
                 <div
@@ -472,7 +472,7 @@ exports[`RequestList should render 1`] = `
                 Suppress
               </td>
               <td>
-                Sep 09, 2019
+                Sep 9, 2019
               </td>
               <td>
                 <div
@@ -528,7 +528,7 @@ exports[`RequestList should render 1`] = `
                 Suppress
               </td>
               <td>
-                Nov 09, 2019
+                Nov 9, 2019
               </td>
               <td>
                 <div
@@ -590,7 +590,7 @@ exports[`RequestList should render 1`] = `
                 Access
               </td>
               <td>
-                Sep 09, 2019
+                Sep 9, 2019
               </td>
               <td>
                 <div
@@ -643,7 +643,7 @@ exports[`RequestList should render 1`] = `
                 Delete
               </td>
               <td>
-                Sep 09, 2019
+                Sep 9, 2019
               </td>
               <td>
                 <div
@@ -695,7 +695,7 @@ exports[`RequestList should render 1`] = `
                 Access
               </td>
               <td>
-                Dec 05, 2019
+                Dec 5, 2019
               </td>
               <td>
                 <div

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/hocs/__tests__/__snapshots__/SuppressedUserList.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/hocs/__tests__/__snapshots__/SuppressedUserList.jsx.snap
@@ -231,7 +231,7 @@ exports[`Suppressed User List should render 1`] = `
                   00001
                 </td>
                 <td>
-                  Sep 09, 2019
+                  Sep 9, 2019
                 </td>
                 <td>
                   Sep 10, 2019
@@ -258,7 +258,7 @@ exports[`Suppressed User List should render 1`] = `
                   00002
                 </td>
                 <td>
-                  Sep 09, 2019
+                  Sep 9, 2019
                 </td>
                 <td>
                   Sep 11, 2019

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/pages/__tests__/__snapshots__/SuppressedUsers.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/data-privacy/pages/__tests__/__snapshots__/SuppressedUsers.jsx.snap
@@ -541,10 +541,10 @@ exports[`SuppressedUsers should render 1`] = `
                             123
                           </td>
                           <td>
-                            Jan 01, 2024
+                            Jan 1, 2024
                           </td>
                           <td>
-                            Jan 01, 2024
+                            Jan 1, 2024
                           </td>
                           <td
                             class="row-inline-actions"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/pages/InterestTopics.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/definitions/pages/InterestTopics.tsx
@@ -22,7 +22,7 @@ import {close, modalTypes, open} from 'shared/actions/modals';
 import {compose} from 'shared/hoc';
 import {connect, ConnectedProps} from 'react-redux';
 import {CREATE_DATE, createOrderIOMap, KEYWORD} from 'shared/util/pagination';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {getDefinitions} from 'shared/util/breadcrumbs';
 import {partition} from 'lodash';
 import {Routes, toRoute} from 'shared/util/router';
@@ -347,7 +347,11 @@ const InterestTopics: React.FC<IInterestTopicsProps> = ({
 						{
 							accessor: CREATE_DATE,
 							dataFormatter: (date: string) =>
-								formatDateToTimeZone(date, 'll', timeZoneId),
+								formatDateToTimeZone(
+									date,
+									getCustomDateFormat(),
+									timeZoneId
+								),
 							label: Liferay.Language.get('added'),
 						},
 					]}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/DataSourceList.tsx
@@ -22,7 +22,7 @@ import {
 } from 'shared/util/pagination';
 import {DataSource} from 'shared/util/records';
 import {DataSourceStates, DataSourceTypes, Sizes} from 'shared/util/constants';
-import {formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {fromJS} from 'immutable';
 import {get} from 'lodash';
 import {
@@ -109,7 +109,7 @@ export const StatusRenderer: React.FC<ICellProps> = ({data}) => {
 };
 
 const dateFormatter = (date: string, timeZoneId: string): string =>
-	formatDateToTimeZone(date, 'll', timeZoneId);
+	formatDateToTimeZone(date, getCustomDateFormat(), timeZoneId);
 
 export const disableRow = ({state}: {state: DataSourceStates}): boolean =>
 	state === DataSourceStates.InProgressDeleting;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/UsageOverview.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/UsageOverview.tsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 import React, {useState} from 'react';
 import {AlertTypes} from 'shared/components/Alert';
 import {compose, withProject} from 'shared/hoc';
-import {CUSTOM_DATE_FORMAT, formatDateToTimeZone} from 'shared/util/date';
+import {formatDateToTimeZone, getCustomDateFormat} from 'shared/util/date';
 import {
 	formatPlanData,
 	isBasicPlan,
@@ -180,7 +180,7 @@ export const UsageOverview = ({
 															moment(
 																currentPlan.startDate
 															).add(1, 'year'),
-															CUSTOM_DATE_FORMAT,
+															getCustomDateFormat(),
 															timeZoneId
 														)}
 													</b>,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/__tests__/UsageOverview.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/__tests__/UsageOverview.jsx
@@ -118,7 +118,7 @@ describe('UsageOverview', () => {
 
 		expect(
 			getByText(
-				'Active users logged on your DXP instance have been tracked by Analytics Cloud since Jul 08, 2018.'
+				'Active users logged on your DXP instance have been tracked by Analytics Cloud since Jul 8, 2018.'
 			)
 		).toBeInTheDocument();
 
@@ -219,7 +219,7 @@ describe('UsageOverview', () => {
 
 		expect(
 			getByText(
-				'Active users logged on your DXP instance have been tracked by Analytics Cloud since Jul 08, 2018.'
+				'Active users logged on your DXP instance have been tracked by Analytics Cloud since Jul 8, 2018.'
 			)
 		).toBeInTheDocument();
 
@@ -317,7 +317,7 @@ describe('UsageOverview', () => {
 		);
 
 		expect(queryByTestId('next-anniversary-date').textContent).toEqual(
-			'Plan usage resets on Jul 08, 2019.'
+			'Plan usage resets on Jul 8, 2019.'
 		);
 	});
 
@@ -339,7 +339,7 @@ describe('UsageOverview', () => {
 		);
 
 		expect(queryByTestId('next-anniversary-date').textContent).toEqual(
-			'Plan usage resets on Jul 08, 2019.'
+			'Plan usage resets on Jul 8, 2019.'
 		);
 	});
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/__tests__/__snapshots__/UsageOverview.jsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/pages/__tests__/__snapshots__/UsageOverview.jsx.snap
@@ -708,7 +708,7 @@ exports[`UsageOverview should render 1`] = `
                       >
                         Plan usage resets on 
                         <b>
-                          Jul 08, 2019
+                          Jul 8, 2019
                         </b>
                         .
                       </span>
@@ -727,7 +727,7 @@ exports[`UsageOverview should render 1`] = `
                       <span
                         class="text-3 text-secondary"
                       >
-                        Active users logged on your DXP instance have been tracked by Analytics Cloud since Jul 08, 2018.
+                        Active users logged on your DXP instance have been tracked by Analytics Cloud since Jul 8, 2018.
                       </span>
                       <div
                         class="mt-3"
@@ -785,7 +785,7 @@ exports[`UsageOverview should render 1`] = `
                     <span
                       class="text-3 text-secondary"
                     >
-                      Total page views have been tracked by Analytics Cloud since Jul 08, 2018.
+                      Total page views have been tracked by Analytics Cloud since Jul 8, 2018.
                     </span>
                     <div
                       class="mt-3"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/components/OutputVersionsCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/settings/recommendations/components/OutputVersionsCard.tsx
@@ -11,7 +11,7 @@ import {
 	getSortFromOrderIOMap,
 	ID,
 } from 'shared/util/pagination';
-import {CUSTOM_DATE_FORMAT} from 'shared/util/date';
+import {getCustomDateFormat} from 'shared/util/date';
 import {getFormattedTitle} from 'shared/components/NoResultsDisplay';
 import {getMapResultToProps} from 'shared/hoc/mappers/metrics';
 import {graphql} from '@apollo/client/react/hoc';
@@ -133,15 +133,23 @@ const OutputVersionsCard: React.FC<IOutputVersionsCardProps> = ({
 					{
 						accessor: 'completedDate',
 						className: 'table-cell-expand',
-						dataFormatter: (val: string) =>
-							applyTimeZone(val, timeZoneId).calendar(null, {
-								lastDay: CUSTOM_DATE_FORMAT,
-								lastWeek: CUSTOM_DATE_FORMAT,
-								nextDay: CUSTOM_DATE_FORMAT,
-								nextWeek: CUSTOM_DATE_FORMAT,
-								sameDay: `[${Liferay.Language.get('today')}]`,
-								sameElse: CUSTOM_DATE_FORMAT,
-							}),
+						dataFormatter: (val: string) => {
+							const dateFormat = getCustomDateFormat();
+
+							return applyTimeZone(val, timeZoneId).calendar(
+								null,
+								{
+									lastDay: dateFormat,
+									lastWeek: dateFormat,
+									nextDay: dateFormat,
+									nextWeek: dateFormat,
+									sameDay: `[${Liferay.Language.get(
+										'today'
+									)}]`,
+									sameElse: dateFormat,
+								}
+							);
+						},
 						label: Liferay.Language.get('training-date'),
 						sortable: false,
 						title: true,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/FrontendDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/FrontendDataSet.tsx
@@ -8,7 +8,7 @@ import {
 	FrontendDataSet as BaseFrontendDataSet,
 	EConfigInURLBehavior,
 } from '@liferay/frontend-data-set-web';
-import {CUSTOM_DATE_FORMAT, formatUTCDate} from 'shared/util/date';
+import {formatUTCDate, getCustomDateFormat} from 'shared/util/date';
 import {Text} from '@clayui/core';
 import {toRoute} from 'shared/util/router';
 
@@ -92,7 +92,7 @@ export const columns = {
 		</Label>
 	),
 	dateRenderer: ({value}: FDSCellProps<string | number>) => (
-		<div>{value && formatUTCDate(value, CUSTOM_DATE_FORMAT)}</div>
+		<div>{value && formatUTCDate(value, getCustomDateFormat())}</div>
 	),
 	nameAndLinkRenderer: ({
 		channelId,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/MaintenanceAlert.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/MaintenanceAlert.tsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 import React from 'react';
 import {compose} from 'redux';
 import {connect} from 'react-redux';
+import {getCustomDateFormat} from 'shared/util/date';
 import {Project} from 'shared/util/records';
 import {ProjectStates} from 'shared/util/constants';
 import {setMaintenanceSeen} from 'shared/actions/maintenance-seen';
@@ -74,7 +75,9 @@ export class MaintenanceAlert extends React.Component<IMaintenanceAlertProps> {
 								'a-system-wide-maintenance-has-been-scheduled-to-take-place-on-x-at-x'
 							),
 							[
-								moment(stateStartDate).format('ll'),
+								moment(stateStartDate).format(
+									getCustomDateFormat()
+								),
 								moment(stateStartDate).format('LT'),
 							]
 						)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/VerticalTimeline.tsx
@@ -22,7 +22,10 @@ import {LIFERAY_DXP_APPLICATION_IDS} from 'shared/util/constants';
 import {sub} from 'shared/util/lang';
 import {Text} from '@clayui/core';
 
-const TIME_FORMAT = 'h:mm a';
+// 'LT' is moment's locale-aware time token: 12-hour with AM/PM for
+// en-US, 24-hour for pt-BR/es-ES/ja-JP.
+
+const TIME_FORMAT = 'LT';
 
 const DEVICE_ICONS_MAP = {
 	any: {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/VerticalTimeline.jsx
@@ -105,7 +105,7 @@ describe('VerticalTimeline', () => {
 			renderTimeline({items: [SESSION_ITEM]});
 
 			expect(
-				screen.getByText('Session: 10:00 am - 11:00 am')
+				screen.getByText('Session: 10:00 AM - 11:00 AM')
 			).toBeInTheDocument();
 		});
 
@@ -113,7 +113,7 @@ describe('VerticalTimeline', () => {
 			renderTimeline({items: [{...SESSION_ITEM, endTime: undefined}]});
 
 			expect(
-				screen.getByText('Session: 10:00 am - in progress')
+				screen.getByText('Session: 10:00 AM - in progress')
 			).toBeInTheDocument();
 		});
 
@@ -121,7 +121,7 @@ describe('VerticalTimeline', () => {
 			renderTimeline({items: [{...SESSION_ITEM, noTimestamps: true}]});
 
 			expect(
-				screen.getByText('Session: 10:00 am - no timestamps')
+				screen.getByText('Session: 10:00 AM - no timestamps')
 			).toBeInTheDocument();
 		});
 
@@ -277,7 +277,7 @@ describe('VerticalTimeline', () => {
 			renderTimeline({items: [EVENT_ITEM]});
 
 			expect(screen.getByText('emailViewed')).toBeInTheDocument();
-			expect(screen.getByText('10:00 am')).toBeInTheDocument();
+			expect(screen.getByText('10:00 AM')).toBeInTheDocument();
 		});
 
 		it('renders the description as a link when a descriptionUrl is provided', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/dropdown-range-key/__tests__/utils.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/dropdown-range-key/__tests__/utils.ts
@@ -80,37 +80,37 @@ describe('formatDateRange', () => {
 	it('returns formatted dates for timeRange', () => {
 		expect(formatTimeRange(timeRange)).toEqual([
 			{
-				description: '15 Jan, 07 PM - 16 Jan, 06 PM',
+				description: 'Jan 15, 7 PM - Jan 16, 6 PM',
 				label: 'Last 24 hours',
 				value: '0',
 			},
 			{
-				description: '15 Jan, 12 AM - 15 Jan, 11 PM',
+				description: 'Jan 15, 12 AM - Jan 15, 11 PM',
 				label: 'Yesterday',
 				value: '1',
 			},
-			{description: '09 Jan - 15 Jan', label: 'Last 7 days', value: '7'},
+			{description: 'Jan 9 - Jan 15', label: 'Last 7 days', value: '7'},
 			{
-				description: '19 Dec - 15 Jan',
+				description: 'Dec 19 - Jan 15',
 				label: 'Last 28 days',
 				value: '28',
 			},
 			{
-				description: '17 Dec - 15 Jan',
+				description: 'Dec 17 - Jan 15',
 				label: 'Last 30 days',
 				value: '30',
 			},
 			{
-				description: '18 Oct - 15 Jan',
+				description: 'Oct 18 - Jan 15',
 				label: 'Last 90 days',
 				value: '90',
 			},
 			{
-				description: '20 Jul - 15 Jan',
+				description: 'Jul 20 - Jan 15',
 				label: 'Last 180 days',
 				value: '180',
 			},
-			{description: '15 Jan - 15 Jan', label: 'Last Year', value: '365'},
+			{description: 'Jan 15 - Jan 15', label: 'Last Year', value: '365'},
 		]);
 	});
 
@@ -124,22 +124,22 @@ describe('formatDateRange', () => {
 				},
 			])
 		).toEqual([
-			{description: '15 Jan - 15 Jan', label: undefined, value: 'CUSTOM'},
+			{description: 'Jan 15 - Jan 15', label: undefined, value: 'CUSTOM'},
 		]);
 	});
 });
 
 describe('formatDateRange', () => {
 	it('returns formatted date range for last 24 hours', () => {
-		expect(formatDateRange(moment(0), 0)).toEqual('01 Jan, 12 AM');
+		expect(formatDateRange(moment(0), 0)).toEqual('Jan 1, 12 AM');
 	});
 
 	it('returns formatted date range for yesterday', () => {
-		expect(formatDateRange(moment(0), 1)).toEqual('01 Jan, 12 AM');
+		expect(formatDateRange(moment(0), 1)).toEqual('Jan 1, 12 AM');
 	});
 
 	it('returns formatted date range for last 30 days', () => {
-		expect(formatDateRange(moment(0), 30)).toEqual('01 Jan');
+		expect(formatDateRange(moment(0), 30)).toEqual('Jan 1');
 	});
 });
 
@@ -155,20 +155,20 @@ describe('getFilteredItems', () => {
 			})
 		).toEqual([
 			{
-				description: '15 Jan, 07 PM - 16 Jan, 06 PM',
+				description: 'Jan 15, 7 PM - Jan 16, 6 PM',
 				label: 'Last 24 hours',
 				value: '0',
 			},
 
-			{description: '09 Jan - 15 Jan', label: 'Last 7 days', value: '7'},
+			{description: 'Jan 9 - Jan 15', label: 'Last 7 days', value: '7'},
 
 			{
-				description: '17 Dec - 15 Jan',
+				description: 'Dec 17 - Jan 15',
 				label: 'Last 30 days',
 				value: '30',
 			},
 			{
-				description: '18 Oct - 15 Jan',
+				description: 'Oct 18 - Jan 15',
 				label: 'Last 90 days',
 				value: '90',
 			},
@@ -186,28 +186,28 @@ describe('getFilteredItems', () => {
 			})
 		).toEqual([
 			{
-				description: '15 Jan, 07 PM - 16 Jan, 06 PM',
+				description: 'Jan 15, 7 PM - Jan 16, 6 PM',
 				label: 'Last 24 hours',
 				value: '0',
 			},
 			{
-				description: '15 Jan, 12 AM - 15 Jan, 11 PM',
+				description: 'Jan 15, 12 AM - Jan 15, 11 PM',
 				label: 'Yesterday',
 				value: '1',
 			},
-			{description: '09 Jan - 15 Jan', label: 'Last 7 days', value: '7'},
+			{description: 'Jan 9 - Jan 15', label: 'Last 7 days', value: '7'},
 			{
-				description: '19 Dec - 15 Jan',
+				description: 'Dec 19 - Jan 15',
 				label: 'Last 28 days',
 				value: '28',
 			},
 			{
-				description: '17 Dec - 15 Jan',
+				description: 'Dec 17 - Jan 15',
 				label: 'Last 30 days',
 				value: '30',
 			},
 			{
-				description: '18 Oct - 15 Jan',
+				description: 'Oct 18 - Jan 15',
 				label: 'Last 90 days',
 				value: '90',
 			},
@@ -225,33 +225,33 @@ describe('getFilteredItems', () => {
 			})
 		).toEqual([
 			{
-				description: '15 Jan, 07 PM - 16 Jan, 06 PM',
+				description: 'Jan 15, 7 PM - Jan 16, 6 PM',
 				label: 'Last 24 hours',
 				value: '0',
 			},
 			{
-				description: '15 Jan, 12 AM - 15 Jan, 11 PM',
+				description: 'Jan 15, 12 AM - Jan 15, 11 PM',
 				label: 'Yesterday',
 				value: '1',
 			},
-			{description: '09 Jan - 15 Jan', label: 'Last 7 days', value: '7'},
+			{description: 'Jan 9 - Jan 15', label: 'Last 7 days', value: '7'},
 			{
-				description: '19 Dec - 15 Jan',
+				description: 'Dec 19 - Jan 15',
 				label: 'Last 28 days',
 				value: '28',
 			},
 			{
-				description: '17 Dec - 15 Jan',
+				description: 'Dec 17 - Jan 15',
 				label: 'Last 30 days',
 				value: '30',
 			},
 			{
-				description: '18 Oct - 15 Jan',
+				description: 'Oct 18 - Jan 15',
 				label: 'Last 90 days',
 				value: '90',
 			},
 			{
-				description: '20 Jul - 15 Jan',
+				description: 'Jul 20 - Jan 15',
 				label: 'Last 180 days',
 				value: '180',
 			},
@@ -276,37 +276,37 @@ describe('getFilteredItems', () => {
 			})
 		).toEqual([
 			{
-				description: '15 Jan, 07 PM - 16 Jan, 06 PM',
+				description: 'Jan 15, 7 PM - Jan 16, 6 PM',
 				label: 'Last 24 hours',
 				value: '0',
 			},
 			{
-				description: '15 Jan, 12 AM - 15 Jan, 11 PM',
+				description: 'Jan 15, 12 AM - Jan 15, 11 PM',
 				label: 'Yesterday',
 				value: '1',
 			},
-			{description: '09 Jan - 15 Jan', label: 'Last 7 days', value: '7'},
+			{description: 'Jan 9 - Jan 15', label: 'Last 7 days', value: '7'},
 			{
-				description: '19 Dec - 15 Jan',
+				description: 'Dec 19 - Jan 15',
 				label: 'Last 28 days',
 				value: '28',
 			},
 			{
-				description: '17 Dec - 15 Jan',
+				description: 'Dec 17 - Jan 15',
 				label: 'Last 30 days',
 				value: '30',
 			},
 			{
-				description: '18 Oct - 15 Jan',
+				description: 'Oct 18 - Jan 15',
 				label: 'Last 90 days',
 				value: '90',
 			},
 			{
-				description: '20 Jul - 15 Jan',
+				description: 'Jul 20 - Jan 15',
 				label: 'Last 180 days',
 				value: '180',
 			},
-			{description: '15 Jan - 15 Jan', label: 'Last Year', value: '365'},
+			{description: 'Jan 15 - Jan 15', label: 'Last Year', value: '365'},
 		]);
 	});
 
@@ -321,37 +321,37 @@ describe('getFilteredItems', () => {
 			})
 		).toEqual([
 			{
-				description: '15 Jan, 07 PM - 16 Jan, 06 PM',
+				description: 'Jan 15, 7 PM - Jan 16, 6 PM',
 				label: 'Last 24 hours',
 				value: '0',
 			},
 			{
-				description: '15 Jan, 12 AM - 15 Jan, 11 PM',
+				description: 'Jan 15, 12 AM - Jan 15, 11 PM',
 				label: 'Yesterday',
 				value: '1',
 			},
-			{description: '09 Jan - 15 Jan', label: 'Last 7 days', value: '7'},
+			{description: 'Jan 9 - Jan 15', label: 'Last 7 days', value: '7'},
 			{
-				description: '19 Dec - 15 Jan',
+				description: 'Dec 19 - Jan 15',
 				label: 'Last 28 days',
 				value: '28',
 			},
 			{
-				description: '17 Dec - 15 Jan',
+				description: 'Dec 17 - Jan 15',
 				label: 'Last 30 days',
 				value: '30',
 			},
 			{
-				description: '18 Oct - 15 Jan',
+				description: 'Oct 18 - Jan 15',
 				label: 'Last 90 days',
 				value: '90',
 			},
 			{
-				description: '20 Jul - 15 Jan',
+				description: 'Jul 20 - Jan 15',
 				label: 'Last 180 days',
 				value: '180',
 			},
-			{description: '15 Jan - 15 Jan', label: 'Last Year', value: '365'},
+			{description: 'Jan 15 - Jan 15', label: 'Last Year', value: '365'},
 		]);
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/dropdown-range-key/utils.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/dropdown-range-key/utils.ts
@@ -1,9 +1,13 @@
 import moment, {Moment} from 'moment';
 import momentTimezone from 'moment-timezone';
-import {getDate} from 'shared/util/date';
+import {
+	getCustomDateFormat,
+	getDate,
+	getDayMonthFormat,
+	getDayMonthHourFormat,
+} from 'shared/util/date';
 import {RangeKeyTimeRanges} from 'shared/util/constants';
 import {TIME_RANGE_LABELS} from 'shared/util/constants';
-import {utcFormat} from 'd3';
 
 type TimeRange = {
 	description: string;
@@ -27,10 +31,10 @@ export function formatDateRange(date: any, rangeKey: string | number) {
 		`${rangeKey}` === RangeKeyTimeRanges.Last24Hours ||
 		`${rangeKey}` === RangeKeyTimeRanges.Yesterday
 	) {
-		return utcFormat('%d %b, %I %p')(date);
+		return moment.utc(date).format(getDayMonthHourFormat());
 	}
 
-	return utcFormat('%d %b')(date);
+	return moment.utc(date).format(getDayMonthFormat());
 }
 
 type RawTimeRange = {
@@ -160,9 +164,9 @@ export function getSelectedItem({
 }: IGetSelectedItemProps) {
 	if (rangeKey === 'CUSTOM') {
 		return {
-			label: `${moment(rangeStart).format('ll')} - ${moment(
+			label: `${moment(rangeStart).format(getCustomDateFormat())} - ${moment(
 				rangeEnd
-			).format('ll')}`,
+			).format(getCustomDateFormat())}`,
 			value: 'CUSTOM',
 		};
 	}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/modals/ExportLogModal.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/modals/ExportLogModal.tsx
@@ -4,6 +4,7 @@ import Loading, {Align} from 'shared/components/Loading';
 import Modal from 'shared/components/modal';
 import moment from 'moment';
 import React, {useState} from 'react';
+import {getCustomDateFormat} from 'shared/util/date';
 import {downloadDataAsFile} from 'shared/util/util';
 
 interface IExportLogModalProps {
@@ -55,6 +56,7 @@ const ExportLogModal: React.FC<IExportLogModalProps> = ({
 				<div className="d-flex">
 					<DateRangeInput
 						className="w-100"
+						displayFormat={getCustomDateFormat()}
 						groupId={groupId}
 						onChange={setDateRange}
 						value={dateRange}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/DateRenderer.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/DateRenderer.jsx
@@ -1,11 +1,12 @@
 import moment from 'moment';
 import React from 'react';
 import {get} from 'lodash';
+import {getCustomDateFormat} from 'shared/util/date';
 import {PropTypes} from 'prop-types';
 
 export default class DateRenderer extends React.Component {
 	static defaultProps = {
-		dateFormatter: date => moment(date).format('ll'),
+		dateFormatter: date => moment(date).format(getCustomDateFormat()),
 		datePath: 'dateCreated'
 	};
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/useCurrentUser.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/hooks/useCurrentUser.ts
@@ -1,5 +1,6 @@
 import {fetchCurrentUser} from 'shared/actions/users';
-import {resolveLocale, setLocale} from 'shared/util/locale';
+import {resolveLanguageId, resolveLocale, setLocale} from 'shared/util/locale';
+import {setMomentLocale} from 'shared/util/date';
 import {useDispatch, useSelector} from 'react-redux';
 import {useEffect} from 'react';
 import {User} from 'shared/util/records';
@@ -31,6 +32,7 @@ export const useFetchCurrentUser = (initialGroupId: string = '0') => {
 
 	useEffect(() => {
 		setLocale(resolveLocale(data.languageId));
+		setMomentLocale(resolveLanguageId(data.languageId));
 	}, [data.languageId]);
 
 	return {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/charts.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/charts.js
@@ -76,11 +76,11 @@ describe('formatTooltipDate', () => {
 			RangeKeyTimeRanges.Last90Days
 		);
 
-		expect(formatedDate).toEqual('2018 May 9');
+		expect(formatedDate).toEqual('May 9, 2018');
 	});
 
 	it('should return the formated date and month', () => {
-		expect(formatTooltipDate(getDate('2018-08-07'))).toEqual('2018 Aug 7');
+		expect(formatTooltipDate(getDate('2018-08-07'))).toEqual('Aug 7, 2018');
 	});
 });
 
@@ -121,7 +121,7 @@ describe('formatXAxisDate', () => {
 
 describe('getDateTitle', () => {
 	it('should return a date display string', () => {
-		expect(getDateTitle([getDate('2019-01-01')])).toEqual('2019 Jan 1');
+		expect(getDateTitle([getDate('2019-01-01')])).toEqual('Jan 1, 2019');
 	});
 
 	it('should return a date display string as a date range if rangeKey is monthly and interval is weekly', () => {
@@ -131,7 +131,7 @@ describe('getDateTitle', () => {
 				RangeKeyTimeRanges.Last30Days,
 				INTERVAL_KEY_MAP.week
 			)
-		).toEqual('2019 Jan 1 - 14');
+		).toEqual('Jan 1, 2019 - 14');
 	});
 
 	it('should return year and month when interval its set to month', () => {
@@ -141,7 +141,7 @@ describe('getDateTitle', () => {
 				RangeKeyTimeRanges.Last30Days,
 				INTERVAL_KEY_MAP.month
 			)
-		).toEqual('2019 Jan');
+		).toEqual('Jan 2019');
 	});
 });
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/date-formats.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/date-formats.js
@@ -1,0 +1,187 @@
+import moment from 'moment';
+import {
+	getCustomDateFormat,
+	getCustomDateTimeFormat,
+	getDayMonthFormat,
+	getFullDayMonthFormat,
+	getHourOnlyFormat,
+	getMonthYearFormat,
+	usesTwelveHourClock,
+} from '../date';
+import {LanguageIds} from 'shared/util/constants';
+import {localeToLanguageId} from 'shared/util/locale';
+
+const DATE = '2026-06-10T14:30:00.000Z';
+
+describe('locale-aware date/time format lookups', () => {
+	afterEach(() => {
+		moment.locale('en');
+	});
+
+	describe('en-US', () => {
+		beforeEach(() => {
+			moment.locale('en');
+		});
+
+		it('usesTwelveHourClock should be true', () => {
+			expect(usesTwelveHourClock()).toBe(true);
+		});
+
+		it('getHourOnlyFormat should omit minutes', () => {
+			expect(moment.utc(DATE).format(getHourOnlyFormat())).toBe('2 PM');
+		});
+
+		it('getDayMonthFormat should be month-first', () => {
+			expect(moment.utc(DATE).format(getDayMonthFormat())).toBe('Jun 10');
+		});
+
+		it('getFullDayMonthFormat should spell out the month', () => {
+			expect(moment.utc(DATE).format(getFullDayMonthFormat())).toBe(
+				'June 10'
+			);
+		});
+
+		it('getMonthYearFormat should format correctly', () => {
+			expect(moment.utc(DATE).format(getMonthYearFormat())).toBe(
+				'Jun 2026'
+			);
+		});
+
+		it('getCustomDateFormat should format correctly', () => {
+			expect(moment.utc(DATE).format(getCustomDateFormat())).toBe(
+				'Jun 10, 2026'
+			);
+		});
+
+		it('getCustomDateTimeFormat should format correctly', () => {
+			expect(moment.utc(DATE).format(getCustomDateTimeFormat())).toBe(
+				'Jun 10, 2026, 2:30 PM'
+			);
+		});
+	});
+
+	describe('es-ES', () => {
+		beforeEach(() => {
+			moment.locale('es');
+		});
+
+		it('usesTwelveHourClock should be false', () => {
+			expect(usesTwelveHourClock()).toBe(false);
+		});
+
+		it('getHourOnlyFormat should include minutes, 24-hour', () => {
+			expect(moment.utc(DATE).format(getHourOnlyFormat())).toBe('14:30');
+		});
+
+		it('getDayMonthFormat should be day-first', () => {
+			expect(moment.utc(DATE).format(getDayMonthFormat())).toBe(
+				'10 jun.'
+			);
+		});
+
+		it('getFullDayMonthFormat should use the "de" connector', () => {
+			expect(moment.utc(DATE).format(getFullDayMonthFormat())).toBe(
+				'10 de junio'
+			);
+		});
+
+		it('getMonthYearFormat should use the "de" connector', () => {
+			expect(moment.utc(DATE).format(getMonthYearFormat())).toBe(
+				'jun. de 2026'
+			);
+		});
+
+		it('getCustomDateFormat should drop "de" connectors (compact convention)', () => {
+			expect(moment.utc(DATE).format(getCustomDateFormat())).toBe(
+				'10 jun. 2026'
+			);
+		});
+
+		it('getCustomDateTimeFormat should format correctly', () => {
+			expect(moment.utc(DATE).format(getCustomDateTimeFormat())).toBe(
+				'10 jun. 2026, 14:30'
+			);
+		});
+	});
+
+	describe('pt-BR', () => {
+		beforeEach(() => {
+			moment.locale('pt-br');
+		});
+
+		it('usesTwelveHourClock should be false', () => {
+			expect(usesTwelveHourClock()).toBe(false);
+		});
+
+		it('getHourOnlyFormat should include minutes, 24-hour', () => {
+			expect(moment.utc(DATE).format(getHourOnlyFormat())).toBe('14:30');
+		});
+
+		it('getDayMonthFormat should be day-first', () => {
+			expect(moment.utc(DATE).format(getDayMonthFormat())).toBe('10 jun');
+		});
+
+		it('getCustomDateFormat should drop "de" connectors (compact convention)', () => {
+			expect(moment.utc(DATE).format(getCustomDateFormat())).toBe(
+				'10 jun 2026'
+			);
+		});
+
+		it('getCustomDateTimeFormat should format correctly', () => {
+			expect(moment.utc(DATE).format(getCustomDateTimeFormat())).toBe(
+				'10 jun 2026, 14:30'
+			);
+		});
+	});
+
+	describe('ja-JP', () => {
+		beforeEach(() => {
+			moment.locale('ja');
+		});
+
+		it('usesTwelveHourClock should be false', () => {
+			expect(usesTwelveHourClock()).toBe(false);
+		});
+
+		it('getHourOnlyFormat should include minutes, 24-hour', () => {
+			expect(moment.utc(DATE).format(getHourOnlyFormat())).toBe('14:30');
+		});
+
+		it('getDayMonthFormat should render 月/日 characters', () => {
+			expect(moment.utc(DATE).format(getDayMonthFormat())).toBe(
+				'6月10日'
+			);
+		});
+
+		it('getMonthYearFormat should render 年/月 characters', () => {
+			expect(moment.utc(DATE).format(getMonthYearFormat())).toBe(
+				'2026年6月'
+			);
+		});
+
+		it('getCustomDateFormat should render 年/月/日 characters', () => {
+			expect(moment.utc(DATE).format(getCustomDateFormat())).toBe(
+				'2026年6月10日'
+			);
+		});
+
+		it('getCustomDateTimeFormat should use a bare space, not a comma', () => {
+			expect(moment.utc(DATE).format(getCustomDateTimeFormat())).toBe(
+				'2026年6月10日 14:30'
+			);
+		});
+	});
+});
+
+describe('localeToLanguageId', () => {
+	it('should reverse resolveLocale for every supported locale', () => {
+		expect(localeToLanguageId('en-US')).toBe(LanguageIds.English);
+		expect(localeToLanguageId('ja-JP')).toBe(LanguageIds.Japanese);
+		expect(localeToLanguageId('pt-BR')).toBe(LanguageIds.Portuguese);
+		expect(localeToLanguageId('es-ES')).toBe(LanguageIds.Spanish);
+	});
+
+	it('should fall back to English for an unsupported locale', () => {
+		expect(localeToLanguageId('fr-FR')).toBe(LanguageIds.English);
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/activities.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/activities.tsx
@@ -4,6 +4,7 @@ import {DEFAULT_ACTIVITY_MAX} from 'shared/api/activities';
 import getEventDashboardUrl, {
 	EventDashboardContext,
 } from './getEventDashboardUrl';
+import {getCustomDateFormat} from 'shared/util/date';
 import {getSafeDecodedURIComponent} from './util';
 import {
 	AssetTypes,
@@ -361,7 +362,7 @@ export const formatGroupingTime = (
 
 	return time.isSame(moment(), 'day')
 		? Liferay.Language.get('today')
-		: time.utc().format('ll');
+		: time.utc().format(getCustomDateFormat());
 };
 
 /**

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/charts.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/charts.ts
@@ -1,6 +1,12 @@
-import * as d3 from 'd3';
 import moment from 'moment';
 import {BAR_COLORS} from 'shared/util/recharts';
+import {
+	getCustomDateFormat,
+	getDayMonthFormat,
+	getDayMonthHourFormat,
+	getHourOnlyFormat,
+	getMonthYearFormat,
+} from 'shared/util/date';
 import {getIntervalHandle} from './intervals';
 import {Interval, RangeSelectors} from 'shared/types';
 import {INTERVAL_KEY_MAP, isMonthlyRangeKey} from 'shared/util/time';
@@ -101,18 +107,23 @@ export const dateRangeFormatter = (
 
 	// TODO: Add timezone param
 
-	const dayFormat = d3.utcFormat('%-d');
-	const dayMonthFormat = d3.utcFormat('%b %-d');
-	const dayMonthYearFormat = d3.utcFormat('%Y %b %-d');
+	const dayFormat = 'D';
+	const dayMonthFormat = getDayMonthFormat();
+	const dayMonthYearFormat = getCustomDateFormat();
+
+	const format = (date: Date, momentFormat: string) =>
+		moment.utc(date).format(momentFormat);
 
 	return `${
-		withYear ? dayMonthYearFormat(dateStart) : dayMonthFormat(dateStart)
+		withYear
+			? format(dateStart, dayMonthYearFormat)
+			: format(dateStart, dayMonthFormat)
 	} - ${
 		moment(dateStart).get('month') !== moment(dateEnd).get('month')
 			? withYear
-				? dayMonthYearFormat(dateEnd)
-				: dayMonthFormat(dateEnd)
-			: dayFormat(dateEnd)
+				? format(dateEnd, dayMonthYearFormat)
+				: format(dateEnd, dayMonthFormat)
+			: format(dateEnd, dayFormat)
 	}`;
 };
 
@@ -132,10 +143,10 @@ export const formatTooltipDate = (
 
 		// display hours for Last 24 hours and yesterday
 
-		return moment.utc(date).format('MMM D, h A');
+		return moment.utc(date).format(getDayMonthHourFormat());
 	}
 
-	return moment.utc(date).format('YYYY MMM D');
+	return moment.utc(date).format(getCustomDateFormat());
 };
 
 export const formatXAxisDate = (
@@ -147,8 +158,9 @@ export const formatXAxisDate = (
 
 	// display date and month
 
-	let formatter = d3.utcFormat('%b %-d');
-	const monthFormat = d3.utcFormat('%b');
+	let formatter = (date: Date) =>
+		moment.utc(date).format(getDayMonthFormat());
+	const monthFormat = (date: Date) => moment.utc(date).format('MMM');
 
 	const dates = dateKeysIMap.get(Number(dateKey));
 	const dateStart = dates ? dates[0] : 0;
@@ -186,7 +198,8 @@ export const formatXAxisDate = (
 
 			// display hours
 
-			formatter = d3.utcFormat('%-I %p');
+			formatter = (date: Date) =>
+				moment.utc(date).format(getHourOnlyFormat());
 			break;
 		default:
 			break;
@@ -343,7 +356,7 @@ export const getDateTitle = (
 		);
 	}
 	else if (interval === INTERVAL_KEY_MAP.month) {
-		return moment.utc(startDate).format('YYYY MMM');
+		return moment.utc(startDate).format(getMonthYearFormat());
 	}
 
 	return formatTooltipDate(startDate, rangeKey);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/date.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/date.js
@@ -4,10 +4,9 @@ import 'moment/locale/pt-br';
 import moment from 'moment';
 import momentTimezone from 'moment-timezone';
 import {flow, get, head, last, rangeRight} from 'lodash/fp';
+import {getLocale, localeToLanguageId} from 'shared/util/locale';
 import {INTERVAL_KEY_MAP} from 'shared/util/time';
 import {LanguageIds} from 'shared/util/constants';
-
-export const CUSTOM_DATE_FORMAT = 'MMM DD, YYYY';
 
 export const DATE_MASK = [
 	/\d/,
@@ -57,6 +56,119 @@ const FORMATTED_LANGUAGE_IDS = {
 };
 
 export const ISO_8601_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSS[Z]';
+
+// Looks up a format string for the active locale, falling back to
+// English. Every `getXFormat` below is one of these lookup tables plus
+// this same fallback rule, so they all delegate to it instead of
+// repeating `TABLE[moment.locale()] || TABLE.en`.
+
+function getLocaleFormat(formatsByLocale) {
+	return formatsByLocale[moment.locale()] || formatsByLocale.en;
+}
+
+// Chart axes/tooltips need a "day + month, no year" and a "month +
+// year, no day" format, which moment doesn't expose as a named token
+// (its named tokens ('ll'/'LL') always include the year). Order and
+// connector words are looked up per locale, same pattern as
+// FORMATTED_LANGUAGE_IDS above.
+
+const DAY_MONTH_FORMATS = {
+	en: 'MMM D',
+	es: 'D MMM',
+	ja: 'M月D日',
+	'pt-br': 'D MMM',
+};
+
+const FULL_DAY_MONTH_FORMATS = {
+	en: 'MMMM D',
+	es: 'D [de] MMMM',
+	ja: 'M月D日',
+	'pt-br': 'D [de] MMMM',
+};
+
+const MONTH_YEAR_FORMATS = {
+	en: 'MMM YYYY',
+	es: 'MMM [de] YYYY',
+	ja: 'YYYY年M月',
+	'pt-br': 'MMM [de] YYYY',
+};
+
+// The app's general-purpose "readable date" fallback (day + short month
+// + year, no time). Deliberately not moment's own 'll' token: 'll'
+// spells out the grammatically complete es/pt-br form ("21 de may. de
+// 2026"), but the product's compact-date convention (matching the
+// acceptance criteria's own "10 Jun 2026" example) drops the "de"
+// connectors ("21 may. 2026") — Japanese is unaffected, since its
+// correct form has no connector words either way.
+
+const CUSTOM_DATE_FORMATS = {
+	en: 'MMM D, YYYY',
+	es: 'D MMM YYYY',
+	ja: 'YYYY年M月D日',
+	'pt-br': 'D MMM YYYY',
+};
+
+export function getCustomDateFormat() {
+	return getLocaleFormat(CUSTOM_DATE_FORMATS);
+}
+
+// Same compact convention as getCustomDateFormat, with the locale-aware
+// time appended. Not a plain `${getCustomDateFormat()}, LT` concat: the
+// date/time connector itself varies by locale (a Western comma reads
+// oddly stitched into Japanese, which conventionally uses a bare space).
+
+const CUSTOM_DATE_TIME_FORMATS = {
+	en: 'MMM D, YYYY, LT',
+	es: 'D MMM YYYY, LT',
+	ja: 'YYYY年M月D日 LT',
+	'pt-br': 'D MMM YYYY, LT',
+};
+
+export function getCustomDateTimeFormat() {
+	return getLocaleFormat(CUSTOM_DATE_TIME_FORMATS);
+}
+
+export function getDayMonthFormat() {
+	return getLocaleFormat(DAY_MONTH_FORMATS);
+}
+
+export function getFullDayMonthFormat() {
+	return getLocaleFormat(FULL_DAY_MONTH_FORMATS);
+}
+
+export function getMonthYearFormat() {
+	return getLocaleFormat(MONTH_YEAR_FORMATS);
+}
+
+/**
+ * Whether the active locale displays time in 12-hour AM/PM form (en-US)
+ * rather than 24-hour form (pt-BR/es-ES/ja-JP), detected from moment's
+ * own locale data rather than hardcoded per language.
+ */
+export function usesTwelveHourClock() {
+	return /a/i.test(moment.localeData().longDateFormat('LT'));
+}
+
+/**
+ * A compact hour label for an hour-bucket (e.g. a chart axis tick or an
+ * hourly range description). For 12-hour locales this drops the
+ * minutes ("6 AM") since the AM/PM marker alone reads unambiguously as
+ * a time; 24-hour locales have no such marker, so a bare hour number
+ * ("6") would not read as a time at all — those use moment's full
+ * `'LT'` token instead ("06:00"), matching the AC's own 24h example
+ * ("14:30").
+ */
+export function getHourOnlyFormat() {
+	return usesTwelveHourClock() ? 'h A' : 'LT';
+}
+
+/**
+ * A day+month label followed by the hour (e.g. an "hourly bucket"
+ * tooltip or range description: "Aug 9, 2 PM" / "9 ago, 14:30").
+ */
+export function getDayMonthHourFormat() {
+	return `${getDayMonthFormat()}, ${getHourOnlyFormat()}`;
+}
 
 export const WEEKDAYS = [
 	Liferay.Language.get('sunday'),
@@ -108,12 +220,24 @@ export function formatDateToTimeZone(
 export function applyTimeZone(
 	date,
 	timeZoneId = DEFAULT_TIMEZONE_ID,
-	languageId = LanguageIds.English
+	languageId = localeToLanguageId(getLocale())
 ) {
 	return momentTimezone
 		.utc(date)
 		.tz(timeZoneId)
 		.locale(FORMATTED_LANGUAGE_IDS[languageId]);
+}
+
+/**
+ * Updates moment's global locale, so every bare `moment(...)` call
+ * (`.calendar()`, `.fromNow()`, `.format('ll')`, etc.) across the app
+ * picks up the current user's language instead of the English default
+ * set at module load. Called whenever the current user's languageId
+ * loads/changes, alongside `setLocale` in `shared/util/locale`.
+ * @param {string} languageId
+ */
+export function setMomentLocale(languageId) {
+	moment.locale(FORMATTED_LANGUAGE_IDS[languageId]);
 }
 
 export function generateDateRange(period = 30, interval = 'days') {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/locale.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/locale.ts
@@ -28,6 +28,24 @@ export function resolveLocale(languageId?: string | null): string {
 	return SUPPORTED_LOCALES[resolveLanguageId(languageId)];
 }
 
+const LANGUAGE_IDS_BY_LOCALE: Record<string, LanguageIds> = Object.fromEntries(
+	Object.entries(SUPPORTED_LOCALES).map(
+		([languageId, locale]): [string, LanguageIds] => [
+			locale,
+			languageId as LanguageIds,
+		]
+	)
+);
+
+/**
+ * Reverses `resolveLocale`: given a BCP-47 locale, returns the portal
+ * languageId it came from (e.g. moment's locale packs, which are keyed
+ * by languageId rather than by the Intl-style locale string).
+ */
+export function localeToLanguageId(locale: string): LanguageIds {
+	return LANGUAGE_IDS_BY_LOCALE[locale] || DEFAULT_LANGUAGE_ID;
+}
+
 let currentLocale: string = DEFAULT_LOCALE;
 
 /**

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/table-columns.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/table-columns.tsx
@@ -23,7 +23,12 @@ import {
 	SourceCell,
 	WillBeRemovedCell,
 } from 'shared/components/table/cell-components';
-import {applyTimeZone, formatDateToTimeZone, formatUTCDate} from './date';
+import {
+	applyTimeZone,
+	formatDateToTimeZone,
+	formatUTCDate,
+	getCustomDateFormat,
+} from './date';
 import {Colors} from './colors-size';
 import {formatTime} from './time';
 import {get, isNil, noop, pickBy} from 'lodash';
@@ -389,7 +394,8 @@ export const changesListColumns = {
 	getDateFirst: (timeZoneId: string) => ({
 		accessor: 'dateFirst',
 		dataFormatter: (value: string | number | null | undefined) =>
-			!isNil(value) && formatDateToTimeZone(value, 'll', timeZoneId),
+			!isNil(value) &&
+			formatDateToTimeZone(value, getCustomDateFormat(), timeZoneId),
 		label: Liferay.Language.get('first-seen'),
 	}),
 	getIndividualName: ({channelId, groupId}: ChannelGroupParams) => ({
@@ -411,7 +417,7 @@ export const changesListColumns = {
 			operation && [
 				<span key="MEMBERSHIP_CHANGE">
 					{applyTimeZone(dateChanged, timeZoneId).calendar(null, {
-						sameElse: 'll',
+						sameElse: getCustomDateFormat(),
 					})}
 
 					<Label
@@ -622,7 +628,11 @@ export const eventListColumns = {
 				})}
 				data={data}
 				dateFormatter={(date: string | number) =>
-					formatDateToTimeZone(date, 'll', timeZoneId)
+					formatDateToTimeZone(
+						date,
+						getCustomDateFormat(),
+						timeZoneId
+					)
 				}
 				datePath="lastSeenDate"
 			/>
@@ -724,7 +734,11 @@ export const individualsListColumns = {
 			<DateCell
 				data={data}
 				dateFormatter={(date: string | number) =>
-					formatDateToTimeZone(date, 'll', timeZoneId)
+					formatDateToTimeZone(
+						date,
+						getCustomDateFormat(),
+						timeZoneId
+					)
 				}
 				datePath="dateCreated"
 			/>
@@ -734,7 +748,8 @@ export const individualsListColumns = {
 	getLastActivityDate: (timeZoneId: string) => ({
 		accessor: 'lastActivityDate',
 		dataFormatter: (data: string | number | null | undefined) =>
-			!isNil(data) && formatDateToTimeZone(data, 'll', timeZoneId),
+			!isNil(data) &&
+			formatDateToTimeZone(data, getCustomDateFormat(), timeZoneId),
 		label: Liferay.Language.get('last-activity'),
 	}),
 	getName: ({channelId, groupId}: ChannelGroupParams) => ({
@@ -923,7 +938,11 @@ export const metricsListColumns = {
 			<DateCell
 				data={data}
 				dateFormatter={(date: string | number) =>
-					formatDateToTimeZone(date, 'll', timeZoneId)
+					formatDateToTimeZone(
+						date,
+						getCustomDateFormat(),
+						timeZoneId
+					)
 				}
 				datePath="createDate"
 			/>
@@ -1013,7 +1032,8 @@ export const metricsListColumns = {
 			};
 		}) => {
 			const date =
-				!isNil(modifiedDate) && moment(modifiedDate).format('ll');
+				!isNil(modifiedDate) &&
+				moment(modifiedDate).format(getCustomDateFormat());
 
 			return (
 				<td>
@@ -1221,7 +1241,11 @@ export const segmentsListColumns = {
 			<DateCell
 				data={data}
 				dateFormatter={(date: string | number) =>
-					formatDateToTimeZone(date, 'll', timeZoneId)
+					formatDateToTimeZone(
+						date,
+						getCustomDateFormat(),
+						timeZoneId
+					)
 				}
 				datePath="dateCreated"
 			/>
@@ -1277,7 +1301,7 @@ export const segmentsListColumns = {
 		cellRendererProps: {
 			dateFormatter: (date: string | number) =>
 				moment(date).calendar(null, {
-					sameElse: 'll',
+					sameElse: getCustomDateFormat(),
 				}),
 			datePath: 'individualAddedDate',
 		},
@@ -1309,7 +1333,7 @@ export const usersListColumns = {
 		cellRendererProps: {
 			dateFormatter: (date: string | number) =>
 				applyTimeZone(date, timeZoneId).calendar(null, {
-					sameElse: 'll',
+					sameElse: getCustomDateFormat(),
 				}),
 			datePath: 'lastLoginDate',
 		},

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/components/cohort-analysis/utils.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/components/cohort-analysis/utils.tsx
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import {CHART_COLOR_NAMES} from 'shared/util/charts';
+import {getDayMonthFormat, getFullDayMonthFormat} from 'shared/util/date';
 import {sub} from 'shared/util/lang';
 
 const {
@@ -79,24 +80,24 @@ export const formatDate = (
 			return momentDate.format('MMM');
 
 		case `${WEEK}-abbreviated`:
-			return `${momentDate.format('MMM DD')} - ${moment(date)
+			return `${momentDate.format(getDayMonthFormat())} - ${moment(date)
 				.add(7, 'day')
-				.format('MMM DD')}`;
+				.format(getDayMonthFormat())}`;
 
 		case `${DAY}-abbreviated`:
-			return momentDate.format('MMM DD');
+			return momentDate.format(getDayMonthFormat());
 
 		case MONTH:
 			return momentDate.format('MMMM');
 
 		case WEEK:
-			return `${momentDate.format('MMM DD')} - ${moment(date)
+			return `${momentDate.format(getDayMonthFormat())} - ${moment(date)
 				.add(7, 'day')
-				.format('MMM DD')}`;
+				.format(getDayMonthFormat())}`;
 
 		case DAY:
 		default:
-			return momentDate.format('MMMM DD');
+			return momentDate.format(getFullDayMonthFormat());
 	}
 };
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/VisitorsByTimeCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/sites/hocs/VisitorsByTimeCard.tsx
@@ -7,6 +7,7 @@ import ChartTooltip, {
 } from 'shared/components/chart-tooltip';
 import ClayLink from '@clayui/link';
 import HeatmapChart from 'shared/components/HeatmapChart';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 import ReactDOMServer from 'react-dom/server';
@@ -22,22 +23,15 @@ import {
 import {ReportContainer} from 'shared/components/download-report/DownloadPDFReport';
 import {sub} from 'shared/util/lang';
 import {toThousands} from 'shared/util/numbers';
+import {getHourOnlyFormat} from 'shared/util/date';
 import {withEmpty, withError, withLoading} from 'shared/hoc';
 
-export const formatHour = (hour: string) => {
-	const hourAsNumber = parseInt(hour);
-	const suffix = hourAsNumber >= 12 ? 'PM' : 'AM';
-	let hourDisplay = hourAsNumber;
-
-	if (hourAsNumber === 0) {
-		hourDisplay = 12;
-	}
-	else if (hourAsNumber > 12) {
-		hourDisplay = hourAsNumber - 12;
-	}
-
-	return `${hourDisplay} ${suffix}`;
-};
+export const formatHour = (hour: string) =>
+	moment
+		.utc()
+		.startOf('day')
+		.add(Number(hour), 'hours')
+		.format(getHourOnlyFormat());
 
 export const renderTooltip = ({
 	column,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100563

## What Is Being Fixed

Dates and times across osb-faro-web were rendered with hardcoded, US-centric formats regardless of the account's language preference. A table cell showing a date, a chart tooltip, a relative "time ago" label, or a date picker would all display "Jun 10, 2026" / 12-hour time / month-first order even for an account set to Japanese, Portuguese, or Spanish, creating a real risk that a marketer misreads when an event or campaign result actually occurred.

## How It Is Being Fixed

The root cause was that `moment`'s global locale was set once, at module load, hardcoded to English, and the one function that did accept a language parameter (`applyTimeZone`) defaulted to English whenever a call site omitted it (nearly all of them did). Two small fixes in `shared/util/date.js` and `shared/util/locale.ts` close that gap for the whole app at once: `applyTimeZone`'s default language now resolves from the current locale, and a new `setMomentLocale` call (wired into `useCurrentUser`) keeps moment's global locale in sync whenever the account's language changes, so every existing `.calendar()`, `.fromNow()`, and locale-aware format token across the app becomes correctly localized without touching each call site.

What that root fix could not reach were literal, non-token format strings ('MMM DD, YYYY', 'YYYY-MM-DD', 'h:mm a', hardcoded d3 axis formats) sprinkled across roughly 90 files — those hardcode English month order and 12-hour time regardless of locale, so they needed replacing one by one with locale-aware moment tokens or new helper functions (`getCustomDateFormat`, `getCustomDateTimeFormat`, `getDayMonthFormat`, `getDayMonthHourFormat`, `getFullDayMonthFormat`, `getMonthYearFormat`, `getHourOnlyFormat`, `usesTwelveHourClock`) that pick the right format per locale — for example day-before-month with no comma for pt-BR/es-ES, and 年/月/日 characters for ja-JP, matching the acceptance criteria's own examples. Tables, charts, tooltips, relative-time labels, date pickers, and the segment/experiment criteria builders were all swept for these hardcoded formats and migrated to the shared helpers, so the same date renders identically everywhere for a given locale. Timestamp values themselves (ISO strings, unix epochs, technical query parameters) were left untouched — only how they are displayed changed.

## PR Check

**pr-check: PASS** — tested on `45b95ff3941f4d8a6a038ba6214a27e942e59469`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "45b95ff3941f4d8a6a038ba6214a27e942e59469"} -->
