### PR TITLE
LPD-102122 Return a clear error when Analytics Cloud is not configured

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ObjectEntryAcquisitionChannelResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ObjectEntryAcquisitionChannelResourceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryAcquisitionChannel;
 import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.resource.v1_0.ObjectEntryAcquisitionChannelResource;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -35,6 +36,9 @@ public class ObjectEntryAcquisitionChannelResourceImpl
 		throws Exception {
 
 		LicenseManagerUtil.checkFreeTier();
+
+		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
+			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
 			_http);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ObjectEntryHistogramMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ObjectEntryHistogramMetricResourceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryHistogramMetric;
 import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.resource.v1_0.ObjectEntryHistogramMetricResource;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.util.Http;
 
@@ -34,6 +35,9 @@ public class ObjectEntryHistogramMetricResourceImpl
 		throws Exception {
 
 		LicenseManagerUtil.checkFreeTier();
+
+		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
+			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
 			_http);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ObjectEntryMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ObjectEntryMetricResourceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryMetric;
 import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.resource.v1_0.ObjectEntryMetricResource;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.util.Http;
 
@@ -33,6 +34,9 @@ public class ObjectEntryMetricResourceImpl
 		throws Exception {
 
 		LicenseManagerUtil.checkFreeTier();
+
+		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
+			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
 			_http);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ObjectEntryTopPagesResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ObjectEntryTopPagesResourceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.analytics.cms.rest.dto.v1_0.ObjectEntryTopPages;
 import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.resource.v1_0.ObjectEntryTopPagesResource;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.util.Http;
 
@@ -32,6 +33,9 @@ public class ObjectEntryTopPagesResourceImpl
 		throws Exception {
 
 		LicenseManagerUtil.checkFreeTier();
+
+		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
+			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
 			_http);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceAssetConsumptionResource;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
@@ -46,6 +47,9 @@ public class PerformanceAssetConsumptionResourceImpl
 		LicenseManagerUtil.checkFreeTier();
 
 		_validateGroupBy(groupBy);
+
+		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
+			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
 			DepotEntryUtil.getDepotEntries(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceHistogramMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceHistogramMetricResourceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceHistogramMetricResource;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.util.Http;
 
@@ -36,6 +37,9 @@ public class PerformanceHistogramMetricResourceImpl
 		throws Exception {
 
 		LicenseManagerUtil.checkFreeTier();
+
+		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
+			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
 			_http);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceMetricResource;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
@@ -50,6 +51,9 @@ public class PerformanceMetricResourceImpl
 
 		_validateMetricType(metricType);
 
+		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
+			_analyticsSettingsManager, contextCompany.getCompanyId());
+
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
 			DepotEntryUtil.getDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
@@ -72,6 +76,9 @@ public class PerformanceMetricResourceImpl
 		LicenseManagerUtil.checkFreeTier();
 
 		_validateMetricType(metricType);
+
+		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
+			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
 			DepotEntryUtil.getDepotEntries(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceOverviewMetricResource;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.util.Http;
 
@@ -36,6 +37,9 @@ public class PerformanceOverviewMetricResourceImpl
 		throws Exception {
 
 		LicenseManagerUtil.checkFreeTier();
+
+		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
+			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
 			DepotEntryUtil.getDepotEntries(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
@@ -10,6 +10,7 @@ import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceTopAssetResource;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -66,6 +67,9 @@ public class PerformanceTopAssetResourceImpl
 
 		LicenseManagerUtil.checkFreeTier();
 
+		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
+			_analyticsSettingsManager, contextCompany.getCompanyId());
+
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
 			DepotEntryUtil.getDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
@@ -96,6 +100,9 @@ public class PerformanceTopAssetResourceImpl
 		throws Exception {
 
 		LicenseManagerUtil.checkFreeTier();
+
+		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
+			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
 			_http);

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceHistogramMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceHistogramMetricResourceTest.java
@@ -30,6 +30,8 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import jakarta.ws.rs.ForbiddenException;
+
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -156,6 +158,17 @@ public class PerformanceHistogramMetricResourceTest
 			ReflectionTestUtil.setFieldValue(
 				_performanceHistogramMetricResource, "_http", _http);
 		}
+	}
+
+	@Test
+	public void testGetPerformanceHistogramMetricWithAnalyticsCloudNotConnected() {
+		Assert.assertThrows(
+			ForbiddenException.class,
+			() ->
+				_performanceHistogramMetricResource.
+					getPerformanceHistogramMetric(
+						new Long[] {_depotEntry.getDepotEntryId()},
+						RandomTestUtil.nextInt(), "downloadsMetric"));
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
@@ -37,6 +37,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
@@ -88,6 +89,7 @@ public class PerformanceMetricResourceTest
 		_testGetPerformanceMetric(
 			"location", "downloadsMetric",
 			"/api/1.0/asset-metric/objectEntry/geolocation");
+		_testGetPerformanceMetricWithAnalyticsCloudNotConnected();
 		_testGetPerformanceMetricWithInvalidMetricType();
 		_testGetPerformanceMetricWithNoData();
 	}
