### PR TITLE
LPD-102540 Derive the synced commerce channels from the synced sites

### DIFF
--- a/modules/apps/analytics/analytics-settings-rest-api/src/main/java/com/liferay/analytics/settings/rest/manager/AnalyticsSettingsManager.java
+++ b/modules/apps/analytics/analytics-settings-rest-api/src/main/java/com/liferay/analytics/settings/rest/manager/AnalyticsSettingsManager.java
@@ -24,6 +24,8 @@ public interface AnalyticsSettingsManager {
 	public AnalyticsConfiguration getAnalyticsConfiguration(long companyId)
 		throws ConfigurationException;
 
+	public long[] getCommerceChannelIds(long companyId, long[] groupIds);
+
 	public Long[] getCommerceChannelIds(
 			String analyticsChannelId, long companyId)
 		throws Exception;

--- a/modules/apps/analytics/analytics-settings-rest-api/src/main/resources/com/liferay/analytics/settings/rest/manager/packageinfo
+++ b/modules/apps/analytics/analytics-settings-rest-api/src/main/resources/com/liferay/analytics/settings/rest/manager/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/manager/AnalyticsSettingsManagerImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/manager/AnalyticsSettingsManagerImpl.java
@@ -125,35 +125,10 @@ public class AnalyticsSettingsManagerImpl implements AnalyticsSettingsManager {
 			String analyticsChannelId, long companyId)
 		throws Exception {
 
-		AnalyticsConfiguration analyticsConfiguration =
-			getAnalyticsConfiguration(companyId);
-
-		List<Long> commerceChannelIds = new ArrayList<>();
-
-		for (String commerceChannelId :
-				analyticsConfiguration.syncedCommerceChannelIds()) {
-
-			Group group = _groupLocalService.fetchGroup(
-				companyId, _commerceChannelClassNameIdSupplier.get(),
-				GetterUtil.getLong(commerceChannelId));
-
-			if (group == null) {
-				continue;
-			}
-
-			UnicodeProperties typeSettingsUnicodeProperties =
-				group.getTypeSettingsProperties();
-
-			if (Objects.equals(
-					analyticsChannelId,
-					typeSettingsUnicodeProperties.getProperty(
-						"analyticsChannelId"))) {
-
-				commerceChannelIds.add(GetterUtil.getLong(commerceChannelId));
-			}
-		}
-
-		return commerceChannelIds.toArray(new Long[0]);
+		return ArrayUtil.toArray(
+			getCommerceChannelIds(
+				companyId,
+				ArrayUtil.toArray(getSiteIds(analyticsChannelId, companyId))));
 	}
 
 	@Override

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/manager/AnalyticsSettingsManagerImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/manager/AnalyticsSettingsManagerImpl.java
@@ -13,6 +13,7 @@ import com.liferay.analytics.settings.rest.constants.FieldOrderConstants;
 import com.liferay.analytics.settings.rest.constants.FieldPeopleConstants;
 import com.liferay.analytics.settings.rest.constants.FieldProductConstants;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
@@ -93,6 +94,30 @@ public class AnalyticsSettingsManagerImpl implements AnalyticsSettingsManager {
 
 		return _configurationProvider.getCompanyConfiguration(
 			AnalyticsConfiguration.class, companyId);
+	}
+
+	@Override
+	public long[] getCommerceChannelIds(long companyId, long[] groupIds) {
+		if (groupIds.length == 0) {
+			return new long[0];
+		}
+
+		return TransformUtil.transformToLongArray(
+			_groupLocalService.getGroups(
+				companyId, _CLASS_NAME_COMMERCE_CHANNEL, 0),
+			group -> {
+				UnicodeProperties typeSettingsUnicodeProperties =
+					group.getTypeSettingsProperties();
+
+				long groupId = GetterUtil.getLong(
+					typeSettingsUnicodeProperties.getProperty("siteGroupId"));
+
+				if (ArrayUtil.contains(groupIds, groupId)) {
+					return group.getClassPK();
+				}
+
+				return null;
+			});
 	}
 
 	@Override

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/ChannelResourceImpl.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/resource/v1_0/ChannelResourceImpl.java
@@ -169,7 +169,10 @@ public class ChannelResourceImpl extends BaseChannelResourceImpl {
 			_analyticsCloudClient.updateAnalyticsChannel(
 				channel.getChannelId(),
 				transform(
-					dataSource.getCommerceChannelIds(),
+					ArrayUtil.toArray(
+						_analyticsSettingsManager.getCommerceChannelIds(
+							contextUser.getCompanyId(),
+							ArrayUtil.toArray(dataSource.getSiteIds()))),
 					commerceChannelId -> _groupLocalService.fetchGroup(
 						contextUser.getCompanyId(),
 						_commerceChannelClassNameIdSupplier.get(),
@@ -190,11 +193,6 @@ public class ChannelResourceImpl extends BaseChannelResourceImpl {
 		_analyticsSettingsManager.updateCompanyConfiguration(
 			contextUser.getCompanyId(),
 			HashMapBuilder.<String, Object>put(
-				"syncedCommerceChannelIds",
-				_analyticsSettingsManager.updateCommerceChannelIds(
-					channel.getChannelId(), contextCompany.getCompanyId(),
-					analyticsDataSource.getCommerceChannelIds())
-			).put(
 				"syncedGroupIds",
 				_analyticsSettingsManager.updateSiteIds(
 					channel.getChannelId(), contextCompany.getCompanyId(),

--- a/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/internal/manager/test/AnalyticsSettingsManagerTest.java
+++ b/modules/apps/analytics/analytics-settings-rest-test/src/testIntegration/java/com/liferay/analytics/settings/rest/internal/manager/test/AnalyticsSettingsManagerTest.java
@@ -54,10 +54,12 @@ public class AnalyticsSettingsManagerTest {
 	public void setUp() throws Exception {
 		_analyticsChannelId1 = RandomTestUtil.randomString(8);
 		_analyticsChannelId2 = RandomTestUtil.randomString(8);
-		_commerceChannelGroup1 = _addCommerceChannelGroup();
-		_commerceChannelGroup2 = _addCommerceChannelGroup();
 		_siteGroup1 = GroupTestUtil.addGroup();
 		_siteGroup2 = GroupTestUtil.addGroup();
+		_commerceChannelGroup1 = _addCommerceChannelGroup(
+			_siteGroup1.getGroupId());
+		_commerceChannelGroup2 = _addCommerceChannelGroup(
+			_siteGroup2.getGroupId());
 	}
 
 	@After
@@ -82,113 +84,13 @@ public class AnalyticsSettingsManagerTest {
 			Arrays.toString(emptyCommerceChannelIds), 0,
 			emptyCommerceChannelIds.length);
 
-		String[] updateCommerceChannelIds =
-			_analyticsSettingsManager.updateCommerceChannelIds(
-				_analyticsChannelId1, TestPropsValues.getCompanyId(),
-				new Long[] {_commerceChannelGroup1.getClassPK()});
-
-		Assert.assertArrayEquals(
-			Arrays.toString(updateCommerceChannelIds),
-			ArrayUtil.sortedUnique(updateCommerceChannelIds),
-			ArrayUtil.sortedUnique(
-				new String[] {
-					String.valueOf(_commerceChannelGroup1.getClassPK())
-				}));
-
 		_analyticsSettingsManager.updateCompanyConfiguration(
 			TestPropsValues.getCompanyId(),
 			HashMapBuilder.<String, Object>put(
-				"syncedCommerceChannelIds", updateCommerceChannelIds
-			).build());
-
-		updateCommerceChannelIds =
-			_analyticsSettingsManager.updateCommerceChannelIds(
-				_analyticsChannelId2, TestPropsValues.getCompanyId(),
-				new Long[] {_commerceChannelGroup2.getClassPK()});
-
-		Assert.assertArrayEquals(
-			Arrays.toString(updateCommerceChannelIds),
-			ArrayUtil.sortedUnique(updateCommerceChannelIds),
-			ArrayUtil.sortedUnique(
-				new String[] {
-					String.valueOf(_commerceChannelGroup1.getClassPK()),
-					String.valueOf(_commerceChannelGroup2.getClassPK())
-				}));
-
-		_analyticsSettingsManager.updateCompanyConfiguration(
-			TestPropsValues.getCompanyId(),
-			HashMapBuilder.<String, Object>put(
-				"syncedCommerceChannelIds", updateCommerceChannelIds
-			).build());
-
-		IdempotentRetryAssert.retryAssert(
-			5, TimeUnit.SECONDS, 1, TimeUnit.SECONDS,
-			() -> {
-				Long[] commerceChannelIds =
-					_analyticsSettingsManager.getCommerceChannelIds(
-						_analyticsChannelId1, TestPropsValues.getCompanyId());
-
-				Assert.assertEquals(
-					Arrays.toString(commerceChannelIds), 1,
-					commerceChannelIds.length);
-
-				return null;
-			});
-
-		updateCommerceChannelIds =
-			_analyticsSettingsManager.updateCommerceChannelIds(
-				_analyticsChannelId1, TestPropsValues.getCompanyId(),
-				new Long[] {
-					_commerceChannelGroup1.getClassPK(),
-					_commerceChannelGroup2.getClassPK()
-				});
-
-		Assert.assertArrayEquals(
-			Arrays.toString(updateCommerceChannelIds),
-			ArrayUtil.sortedUnique(updateCommerceChannelIds),
-			ArrayUtil.sortedUnique(
-				new String[] {
-					String.valueOf(_commerceChannelGroup1.getClassPK()),
-					String.valueOf(_commerceChannelGroup2.getClassPK())
-				}));
-
-		_analyticsSettingsManager.updateCompanyConfiguration(
-			TestPropsValues.getCompanyId(),
-			HashMapBuilder.<String, Object>put(
-				"syncedCommerceChannelIds", updateCommerceChannelIds
-			).build());
-
-		IdempotentRetryAssert.retryAssert(
-			5, TimeUnit.SECONDS, 1, TimeUnit.SECONDS,
-			() -> {
-				Long[] commerceChannelIds =
-					_analyticsSettingsManager.getCommerceChannelIds(
-						_analyticsChannelId1, TestPropsValues.getCompanyId());
-
-				Assert.assertEquals(
-					Arrays.toString(commerceChannelIds), 2,
-					commerceChannelIds.length);
-
-				return null;
-			});
-
-		updateCommerceChannelIds =
-			_analyticsSettingsManager.updateCommerceChannelIds(
-				_analyticsChannelId1, TestPropsValues.getCompanyId(),
-				new Long[] {_commerceChannelGroup1.getClassPK()});
-
-		Assert.assertArrayEquals(
-			Arrays.toString(updateCommerceChannelIds),
-			ArrayUtil.sortedUnique(updateCommerceChannelIds),
-			ArrayUtil.sortedUnique(
-				new String[] {
-					String.valueOf(_commerceChannelGroup1.getClassPK())
-				}));
-
-		_analyticsSettingsManager.updateCompanyConfiguration(
-			TestPropsValues.getCompanyId(),
-			HashMapBuilder.<String, Object>put(
-				"syncedCommerceChannelIds", updateCommerceChannelIds
+				"syncedGroupIds",
+				_analyticsSettingsManager.updateSiteIds(
+					_analyticsChannelId1, TestPropsValues.getCompanyId(),
+					new Long[] {_siteGroup1.getGroupId()})
 			).build());
 
 		IdempotentRetryAssert.retryAssert(
@@ -207,6 +109,14 @@ public class AnalyticsSettingsManagerTest {
 
 				return null;
 			});
+
+		Long[] otherCommerceChannelIds =
+			_analyticsSettingsManager.getCommerceChannelIds(
+				_analyticsChannelId2, TestPropsValues.getCompanyId());
+
+		Assert.assertEquals(
+			Arrays.toString(otherCommerceChannelIds), 0,
+			otherCommerceChannelIds.length);
 	}
 
 	@Ignore
@@ -462,14 +372,14 @@ public class AnalyticsSettingsManagerTest {
 			});
 	}
 
-	private Group _addCommerceChannelGroup() throws Exception {
+	private Group _addCommerceChannelGroup(long siteGroupId) throws Exception {
 		return _groupLocalService.addGroup(
 			StringPool.BLANK, TestPropsValues.getUserId(), 0,
 			"com.liferay.commerce.product.model.CommerceChannel",
 			RandomTestUtil.randomLong(), 0,
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),
-			GroupConstants.TYPE_SITE_OPEN, null, false,
+			GroupConstants.TYPE_SITE_OPEN, "siteGroupId=" + siteGroupId, false,
 			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
 			"/" + RandomTestUtil.randomString(6), false, false, true,
 			ServiceContextTestUtil.getServiceContext());

--- a/modules/apps/site/site-dsr-site-initializer-test/src/testIntegration/java/com/liferay/site/dsr/site/initializer/internal/model/listener/test/ObjectEntryModelListenerTest.java
+++ b/modules/apps/site/site-dsr-site-initializer-test/src/testIntegration/java/com/liferay/site/dsr/site/initializer/internal/model/listener/test/ObjectEntryModelListenerTest.java
@@ -533,6 +533,11 @@ public class ObjectEntryModelListenerTest {
 		}
 
 		@Override
+		public long[] getCommerceChannelIds(long companyId, long[] groupIds) {
+			return new long[0];
+		}
+
+		@Override
 		public Long[] getCommerceChannelIds(
 			String analyticsChannelId, long companyId) {
 

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/dispatch/executor/BaseDispatchTaskExecutor.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/dispatch/executor/BaseDispatchTaskExecutor.java
@@ -15,6 +15,7 @@ import com.liferay.dispatch.service.DispatchLogLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.text.DateFormat;
@@ -42,16 +43,13 @@ public abstract class BaseDispatchTaskExecutor
 		AnalyticsConfiguration analyticsConfiguration =
 			analyticsSettingsManager.getAnalyticsConfiguration(companyId);
 
-		for (String analyticsChannelId :
-				analyticsConfiguration.
-					commerceSyncEnabledAnalyticsChannelIds()) {
+		for (long commerceChannelId :
+				analyticsSettingsManager.getCommerceChannelIds(
+					companyId,
+					GetterUtil.getLongValues(
+						analyticsConfiguration.syncedGroupIds()))) {
 
-			for (Long commerceChannelId :
-					analyticsSettingsManager.getCommerceChannelIds(
-						analyticsChannelId, companyId)) {
-
-				filterStrings.add(filterFunction.apply(commerceChannelId));
-			}
+			filterStrings.add(filterFunction.apply(commerceChannelId));
 		}
 
 		return StringUtil.merge(filterStrings, " or ");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102540

## What Is Being Fixed

Synchronizing DXP commerce channels with Analytics Cloud requires an administrator to select the channels by hand, on the Analytics Cloud screen in Instance Settings. Those channels are what filters the orders and products DXP uploads, and Analytics Cloud feeds that data to the machine learning jobs whose recommendations DXP downloads back into the Commerce pages. The selection is therefore load-bearing, which blocks removing the screen that LPD-101238 sets out to clean up.

The selection is also redundant. A commerce channel already records the site it belongs to, and an administrator already chooses which sites each property synchronizes, so the channels can be derived instead of asked for.

## How It Is Being Fixed

Commerce stores the site of a channel in the `siteGroupId` type setting of the channel's group, so the channels of a site can be read through the group service alone. That keeps the derivation inside `analytics-settings`, which deliberately has no compile dependency on Commerce and already reaches commerce channel groups through their class name.

`AnalyticsSettingsManager` gains a lookup for the commerce channels of a set of sites, and the existing per-property method delegates to it with the sites that property synchronizes, so it no longer reads `syncedCommerceChannelIds`. The channel patch sends Analytics Cloud the channels derived from the sites being assigned rather than the ones the client sent, which keeps the mapping the order ingestion needs, and it stops persisting the configuration property. The orders and products upload derives its filter from the synced sites instead of walking the analytics channels with commerce sync enabled.

Two follow-ups stay out of this change, so it has a single subject: `updateCommerceChannelIds` is left without callers, and the commerce toggle, the configuration model listener and the two configuration properties are still in place. LPD-102498 removes them together with the package version bump they need.

## PR Check

**pr-check: PASS** — tested on `2405c46b523c4c2c00b23cdd4ec67102d79d136a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Baseline required the `com.liferay.analytics.settings.rest.manager` package to go from `2.0.0` to `2.1.0` for the added method, and Cross-Module Compile caught the `AnalyticsSettingsManager` stub in the site-dsr integration test, which now implements it. Java Unit Tests found no unit counterpart for the changed classes.

Beyond pr-check, `AnalyticsSettingsManagerTest.testGetCommerceChannelIds` was rewritten for the derivation and passes against a running portal, with its `@Ignore` temporarily removed to confirm it. The annotation is restored in the branch, matching the rest of the file.

<!-- pr-check {"result": "success", "sha": "2405c46b523c4c2c00b23cdd4ec67102d79d136a"} -->
