### PR TITLE
LPD-100731 Enable all campaigns when saving a Salesforce data source

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/__tests__/data-source.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/__tests__/data-source.js
@@ -1,7 +1,12 @@
 jest.mock('shared/util/request');
 
 import sendRequest from 'shared/util/request';
-import {createLiferay, updateLiferay} from '../data-source';
+import {
+	createLiferay,
+	createSalesforce,
+	updateLiferay,
+	updateSalesforce,
+} from '../data-source';
 
 const commonLiferayArgs = {
 	credentials: {
@@ -38,6 +43,58 @@ describe('Data Source API', () => {
 				data: dataArgs,
 				method: 'PATCH',
 				path: 'contacts/23/data_source/1/liferay',
+			});
+		});
+	});
+
+	describe('Salesforce Data Sources', () => {
+		it('should enable all campaigns when CREATING a salesforce data source', () => {
+			createSalesforce({
+				accountsConfiguration: {enableAllAccounts: true},
+				groupId: '23',
+				name: 'test',
+			});
+
+			expect(sendRequest).toHaveBeenCalledWith({
+				data: {
+					accountsConfiguration: {enableAllAccounts: true},
+					campaignsConfiguration: {enableAllCampaigns: true},
+					name: 'test',
+				},
+				method: 'POST',
+				path: 'contacts/23/data_source/salesforce',
+			});
+		});
+
+		it('should enable all campaigns when UPDATING a salesforce data source', () => {
+			updateSalesforce({
+				accountsConfiguration: {enableAllAccounts: true},
+				groupId: '23',
+				id: '1',
+				name: 'test',
+			});
+
+			expect(sendRequest).toHaveBeenCalledWith({
+				data: {
+					accountsConfiguration: {enableAllAccounts: true},
+					campaignsConfiguration: {enableAllCampaigns: true},
+					name: 'test',
+				},
+				method: 'PATCH',
+				path: 'contacts/23/data_source/1/salesforce',
+			});
+		});
+
+		it('should enable all campaigns when UPDATING only the name', () => {
+			updateSalesforce({groupId: '23', id: '1', name: 'test'});
+
+			expect(sendRequest).toHaveBeenCalledWith({
+				data: {
+					campaignsConfiguration: {enableAllCampaigns: true},
+					name: 'test',
+				},
+				method: 'PATCH',
+				path: 'contacts/23/data_source/1/salesforce',
 			});
 		});
 	});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/data-source.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/data-source.js
@@ -333,6 +333,9 @@ export function createSalesforce({
 	return sendRequest({
 		data: {
 			...data,
+			campaignsConfiguration: {
+				enableAllCampaigns: true,
+			},
 			name,
 		},
 		method: 'POST',
@@ -459,6 +462,9 @@ export function updateSalesforce({
 	return sendRequest({
 		data: {
 			...data,
+			campaignsConfiguration: {
+				enableAllCampaigns: true,
+			},
 			name,
 		},
 		method: 'PATCH',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100731

## What Is Being Fixed

Saving a Salesforce data source threw a NullPointerException. The Salesforce extractor unboxes `DataSource.getEnableAllCampaigns()` without a null check, and the web client never sent a `campaignsConfiguration` block, so the getter returned null on every request and the save failed at `SalesforceExtractorConfigurationImpl.setCampaignsConfiguration`.

## How It Is Being Fixed

Both `createSalesforce` and `updateSalesforce` now always send `campaignsConfiguration` with `enableAllCampaigns` set to true, the value agreed on the ticket. The block is added alongside `name` in the final payload rather than inside the `pickBy` filter, since it is unconditional rather than dependent on a caller argument, and it is hardcoded in the API helpers rather than threaded through as a parameter so that every call path is covered. That last point matters for the overview page, which calls `updateSalesforce` with only a group ID, an ID, and a name when renaming a data source, and was therefore the most direct route to the crash. A dedicated campaigns toggle was deferred until the product decides whether one is wanted.

Note that the extractor remains vulnerable to the same NullPointerException for any other client that omits the field; making `setCampaignsConfiguration` null-safe is worth a follow-up on the backend.

## PR Check

**pr-check: PASS** — tested on `410d136fdff26657493e8b820e78e05a92b7b01a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| JavaScript Unit Tests | PASS |

The JavaScript Unit Tests row is reported from the module's full Jest suite (710 suites, 4037 tests, 584 snapshots) as executed by the Workspace Build `check` task on the tested SHA. The validation's own `Match` regex is anchored `^modules/` and does not fire for modules nested under `workspaces/`.

<!-- pr-check {"result": "success", "sha": "410d136fdff26657493e8b820e78e05a92b7b01a"} -->
