### PR TITLE
LPD-102099 Fix the HTTP 500 when a range parameter is omitted

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/InventoryAnalysisResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/InventoryAnalysisResourceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.analytics.cms.rest.internal.resource.v1_0;
 import com.liferay.analytics.cms.rest.dto.v1_0.InventoryAnalysis;
 import com.liferay.analytics.cms.rest.dto.v1_0.InventoryAnalysisItem;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
+import com.liferay.analytics.cms.rest.internal.resource.v1_0.util.DateRangeUtil;
 import com.liferay.analytics.cms.rest.internal.resource.v1_0.util.ObjectEntryVersionTitleExpressionUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.InventoryAnalysisResource;
 import com.liferay.asset.entry.rel.model.AssetEntryAssetCategoryRelTable;
@@ -33,10 +34,7 @@ import com.liferay.petra.sql.dsl.query.FromStep;
 import com.liferay.petra.sql.dsl.query.GroupByStep;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -44,10 +42,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -158,34 +152,6 @@ public class InventoryAnalysisResourceImpl
 					structureId, tagId, vocabularyId)));
 
 		return inventoryAnalysis;
-	}
-
-	private DateFormat _getDateFormat() {
-		return DateFormatFactoryUtil.getSimpleDateFormat("yyyy-MM-dd");
-	}
-
-	private Date _getEndDate(String rangeEnd) {
-		try {
-			Calendar calendar = Calendar.getInstance();
-
-			DateFormat dateFormat = _getDateFormat();
-
-			calendar.setTime(dateFormat.parse(rangeEnd));
-
-			calendar.set(Calendar.HOUR_OF_DAY, 23);
-			calendar.set(Calendar.MILLISECOND, 59);
-			calendar.set(Calendar.MINUTE, 59);
-			calendar.set(Calendar.SECOND, 59);
-
-			return calendar.getTime();
-		}
-		catch (ParseException parseException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(parseException);
-			}
-		}
-
-		return null;
 	}
 
 	private Expression<?>[] _getGroupByExpressions(String groupBy) {
@@ -343,16 +309,18 @@ public class InventoryAnalysisResourceImpl
 				).isNotNull());
 		}
 
-		if (Validator.isNotNull(rangeStart)) {
+		Date startDate = DateRangeUtil.getStartDate(
+			rangeEnd, rangeKey, rangeStart);
+
+		if (startDate != null) {
 			predicate = predicate.and(
-				ObjectEntryTable.INSTANCE.createDate.gte(
-					_getStartDate(rangeKey, rangeStart)));
+				ObjectEntryTable.INSTANCE.createDate.gte(startDate));
 		}
 
 		if (Validator.isNotNull(rangeEnd)) {
 			predicate = predicate.and(
 				ObjectEntryTable.INSTANCE.createDate.lte(
-					_getEndDate(rangeEnd)));
+					DateRangeUtil.getEndDate(rangeEnd)));
 		}
 
 		if (structureId != null) {
@@ -420,36 +388,6 @@ public class InventoryAnalysisResourceImpl
 			ObjectDefinitionTable.INSTANCE.label.as("title")
 		};
 	}
-
-	private Date _getStartDate(Integer rangeKey, String rangeStart) {
-		Calendar calendar = Calendar.getInstance();
-
-		if (Validator.isNotNull(rangeStart)) {
-			try {
-				DateFormat dateFormat = _getDateFormat();
-
-				calendar.setTime(dateFormat.parse(rangeStart));
-			}
-			catch (ParseException parseException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(parseException);
-				}
-			}
-		}
-		else {
-			calendar.add(Calendar.DAY_OF_MONTH, -rangeKey);
-		}
-
-		calendar.set(Calendar.HOUR_OF_DAY, 0);
-		calendar.set(Calendar.MILLISECOND, 0);
-		calendar.set(Calendar.MINUTE, 0);
-		calendar.set(Calendar.SECOND, 0);
-
-		return calendar.getTime();
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		InventoryAnalysisResourceImpl.class);
 
 	@Reference
 	private Localization _localization;

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/InventoryAnalysisResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/InventoryAnalysisResourceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.asset.kernel.model.AssetTagGroupRelTable;
 import com.liferay.asset.kernel.model.AssetTagTable;
 import com.liferay.asset.kernel.model.AssetVocabularyGroupRelTable;
 import com.liferay.asset.kernel.model.AssetVocabularyTable;
