### PR TITLE
LPD-101264 Hide Last Enriched from the default accounts view

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/accounts-data-set/__tests__/AccountsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/accounts-data-set/__tests__/AccountsDataSet.tsx
@@ -38,6 +38,10 @@ const DEFAULT_VIEW_FIELD_NAMES = [
 	'firstActive',
 	'lastActive',
 	'activitiesCount',
+];
+
+const ALL_ATTRIBUTES_FIXED_FIELD_NAMES = [
+	...DEFAULT_VIEW_FIELD_NAMES,
 	'lastEnriched',
 ];
 
@@ -540,17 +544,9 @@ describe('AccountsDataSet', () => {
 			expect(view.default).toBe(true);
 			expect(view.label).toBe('Default View');
 
-			expect(view.schema.fields.map((f) => f.fieldName)).toEqual([
-				'accountName',
-				'industry',
-				'lifecycleStage',
-				'annualRevenue',
-				'country',
-				'firstActive',
-				'lastActive',
-				'activitiesCount',
-				'lastEnriched',
-			]);
+			expect(view.schema.fields.map((f) => f.fieldName)).toEqual(
+				DEFAULT_VIEW_FIELD_NAMES
+			);
 		});
 	});
 
@@ -626,7 +622,7 @@ describe('AccountsDataSet', () => {
 			expect(field?.contentRenderer).toBeUndefined();
 		});
 