@@ -101,6 +103,7 @@ public class PerformanceMetricResourceTest
 		_testGetPerformanceMetricExport(
 			"location", "downloadsMetric",
 			"/api/1.0/asset-metric/objectEntry/geolocation/export");
+		_testGetPerformanceMetricExportWithAnalyticsCloudNotConnected();
 		_testGetPerformanceMetricExportWithInvalidMetricType();
 	}
 
@@ -307,6 +310,15 @@ public class PerformanceMetricResourceTest
 		}
 	}
 
+	private void _testGetPerformanceMetricExportWithAnalyticsCloudNotConnected() {
+		Assert.assertThrows(
+			ForbiddenException.class,
+			() -> _performanceMetricResource.getPerformanceMetricExport(
+				TransformUtil.transformToArray(
+					_depotEntries, DepotEntry::getDepotEntryId, Long.class),
+				"categories", "viewsMetric", RandomTestUtil.nextInt()));
+	}
+
 	private void _testGetPerformanceMetricExportWithInvalidMetricType() {
 		Assert.assertThrows(
 			BadRequestException.class,
@@ -315,6 +327,15 @@ public class PerformanceMetricResourceTest
 					_depotEntries, DepotEntry::getDepotEntryId, Long.class),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				RandomTestUtil.nextInt()));
+	}
+
+	private void _testGetPerformanceMetricWithAnalyticsCloudNotConnected() {
+		Assert.assertThrows(
+			ForbiddenException.class,
+			() -> _performanceMetricResource.getPerformanceMetric(
+				TransformUtil.transformToArray(
+					_depotEntries, DepotEntry::getDepotEntryId, Long.class),
+				"categories", "viewsMetric", RandomTestUtil.nextInt()));
 	}
 
 	private void _testGetPerformanceMetricWithInvalidMetricType() {

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
@@ -30,6 +30,8 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import jakarta.ws.rs.ForbiddenException;
+
 import java.util.Collections;
 
 import org.junit.Assert;
@@ -176,6 +178,16 @@ public class PerformanceOverviewMetricResourceTest
 			ReflectionTestUtil.setFieldValue(
 				_performanceOverviewMetricResource, "_http", _http);
 		}
+	}
+
+	@Test
+	public void testGetPerformanceOverviewMetricWithAnalyticsCloudNotConnected() {
+		Assert.assertThrows(
+			ForbiddenException.class,
+			() ->
+				_performanceOverviewMetricResource.getPerformanceOverviewMetric(
+					new Long[] {_depotEntry.getDepotEntryId()},
+					RandomTestUtil.nextInt()));
 	}
 
 	private void _assertMetric(

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
@@ -94,6 +95,15 @@ public class PerformanceTopAssetResourceTest
 		}
 	}
 
+	@Test
+	public void testGetPerformanceTopAssetExportWithAnalyticsCloudNotConnected() {
+		Assert.assertThrows(
+			ForbiddenException.class,
+			() -> _performanceTopAssetResource.getPerformanceTopAssetExport(
+				null, RandomTestUtil.nextInt(), RandomTestUtil.randomString(),
+				null, null));
+	}
+
 	@Override
 	@Test
 	public void testGetPerformanceTopAssetPage() throws Exception {
@@ -123,6 +133,15 @@ public class PerformanceTopAssetResourceTest
 			ReflectionTestUtil.setFieldValue(
 				_performanceTopAssetResource, "_http", _http);
 		}
