### PR TITLE
LPD-101885 Paginate account activities by session count

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
@@ -156,7 +156,8 @@ const AccountActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 							rangeSelectors,
 						}
 					),
-					total: eventsByUserSessions?.totalEventsMetric?.value ?? 0,
+					total:
+						eventsByUserSessions?.totalSessionsMetric?.value ?? 0,
 				})
 			),
 		[

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamCard.tsx
@@ -103,13 +103,13 @@ describe('ActivityStreamCard', () => {
 		expect(link.getAttribute('href')).toContain('accountName=Acme');
 	});
 
-	it('drives pagination from the activity stream event total, not the session count', async () => {
+	it('drives pagination from the activity stream session total, not the event count', async () => {
 		const {container} = render(
 			<Wrapper
 				mocks={[
 					mockAccountEventMetricsReq(),
 					mockAccountEventsTrendReq(),
-					mockAccountUserSessionsReq({totalEvents: 186}),
+					mockAccountUserSessionsReq({totalSessions: 186}),
 				]}
 			/>
 		);
@@ -131,7 +131,10 @@ describe('ActivityStreamCard', () => {
 						trendClassification: 'NEUTRAL',
 						value: 0,
 					}),
-					mockAccountUserSessionsReq({sessions: [], totalEvents: 0}),
+					mockAccountUserSessionsReq({
+						sessions: [],
+						totalSessions: 0,
+					}),
 				]}
 			/>
 		);
@@ -159,7 +162,7 @@ describe('ActivityStreamCard', () => {
 					mockAccountUserSessionsReq({
 						keywords: SEARCH_KEYWORDS,
 						sessions: [],
-						totalEvents: 0,
+						totalSessions: 0,
 					}),
 					mockAccountEventMetricsReq(),
 					mockAccountEventsTrendReq(),

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AccountUserSessionQuery.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AccountUserSessionQuery.ts
@@ -37,7 +37,7 @@ export interface AccountUserSession {
 
 export interface AccountUserSessionData {
 	eventsByUserSessions: {
-		totalEventsMetric: {value: number} | null;
+		totalSessionsMetric: {value: number} | null;
 		userSessions: AccountUserSession[];
 	};
 }
@@ -81,7 +81,7 @@ export default gql`
 			rangeStart: $rangeStart
 			size: $size
 		) {
-			totalEventsMetric {
+			totalSessionsMetric {
 				value
 			}
 			userSessions {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/test/graphql-data.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/test/graphql-data.js
@@ -2458,7 +2458,7 @@ export const mockAccountUserSessionsReq = ({
 	rangeKey = 30,
 	sessions = DEFAULT_ACCOUNT_USER_SESSIONS,
 	size = 2,
-	totalEvents = 1,
+	totalSessions = 1,
 } = {}) => ({
 	request: {
 		query: AccountUserSessionQuery,
@@ -2479,9 +2479,9 @@ export const mockAccountUserSessionsReq = ({
 		data: {
 			eventsByUserSessions: {
 				__typename: 'EventsByUserSession',
-				totalEventsMetric: {
+				totalSessionsMetric: {
 					__typename: 'Metric',
-					value: totalEvents,
+					value: totalSessions,
 				},
 				userSessions: sessions,
 			},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101885

## What Is Being Fixed

The account activity stream lists user sessions, but the pagination total on the `eventsByUserSessions` query came from `totalEventsMetric`. The result count and the page count therefore described events rather than the sessions actually listed, so the footer could report a total far larger than the list and paginate into empty pages.

## How It Is Being Fixed

The session list query now selects `totalSessionsMetric`, and the account activity stream card reads its `value` for the mapped total. The trend summary deliberately keeps reading `totalEventsMetric`, which is the count its "N activities" label describes. The Jest mock returns the new field and its parameter was renamed to match, along with its three call sites, and the pagination test now asserts the session total instead of the event total.

## PR Check

**pr-check: PASS** — tested on `dd619c1bbca4bc550d04dc286eb74092953ad560`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "dd619c1bbca4bc550d04dc286eb74092953ad560"} -->
