### PR TITLE
LPD-102168 Reject connection info the caller cannot view

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ConnectionInfoResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ConnectionInfoResourceImpl.java
@@ -11,7 +11,7 @@ import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.depot.model.DepotEntryGroupRelModel;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
-import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.depot.service.DepotEntryService;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -44,7 +44,7 @@ public class ConnectionInfoResourceImpl extends BaseConnectionInfoResourceImpl {
 
 		List<Long> groupIds = transform(
 			_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
-				_depotEntryLocalService.getGroupDepotEntry(depotEntryGroupId)),
+				_depotEntryService.getGroupDepotEntry(depotEntryGroupId)),
 			DepotEntryGroupRelModel::getToGroupId);
 
 		return _toConnectionInfo(
@@ -94,6 +94,6 @@ public class ConnectionInfoResourceImpl extends BaseConnectionInfoResourceImpl {
 	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
 
 	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
+	private DepotEntryService _depotEntryService;
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ConnectionInfoResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ConnectionInfoResourceTest.java
@@ -6,6 +6,8 @@
 package com.liferay.analytics.cms.rest.resource.v1_0.test;
 
 import com.liferay.analytics.cms.rest.client.dto.v1_0.ConnectionInfo;
+import com.liferay.analytics.cms.rest.client.problem.Problem;
+import com.liferay.analytics.cms.rest.client.resource.v1_0.ConnectionInfoResource;
 import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
@@ -14,15 +16,19 @@ import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -75,6 +81,11 @@ public class ConnectionInfoResourceTest
 	@Override
 	@Test
 	public void testGetConnectionInfo() throws Exception {
+		_testGetConnectionInfo();
+		_testGetConnectionInfoWithoutViewPermission();
+	}
+
+	private void _testGetConnectionInfo() throws Exception {
 		Assert.assertEquals(
 			new ConnectionInfo() {
 				{
@@ -169,6 +180,29 @@ public class ConnectionInfoResourceTest
 		}
 	}
 
+	private void _testGetConnectionInfoWithoutViewPermission()
+		throws Exception {
+
+		_user = UserTestUtil.addUser(
+			testCompany, PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		ConnectionInfoResource connectionInfoResource =
+			ConnectionInfoResource.builder(
+			).authentication(
+				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+
+		Assert.assertThrows(
+			Problem.ProblemException.class,
+			() -> connectionInfoResource.getConnectionInfo(
+				_depotEntry1.getGroupId()));
+	}
+
 	@DeleteAfterTestRun
 	private DepotEntry _depotEntry1;
 
@@ -185,5 +219,8 @@ public class ConnectionInfoResourceTest
 	private Group _group;
 
 	private ServiceContext _serviceContext;
+
+	@DeleteAfterTestRun
+	private User _user;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102168

## What Is Being Fixed

The `analytics-cms-rest/v1.0/connection-info` endpoint did not check permissions. Any authenticated user could read the connection info of any asset library by passing its group ID, since the endpoint resolved the asset library through `DepotEntryLocalService`, and local services do not consult permissions.

## How It Is Being Fixed

The asset library is now resolved through `DepotEntryService`, the remote counterpart, which checks the view permission on the depot entry before returning it. This is the same approach taken in LPD-102164 for the object entry metric endpoints, so the whole module now gates on the entity it is asked about rather than trusting the identifier in the request. Note that Vulcan's `PrincipalExceptionMapper` turns a `PrincipalException` into a 404 on GET requests, so the rejected call answers 404 rather than 403.

The integration test authenticates a user with no permissions in the test company against its own REST client and asserts the call is rejected. Reverting the fix makes it fail with "nothing was thrown", so it reproduces the reported behavior.

## PR Check

**pr-check: PASS** — tested on `7c5b395c4af1f3e57e9cf9b085725f99627233b6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7c5b395c4af1f3e57e9cf9b085725f99627233b6"} -->
