### PR TITLE
LPD-102675 Request the audience report and segment breakdown in parallel

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/apollo/cache.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/apollo/cache.js
@@ -58,10 +58,10 @@ const metricRootMerge = {
 	site: metricRootField,
 };
 
-export default new InMemoryCache({
-	typePolicies: {
-		Query: {
-			fields: metricRootMerge,
-		},
+export const typePolicies = {
+	Query: {
+		fields: metricRootMerge,
 	},
-});
+};
+
+export default new InMemoryCache({typePolicies});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/AudienceReport.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/AudienceReport.tsx
@@ -27,23 +27,19 @@ const AudienceReportTitle: React.FC<IInfoPopoverProps> = ({content, title}) => (
 	</div>
 );
 
-interface IAudienceReportWithDataProps<TRawData>
+interface IAudienceReportWithDataProps
 	extends Partial<IAudienceReportBaseCardProps> {
-	mapper: (data: TRawData) => TData;
-	data: TRawData;
 	name: Name;
+	result: TData;
 }
 
-function AudienceReportWithData<TRawData>({
-	data,
+function AudienceReportWithData({
 	knownIndividualsTitle,
-	mapper,
 	name,
+	result,
 	segmentsTitle = Liferay.Language.get('viewer-segments'),
 	uniqueVisitorsTitle = Liferay.Language.get('visitors'),
-}: IAudienceReportWithDataProps<TRawData>) {
-	const result: TData = mapper(data);
-
+}: IAudienceReportWithDataProps) {
 	const {knownIndividuals, segments, uniqueVisitors} = formatData(result);
 
 	return (
@@ -100,45 +96,72 @@ function AudienceReportWithData<TRawData>({
 interface IAudienceReportProps<TRawData>
 	extends Partial<IAudienceReportBaseCardProps> {
 	accountId?: string | null;
+	AudienceReportQuery: DocumentNode;
 	experienceId?: string | null;
 	filters: RawFilters;
 	rangeSelectors: RangeSelectors;
 	segmentId?: string | null;
-	Query: DocumentNode;
+	SegmentQuery: DocumentNode;
 	mapper: (data: TRawData) => TData;
 	name: Name;
 }
 
 function AudienceReport<TRawData>({
-	Query,
+	AudienceReportQuery,
+	SegmentQuery,
 	accountId,
 	experienceId,
 	filters,
+	mapper,
 	rangeSelectors,
 	segmentId,
 	...otherProps
 }: IAudienceReportProps<TRawData>) {
 	const {assetId, channelId, title, touchpoint} = useParams();
-	const {data, error, loading} = useQuery(Query, {
+
+	const variables = {
+		assetId,
+		touchpoint: getSafeTouchpoint(touchpoint as string),
+		...(accountId && {accountId}),
+		...(experienceId && {experienceId}),
+		...(segmentId && {segmentId}),
+		...(otherProps.name !== Name.ObjectEntry && {
+			channelId,
+			title: getSafeDecodedURIComponent(title as string),
+		}),
+		...getFilters(filters),
+		...getSafeRangeSelectors(rangeSelectors),
+	};
+
+	const {
+		data: audienceReportData,
+		error: audienceReportError,
+		loading: audienceReportLoading,
+	} = useQuery(AudienceReportQuery, {
 		fetchPolicy: fetchPolicyDefinition(rangeSelectors),
-		variables: {
-			assetId,
-			touchpoint: getSafeTouchpoint(touchpoint as string),
-			...(accountId && {accountId}),
-			...(experienceId && {experienceId}),
-			...(segmentId && {segmentId}),
-			...(otherProps.name !== Name.ObjectEntry && {
-				channelId,
-				title: getSafeDecodedURIComponent(title as string),
-			}),
-			...getFilters(filters),
-			...getSafeRangeSelectors(rangeSelectors),
-		},
+		variables,
 	});
 
+	const {
+		data: segmentData,
+		error: segmentError,
+		loading: segmentLoading,
+	} = useQuery(SegmentQuery, {
+		fetchPolicy: fetchPolicyDefinition(rangeSelectors),
+		variables,
+	});
+
+	const result = {
+		...mapper(audienceReportData),
+		...mapper(segmentData),
+	} as TData;
+
 	return (
-		<AudienceReportStateRenderer error={error!} loading={loading}>
-			<AudienceReportWithData {...otherProps} data={data} />
+		<AudienceReportStateRenderer
+			error={(audienceReportError ?? segmentError)!}
+			loading={audienceReportLoading || segmentLoading}
+		>
+			<AudienceReportWithData {...otherProps} result={result} />
 		</AudienceReportStateRenderer>
 	);
 }

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/AudienceReportBaseCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/AudienceReportBaseCard.tsx
@@ -2,7 +2,12 @@ import AudienceReport from './AudienceReport';
 import BaseCard from 'shared/components/base-card';
 import Card from '../Card';
 import React from 'react';
-import {AssetAudienceReportQuery, PageAudienceReportQuery} from './queries';
+import {
+	AssetAudienceReportQuery,
+	AssetSegmentQuery,
+	PageAudienceReportQuery,
+	PageSegmentQuery,
+} from './queries';
 import {IAudienceReportBaseCardProps, Name} from './types';
 import {ReportContainer} from '../download-report/DownloadPDFReport';
 
@@ -12,6 +17,9 @@ function AudienceReportBaseCard({
 }: IAudienceReportBaseCardProps) {
 	const AudienceReportQuery =
 		name === Name.Page ? PageAudienceReportQuery : AssetAudienceReportQuery;
+
+	const SegmentQuery =
+		name === Name.Page ? PageSegmentQuery : AssetSegmentQuery;
 
 	return (
 		<BaseCard
@@ -32,16 +40,20 @@ function AudienceReportBaseCard({
 					<AudienceReport
 						{...props}
 						accountId={accountId}
+						AudienceReportQuery={AudienceReportQuery({
+							metricName,
+							name,
+						})}
 						experienceId={experienceId}
 						filters={filters}
 						mapper={(result: any) => result?.[name]?.[metricName]}
 						name={name}
-						Query={AudienceReportQuery({
+						rangeSelectors={rangeSelectors}
+						segmentId={segmentId}
+						SegmentQuery={SegmentQuery({
 							metricName,
 							name,
 						})}
-						rangeSelectors={rangeSelectors}
-						segmentId={segmentId}
 					/>
 				</Card.Body>
 			)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/__tests__/AudienceReport.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/__tests__/AudienceReport.tsx
@@ -2,18 +2,21 @@ import AudienceReport from '../AudienceReport';
 import mockStore from 'test/mock-store';
 import React from 'react';
 import {fireEvent, render} from '@testing-library/react';
+import {InMemoryCache} from '@apollo/client';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MetricName} from 'shared/types/MetricName';
 import {
 	mockAudienceReportReq,
 	mockPreferenceReq,
+	mockSegmentReq,
 	mockTimeRangeReq,
 } from 'test/graphql-data';
 import {MockedProvider} from '@apollo/client/testing';
 import {Name} from '../types';
-import {PageAudienceReportQuery} from '../queries';
+import {PageAudienceReportQuery, PageSegmentQuery} from '../queries';
 import {Provider} from 'react-redux';
 import {RangeKeyTimeRanges} from 'shared/util/constants';
+import {typePolicies} from 'shared/apollo/cache';
 import {waitForLoadingToBeRemoved} from 'test/helpers';
 
 jest.unmock('react-dom');
@@ -60,24 +63,29 @@ const WrappedComponent = ({queryProps}: {queryProps: any}) => (
 			<Route path="/workspace/:groupId/:channelId/:title/:touchpoint">
 				<MockedProvider
 					{...({freezeResults: false} as any)}
+					cache={new InMemoryCache({typePolicies})}
 					mocks={[
 						mockTimeRangeReq(),
 						mockPreferenceReq(),
 						mockAudienceReportReq({queryProps}),
+						mockSegmentReq({queryProps}),
 					]}
 				>
 					<AudienceReport
+						AudienceReportQuery={PageAudienceReportQuery(
+							queryProps
+						)}
 						filters={{devices: [], location: []}}
 						mapper={(result: any) =>
 							result?.[queryProps.name]?.[queryProps.metricName]
 						}
 						name={Name.Page}
-						Query={PageAudienceReportQuery(queryProps)}
 						rangeSelectors={{
 							rangeEnd: '',
 							rangeKey: RangeKeyTimeRanges.Last30Days,
 							rangeStart: '',
 						}}
+						SegmentQuery={PageSegmentQuery(queryProps)}
 					/>
 				</MockedProvider>
 			</Route>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/queries.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/audience-report/queries.ts
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import {DocumentNode} from '@apollo/client';
 import {Name} from './types';
 
 const AudienceReportFragment = gql`
@@ -10,6 +11,11 @@ const AudienceReportFragment = gql`
 			segmentedAnonymousUsersCount
 			segmentedKnownUsersCount
 		}
+	}
+`;
+
+const SegmentFragment = gql`
+	fragment segmentFragment on Metric {
 		segment {
 			metrics {
 				value
@@ -20,14 +26,18 @@ const AudienceReportFragment = gql`
 	}
 `;
 
-export const PageAudienceReportQuery = ({
-	metricName,
-	name,
-}: {
+interface IQueryProps {
 	metricName: string;
 	name: Name;
-}) => gql`
-	query ${name}AudienceReportQuery(
+}
+
+const getPageQuery = (
+	{metricName, name}: IQueryProps,
+	fragment: DocumentNode,
+	fragmentName: string,
+	operationName: string
+) => gql`
+	query ${name}${operationName}(
 		$accountId: String
 		$channelId: String
 		$devices: String
@@ -54,22 +64,21 @@ export const PageAudienceReportQuery = ({
 			title: $title
 		) {
 			${metricName} {
-				...audienceReportFragment
+				...${fragmentName}
 			}
 		}
 	}
 
-	${AudienceReportFragment}
+	${fragment}
 `;
 
-export const AssetAudienceReportQuery = ({
-	metricName,
-	name,
-}: {
-	metricName: string;
-	name: Name;
-}) => gql`
-	query ${name}AudienceReportQuery(
+const getAssetQuery = (
+	{metricName, name}: IQueryProps,
+	fragment: DocumentNode,
+	fragmentName: string,
+	operationName: string
+) => gql`
+	query ${name}${operationName}(
 		$accountId: String
 		$assetId: String!
 		$channelId: String
@@ -99,10 +108,42 @@ export const AssetAudienceReportQuery = ({
 			assetTitle
 			urls
 			${metricName} {
-				...audienceReportFragment
+				...${fragmentName}
 			}
 		}
 	}
 
-	${AudienceReportFragment}
+	${fragment}
 `;
+
+export const AssetAudienceReportQuery = (queryProps: IQueryProps) =>
+	getAssetQuery(
+		queryProps,
+		AudienceReportFragment,
+		'audienceReportFragment',
+		'AudienceReportQuery'
+	);
+
+export const AssetSegmentQuery = (queryProps: IQueryProps) =>
+	getAssetQuery(
+		queryProps,
+		SegmentFragment,
+		'segmentFragment',
+		'SegmentQuery'
+	);
+
+export const PageAudienceReportQuery = (queryProps: IQueryProps) =>
+	getPageQuery(
+		queryProps,
+		AudienceReportFragment,
+		'audienceReportFragment',
+		'AudienceReportQuery'
+	);
+
+export const PageSegmentQuery = (queryProps: IQueryProps) =>
+	getPageQuery(
+		queryProps,
+		SegmentFragment,
+		'segmentFragment',
+		'SegmentQuery'
+	);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/test/graphql-data.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/test/graphql-data.js
@@ -63,7 +63,10 @@ import {
 import {getSafeRangeSelectors} from 'shared/util/util';
 import {INTERVAL_KEY_MAP} from 'shared/util/time';
 import {isArray, mapValues, range} from 'lodash';
-import {PageAudienceReportQuery} from 'shared/components/audience-report/queries';
+import {
+	PageAudienceReportQuery,
+	PageSegmentQuery,
+} from 'shared/components/audience-report/queries';
 
 const METRIC_TYPENAME_MAP = {
 	histogram: 'HistogramMetric',
@@ -274,20 +277,22 @@ export function mockAssetTabsReq({metrics, name, rangeKey}) {
 	};
 }
 
+const AUDIENCE_REPORT_VARIABLES = {
+	channelId: '456',
+	devices: 'Any',
+	location: 'Any',
+	rangeEnd: null,
+	rangeKey: 30,
+	rangeStart: null,
+	title: 'Home Page',
+	touchpoint: 'https://www.liferay.com',
+};
+
 export function mockAudienceReportReq({queryProps}) {
 	return {
 		request: {
 			query: PageAudienceReportQuery(queryProps),
-			variables: {
-				channelId: '456',
-				devices: 'Any',
-				location: 'Any',
-				rangeEnd: null,
-				rangeKey: 30,
-				rangeStart: null,
-				title: 'Home Page',
-				touchpoint: 'https://www.liferay.com',
-			},
+			variables: AUDIENCE_REPORT_VARIABLES,
 		},
 		result: {
 			data: {
@@ -303,6 +308,25 @@ export function mockAudienceReportReq({queryProps}) {
 							segmentedAnonymousUsersCount: null,
 							segmentedKnownUsersCount: 2,
 						},
+					},
+				},
+			},
+		},
+	};
+}
+
+export function mockSegmentReq({queryProps}) {
+	return {
+		request: {
+			query: PageSegmentQuery(queryProps),
+			variables: AUDIENCE_REPORT_VARIABLES,
+		},
+		result: {
+			data: {
+				page: {
+					__typename: 'PageMetric',
+					viewsMetric: {
+						__typename: 'Metric',
 						segment: {
 							__typename: 'MetricBag',
 							metrics: [


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102675

## What Is Being Fixed

The audience card of a page detail resolved the audience report and the segment breakdown from a single GraphQL query. Each of them runs its own BigQuery query on the backend, and the data fetchers block, so the card waited for the sum of the two instead of for the slower one.

## How It Is Being Fixed

The card now asks for the audience report and the segment breakdown in two queries, which the browser runs at the same time. Both still hang off the same metric field, so the backend work per query is unchanged; only the waiting is now concurrent.

The card renders once both queries resolve, because the total of the segment chart is derived from the audience report counts.

Sharing a cache entry between sibling queries is an established pattern here: the recursive merge for the root metric fields already exists for other metric cards that split their data the same way. The test builds its mocked cache with those type policies so it exercises the browser's behavior; without them each write evicts the other's data and both queries are requested twice, which the single-use mocks now catch.

## PR Check

**pr-check: PASS** — tested on `ec49c45e1554c8c5d838ddebd78c00d49072b9e0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Workspace Build | PASS |

Baseline could not resolve artifacts from Nexus (read timeout on an unrelated module), so the local fallback applies: the branch changes no Java and no exported API, and no `bnd.bnd` or `packageinfo` changed.

<!-- pr-check {"result": "success", "sha": "ec49c45e1554c8c5d838ddebd78c00d49072b9e0"} -->
