### PR TITLE
LPD-102051 Stop the segment membership chart throwing on click

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/Growth.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/Growth.tsx
@@ -338,7 +338,7 @@ export const SegmentGrowthChart: React.FC<ISegmentGrowthChartProps> = ({
 			return;
 		}
 
-		onSelectedPointChange(data?.activeTooltipIndex);
+		onSelectedPointChange?.(data?.activeTooltipIndex);
 	};
 
 	return (

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/__tests__/SegmentGrowthChart.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/components/__tests__/SegmentGrowthChart.tsx
@@ -306,4 +306,19 @@ describe('SegmentGrowthChart', () => {
 			container.querySelector('.recharts-wrapper')
 		).toBeInTheDocument();
 	});
+
+	it('does not throw when clicked without a selection handler', () => {
+		const {container} = render(
+			<SegmentGrowthChart data={chartData} hasSelectedPoint={false} />
+		);
+
+		const event = new MouseEvent('click', {bubbles: true});
+
+		Object.defineProperty(event, 'pageX', {value: 400});
+		Object.defineProperty(event, 'pageY', {value: 150});
+
+		expect(() =>
+			fireEvent(container.querySelector('.recharts-wrapper')!, event)
+		).not.toThrow();
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102051

## What Is Being Fixed

Clicking any point on the Segment Membership Trend chart threw `TypeError: onSelectedPointChange is not a function`. It affected both charts that render `SegmentGrowthChart`: the segment Membership tab and the Overview card.

LPD-73232 added the click handler and wired the callback only on the real time segment overview, which owned the selection state. The Membership tab and the Overview card never passed it, and LPD-100237 later removed the real time dashboard along with the one consumer that did, leaving the call with no handler anywhere.

## How It Is Being Fixed

The `onSelectedPointChange` prop is already declared optional on `ISegmentGrowthChartProps`, so the call site is what disagreed with the contract. Calling it optionally makes the two match, and a chart rendered without a handler now treats the click as a no-op.

Selecting a day to narrow the list below is deliberately not part of this change. That behavior was removed from batch segments in 2023 by LRAC-13139 and never re-added, and the backend does not support it for batch segments today, so it belongs to a separate story rather than this fix.

## PR Check

**pr-check: PASS** — tested on `3a7c424ab66804505d66eeea86db6e88e310b933`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "3a7c424ab66804505d66eeea86db6e88e310b933"} -->
