### PR TITLE
LPD-100935 Avoid hardcoded company and group IDs in unit tests

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImplTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-image-impl/src/test/java/com/liferay/adaptive/media/image/internal/media/query/MediaQueryProviderImplTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -933,7 +934,7 @@ public class MediaQueryProviderImplTest {
 		return amImageConfigurationEntry;
 	}
 
-	private static final long _COMPANY_ID = 1L;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private final AMImageConfigurationHelper _amImageConfigurationHelper =
 		Mockito.mock(AMImageConfigurationHelper.class);

--- a/modules/apps/document-library/document-library-service/src/test/java/com/liferay/document/library/internal/configuration/persistence/listener/DLFileEntryConfigurationModelListenerTest.java
+++ b/modules/apps/document-library/document-library-service/src/test/java/com/liferay/document/library/internal/configuration/persistence/listener/DLFileEntryConfigurationModelListenerTest.java
@@ -262,9 +262,9 @@ public class DLFileEntryConfigurationModelListenerTest {
 			).build());
 	}
 
-	private static final long _COMPANY_ID = 12345L;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
-	private static final long _GROUP_ID = 67890L;
+	private static final long _GROUP_ID = RandomTestUtil.randomLong();
 
 	private final DLFileEntryConfigurationModelListener
 		_dlFileEntryConfigurationModelListener =

--- a/modules/apps/feature-flag/feature-flag-web/src/test/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagTest.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/test/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagTest.java
@@ -128,7 +128,7 @@ public class FeatureFlagsBagTest {
 			UniqueStringRandomizerBumper.INSTANCE);
 	}
 
-	private static final long _COMPANY_ID = 1L;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private final FeatureFlag _betaFeatureFlag = _createFeatureFlag(
 		FeatureFlagType.BETA);

--- a/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeLocatorImplTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-scope-impl/src/test/java/com/liferay/oauth2/provider/scope/internal/liferay/ScopeLocatorImplTest.java
@@ -18,6 +18,7 @@ import com.liferay.osgi.service.tracker.collections.map.ScopedServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.remote.jaxrs.whiteboard.lifecycle.JAXRSLifecycle;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -389,7 +390,7 @@ public class ScopeLocatorImplTest {
 
 	private static final String _APPLICATION_NAME = "com.liferay.test1";
 
-	private static final long _COMPANY_ID = 1;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private static final MockedStatic<FrameworkUtil>
 		_frameworkUtilMockedStatic = Mockito.mockStatic(FrameworkUtil.class);

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/test/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/v2_0_0/OAuth2ApplicationAnalyticsCloudUpgradeProcessTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/test/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/v2_0_0/OAuth2ApplicationAnalyticsCloudUpgradeProcessTest.java
@@ -9,6 +9,7 @@ import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Arrays;
@@ -160,7 +161,7 @@ public class OAuth2ApplicationAnalyticsCloudUpgradeProcessTest {
 		return oAuth2Application;
 	}
 
-	private static final long _COMPANY_ID = 12345;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private final CompanyLocalService _companyLocalService = Mockito.mock(
 		CompanyLocalService.class);

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterExceptionsTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.elasticsearch8.internal.ElasticsearchIndexWriter;
 import com.liferay.portal.search.elasticsearch8.internal.indexing.LiferayElasticsearchIndexingFixtureFactory;
 import com.liferay.portal.search.elasticsearch8.internal.search.engine.adapter.document.BulkDocumentRequestExecutor;
@@ -325,7 +326,7 @@ public class ElasticsearchIndexWriterExceptionsTest
 		consumer.accept(logEntry.getMessage());
 	}
 
-	private static final long _COMPANY_ID = 1;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private static final String _UID = "1";
 

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/test/java/com/liferay/portal/search/elasticsearch8/internal/logging/ElasticsearchIndexWriterLogExceptionsOnlyTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.IndexWriter;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.search.elasticsearch8.internal.ElasticsearchIndexWriter;
 import com.liferay.portal.search.elasticsearch8.internal.connection.ElasticsearchConnectionFixture;
 import com.liferay.portal.search.elasticsearch8.internal.connection.ElasticsearchFixture;
@@ -415,7 +416,7 @@ public class ElasticsearchIndexWriterLogExceptionsOnlyTest
 		consumer.accept(logEntry.getMessage());
 	}
 
-	private static final long _COMPANY_ID = 1;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private static final String _UID = "1";
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptorTest.java
@@ -268,7 +268,7 @@ public class EntityExtensionWriterInterceptorTest {
 		);
 	}
 
-	private static final long _COMPANY_ID = 11111;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private static final TestEntity _TEST_ENTITY = new TestEntity();
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/PageEntityExtensionWriterInterceptorTest.java
@@ -273,7 +273,7 @@ public class PageEntityExtensionWriterInterceptorTest {
 		).proceed();
 	}
 
-	private static final long _COMPANY_ID = 11111;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private static final TestEntity _TEST_ENTITY = new TestEntity();
 

--- a/portal-impl/test/unit/com/liferay/portal/service/persistence/impl/GroupFinderImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/service/persistence/impl/GroupFinderImplTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalServiceWrapper;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceWrapper;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.xml.UnsecureSAXReaderUtil;
@@ -455,7 +456,7 @@ public class GroupFinderImplTest {
 			join);
 	}
 
-	private static final long _COMPANY_ID = 12345L;
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private static String _capturedSQL;
 	private static GroupFinderImpl _groupFinderImpl;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100935

## What Is Being Fixed

Follow-up to #3825, which introduced a unit test for the Analytics Cloud OAuth2 application upgrade process. Review feedback on that change (https://github.com/brianchandotcom/liferay-portal/pull/179983#issuecomment-5247962491) asked for the hardcoded company ID in the new test to be randomized. A sweep of the surrounding code found the same pattern in nine other unit test classes, each declaring a company ID (and in one case a group ID) as a literal constant.

## How It Is Being Fixed

Each hardcoded constant is replaced with RandomTestUtil.randomLong(). Note that RandomTestUtil exposes two families of number generators and only one is usable here: nextInt and nextLong delegate to CounterLocalServiceUtil.increment(), which requires a running portal and throws in a unit test, while randomInt and randomLong are backed by a plain java.util.Random. Every changed file is a unit test (src/test, or portal-impl/test/unit for portal core); integration tests and main source are untouched. Before changing each constant its value was checked for semantic dependence, since several were 0 or 1, and none of the tests assert on the value or derive anything from it.

## PR Check

**pr-check: PASS** — tested on `da13ab7e00bad719c00f442b30dd0202b58e6503`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "da13ab7e00bad719c00f442b30dd0202b58e6503"} -->
