### PR TITLE
LPD-101237 Link to the profile of anonymous individuals

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/Growth.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/Growth.tsx
@@ -596,7 +596,7 @@ export const SegmentGrowthChart: React.FC<ISegmentGrowthChartProps> = ({
 
 export const SelectedPointInfo: React.FC = () => (
 	<div className="selected-point-info">
-		<div className="h4">{Liferay.Language.get('known-members')}</div>
+		<div className="h4">{Liferay.Language.get('members')}</div>
 	</div>
 );
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/__tests__/Growth.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/__tests__/Growth.jsx
@@ -42,10 +42,10 @@ describe('SegmentGrowthWithList', () => {
 
 		await waitForLoadingToBeRemoved(container);
 
-		expect(screen.getByText('Known Members')).toBeInTheDocument();
+		expect(screen.getByText(/^members$/i)).toBeInTheDocument();
 	});
 
-	it('requests only known members when the segment excludes anonymous users', async () => {
+	it('requests only known individuals when the segment excludes anonymous users', async () => {
 		const {container} = render(
 			<MemoryRouter
 				initialEntries={[
@@ -108,6 +108,6 @@ describe('SelectedPointInfo', () => {
 			/>
 		);
 
-		expect(screen.getByText('Known Members')).toBeInTheDocument();
+		expect(screen.getByText(/^members$/i)).toBeInTheDocument();
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/__tests__/Membership.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/__tests__/Membership.jsx
@@ -57,6 +57,6 @@ describe('MembershipChart', () => {
 
 		await waitForLoadingToBeRemoved(container);
 
-		expect(screen.getByText('Known Members')).toBeInTheDocument();
+		expect(screen.getByText(/^members$/i)).toBeInTheDocument();
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/IndividualLink.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/IndividualLink.tsx
@@ -1,17 +1,13 @@
 import NameCell from './Name';
 import React from 'react';
-import {get} from 'lodash';
-import {isBlank} from 'shared/util/util';
 import {Routes, toRoute} from 'shared/util/router';
 
 interface IIndividualLinksProps {
 	channelId?: string;
 	className?: string;
 	data: {
-		emailAddress?: string;
 		id: string;
 		individualDeleted: boolean;
-		individualEmail: string;
 		individualId: string;
 		individualName: string;
 		name: string;
@@ -32,18 +28,11 @@ const IndividualLinkCell: React.FC<IIndividualLinksProps> = ({
 
 	const name = data.name || data.individualName || '-';
 
-	const email =
-		get(data, ['properties', 'email']) ||
-		data.individualEmail ||
-		data.emailAddress;
-
-	const anonymous = isBlank(email);
-
 	return (
 		<NameCell
 			className={className}
 			data={{...data, id, name}}
-			disabled={data.individualDeleted || anonymous || disabled}
+			disabled={data.individualDeleted || disabled}
 			routeFn={({data: {id}}: {data: {id: string}}) =>
 				toRoute(Routes.CONTACTS_INDIVIDUAL, {
 					channelId,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/__tests__/IndividualLink.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/__tests__/IndividualLink.jsx
@@ -60,18 +60,22 @@ describe('IndividualLinkCell', () => {
 		expect(container.querySelectorAll('a').length).toEqual(0);
 	});
 
-	it('should NOT render as a link if the individual is anonymous', () => {
+	it('should render as a link if the individual is anonymous', () => {
+		const individualId = 'individual456';
+
 		const {container} = render(
 			<DefaultComponent
 				data={{
-					individualDeleted: true,
-					individualId: 'individual456',
+					individualDeleted: false,
+					individualId,
 					individualName: 'individual Test'
 				}}
 			/>
 		);
 
-		expect(container.querySelectorAll('a').length).toEqual(0);
+		expect(container.querySelector('a').getAttribute('href')).toContain(
+			individualId
+		);
 	});
 
 	it('should render with individualId in the link', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101237

## What Is Being Fixed

Two problems on the Segment Membership list.

The list rendered an individual as plain text whenever no email address was found on the row, so every anonymous individual was a dead end — the profile existed and was reachable by URL, but nothing in the list led to it.

Separately, the heading above that list was hardcoded to "Known Members" while the list itself holds every member of the segment. On a segment that includes anonymous users the mismatch is plain: the list shows all 41 members under a heading claiming they are the 4 known ones.

## How It Is Being Fixed

The cell no longer derives an `anonymous` flag from the email and no longer disables the link on it. Individuals are keyed by id rather than by email, so the profile route resolves for anonymous individuals exactly as it does for known ones; the guard only stood between the row and a page that was already there. Deleted individuals stay unlinked, which is a separate condition and unchanged. The same cell renders the name column of the individuals list, so anonymous individuals become reachable from there as well.

The heading now uses the existing `members` language key. The chart legend keeps its known, anonymous, and total labels, since those name distinct series rather than describing the list.

The existing test asserting that anonymous individuals are not linked was passing for the wrong reason — its fixture also set `individualDeleted`, so it never exercised the anonymous path. It now asserts the linked behavior with a fixture that does.

## PR Check

**pr-check: PASS** — tested on `d06816d4d039fb4589a9374a4eb01b0cce9c496b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "d06816d4d039fb4589a9374a4eb01b0cce9c496b"} -->