+import com.liferay.depot.model.DepotEntry;
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.model.ObjectDefinitionTable;
 import com.liferay.object.model.ObjectEntryTable;
@@ -77,9 +78,19 @@ public class InventoryAnalysisResourceImpl
 
 		LicenseManagerUtil.checkFreeTier();
 
-		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getDepotEntries(
-				contextCompany.getCompanyId(), depotEntryId));
+		List<DepotEntry> depotEntries = DepotEntryUtil.getDepotEntries(
+			contextCompany.getCompanyId(), depotEntryId);
+
+		if (depotEntries.isEmpty()) {
+			inventoryAnalysis.setInventoryAnalysisItems(
+				() -> new InventoryAnalysisItem[0]);
+			inventoryAnalysis.setInventoryAnalysisItemsCount(() -> 0L);
+			inventoryAnalysis.setTotalCount(() -> 0L);
+
+			return inventoryAnalysis;
+		}
+
+		Long[] groupIds = DepotEntryUtil.getGroupIds(depotEntries);
 
 		inventoryAnalysis.setInventoryAnalysisItems(
 			() -> transformToArray(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OverviewResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OverviewResourceImpl.java
@@ -8,6 +8,7 @@ package com.liferay.analytics.cms.rest.internal.resource.v1_0;
 import com.liferay.analytics.cms.rest.dto.v1_0.Overview;
 import com.liferay.analytics.cms.rest.dto.v1_0.Trend;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
+import com.liferay.analytics.cms.rest.internal.resource.v1_0.util.DateRangeUtil;
 import com.liferay.analytics.cms.rest.internal.resource.v1_0.util.ObjectEntryVersionTitleExpressionUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.OverviewResource;
 import com.liferay.asset.entry.rel.model.AssetEntryAssetCategoryRelTable;
@@ -29,19 +30,11 @@ import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
-import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -108,34 +101,6 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 			_getPreviousTotalCount(
 				"L_CMS_FILE_TYPES", groupIds, languageId, rangeEnd, rangeKey,
 				rangeStart));
-	}
-
-	private DateFormat _getDateFormat() {
-		return DateFormatFactoryUtil.getSimpleDateFormat("yyyy-MM-dd");
-	}
-
-	private Date _getEndDate(String rangeEnd) {
-		try {
-			Calendar calendar = Calendar.getInstance();
-
-			DateFormat dateFormat = _getDateFormat();
-
-			calendar.setTime(dateFormat.parse(rangeEnd));
-
-			calendar.set(Calendar.HOUR_OF_DAY, 23);
-			calendar.set(Calendar.MILLISECOND, 59);
-			calendar.set(Calendar.MINUTE, 59);
-			calendar.set(Calendar.SECOND, 59);
-
-			return calendar.getTime();
-		}
-		catch (ParseException parseException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(parseException);
-			}
-		}
-
-		return null;
 	}
 
 	private Object[] _getOverviewObjects(
@@ -285,7 +250,8 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 				).isNotNull());
 		}
 
-		Date startDate = _getStartDate(rangeEnd, rangeKey, rangeStart);
+		Date startDate = DateRangeUtil.getStartDate(
+			rangeEnd, rangeKey, rangeStart);
 
 		if (startDate == null) {
 			return predicate;
@@ -298,56 +264,20 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 			if (Validator.isNotNull(rangeEnd)) {
 				predicate = predicate.and(
 					ObjectEntryTable.INSTANCE.createDate.lte(
-						_getEndDate(rangeEnd)));
+						DateRangeUtil.getEndDate(rangeEnd)));
 			}
 		}
 		else {
 			predicate = predicate.and(
 				ObjectEntryTable.INSTANCE.createDate.gte(
-					_getPreviousStartDate(rangeEnd, rangeKey, rangeStart))
+					DateRangeUtil.getPreviousStartDate(
+						rangeEnd, rangeKey, rangeStart))
 			).and(
 				ObjectEntryTable.INSTANCE.createDate.lt(startDate)
 			);
 		}
 
 		return predicate;
