### PR TITLE
LPD-101252 Hide the Exclude toggle in the data set filters

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_frontend_data_set.scss
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/css/_frontend_data_set.scss
@@ -63,3 +63,11 @@
 		}
 	}
 }
+
+.dropdown-caption:has([id^='autocomplete-exclude-']) {
+	display: none;
+
+	+ .dropdown-divider {
+		display: none;
+	}
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101252

## What Is Being Fixed

The "Exclude" operator is offered on every selection filter of every data set table in LDP, and its behavior is inconsistent enough that it should not be offered at all.

## How It Is Being Fixed

The toggle is rendered by the Frontend Data Set itself, in SelectionFilter, for every filter of type selection, and there is no filter definition property or backend configuration to turn it off. Hiding it from LDP therefore takes CSS: the rule matches the dropdown caption that holds the toggle and drops it along with the divider that follows it, so the filter panel keeps its shape. The rule lives at the root of the data set stylesheet rather than nested under a page wrapper because the dropdown menu is mounted on the document body through a portal, outside the portlet. It reaches only LDP because that stylesheet is loaded by the Faro theme.

This is a temporary workaround. Once the Frontend Data Set supports removing the operator, this rule goes away and the code aligns with the new functionality.

## Why Are There No Tests?

CSS visibility is only reachable from Playwright, and no LDP spec currently drills into a data set selection filter, so covering this would mean building the whole flow and its fixtures from scratch for a rule that is meant to be deleted. The change was verified manually in the browser instead.

## PR Check

**pr-check: PASS** — tested on `0a8eadbbe2b607e3ad3eda4773af787407b40e3d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Workspace Build | PASS |

Baseline lowers `headless-cms-api/.../resource/v1_0/packageinfo` from 3.1.0 to 3.0.0 on top of current master. This branch does not touch that module, so the change was left uncommitted.

<!-- pr-check {"result": "success", "sha": "0a8eadbbe2b607e3ad3eda4773af787407b40e3d"} -->
