### PR TITLE
LPD-102839 Serve the production robots.txt from the upstream

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/configs/common/conf.d/liferay.conf
+++ b/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/configs/common/conf.d/liferay.conf
@@ -12,6 +12,20 @@ if ($redirect_host != "") {
     return 302 https://$redirect_host$request_uri;
 }
 
+set $robots_disallow "";
+
+if ($host ~* ^(analytics|ldp)-(internal|stg)\.liferay\.com$) {
+    set $robots_disallow "disallow";
+}
+
+if ($uri != "/robots.txt") {
+    set $robots_disallow "";
+}
+
+if ($robots_disallow != "") {
+    return 200 "User-Agent: *\nDisallow: /\n";
+}
+
 location / {
 
     fastcgi_read_timeout 60s;
@@ -36,12 +50,4 @@ location / {
 
     proxy_pass http://upstream_server;
     proxy_http_version 1.1;
-}
-
-location = /robots.txt {
-    add_header Content-Type text/plain;
-
-    if ($host ~* ^(analytics|ldp)-(internal|stg)\.liferay\.com$) {
-        return 200 "User-Agent: *\nDisallow: /\n";
-    }
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102839

## What Is Being Fixed

The disallow response that keeps crawlers off the internal and staging domains lived in a `location = /robots.txt` block. That block matched every request for `/robots.txt`, production included, and on production the host condition inside it never fired and no `proxy_pass` ran. NGINX fell through to the filesystem and answered 404, so production served no robots.txt at all. The block also emitted `Content-Type` twice, because `add_header` appends a header instead of replacing the one NGINX already derives from the request.

## How It Is Being Fixed

The host condition moves out of the location block up to the server level, following the same ladder the `$redirect_host` block above it already uses: a variable defaults to empty, a host match sets it, a URI check clears it for anything other than `/robots.txt`, and a final guard returns the disallow body. Production no longer matches a location specific to robots.txt, so it falls through to `location /` and reaches the portal, which serves the real file. Removing `add_header Content-Type text/plain` leaves a single correct `Content-Type: text/plain`, derived from the `.txt` extension through `mime.types`. The `analytics` alternative stays in the host regex on purpose. It is unreachable while the redirect above covers those hosts, and it keeps this block correct on its own should that redirect ever be removed while the analytics domains are still live.

## Why Are There No Tests?

This repository has no test harness for NGINX configuration, and this file is the only NGINX config in the tree; the earlier robots.txt changes under LPD-65892 shipped without tests as well. The change was instead verified by running the old and the new configuration against the `liferaycloud/nginx:1.24.0-6.1.1` image with a stub upstream, which confirmed that production falls through to the portal rather than returning 404, that the internal and staging domains still serve `Disallow: /` with a single `Content-Type: text/plain`, and that the `/api`, `/endpoints`, and `/o` carve out and the `/nginx_status` health probe are unaffected.

## PR Check

**pr-check: PASS** — tested on `97fb283e09dfda79cca350fca3a3f53e067612d3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "97fb283e09dfda79cca350fca3a3f53e067612d3"} -->