-	}
-
-	private Date _getPreviousStartDate(
-		String rangeEnd, Integer rangeKey, String rangeStart) {
-
-		Calendar calendar = Calendar.getInstance();
-
-		if (Validator.isNotNull(rangeEnd) && Validator.isNotNull(rangeStart)) {
-			try {
-				calendar.setTime(_getStartDate(rangeEnd, null, rangeStart));
-
-				DateFormat dateFormat = _getDateFormat();
-
-				int delta = DateUtil.getDaysBetween(
-					dateFormat.parse(rangeStart), dateFormat.parse(rangeEnd));
-
-				calendar.add(Calendar.DAY_OF_MONTH, -delta);
-			}
-			catch (ParseException parseException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(parseException);
-				}
-			}
-		}
-		else if (rangeKey != null) {
-			calendar.add(Calendar.DAY_OF_MONTH, -(rangeKey * 2));
-		}
-		else {
-			return null;
-		}
-
-		calendar.set(Calendar.HOUR_OF_DAY, 0);
-		calendar.set(Calendar.MILLISECOND, 0);
-		calendar.set(Calendar.MINUTE, 0);
-		calendar.set(Calendar.SECOND, 0);
-
-		return calendar.getTime();
 	}
 
 	private long _getPreviousTotalCount(
@@ -406,38 +336,6 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 		return GetterUtil.getLong(results.get(0));
 	}
 
-	private Date _getStartDate(
-		String rangeEnd, Integer rangeKey, String rangeStart) {
-
-		Calendar calendar = Calendar.getInstance();
-
-		if (Validator.isNotNull(rangeEnd) && Validator.isNotNull(rangeStart)) {
-			try {
-				DateFormat dateFormat = _getDateFormat();
-
-				calendar.setTime(dateFormat.parse(rangeStart));
-			}
-			catch (ParseException parseException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(parseException);
-				}
-			}
-		}
-		else if (rangeKey != null) {
-			calendar.add(Calendar.DAY_OF_MONTH, -rangeKey);
-		}
-		else {
-			return null;
-		}
-
-		calendar.set(Calendar.HOUR_OF_DAY, 0);
-		calendar.set(Calendar.MILLISECOND, 0);
-		calendar.set(Calendar.MINUTE, 0);
-		calendar.set(Calendar.SECOND, 0);
-
-		return calendar.getTime();
-	}
-
 	private Overview _toOverview(
 		long categoriesCount, Trend.Classification classification,
 		double percentage, long tagsCount, long totalCount,
@@ -491,9 +389,6 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 			categoriesCount, classification, percentage, tagsCount, totalCount,
 			vocabulariesCount);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		OverviewResourceImpl.class);
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OverviewResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OverviewResourceImpl.java
@@ -285,10 +285,15 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 				).isNotNull());
 		}
 
+		Date startDate = _getStartDate(rangeEnd, rangeKey, rangeStart);
+
+		if (startDate == null) {
+			return predicate;
+		}
+
 		if (!previous) {
 			predicate = predicate.and(
-				ObjectEntryTable.INSTANCE.createDate.gte(
-					_getStartDate(rangeKey, rangeStart)));
+				ObjectEntryTable.INSTANCE.createDate.gte(startDate));
 
 			if (Validator.isNotNull(rangeEnd)) {
 				predicate = predicate.and(
@@ -301,8 +306,7 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 				ObjectEntryTable.INSTANCE.createDate.gte(
 					_getPreviousStartDate(rangeEnd, rangeKey, rangeStart))
 			).and(
-				ObjectEntryTable.INSTANCE.createDate.lt(
-					_getStartDate(rangeKey, rangeStart))
+				ObjectEntryTable.INSTANCE.createDate.lt(startDate)
 			);
 		}
 
