### PR TITLE
LPD-101248 Return objectType in asset summary results

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/AssetSummary.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/AssetSummary.java
@@ -57,6 +57,10 @@ public class AssetSummary {
 		return _mimeType;
 	}
 
+	public String getObjectType() {
+		return _objectType;
+	}
+
 	public Metric getReadsMetric() {
 		return _readsMetric;
 	}
@@ -107,6 +111,10 @@ public class AssetSummary {
 		_mimeType = mimeType;
 	}
 
+	public void setObjectType(String objectType) {
+		_objectType = objectType;
+	}
+
 	public void setReadsMetric(Metric readsMetric) {
 		_readsMetric = readsMetric;
 	}
@@ -125,6 +133,7 @@ public class AssetSummary {
 	private Map<String, Object> _embeddedResources = new HashMap<>();
 	private Metric _impressionsMetric;
 	private String _mimeType;
+	private String _objectType;
 	private Metric _readsMetric;
 	private Metric _viewsMetric;
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/AssetSummaryDisplay.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/model/display/contacts/AssetSummaryDisplay.java
@@ -28,6 +28,7 @@ public class AssetSummaryDisplay {
 		_downloadsMetric = assetSummary.getDownloadsMetric();
 		_impressionsMetric = assetSummary.getImpressionsMetric();
 		_mimeType = assetSummary.getMimeType();
+		_objectType = assetSummary.getObjectType();
 		_viewsMetric = assetSummary.getViewsMetric();
 	}
 
@@ -43,6 +44,7 @@ public class AssetSummaryDisplay {
 	private final Metric _downloadsMetric;
 	private final Metric _impressionsMetric;
 	private final String _mimeType;
+	private final String _objectType;
 	private final Metric _viewsMetric;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101248

## What Is Being Fixed

`getAssetSummaries` gave no indication of whether an asset came from a CMS content structure or a file type. That classification is already produced upstream — the fragment layer emits it as `data-analytics-object-type`, and the analytics client sends it on the object-entry event payload as `objectType` — but the asset summary model did not expose it, so it never reached consumers of the endpoint.

## How It Is Being Fixed

`AssetSummary` gains an `objectType` property so the engine response deserializes it, and `AssetSummaryDisplay` copies it through so `GET /{groupId}/asset-summary` serializes it alongside the existing asset fields. The engine client's mapper uses default bean naming and the web mapper strips the leading underscore from fields, so the property binds and serializes as `objectType` without further configuration.

## Why Are There No Tests?

The value originates in the engine response and is verified end-to-end there. The osb-faro side is a DTO mapping with no behavior of its own to assert.

## PR Check

**pr-check: PASS** — tested on `fb4c2e8479fd0dafef15f61b0689184c0c86f118`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "fb4c2e8479fd0dafef15f61b0689184c0c86f118"} -->