-		it('should build the Default View with the 9 fixed fields in order, with the correct renderers', () => {
+		it('should build the Default View with the 8 fixed fields in order, with the correct renderers', () => {
 			render(
 				<AccountsDataSet
 					apiURL="fake-url"
@@ -640,17 +636,9 @@ describe('AccountsDataSet', () => {
 
 			expect(defaultView).toBeDefined();
 			expect(defaultView!.label).toBe('Default View');
-			expect(defaultView!.schema.fields.map((f) => f.fieldName)).toEqual([
-				'accountName',
-				'industry',
-				'lifecycleStage',
-				'annualRevenue',
-				'country',
-				'firstActive',
-				'lastActive',
-				'activitiesCount',
-				'lastEnriched',
-			]);
+			expect(defaultView!.schema.fields.map((f) => f.fieldName)).toEqual(
+				DEFAULT_VIEW_FIELD_NAMES
+			);
 
 			expect(
 				defaultView!.schema.fields.map((f) => f.contentRenderer)
@@ -663,7 +651,6 @@ describe('AccountsDataSet', () => {
 				'dateRenderer',
 				'dateRenderer',
 				'activitiesCountRenderer',
-				'dateRenderer',
 			]);
 
 			const activitiesCountField = defaultView!.schema.fields.find(
@@ -692,9 +679,10 @@ describe('AccountsDataSet', () => {
 			expect(allAttributesView).toBeDefined();
 			expect(allAttributesView!.label).toBe('All Attributes');
 			expect(allAttributesView!.schema.fields).toHaveLength(
-				DEFAULT_VIEW_FIELD_NAMES.length +
+				ALL_ATTRIBUTES_FIXED_FIELD_NAMES.length +
 					ALL_ATTRIBUTES_FIELD_CATALOG.filter(
-						({name}) => !DEFAULT_VIEW_FIELD_NAMES.includes(name)
+						({name}) =>
+							!ALL_ATTRIBUTES_FIXED_FIELD_NAMES.includes(name)
 					).length
 			);
 
@@ -731,7 +719,7 @@ describe('AccountsDataSet', () => {
 
 			expect(
 				allAttributesView!.schema.fields.map((f) => f.fieldName)
-			).toEqual([...DEFAULT_VIEW_FIELD_NAMES, 'website', 'city']);
+			).toEqual([...ALL_ATTRIBUTES_FIXED_FIELD_NAMES, 'website', 'city']);
 		});
 
 		it('should build only the Default View when the catalog comes back empty', () => {
@@ -794,6 +782,70 @@ describe('AccountsDataSet', () => {
 
 			expect(byFieldName('description')?.label).toBe('Description');
 			expect(byFieldName('signupDate')?.label).toBe('signupDate');
+		});
+	});
+
+	describe('the Last Enriched column', () => {
+		it('should be left out of the Default View', () => {
+			render(
+				<AccountsDataSet
+					apiURL="fake-url"
+					channelId="123"
+					fieldCatalog={ALL_ATTRIBUTES_FIELD_CATALOG}
+					groupId="23"
+				/>
+			);
+
+			const defaultView = lastViews!.find((v) => v.default);
+
+			expect(
+				defaultView!.schema.fields.map((f) => f.fieldName)
+			).not.toContain('lastEnriched');
+		});
+
+		it('should sit at the end of the fixed columns in the All Attributes View, still curated', () => {
+			render(
+				<AccountsDataSet
+					apiURL="fake-url"
+					channelId="123"
+					fieldCatalog={ALL_ATTRIBUTES_FIELD_CATALOG}
+					groupId="23"
+				/>
+			);
+
+			expect(
+				allAttributesFields().findIndex(
+					(field) => field.fieldName === 'lastEnriched'
+				)
+			).toBe(DEFAULT_VIEW_FIELD_NAMES.length);
+
+			const field = byFieldName('lastEnriched');
+
+			expect(field?.contentRenderer).toBe('dateRenderer');
+			expect(field?.sortable).toBe(true);
+			expect(field?.label).toMatch(/last.enriched/i);
+		});
+
+		it('should not be duplicated when the catalog also reports it', () => {
+			render(
+				<AccountsDataSet
+					apiURL="fake-url"
+					channelId="123"
+					fieldCatalog={[
+						buildCatalogField('lastEnriched', 'Date'),
+						buildCatalogField('website', 'Text'),
+					]}
+					groupId="23"
+				/>
+			);
+
+			expect(
+				allAttributesFields().filter(
+					(field) => field.fieldName === 'lastEnriched'
+				)
+			).toHaveLength(1);
+
+			expect(byFieldName('lastEnriched')?.sortable).toBe(true);
 		});
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/accounts-data-set/utils.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/accounts-data-set/utils.ts
@@ -56,6 +56,10 @@ const DEFAULT_VIEW_FIELDS: IViewField[] = [
 		label: Liferay.Language.get('recent-activities'),
 		sortable: true,
 	},
+];
+
+const ALL_ATTRIBUTES_VIEW_FIELDS: IViewField[] = [
+	...DEFAULT_VIEW_FIELDS,
 	{
 		contentRenderer: 'dateRenderer',
 		fieldName: 'lastEnriched',
@@ -64,8 +68,8 @@ const DEFAULT_VIEW_FIELDS: IViewField[] = [
 	},
 ];
 
-const DEFAULT_VIEW_FIELD_NAMES = new Set(
-	DEFAULT_VIEW_FIELDS.map(({fieldName}) => fieldName)
+const ALL_ATTRIBUTES_VIEW_FIELD_NAMES = new Set(
+	ALL_ATTRIBUTES_VIEW_FIELDS.map(({fieldName}) => fieldName)
 );
 
 const DATA_CATEGORY_RENDERERS: {[dataCategory: string]: string} = {
@@ -81,7 +85,7 @@ const buildViewField = (field: ICatalogField): IViewField => ({
 });
 
 const buildCatalogFields = (fieldCatalog: ICatalogField[]): IViewField[] => {
-	const seen = new Set(DEFAULT_VIEW_FIELD_NAMES);
+	const seen = new Set(ALL_ATTRIBUTES_VIEW_FIELD_NAMES);
 
 	return fieldCatalog
 		.filter(({name}) => {
@@ -118,7 +122,9 @@ export const buildViews = (fieldCatalog?: ICatalogField[]) => {
 			contentRenderer: 'table',
 			label: Liferay.Language.get('all-attributes'),
 			name: 'allAttributes',
-			schema: {fields: [...DEFAULT_VIEW_FIELDS, ...catalogFields]},
+			schema: {
+				fields: [...ALL_ATTRIBUTES_VIEW_FIELDS, ...catalogFields],
+			},
 			thumbnail: 'table',
 		},
 	];


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101264

## What Is Being Fixed

The accounts table shipped `Last Enriched` as one of its out-of-the-box columns. Account-Based Marketers do not use it day to day, so it crowds the default view of the Account Dashboard. Hiding it through column configuration is not possible: the data set's table view falls back to rendering every field in the schema whenever no visibility preference is stored, so any field left in the default view's schema is visible on first load.

## How It Is Being Fixed

The curated `lastEnriched` column moves out of `DEFAULT_VIEW_FIELDS` into a new `ALL_ATTRIBUTES_VIEW_FIELDS` list, which the All Attributes view prepends to the catalog-derived columns. Keeping the entry curated rather than letting it fall through to the field catalog preserves its date renderer, its translated label, and its sortability, and the dedupe set now derives from the same list so the catalog cannot introduce a second copy. The default view drops to eight columns and the underlying data is untouched, so the column stays one view switch away. The lifecycle and segment account tables pass no field catalog and therefore only ever build the default view, so they lose the column entirely, which is accepted as part of this change.

## PR Check

**pr-check: PASS** — tested on `12089389235260caf23ee411cf680f6c0d5ca964`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| JavaScript Unit Tests | PASS |

The JavaScript Unit Tests validation is listed although its match regex did not fire: the regex anchors on `^modules/` while this module lives under `workspaces/liferay-osbfaro-workspace/modules/`. The suite was run explicitly and passed (710 suites, 4006 tests).

<!-- pr-check {"result": "success", "sha": "12089389235260caf23ee411cf680f6c0d5ca964"} -->