@@ -316,7 +320,7 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 
 		if (Validator.isNotNull(rangeEnd) && Validator.isNotNull(rangeStart)) {
 			try {
-				calendar.setTime(_getStartDate(null, rangeStart));
+				calendar.setTime(_getStartDate(rangeEnd, null, rangeStart));
 
 				DateFormat dateFormat = _getDateFormat();
 
@@ -331,8 +335,11 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 				}
 			}
 		}
-		else {
+		else if (rangeKey != null) {
 			calendar.add(Calendar.DAY_OF_MONTH, -(rangeKey * 2));
+		}
+		else {
+			return null;
 		}
 
 		calendar.set(Calendar.HOUR_OF_DAY, 0);
@@ -399,10 +406,12 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 		return GetterUtil.getLong(results.get(0));
 	}
 
-	private Date _getStartDate(Integer rangeKey, String rangeStart) {
+	private Date _getStartDate(
+		String rangeEnd, Integer rangeKey, String rangeStart) {
+
 		Calendar calendar = Calendar.getInstance();
 
-		if (Validator.isNotNull(rangeStart)) {
+		if (Validator.isNotNull(rangeEnd) && Validator.isNotNull(rangeStart)) {
 			try {
 				DateFormat dateFormat = _getDateFormat();
 
@@ -414,8 +423,11 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 				}
 			}
 		}
-		else {
+		else if (rangeKey != null) {
 			calendar.add(Calendar.DAY_OF_MONTH, -rangeKey);
+		}
+		else {
+			return null;
 		}
 
 		calendar.set(Calendar.HOUR_OF_DAY, 0);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
@@ -17,7 +17,7 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
-import jakarta.ws.rs.BadRequestException;
+import jakarta.validation.ValidationException;
 
 import java.util.Arrays;
 
@@ -81,7 +81,7 @@ public class PerformanceAssetConsumptionResourceImpl
 			!StringUtil.equalsIgnoreCase(groupBy, "tag") &&
 			!StringUtil.equalsIgnoreCase(groupBy, "vocabulary")) {
 
-			throw new BadRequestException("Invalid group by: " + groupBy);
+			throw new ValidationException("Invalid group by: " + groupBy);
 		}
 	}
 

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
@@ -16,7 +16,8 @@ import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 
-import jakarta.ws.rs.BadRequestException;
+import jakarta.validation.ValidationException;
+
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
@@ -106,7 +107,7 @@ public class PerformanceMetricResourceImpl
 			return "/geolocation";
 		}
 