+	}
+
+	@Test
+	public void testGetPerformanceTopAssetPageWithAnalyticsCloudNotConnected() {
+		Assert.assertThrows(
+			ForbiddenException.class,
+			() -> _performanceTopAssetResource.getPerformanceTopAssetPage(
+				null, RandomTestUtil.nextInt(), RandomTestUtil.randomString(),
+				null, Pagination.of(1, 10), null));
 	}
 
 	@Override

--- a/modules/apps/analytics/analytics-settings-rest-api/bnd.bnd
+++ b/modules/apps/analytics/analytics-settings-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Analytics Settings REST API
 Bundle-SymbolicName: com.liferay.analytics.settings.rest.api
-Bundle-Version: 8.1.6
+Bundle-Version: 8.2.0
 Export-Package:\
 	com.liferay.analytics.settings.rest.constants,\
 	com.liferay.analytics.settings.rest.dto.v1_0,\

--- a/modules/apps/analytics/analytics-settings-rest-api/src/main/java/com/liferay/analytics/settings/rest/util/AnalyticsSettingsManagerUtil.java
+++ b/modules/apps/analytics/analytics-settings-rest-api/src/main/java/com/liferay/analytics/settings/rest/util/AnalyticsSettingsManagerUtil.java
@@ -9,11 +9,21 @@ import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.portal.kernel.model.Group;
 
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
 
 /**
  * @author Rachael Koestartyo
  */
 public class AnalyticsSettingsManagerUtil {
+
+	public static void checkAnalyticsEnabled(
+			AnalyticsSettingsManager analyticsSettingsManager, long companyId)
+		throws Exception {
+
+		if (!analyticsSettingsManager.isAnalyticsEnabled(companyId)) {
+			throw new ForbiddenException("Analytics Cloud is not configured");
+		}
+	}
 
 	public static void checkSiteIdSynced(
 			AnalyticsSettingsManager analyticsSettingsManager, Group group)

--- a/modules/apps/analytics/analytics-settings-rest-api/src/main/resources/com/liferay/analytics/settings/rest/util/packageinfo
+++ b/modules/apps/analytics/analytics-settings-rest-api/src/main/resources/com/liferay/analytics/settings/rest/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102122

## What Is Being Fixed

With no Analytics Cloud configuration the configured backend URL is blank, so every performance endpoint under `/o/analytics-cms-rest/v1.0` built a location with no host. The resulting `IllegalArgumentException` reached the client as a 400 titled "Host name may not be null", exposing an internal exception class and telling the caller nothing about the actual problem. The status was wrong too: the request was valid, the server was unconfigured.

The reporter hit `performance-top-asset`, `performance-overview-metric` and `performance-histogram-metric`, but all nine resources that call Analytics Cloud failed the same way.

## How It Is Being Fixed

`AnalyticsSettingsManagerUtil` gains a `checkAnalyticsEnabled` method next to its twin `checkSiteIdSynced`, throwing a `ForbiddenException` that reports Analytics Cloud is not configured. It reuses the existing `AnalyticsSettingsManager.isAnalyticsEnabled` predicate, which checks exactly the three configuration values that are blank when Analytics Cloud is not set up. Adding a method to that exported package required the `packageinfo` and `Bundle-Version` bumps.

The eleven call sites across the nine resources call it after validating the request, so an invalid parameter still reports as a bad request rather than as a configuration problem. 403 follows the closest precedent for an unconfigured subsystem, `CaptchaResourceImpl`; `checkSiteIdSynced` answers 400 because it judges a request parameter, while this check reports server state.

Note that `performance-top-asset/export` and `performance-metric/export` will keep answering 500 for an `Accept: text/csv` request until LPD-102125 is fixed, because the `Problem` entity has no writer for that content type.

## PR Check

**pr-check: PASS** — tested on `53c55bf06e17176b6d8c364dada563fa28ff3bf4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "53c55bf06e17176b6d8c364dada563fa28ff3bf4"} -->
