### PR TITLE
LPD-101738 Update listener time

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/messaging/UpdateFaroDataSourceUsageMessageListener.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/messaging/UpdateFaroDataSourceUsageMessageListener.java
@@ -61,7 +61,7 @@ public class UpdateFaroDataSourceUsageMessageListener
 
 			_trigger = _triggerFactory.createTrigger(
 				clazz.getName(), clazz.getName(), new Date(), null,
-				"0 0 1 * * ?");
+				"0 0 0/6 * * ?");
 
 			_schedulerEngineHelper.schedule(
 				_trigger, StorageType.PERSISTED, null,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101738

## What Is Being Fixed

The data source usage sync ran once a day, at 01:00, so usage metrics stayed stale for most of the day and the listener was slow to verify while the retrieval path was still being diagnosed.

## How It Is Being Fixed

The Quartz expression on the persisted trigger changes from `0 0 1 * * ?` to `0 0 0/6 * * ?`, so the sync fires every six hours, at 00:00, 06:00, 12:00 and 18:00, matching the `0 0 0/6 * * ?` form already used by a sibling listener in the same package. The trigger is registered with `StorageType.PERSISTED`, so an instance that already scheduled this job may keep the previous daily schedule until the stored trigger is refreshed.

## Why Are There No Tests?

The change is a Quartz scheduling constant on an OSGi component activation path. There is no test harness around the trigger registration, and the cadence is not assertable without exercising the Quartz scheduler.

## PR Check

**pr-check: SKIPPED** — Workspace Build fails only on a pre-existing master Jest timeout in Settings.jsx (34416ec), unrelated to this Java-only change

<!-- pr-check {"reason": "Workspace Build fails only on a pre-existing master Jest timeout in Settings.jsx (34416ec), unrelated to this Java-only change", "result": "skipped", "sha": "435af7d61f691e44ac99c8c463e38d6e5413a54d"} -->