-		throw new BadRequestException("Invalid group by: " + groupBy);
+		throw new ValidationException("Invalid group by: " + groupBy);
 	}
 
 	private void _validateMetricType(String metricType) {
@@ -115,7 +116,7 @@ public class PerformanceMetricResourceImpl
 			!StringUtil.equalsIgnoreCase(metricType, "readsMetric") &&
 			!StringUtil.equalsIgnoreCase(metricType, "viewsMetric")) {
 
-			throw new BadRequestException("Invalid metric type: " + metricType);
+			throw new ValidationException("Invalid metric type: " + metricType);
 		}
 	}
 

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/util/DateRangeUtil.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/util/DateRangeUtil.java
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.internal.resource.v1_0.util;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class DateRangeUtil {
+
+	public static Date getEndDate(String rangeEnd) {
+		try {
+			Calendar calendar = Calendar.getInstance();
+
+			DateFormat dateFormat = _getDateFormat();
+
+			calendar.setTime(dateFormat.parse(rangeEnd));
+
+			calendar.set(Calendar.HOUR_OF_DAY, 23);
+			calendar.set(Calendar.MILLISECOND, 59);
+			calendar.set(Calendar.MINUTE, 59);
+			calendar.set(Calendar.SECOND, 59);
+
+			return calendar.getTime();
+		}
+		catch (ParseException parseException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(parseException);
+			}
+		}
+
+		return null;
+	}
+
+	public static Date getPreviousStartDate(
+		String rangeEnd, Integer rangeKey, String rangeStart) {
+
+		Calendar calendar = Calendar.getInstance();
+
+		if (Validator.isNotNull(rangeEnd) && Validator.isNotNull(rangeStart)) {
+			try {
+				calendar.setTime(getStartDate(rangeEnd, null, rangeStart));
+
+				DateFormat dateFormat = _getDateFormat();
+
+				int delta = DateUtil.getDaysBetween(
+					dateFormat.parse(rangeStart), dateFormat.parse(rangeEnd));
+
+				calendar.add(Calendar.DAY_OF_MONTH, -delta);
+			}
+			catch (ParseException parseException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(parseException);
+				}
+			}
+		}
+		else if (rangeKey != null) {
+			calendar.add(Calendar.DAY_OF_MONTH, -(rangeKey * 2));
+		}
+		else {
+			return null;
+		}
+
+		calendar.set(Calendar.HOUR_OF_DAY, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+
+		return calendar.getTime();
+	}
+
+	public static Date getStartDate(
+		String rangeEnd, Integer rangeKey, String rangeStart) {
+
+		Calendar calendar = Calendar.getInstance();
+
+		if (Validator.isNotNull(rangeEnd) && Validator.isNotNull(rangeStart)) {
+			try {
+				DateFormat dateFormat = _getDateFormat();
+
+				calendar.setTime(dateFormat.parse(rangeStart));
+			}
+			catch (ParseException parseException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(parseException);
+				}
+			}
+		}
+		else if (rangeKey != null) {
+			calendar.add(Calendar.DAY_OF_MONTH, -rangeKey);
+		}
+		else {
+			return null;
+		}
+
+		calendar.set(Calendar.HOUR_OF_DAY, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+
+		return calendar.getTime();
+	}
+
+	private static DateFormat _getDateFormat() {
+		return DateFormatFactoryUtil.getSimpleDateFormat("yyyy-MM-dd");
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(DateRangeUtil.class);
+
+}

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/util/DateRangeUtil.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/util/DateRangeUtil.java
@@ -5,11 +5,11 @@
 
 package com.liferay.analytics.cms.rest.internal.resource.v1_0.util;
 
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.Validator;
+
+import jakarta.validation.ValidationException;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -23,27 +23,16 @@ import java.util.Date;
 public class DateRangeUtil {
 
 	public static Date getEndDate(String rangeEnd) {
-		try {
-			Calendar calendar = Calendar.getInstance();
+		Calendar calendar = Calendar.getInstance();
 
-			DateFormat dateFormat = _getDateFormat();
+		calendar.setTime(_parseRangeEnd(rangeEnd));
 
-			calendar.setTime(dateFormat.parse(rangeEnd));
+		calendar.set(Calendar.HOUR_OF_DAY, 23);
+		calendar.set(Calendar.MILLISECOND, 59);
+		calendar.set(Calendar.MINUTE, 59);
+		calendar.set(Calendar.SECOND, 59);
 
-			calendar.set(Calendar.HOUR_OF_DAY, 23);
-			calendar.set(Calendar.MILLISECOND, 59);
-			calendar.set(Calendar.MINUTE, 59);
-			calendar.set(Calendar.SECOND, 59);
-
-			return calendar.getTime();
-		}
-		catch (ParseException parseException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(parseException);
-			}
-		}
-
-		return null;
+		return calendar.getTime();
 	}
 
 	public static Date getPreviousStartDate(
@@ -52,21 +41,12 @@ public class DateRangeUtil {
 		Calendar calendar = Calendar.getInstance();
 
 		if (Validator.isNotNull(rangeEnd) && Validator.isNotNull(rangeStart)) {
-			try {
-				calendar.setTime(getStartDate(rangeEnd, null, rangeStart));
+			calendar.setTime(getStartDate(rangeEnd, null, rangeStart));
 
-				DateFormat dateFormat = _getDateFormat();
+			int delta = DateUtil.getDaysBetween(
+				_parseRangeStart(rangeStart), _parseRangeEnd(rangeEnd));
 
-				int delta = DateUtil.getDaysBetween(
-					dateFormat.parse(rangeStart), dateFormat.parse(rangeEnd));
-
-				calendar.add(Calendar.DAY_OF_MONTH, -delta);
-			}
-			catch (ParseException parseException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(parseException);
-				}
-			}
+			calendar.add(Calendar.DAY_OF_MONTH, -delta);
 		}
 		else if (rangeKey != null) {
 			calendar.add(Calendar.DAY_OF_MONTH, -(rangeKey * 2));
@@ -89,16 +69,7 @@ public class DateRangeUtil {
 		Calendar calendar = Calendar.getInstance();
 
 		if (Validator.isNotNull(rangeEnd) && Validator.isNotNull(rangeStart)) {
-			try {
-				DateFormat dateFormat = _getDateFormat();
-
-				calendar.setTime(dateFormat.parse(rangeStart));
-			}
-			catch (ParseException parseException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(parseException);
-				}
-			}
+			calendar.setTime(_parseRangeStart(rangeStart));
 		}
 		else if (rangeKey != null) {
 			calendar.add(Calendar.DAY_OF_MONTH, -rangeKey);
@@ -119,6 +90,28 @@ public class DateRangeUtil {
 		return DateFormatFactoryUtil.getSimpleDateFormat("yyyy-MM-dd");
 	}
 
-	private static final Log _log = LogFactoryUtil.getLog(DateRangeUtil.class);
+	private static Date _parseRangeEnd(String rangeEnd) {
+		try {
+			DateFormat dateFormat = _getDateFormat();
+
+			return dateFormat.parse(rangeEnd);
+		}
+		catch (ParseException parseException) {
+			throw new ValidationException(
+				"Invalid range end: " + rangeEnd, parseException);
+		}
+	}
+
+	private static Date _parseRangeStart(String rangeStart) {
+		try {
+			DateFormat dateFormat = _getDateFormat();
+
+			return dateFormat.parse(rangeStart);
+		}
+		catch (ParseException parseException) {
+			throw new ValidationException(
+				"Invalid range start: " + rangeStart, parseException);
+		}
+	}
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/build.gradle
+++ b/modules/apps/analytics/analytics-cms-rest-test/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.test", version: "default"
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.test.integration", version: "default"
 	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
+	testIntegrationImplementation group: "jakarta.validation", name: "jakarta.validation-api", version: "3.1.0"
 	testIntegrationImplementation project(":apps:analytics:analytics-cms-rest-api")
 	testIntegrationImplementation project(":apps:analytics:analytics-cms-rest-client")
 	testIntegrationImplementation project(":apps:analytics:analytics-settings-api")

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/InventoryAnalysisResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/InventoryAnalysisResourceTest.java
@@ -142,6 +142,27 @@ public class InventoryAnalysisResourceTest
 		Assert.assertEquals(1L, (long)inventoryAnalysisItem.getCount());
 
 		Assert.assertEquals("Category", inventoryAnalysisItem.getTitle());
+
+		_assertInventoryAnalysis(
+			inventoryAnalysisResource.getInventoryAnalysis(
+				null, _depotEntry.getDepotEntryId(), null, null, null, 7, null,
+				null, null, null, null),
+			3, 5L, null);
+
+		_assertInventoryAnalysis(
+			inventoryAnalysisResource.getInventoryAnalysis(
+				null, _depotEntry.getDepotEntryId(), null, null, null, -1, null,
+				null, null, null, null),
+			0, 0L, null);
+	}
+
+	@Test
+	public void testGetInventoryAnalysisWithoutSpaces() throws Exception {
+		_assertInventoryAnalysis(
+			inventoryAnalysisResource.getInventoryAnalysis(
+				null, null, null, null, null, null, null, null, null, null,
+				null),
+			0, 0L, null);
 	}
 
 	private void _assertInventoryAnalysis(

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
@@ -7,6 +7,7 @@ package com.liferay.analytics.cms.rest.resource.v1_0.test;
 
 import com.liferay.analytics.cms.rest.client.dto.v1_0.Overview;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.Trend;
+import com.liferay.analytics.cms.rest.client.problem.Problem;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.entry.rel.model.AssetEntryAssetCategoryRel;
 import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalService;
@@ -28,6 +29,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -207,6 +209,16 @@ public class OverviewResourceTest extends BaseOverviewResourceTestCase {
 			},
 			overviewResource.getContentOverview(
 				null, null, _getRangeDate(0), null, null));
+
+		_assertBadRequest(
+			"Invalid range end: not a date",
+			() -> overviewResource.getContentOverview(
+				null, null, "not a date", null, _getRangeDate(-7)));
+
+		_assertBadRequest(
+			"Invalid range start: not a date",
+			() -> overviewResource.getContentOverview(
+				null, null, _getRangeDate(0), null, "not a date"));
 	}
 
 	@Override
@@ -290,6 +302,23 @@ public class OverviewResourceTest extends BaseOverviewResourceTestCase {
 			},
 			overviewResource.getFileOverview(
 				null, null, null, null, _getRangeDate(-7)));
