### PR TITLE
LPD-101700 Show the activity count on the individual activity stream

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/ProfileCardWithDataCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/ProfileCardWithDataCDP.tsx
@@ -7,6 +7,10 @@ import EventMetricQuery, {
 	EventMetricsData,
 	EventMetricsVariables,
 } from 'shared/queries/EventMetricQuery';
+import EventsTrendQuery, {
+	EventsTrendData,
+	EventsTrendVariables,
+} from 'shared/queries/EventsTrendQuery';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
 import React, {useMemo, useState} from 'react';
 import URLConstants from 'shared/util/url-constants';
@@ -69,6 +73,8 @@ const ProfileCardWithDataCDP: React.FC<IProfileCardWithDataCDPProps> = ({
 
 	const {groupId} = useParams<{groupId: string}>();
 
+	const safeRangeSelectors = getSafeRangeSelectors(rangeSelectors);
+
 	const activityResponse = useQuery<EventMetricsData, EventMetricsVariables>(
 		EventMetricQuery,
 		{
@@ -79,7 +85,7 @@ const ProfileCardWithDataCDP: React.FC<IProfileCardWithDataCDPProps> = ({
 				entityType: SessionEntityTypes.Individual,
 				interval,
 				keywords: query,
-				...getSafeRangeSelectors(rangeSelectors),
+				...safeRangeSelectors,
 			},
 		}
 	);
@@ -92,6 +98,20 @@ const ProfileCardWithDataCDP: React.FC<IProfileCardWithDataCDPProps> = ({
 	} = mapListResultsToProps(activityResponse, ({eventMetric}) => ({
 		items: mapEventMetricToActivityHistory(eventMetric),
 	}));
+
+	const trendResponse = useQuery<EventsTrendData, EventsTrendVariables>(
+		EventsTrendQuery,
+		{
+			fetchPolicy: fetchPolicyDefinition(rangeSelectors),
+			variables: {
+				channelId,
+				entityId,
+				entityType: SessionEntityTypes.Individual,
+				keywords: query,
+				...safeRangeSelectors,
+			},
+		}
+	);
 
 	const sessionsResponse = useQuery<UserSessionData, UserSessionVariables>(
 		UserSessionQuery,
@@ -154,6 +174,9 @@ const ProfileCardWithDataCDP: React.FC<IProfileCardWithDataCDPProps> = ({
 		onQueryChange('');
 		setSearchValue('');
 	};
+
+	const trendMetric =
+		trendResponse.data?.eventsByUserSessions?.totalEventsMetric;
 
 	const selected = hasSelectedPoint || selectedPoint !== undefined;
 
@@ -249,6 +272,11 @@ const ProfileCardWithDataCDP: React.FC<IProfileCardWithDataCDPProps> = ({
 			selectedPoint={selectedPoint}
 			sessionsMappedResults={sessionsMappedResults}
 			timeZoneId={timeZoneId}
+			trendSummary={{
+				classification: trendMetric?.trend?.trendClassification,
+				percentage: trendMetric?.trend?.percentage ?? 0,
+				value: trendMetric?.value ?? 0,
+			}}
 		/>
 	);
 };

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/ProfileCardWithDataCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/ProfileCardWithDataCDP.tsx
@@ -7,6 +7,7 @@ import {MemoryRouter, Route} from 'react-router-dom';
 import {MockedProvider} from '@apollo/client/testing';
 import {
 	mockEventMetrics,
+	mockEventsTrend,
 	mockPreferenceReq,
 	mockSessions,
 	mockTimeRangeReq,
@@ -41,6 +42,9 @@ describe('IndividualProfileCard', () => {
 				<MockedProvider
 					mocks={[
 						mockEventMetrics({
+							rangeKey: 30,
+						}),
+						mockEventsTrend({
 							rangeKey: 30,
 						}),
 						mockTimeRangeReq(),
@@ -79,12 +83,15 @@ describe('IndividualProfileCard', () => {
 		expect(getByPlaceholderText('Search')).toBeInTheDocument();
 	});
 
-	it('does not render the activities trend summary', async () => {
-		const {container} = render(
+	it('renders the activities count and the trend versus the previous period', async () => {
+		const {container, getByText} = render(
 			<DefaultComponent>
 				<MockedProvider
 					mocks={[
 						mockEventMetrics({
+							rangeKey: 30,
+						}),
+						mockEventsTrend({
 							rangeKey: 30,
 						}),
 						mockTimeRangeReq(),
@@ -120,7 +127,9 @@ describe('IndividualProfileCard', () => {
 
 		await waitForLoadingToBeRemoved(container);
 
-		expect(container.querySelector('.trend-summary')).toBeNull();
+		expect(container.querySelector('.trend-summary')).toBeInTheDocument();
+		expect(getByText('56 Activities')).toBeInTheDocument();
+		expect(getByText('22.5%')).toBeInTheDocument();
 	});
 
 	it('should clear search input when X clear button is clicked', async () => {
@@ -129,23 +138,30 @@ describe('IndividualProfileCard', () => {
 				<MockedProvider
 					mocks={[
 						mockEventMetrics(),
+						mockEventsTrend(),
 						mockTimeRangeReq(),
 						mockPreferenceReq(),
 						mockSessions(),
 						mockEventMetrics(),
+						mockEventsTrend(),
 						mockSessions(),
 						mockEventMetrics(),
+						mockEventsTrend(),
 						mockSessions(),
 						mockTimeRangeReq(),
 						mockEventMetrics(),
+						mockEventsTrend(),
 						mockSessions(),
 						mockTimeRangeReq(),
 						mockEventMetrics(searchKeyword),
+						mockEventsTrend(searchKeyword),
 						mockTimeRangeReq(),
 						mockSessions(searchKeyword),
 						mockEventMetrics(searchKeyword),
+						mockEventsTrend(searchKeyword),
 						mockSessions(searchKeyword),
 						mockEventMetrics(searchKeyword),
+						mockEventsTrend(searchKeyword),
 						mockSessions(searchKeyword),
 					]}
 				>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/ActivityStreamCard.tsx
@@ -66,8 +66,8 @@ interface IActivityStreamCardProps {
 /**
  * Shared activity-stream card used by both the account and individual detail
  * pages. It renders a search box, an optional trend summary (activities count
- * plus change versus the previous period — account only), the interactive
- * activities chart, a chart footer, and the paginated vertical timeline. The
+ * plus change versus the previous period), the interactive activities chart, a
+ * chart footer, and the paginated vertical timeline. The
  * card is presentational: each page owns its own queries and feeds the mapped
  * data, labels, and handlers in. Card title/description come from the wrapping
  * BaseCard, so each page keeps its own heading.

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/EventsTrendQuery.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/EventsTrendQuery.ts
@@ -1,0 +1,60 @@
+import {gql} from '@apollo/client';
+import {SessionEntityTypes} from 'shared/util/constants';
+import {TrendClassification} from 'segment/types';
+
+export interface EventsTrendData {
+	eventsByUserSessions: {
+		totalEventsMetric: {
+			previousValue: number;
+			trend: {
+				percentage: number;
+				trendClassification: TrendClassification;
+			};
+			value: number;
+		} | null;
+	};
+}
+
+export interface EventsTrendVariables {
+	channelId: string;
+	entityId: string;
+	entityType: SessionEntityTypes;
+	keywords?: string;
+	rangeEnd?: string | null;
+	rangeKey?: number | null;
+	rangeStart?: string | null;
+}
+
+export default gql`
+	query EventsTrend(
+		$channelId: String!
+		$entityId: String!
+		$entityType: EntityType!
+		$keywords: String
+		$rangeEnd: String
+		$rangeKey: Int
+		$rangeStart: String
+	) {
+		eventsByUserSessions(
+			channelId: $channelId
+			entityId: $entityId
+			entityType: $entityType
+			includeWebhookEvents: true
+			keywords: $keywords
+			page: 0
+			size: 1
+			rangeEnd: $rangeEnd
+			rangeKey: $rangeKey
+			rangeStart: $rangeStart
+		) {
+			totalEventsMetric {
+				previousValue
+				trend {
+					percentage
+					trendClassification
+				}
+				value
+			}
+		}
+	}
+`;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/test/graphql-data.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/test/graphql-data.js
@@ -14,6 +14,7 @@ import EventDefinitionQuery from 'event-analysis/queries/EventDefinitionQuery';
 import EventDefinitionsQuery from 'event-analysis/queries/EventDefinitionsQuery';
 import EventMetricQuery from 'shared/queries/EventMetricQuery';
 import EventPropertiesQuery from 'segment/segment-editor/dynamic/queries/EventPropertiesQuery';
+import EventsTrendQuery from 'shared/queries/EventsTrendQuery';
 import getInterestsQuery from 'contacts/queries/InterestsQuery';
 import IndividualInterestsQuery from 'shared/queries/IndividualInterestsQuery';
 import IndividualMetricsQuery from 'shared/queries/IndividualMetricsQuery';
@@ -2282,6 +2283,39 @@ export const mockSessions = (variables) => ({
 							'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36',
 					},
 				],
+			},
+		},
+	},
+});
+
+export const mockEventsTrend = (variables) => ({
+	request: {
+		query: EventsTrendQuery,
+		variables: {
+			channelId: '123123',
+			entityId: '0',
+			entityType: 'INDIVIDUAL',
+			keywords: '',
+			rangeEnd: null,
+			rangeKey: 30,
+			rangeStart: null,
+			...variables,
+		},
+	},
+	result: {
+		data: {
+			eventsByUserSessions: {
+				__typename: 'EventsByUserSession',
+				totalEventsMetric: {
+					__typename: 'Metric',
+					previousValue: 45,
+					trend: {
+						__typename: 'Trend',
+						percentage: 22.5,
+						trendClassification: 'POSITIVE',
+					},
+					value: 56,
+				},
 			},
 		},
 	},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101700

## What Is Being Fixed

The activity stream of an individual profile shows no total activity count. The account activity stream shows one — the number of events in the selected period plus the change versus the previous period — and the individual one used to show a count as well, until LPD-97795 moved the individual card onto the shared activity stream card. That card renders the block only when a page feeds it a trend summary, and only the account page did.

## How It Is Being Fixed

The individual card now feeds the same trend summary as the account card, so both read the same block from the shared card. The count comes from a new EventsTrendQuery, a copy of the sibling AccountEventsTrendQuery with the accountId argument dropped, because eventsByUserSessions is the only resolver that computes a value for the previous period; the eventMetric query the card already issues carries no previous value and cannot produce the percentage. The query covers the whole selected range rather than the range narrowed by the selected chart point, so the count stays on the period total while the footer and the timeline narrow, as they do for an account.

It also passes includeWebhookEvents, which the account query does not, so the count agrees with the chart above it and with the timeline total below it on the same card. The equivalent mismatch on the account header is tracked in LPD-101695.

Verified against a locally seeded individual with 47 events in the period and 20 in the previous one: the card reads "47 Activities" and "135.0% vs. Previous Period", and the timeline paginator reports the same 47.

## PR Check

**pr-check: PASS** — tested on `3a61d5d7ce7c039433215228e7b4aa8c731ab7a4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "3a61d5d7ce7c039433215228e7b4aa8c731ab7a4"} -->
