### PR TITLE
[BACKPORT] [faro-v5.0.x] LPD-101249 LPD-101264 LPD-101237 Remove % change from metric cards, hide Last Enriched, and link anonymous individual profiles

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/TotalAccounts.tsx
@@ -53,9 +53,7 @@ const TotalAccounts = ({groupId}: {groupId: string}) => {
 					)}
 					loading={loading}
 					minHeight={160}
-					renderTrendLabel={renderTrendLabel}
 					title={Liferay.Language.get('total-accounts')}
-					trend={getMetric(AccountMetricType.Total)?.trend}
 					value={renderAccountValue(
 						getMetric(AccountMetricType.Total)
 					)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/__tests__/TotalAccounts.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/__tests__/TotalAccounts.tsx
@@ -11,41 +11,59 @@ jest.mock('react-router', () => ({
 	useParams: () => ({channelId: '456'}),
 }));
 
+const mockMetrics = () => {
+	const useRequest = require('shared/hooks/useRequest');
+
+	useRequest.useRequest = jest.fn(() => ({
+		data: [
+			{
+				metricType: AccountMetricType.Total,
+				trend: {
+					percentage: 50,
+					trendClassification: TrendClassification.Positive,
+				},
+				value: 15,
+			},
+			{
+				metricType: AccountMetricType.New,
+				trend: {
+					percentage: -30,
+					trendClassification: TrendClassification.Negative,
+				},
+				value: 10,
+			},
+			{
+				metricType: AccountMetricType.Active,
+				trend: {
+					percentage: 0,
+					trendClassification: TrendClassification.Neutral,
+				},
+				value: 1,
+			},
+		],
+	}));
+};
+
 describe('TotalAccounts', () => {
 	it('should render', () => {
-		const useRequest = require('shared/hooks/useRequest');
-		useRequest.useRequest = jest.fn(() => ({
-			data: [
-				{
-					metricType: AccountMetricType.Total,
-					trend: {
-						percentage: 50,
-						trendClassification: TrendClassification.Positive,
-					},
-					value: 15,
-				},
-				{
-					metricType: AccountMetricType.New,
-					trend: {
-						percentage: -30,
-						trendClassification: TrendClassification.Negative,
-					},
-					value: 10,
-				},
-				{
-					metricType: AccountMetricType.Active,
-					trend: {
-						percentage: 0,
-						trendClassification: TrendClassification.Neutral,
-					},
-					value: 1,
-				},
-			],
-		}));
+		mockMetrics();
 
 		const {container} = render(<TotalAccounts groupId="123" />);
 
 		expect(container).toMatchSnapshot();
+	});
+
+	it('should render the period-over-period trend only for the new and active accounts cards', () => {
+		mockMetrics();
+
+		const {getAllByText, queryByText} = render(
+			<TotalAccounts groupId="123" />
+		);
+
+		expect(getAllByText(/vs\. Previous 90 Days/)).toHaveLength(2);
+		expect(queryByText('50%')).toBeNull();
+		expect(getAllByText('30%')).toHaveLength(1);
+		expect(getAllByText('0%')).toHaveLength(1);
 	});
 
 	it("should load with empty values when there's no data", () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/__tests__/__snapshots__/TotalAccounts.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/components/account/__tests__/__snapshots__/TotalAccounts.tsx.snap
@@ -49,14 +49,9 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
-              <span
-                class="mr-1"
-                style="color: rgb(107, 108, 126);"
-              >
-                0%
-              </span>
-               vs. Previous 90 Days
+               
             </div>
           </div>
         </div>
@@ -106,6 +101,7 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
               <span
                 class="mr-1"
@@ -163,6 +159,7 @@ exports[`TotalAccounts should load with empty values when there's no data 1`] = 
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
               <span
                 class="mr-1"
@@ -229,23 +226,9 @@ exports[`TotalAccounts should render 1`] = `
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
-              <svg
-                class="lexicon-icon lexicon-icon-caret-top-l"
-                role="presentation"
-                style="color: rgb(40, 125, 60);"
-              >
-                <use
-                  href="#caret-top-l"
-                />
-              </svg>
-              <span
-                class="mr-1"
-                style="color: rgb(40, 125, 60);"
-              >
-                50%
-              </span>
-               vs. Previous 90 Days
+               
             </div>
           </div>
         </div>
@@ -295,6 +278,7 @@ exports[`TotalAccounts should render 1`] = `
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
               <svg
                 class="lexicon-icon lexicon-icon-caret-bottom-l"
@@ -361,6 +345,7 @@ exports[`TotalAccounts should render 1`] = `
             </div>
             <div
               class="text-secondary"
+              data-testid="metric-card-trend"
             >
               <span
                 class="mr-1"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/__tests__/__snapshots__/List.tsx.snap
@@ -113,14 +113,9 @@ exports[`List rendering should match the snapshot 1`] = `
                   </div>
                   <div
                     class="text-secondary"
+                    data-testid="metric-card-trend"
                   >
-                    <span
-                      class="mr-1"
-                      style="color: rgb(107, 108, 126);"
-                    >
-                      0%
-                    </span>
-                     vs. Previous 90 Days
+                     
                   </div>
                 </div>
               </div>
@@ -170,6 +165,7 @@ exports[`List rendering should match the snapshot 1`] = `
                   </div>
                   <div
                     class="text-secondary"
+                    data-testid="metric-card-trend"
                   >
                     <span
                       class="mr-1"
@@ -227,6 +223,7 @@ exports[`List rendering should match the snapshot 1`] = `
                   </div>
                   <div
                     class="text-secondary"
+                    data-testid="metric-card-trend"
                   >
                     <span
                       class="mr-1"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
@@ -16,7 +16,7 @@ const MostEngagedIndividuals: React.FC = () => {
 	return (
 		<Card minHeight={260} testId="most-engaged-individuals">
 			<Card.Title className="p-3">
-				<Text weight="semi-bold">
+				<Text size={5} weight="semi-bold">
 					{Liferay.Language.get(
 						'most-engaged-individuals'
 					).toUpperCase()}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/IndividualsOverviewCDP.tsx
@@ -178,14 +178,9 @@ const IndividualsOverviewCDP = () => {
 									)}
 									loading={loading}
 									minHeight={198}
-									renderTrendLabel={renderTrendLabel}
 									title={Liferay.Language.get(
 										'total-individuals'
 									)}
-									trend={
-										data?.individualMetric
-											?.totalIndividualsMetric?.trend
-									}
 									value={renderIndividualsValue(
 										data?.individualMetric
 											?.totalIndividualsMetric?.value

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/dashboard/pages/__tests__/IndividualsOverviewCDP.tsx
@@ -113,6 +113,20 @@ describe('IndividualsOverviewCDP', () => {
 		expect(getByText('Anonymous Individuals')).toBeInTheDocument();
 	});
 
+	it('should render the period-over-period trend only for the known and anonymous individuals cards', () => {
+		(useQuery as jest.Mock).mockReturnValue({
+			data: mockedIndividualMetrics.data,
+			loading: false,
+		});
+
+		const {getAllByText, queryByText} = renderIndividualsOverviewCDP();
+
+		expect(getAllByText(/vs\. Last 30 Days/)).toHaveLength(2);
+		expect(queryByText('30.2%')).toBeNull();
+		expect(getAllByText('28.1%')).toHaveLength(1);
+		expect(getAllByText('11.1%')).toHaveLength(1);
+	});
+
 	it('should render a centered loader inside each metric card while metrics are loading', () => {
 		(useQuery as jest.Mock).mockReturnValue({
 			data: undefined,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/Growth.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/Growth.tsx
@@ -596,7 +596,7 @@ export const SegmentGrowthChart: React.FC<ISegmentGrowthChartProps> = ({
 
 export const SelectedPointInfo: React.FC = () => (
 	<div className="selected-point-info">
-		<div className="h4">{Liferay.Language.get('known-members')}</div>
+		<div className="h4">{Liferay.Language.get('members')}</div>
 	</div>
 );
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/__tests__/Growth.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/__tests__/Growth.jsx
@@ -42,10 +42,10 @@ describe('SegmentGrowthWithList', () => {
 
 		await waitForLoadingToBeRemoved(container);
 
-		expect(screen.getByText('Known Members')).toBeInTheDocument();
+		expect(screen.getByText(/^members$/i)).toBeInTheDocument();
 	});
 
-	it('requests only known members when the segment excludes anonymous users', async () => {
+	it('requests only known individuals when the segment excludes anonymous users', async () => {
 		const {container} = render(
 			<MemoryRouter
 				initialEntries={[
@@ -108,6 +108,6 @@ describe('SelectedPointInfo', () => {
 			/>
 		);
 
-		expect(screen.getByText('Known Members')).toBeInTheDocument();
+		expect(screen.getByText(/^members$/i)).toBeInTheDocument();
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/__tests__/Membership.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/pages/__tests__/Membership.jsx
@@ -57,6 +57,6 @@ describe('MembershipChart', () => {
 
 		await waitForLoadingToBeRemoved(container);
 
-		expect(screen.getByText('Known Members')).toBeInTheDocument();
+		expect(screen.getByText(/^members$/i)).toBeInTheDocument();
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
@@ -3,10 +3,10 @@ import classNames from 'classnames';
 import ClayIcon from '@clayui/icon';
 import Loading from 'shared/components/Loading';
 import React, {ReactNode} from 'react';
+import {formatPercent} from 'shared/util/numbers';
 import {getIcon, getStatsColor} from 'shared/util/metrics';
 import {isNil} from 'lodash';
 import {Text} from '@clayui/core';
-import {formatPercent} from 'shared/util/numbers';
 import {TrendClassification} from 'segment/types';
 
 interface IMetricCardTrend {
@@ -14,12 +14,18 @@ interface IMetricCardTrend {
 	trendClassification: TrendClassification;
 }
 
+/**
+ * Fills the trend row on cards without a trend so that it keeps its height,
+ * leaving the value aligned with the sibling cards that do render a trend.
+ */
+const TREND_PLACEHOLDER = '\u00A0';
+
 interface IMetricCardProps {
 	className?: string;
 	description: string;
 	loading?: boolean;
 	minHeight?: number;
-	renderTrendLabel: (percentageNode: ReactNode) => ReactNode;
+	renderTrendLabel?: (percentageNode: ReactNode) => ReactNode;
 	title: string;
 	trend?: IMetricCardTrend;
 	trendClassName?: string;
@@ -77,29 +83,38 @@ const MetricCard: React.FC<IMetricCardProps> = ({
 
 					<div
 						className={classNames('text-secondary', trendClassName)}
+						data-testid="metric-card-trend"
 					>
-						{!isNil(trend?.trendClassification) &&
-							trend?.trendClassification !==
-								TrendClassification.Neutral && (
-								<ClayIcon
-									style={{color: percentageColor}}
-									symbol={
-										getIcon(trend?.percentage ?? 0) ?? ''
-									}
-								/>
-							)}
+						{renderTrendLabel ? (
+							<>
+								{!isNil(trend?.trendClassification) &&
+									trend?.trendClassification !==
+										TrendClassification.Neutral && (
+										<ClayIcon
+											style={{color: percentageColor}}
+											symbol={
+												getIcon(
+													trend?.percentage ?? 0
+												) ?? ''
+											}
+										/>
+									)}
 
-						{renderTrendLabel(
-							<span
-								className="mr-1"
-								key="percentage"
-								style={{color: percentageColor}}
-							>
-								{formatPercent(
-									Math.abs(trend?.percentage ?? 0),
-									1
+								{renderTrendLabel(
+									<span
+										className="mr-1"
+										key="percentage"
+										style={{color: percentageColor}}
+									>
+										{formatPercent(
+											Math.abs(trend?.percentage ?? 0),
+											1
+										)}
+									</span>
 								)}
-							</span>
+							</>
+						) : (
+							TREND_PLACEHOLDER
 						)}
 					</div>
 				</div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/MetricCard.tsx
@@ -8,18 +8,12 @@ import {getIcon, getStatsColor} from 'shared/util/metrics';
 import {isNil} from 'lodash';
 import {Text} from '@clayui/core';
 import {TrendClassification} from 'segment/types';
+import {TREND_PLACEHOLDER} from '../util/constants';
 
 interface IMetricCardTrend {
 	percentage: number;
 	trendClassification: TrendClassification;
 }
-
-/**
- * Fills the trend row on cards without a trend so that it keeps its height,
- * leaving the value aligned with the sibling cards that do render a trend.
- */
-const TREND_PLACEHOLDER = '\u00A0';
-
 interface IMetricCardProps {
 	className?: string;
 	description: string;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/MetricCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/MetricCard.tsx
@@ -105,6 +105,37 @@ describe('MetricCard', () => {
 		).toBeNull();
 	});
 
+	it('should not render the trend when renderTrendLabel is omitted', () => {
+		const {container, getByText, queryByText} = render(
+			<MetricCard
+				description={defaultProps.description}
+				title={defaultProps.title}
+				trend={{
+					percentage: 10,
+					trendClassification: TrendClassification.Positive,
+				}}
+				value={defaultProps.value}
+			/>
+		);
+
+		expect(getByText('42')).toBeTruthy();
+		expect(queryByText('10%')).toBeNull();
+		expect(queryByText('vs last period')).toBeNull();
+		expect(container.querySelector('.lexicon-icon-caret-top-l')).toBeNull();
+	});
+
+	it('should keep the trend row height when renderTrendLabel is omitted so the value stays aligned', () => {
+		const {getByTestId} = render(
+			<MetricCard
+				description={defaultProps.description}
+				title={defaultProps.title}
+				value={defaultProps.value}
+			/>
+		);
+
+		expect(getByTestId('metric-card-trend').textContent).toBe('\u00A0');
+	});
+
 	it('should apply className and trendClassName', () => {
 		const {container} = render(
 			<MetricCard

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/MetricCard.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/__snapshots__/MetricCard.tsx.snap
@@ -42,6 +42,7 @@ exports[`MetricCard should render 1`] = `
         </div>
         <div
           class="text-secondary"
+          data-testid="metric-card-trend"
         >
           <span
             class="mr-1"

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/accounts-data-set/__tests__/AccountsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/accounts-data-set/__tests__/AccountsDataSet.tsx
@@ -38,6 +38,10 @@ const DEFAULT_VIEW_FIELD_NAMES = [
 	'firstActive',
 	'lastActive',
 	'activitiesCount',
+];
+
+const ALL_ATTRIBUTES_FIXED_FIELD_NAMES = [
+	...DEFAULT_VIEW_FIELD_NAMES,
 	'lastEnriched',
 ];
 
@@ -540,17 +544,9 @@ describe('AccountsDataSet', () => {
 			expect(view.default).toBe(true);
 			expect(view.label).toBe('Default View');
 
-			expect(view.schema.fields.map((f) => f.fieldName)).toEqual([
-				'accountName',
-				'industry',
-				'lifecycleStage',
-				'annualRevenue',
-				'country',
-				'firstActive',
-				'lastActive',
-				'activitiesCount',
-				'lastEnriched',
-			]);
+			expect(view.schema.fields.map((f) => f.fieldName)).toEqual(
+				DEFAULT_VIEW_FIELD_NAMES
+			);
 		});
 	});
 
@@ -626,7 +622,7 @@ describe('AccountsDataSet', () => {
 			expect(field?.contentRenderer).toBeUndefined();
 		});
 
-		it('should build the Default View with the 9 fixed fields in order, with the correct renderers', () => {
+		it('should build the Default View with the 8 fixed fields in order, with the correct renderers', () => {
 			render(
 				<AccountsDataSet
 					apiURL="fake-url"
@@ -640,17 +636,9 @@ describe('AccountsDataSet', () => {
 
 			expect(defaultView).toBeDefined();
 			expect(defaultView!.label).toBe('Default View');
-			expect(defaultView!.schema.fields.map((f) => f.fieldName)).toEqual([
-				'accountName',
-				'industry',
-				'lifecycleStage',
-				'annualRevenue',
-				'country',
-				'firstActive',
-				'lastActive',
-				'activitiesCount',
-				'lastEnriched',
-			]);
+			expect(defaultView!.schema.fields.map((f) => f.fieldName)).toEqual(
+				DEFAULT_VIEW_FIELD_NAMES
+			);
 
 			expect(
 				defaultView!.schema.fields.map((f) => f.contentRenderer)
@@ -663,7 +651,6 @@ describe('AccountsDataSet', () => {
 				'dateRenderer',
 				'dateRenderer',
 				'activitiesCountRenderer',
-				'dateRenderer',
 			]);
 
 			const activitiesCountField = defaultView!.schema.fields.find(
@@ -692,9 +679,10 @@ describe('AccountsDataSet', () => {
 			expect(allAttributesView).toBeDefined();
 			expect(allAttributesView!.label).toBe('All Attributes');
 			expect(allAttributesView!.schema.fields).toHaveLength(
-				DEFAULT_VIEW_FIELD_NAMES.length +
+				ALL_ATTRIBUTES_FIXED_FIELD_NAMES.length +
 					ALL_ATTRIBUTES_FIELD_CATALOG.filter(
-						({name}) => !DEFAULT_VIEW_FIELD_NAMES.includes(name)
+						({name}) =>
+							!ALL_ATTRIBUTES_FIXED_FIELD_NAMES.includes(name)
 					).length
 			);
 
@@ -731,7 +719,7 @@ describe('AccountsDataSet', () => {
 
 			expect(
 				allAttributesView!.schema.fields.map((f) => f.fieldName)
-			).toEqual([...DEFAULT_VIEW_FIELD_NAMES, 'website', 'city']);
+			).toEqual([...ALL_ATTRIBUTES_FIXED_FIELD_NAMES, 'website', 'city']);
 		});
 
 		it('should build only the Default View when the catalog comes back empty', () => {
@@ -794,6 +782,70 @@ describe('AccountsDataSet', () => {
 
 			expect(byFieldName('description')?.label).toBe('Description');
 			expect(byFieldName('signupDate')?.label).toBe('signupDate');
+		});
+	});
+
+	describe('the Last Enriched column', () => {
+		it('should be left out of the Default View', () => {
+			render(
+				<AccountsDataSet
+					apiURL="fake-url"
+					channelId="123"
+					fieldCatalog={ALL_ATTRIBUTES_FIELD_CATALOG}
+					groupId="23"
+				/>
+			);
+
+			const defaultView = lastViews!.find((v) => v.default);
+
+			expect(
+				defaultView!.schema.fields.map((f) => f.fieldName)
+			).not.toContain('lastEnriched');
+		});
+
+		it('should sit at the end of the fixed columns in the All Attributes View, still curated', () => {
+			render(
+				<AccountsDataSet
+					apiURL="fake-url"
+					channelId="123"
+					fieldCatalog={ALL_ATTRIBUTES_FIELD_CATALOG}
+					groupId="23"
+				/>
+			);
+
+			expect(
+				allAttributesFields().findIndex(
+					(field) => field.fieldName === 'lastEnriched'
+				)
+			).toBe(DEFAULT_VIEW_FIELD_NAMES.length);
+
+			const field = byFieldName('lastEnriched');
+
+			expect(field?.contentRenderer).toBe('dateRenderer');
+			expect(field?.sortable).toBe(true);
+			expect(field?.label).toMatch(/last.enriched/i);
+		});
+
+		it('should not be duplicated when the catalog also reports it', () => {
+			render(
+				<AccountsDataSet
+					apiURL="fake-url"
+					channelId="123"
+					fieldCatalog={[
+						buildCatalogField('lastEnriched', 'Date'),
+						buildCatalogField('website', 'Text'),
+					]}
+					groupId="23"
+				/>
+			);
+
+			expect(
+				allAttributesFields().filter(
+					(field) => field.fieldName === 'lastEnriched'
+				)
+			).toHaveLength(1);
+
+			expect(byFieldName('lastEnriched')?.sortable).toBe(true);
 		});
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/accounts-data-set/utils.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/accounts-data-set/utils.ts
@@ -56,6 +56,10 @@ const DEFAULT_VIEW_FIELDS: IViewField[] = [
 		label: Liferay.Language.get('recent-activities'),
 		sortable: true,
 	},
+];
+
+const ALL_ATTRIBUTES_VIEW_FIELDS: IViewField[] = [
+	...DEFAULT_VIEW_FIELDS,
 	{
 		contentRenderer: 'dateRenderer',
 		fieldName: 'lastEnriched',
@@ -64,8 +68,8 @@ const DEFAULT_VIEW_FIELDS: IViewField[] = [
 	},
 ];
 
-const DEFAULT_VIEW_FIELD_NAMES = new Set(
-	DEFAULT_VIEW_FIELDS.map(({fieldName}) => fieldName)
+const ALL_ATTRIBUTES_VIEW_FIELD_NAMES = new Set(
+	ALL_ATTRIBUTES_VIEW_FIELDS.map(({fieldName}) => fieldName)
 );
 
 const DATA_CATEGORY_RENDERERS: {[dataCategory: string]: string} = {
@@ -81,7 +85,7 @@ const buildViewField = (field: ICatalogField): IViewField => ({
 });
 
 const buildCatalogFields = (fieldCatalog: ICatalogField[]): IViewField[] => {
-	const seen = new Set(DEFAULT_VIEW_FIELD_NAMES);
+	const seen = new Set(ALL_ATTRIBUTES_VIEW_FIELD_NAMES);
 
 	return fieldCatalog
 		.filter(({name}) => {
@@ -118,7 +122,9 @@ export const buildViews = (fieldCatalog?: ICatalogField[]) => {
 			contentRenderer: 'table',
 			label: Liferay.Language.get('all-attributes'),
 			name: 'allAttributes',
-			schema: {fields: [...DEFAULT_VIEW_FIELDS, ...catalogFields]},
+			schema: {
+				fields: [...ALL_ATTRIBUTES_VIEW_FIELDS, ...catalogFields],
+			},
 			thumbnail: 'table',
 		},
 	];

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/IndividualLink.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/IndividualLink.tsx
@@ -1,17 +1,13 @@
 import NameCell from './Name';
 import React from 'react';
-import {get} from 'lodash';
-import {isBlank} from 'shared/util/util';
 import {Routes, toRoute} from 'shared/util/router';
 
 interface IIndividualLinksProps {
 	channelId?: string;
 	className?: string;
 	data: {
-		emailAddress?: string;
 		id: string;
 		individualDeleted: boolean;
-		individualEmail: string;
 		individualId: string;
 		individualName: string;
 		name: string;
@@ -32,18 +28,11 @@ const IndividualLinkCell: React.FC<IIndividualLinksProps> = ({
 
 	const name = data.name || data.individualName || '-';
 
-	const email =
-		get(data, ['properties', 'email']) ||
-		data.individualEmail ||
-		data.emailAddress;
-
-	const anonymous = isBlank(email);
-
 	return (
 		<NameCell
 			className={className}
 			data={{...data, id, name}}
-			disabled={data.individualDeleted || anonymous || disabled}
+			disabled={data.individualDeleted || disabled}
 			routeFn={({data: {id}}: {data: {id: string}}) =>
 				toRoute(Routes.CONTACTS_INDIVIDUAL, {
 					channelId,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/__tests__/IndividualLink.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/table/cell-components/__tests__/IndividualLink.jsx
@@ -60,18 +60,22 @@ describe('IndividualLinkCell', () => {
 		expect(container.querySelectorAll('a').length).toEqual(0);
 	});
 
-	it('should NOT render as a link if the individual is anonymous', () => {
+	it('should render as a link if the individual is anonymous', () => {
+		const individualId = 'individual456';
+
 		const {container} = render(
 			<DefaultComponent
 				data={{
-					individualDeleted: true,
-					individualId: 'individual456',
+					individualDeleted: false,
+					individualId,
 					individualName: 'individual Test'
 				}}
 			/>
 		);
 
-		expect(container.querySelectorAll('a').length).toEqual(0);
+		expect(container.querySelector('a').getAttribute('href')).toContain(
+			individualId
+		);
 	});
 
 	it('should render with individualId in the link', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/constants.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/constants.ts
@@ -493,6 +493,12 @@ export const TIME_RANGE_LABELS = {
 	[RangeKeyTimeRanges.Yesterday]: Liferay.Language.get('yesterday'),
 };
 
+/**
+ * Fills the trend row on cards without a trend so that it keeps its height,
+ * leaving the value aligned with the sibling cards that do render a trend.
+ */
+export const TREND_PLACEHOLDER = '\u00A0';
+
 export const TWO_DAYS = '172800000';
 
 const Constants: Window['faroConstants'] = window.faroConstants;


### PR DESCRIPTION
## Summary

Backport of:
- https://github.com/liferay-ac/liferay-portal/pull/3830
- https://github.com/liferay-ac/liferay-portal/pull/3838
- https://github.com/liferay-ac/liferay-portal/pull/3840

PR https://github.com/liferay-ac/liferay-portal/pull/3836 (LPD-100563) was not included — its commits are already present on `faro-v5.0.x`.