+	}
+
+	private void _assertBadRequest(
+			String expectedTitle, UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try {
+			unsafeRunnable.run();
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+			Assert.assertEquals(expectedTitle, problem.getTitle());
+		}
 	}
 
 	private String _getRangeDate(int days) {

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -46,6 +47,9 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import java.io.ByteArrayInputStream;
 import java.io.Serializable;
 
+import java.text.DateFormat;
+
+import java.util.Calendar;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -160,6 +164,49 @@ public class OverviewResourceTest extends BaseOverviewResourceTestCase {
 				}
 			},
 			overviewResource.getContentOverview(null, null, null, 7, null));
+
+		Trend neutralTrend = new Trend();
+
+		neutralTrend.setClassification(Trend.Classification.NEUTRAL);
+		neutralTrend.setPercentage(0.0);
+
+		Assert.assertEquals(
+			new Overview() {
+				{
+					categoriesCount = 2L;
+					tagsCount = 1L;
+					totalCount = 3L;
+					trend = neutralTrend;
+					vocabulariesCount = 1L;
+				}
+			},
+			overviewResource.getContentOverview(null, null, null, null, null));
+
+		Assert.assertEquals(
+			new Overview() {
+				{
+					categoriesCount = 2L;
+					tagsCount = 1L;
+					totalCount = 3L;
+					trend = neutralTrend;
+					vocabulariesCount = 1L;
+				}
+			},
+			overviewResource.getContentOverview(
+				null, null, null, null, _getRangeDate(-7)));
+
+		Assert.assertEquals(
+			new Overview() {
+				{
+					categoriesCount = 2L;
+					tagsCount = 1L;
+					totalCount = 3L;
+					trend = neutralTrend;
+					vocabulariesCount = 1L;
+				}
+			},
+			overviewResource.getContentOverview(
+				null, null, _getRangeDate(0), null, null));
 	}
 
 	@Override
@@ -213,6 +260,47 @@ public class OverviewResourceTest extends BaseOverviewResourceTestCase {
 				}
 			},
 			overviewResource.getFileOverview(null, null, null, 7, null));
+
+		Trend neutralTrend = new Trend();
+
+		neutralTrend.setClassification(Trend.Classification.NEUTRAL);
+		neutralTrend.setPercentage(0.0);
+
+		Assert.assertEquals(
+			new Overview() {
+				{
+					categoriesCount = 0L;
+					tagsCount = 0L;
+					totalCount = 1L;
+					trend = neutralTrend;
+					vocabulariesCount = 0L;
+				}
+			},
+			overviewResource.getFileOverview(null, null, null, null, null));
+
+		Assert.assertEquals(
+			new Overview() {
+				{
+					categoriesCount = 0L;
+					tagsCount = 0L;
+					totalCount = 1L;
+					trend = neutralTrend;
+					vocabulariesCount = 0L;
+				}
+			},
+			overviewResource.getFileOverview(
+				null, null, null, null, _getRangeDate(-7)));
+	}
+
+	private String _getRangeDate(int days) {
+		Calendar calendar = Calendar.getInstance();
+
+		calendar.add(Calendar.DAY_OF_MONTH, days);
+
+		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd");
+
+		return dateFormat.format(calendar.getTime());
 	}
 
 	private void _setUpCMSContext() throws Exception {

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -38,7 +38,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
-import jakarta.ws.rs.BadRequestException;
+import jakarta.validation.ValidationException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -351,7 +351,7 @@ public class PerformanceAssetConsumptionResourceTest
 
 	private void _testGetPerformanceAssetConsumptionWithInvalidGroupBy() {
 		Assert.assertThrows(
-			BadRequestException.class,
+			ValidationException.class,
 			() ->
 				_performanceAssetConsumptionResource.
 					getPerformanceAssetConsumption(

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
@@ -36,7 +36,8 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import jakarta.ws.rs.BadRequestException;
+import jakarta.validation.ValidationException;
+
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
@@ -309,7 +310,7 @@ public class PerformanceMetricResourceTest
 
 	private void _testGetPerformanceMetricExportWithInvalidMetricType() {
 		Assert.assertThrows(
-			BadRequestException.class,
+			ValidationException.class,
 			() -> _performanceMetricResource.getPerformanceMetricExport(
 				TransformUtil.transformToArray(
 					_depotEntries, DepotEntry::getDepotEntryId, Long.class),
@@ -319,7 +320,7 @@ public class PerformanceMetricResourceTest
 
 	private void _testGetPerformanceMetricWithInvalidMetricType() {
 		Assert.assertThrows(
-			BadRequestException.class,
+			ValidationException.class,
 			() -> _performanceMetricResource.getPerformanceMetric(
 				TransformUtil.transformToArray(
 					_depotEntries, DepotEntry::getDepotEntryId, Long.class),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102099

## What Is Being Fixed

`/content-overview` and `/file-overview` answered HTTP 500 when `rangeKey` was omitted, because the optional parameter was unboxed to compute the lower bound of the date filter. None of the three range parameters is required by the served `openapi.json`, so such a request is valid and must be answered.

The same defect had three more entrances. A request carrying only `rangeStart`, and one carrying only `rangeEnd`, reached it through the trend query. And an unparseable range end was swallowed into a null that reached the `lte` condition, where PostgreSQL aborted the query comparing a `timestamp` with a `bytea` — while an unparseable range start silently became today, so the answer covered a window the caller never asked for.

Two neighbouring defects turned up while fixing it. `/inventory-analysis` answered HTTP 400 on an instance with no space, because the predicate built `groupId.in(groupIds)` with an empty array. And it published `rangeKey` in its `openapi.json` while the parameter filtered nothing, since its date predicate was guarded by `rangeStart` and its local copy of the helper preferred `rangeStart` over `rangeKey`, leaving the `rangeKey` branch unreachable.

## How It Is Being Fixed

The range is resolved as a whole, the way `BaseRestController.getTimeRange` resolves a time range on the Analytics Cloud side: a custom range needs both of its ends, otherwise fall back to `rangeKey`, and otherwise there is no range at all. With no range there is no date filtering, which is what the platform already does elsewhere — `AnalyticsCloudClient` omits an absent `rangeKey` from the outgoing URL, and a null time range leaves the date condition out of the `WHERE` clause. Resolving the previous start date the same way keeps both queries describing the same range, which they did not when one preferred the range start and the other preferred `rangeKey`.

Since the two resources each carried their own copy of the helpers, and that divergence is precisely the `rangeKey` defect, the resolution is extracted into `DateRangeUtil` first as a pure move, and the divergent copy is replaced after.

An unparseable range is now reported as HTTP 400 naming the offending parameter, through a `ValidationException`, which `ValidationExceptionMapper` turns into the same status and title without logging. The two `BadRequestException` cases the application already had move to the same form, because `WebApplicationExceptionMapper` logs every `WebApplicationException` at ERROR and a malformed request left a server error in the log.

The frontend is unaffected throughout: `buildQueryString` drops empty values, so the dashboard only ever sends a lone `rangeKey` or both custom ends, and `InventoryAnalysisCard` sends no range parameter at all.

## PR Check

**pr-check: PASS** — tested on `a9a5d903c4130`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a9a5d903c4130017a81db5ca06e3dad1a450a3c2"} -->
