### PR TITLE
LPD-102964 Prevent retry storms on Faro project provisioning

### DIFF
--- a/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.0.0

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-api/src/main/java/com/liferay/osb/faro/util/FaroPropsValues.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-api/src/main/java/com/liferay/osb/faro/util/FaroPropsValues.java
@@ -7,6 +7,7 @@ package com.liferay.osb.faro.util;
 
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.Time;
 
 /**
  * @author Leilany Ulisses
@@ -104,6 +105,14 @@ public class FaroPropsValues {
 	public static final Integer OSB_FARO_CLAMAV_TIMEOUT = GetterUtil.getInteger(
 		PropsUtil.get("osb.faro.clamav.timeout"),
 		GetterUtil.getInteger(System.getenv("OSB_FARO_CLAMAV_TIMEOUT")));
+
+	public static final long OSB_FARO_PROJECT_PROVISION_BACKOFF_WINDOW_MILLIS =
+		GetterUtil.getLong(
+			PropsUtil.get("osb.faro.project.provision.backoff.window.millis"),
+			GetterUtil.getLong(
+				System.getenv(
+					"OSB_FARO_PROJECT_PROVISION_BACKOFF_WINDOW_MILLIS"),
+				Time.MINUTE * 5));
 
 	public static final boolean OSB_FARO_SUBSCRIPTION_PUSH_ENABLED =
 		GetterUtil.getBoolean(

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
@@ -310,8 +310,10 @@ public class ProjectFaroController extends BaseFaroController {
 			FaroParam
 				<List<String>> incidentReportEmailAddressesFaroParam,
 			@FormParam("name") String name,
-			@FormParam("offeringEntries") FaroParam<List<OSBOfferingEntry>>
-				offeringEntriesFaroParam,
+			@DefaultValue(JSONConstants.NULL_JSON_ARRAY)
+			@FormParam("offeringEntries")
+			FaroParam
+				<List<OSBOfferingEntry>> offeringEntriesFaroParam,
 			@FormParam("ownerEmailAddress") String ownerEmailAddress,
 			@FormParam("serverLocation") String serverLocation,
 			@DefaultValue("UTC") @FormParam("timeZoneId") String timeZoneId)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
@@ -60,6 +60,8 @@ import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.GroupFriendlyURLException;
 import com.liferay.portal.kernel.exception.LayoutFriendlyURLException;
@@ -114,7 +116,9 @@ import java.util.ResourceBundle;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.component.annotations.ReferencePolicyOption;
@@ -313,44 +317,55 @@ public class ProjectFaroController extends BaseFaroController {
 			@DefaultValue("UTC") @FormParam("timeZoneId") String timeZoneId)
 		throws Exception {
 
-		User user = getUser();
+		_checkProvisionBackoff(corpProjectUuid);
 
-		FaroProject faroProject = _create(
-			corpProjectName, corpProjectUuid,
-			emailAddressDomainsFaroParam.getValue(), friendlyURL,
-			incidentReportEmailAddressesFaroParam.getValue(), name,
-			offeringEntriesFaroParam.getValue(), serverLocation,
-			FaroProjectConstants.STATE_UNCONFIGURED, timeZoneId);
+		try {
+			User user = getUser();
 
-		Role role = _roleLocalService.getRole(
-			user.getCompanyId(), RoleConstants.SITE_OWNER);
+			FaroProject faroProject = _create(
+				corpProjectName, corpProjectUuid,
+				emailAddressDomainsFaroParam.getValue(), friendlyURL,
+				incidentReportEmailAddressesFaroParam.getValue(), name,
+				offeringEntriesFaroParam.getValue(), serverLocation,
+				FaroProjectConstants.STATE_UNCONFIGURED, timeZoneId);
 
-		_faroUserLocalService.addFaroUser(
-			getUserId(), faroProject.getGroupId(), 0, role.getRoleId(),
-			ownerEmailAddress, FaroUserConstants.STATUS_PENDING, false);
+			Role role = _roleLocalService.getRole(
+				user.getCompanyId(), RoleConstants.SITE_OWNER);
 
-		if (_shouldSendCreatedWorkspaceEmail(faroProject)) {
-			_faroProjectLocalService.sendCreatedWorkspaceEmail(
-				faroProject.getWeDeployKey());
+			_faroUserLocalService.addFaroUser(
+				getUserId(), faroProject.getGroupId(), 0, role.getRoleId(),
+				ownerEmailAddress, FaroUserConstants.STATUS_PENDING, false);
+
+			if (_shouldSendCreatedWorkspaceEmail(faroProject)) {
+				_faroProjectLocalService.sendCreatedWorkspaceEmail(
+					faroProject.getWeDeployKey());
+			}
+
+			ProjectDisplay projectDisplay = null;
+
+			if (enableAutoConfiguration) {
+				projectDisplay = configure(
+					friendlyURL, faroProject.getGroupId(),
+					emailAddressDomainsFaroParam,
+					incidentReportEmailAddressesFaroParam, name, timeZoneId);
+			}
+			else {
+				projectDisplay = new ProjectDisplay(faroProject);
+			}
+
+			projectDisplay.setDataSourceAccessToken(
+				_dataSourceFaroController.generateDataSourceAccessToken(
+					faroProject.getGroupId(), faroProject.getFaroProjectId()));
+
+			_clearProvisionBackoff(corpProjectUuid);
+
+			return projectDisplay;
 		}
+		catch (Exception exception) {
+			_putProvisionBackoff(corpProjectUuid, exception);
 
-		ProjectDisplay projectDisplay = null;
-
-		if (enableAutoConfiguration) {
-			projectDisplay = configure(
-				friendlyURL, faroProject.getGroupId(),
-				emailAddressDomainsFaroParam,
-				incidentReportEmailAddressesFaroParam, name, timeZoneId);
+			throw exception;
 		}
-		else {
-			projectDisplay = new ProjectDisplay(faroProject);
-		}
-
-		projectDisplay.setDataSourceAccessToken(
-			_dataSourceFaroController.generateDataSourceAccessToken(
-				faroProject.getGroupId(), faroProject.getFaroProjectId()));
-
-		return projectDisplay;
 	}
 
 	@Path("/trial")
@@ -423,11 +438,24 @@ public class ProjectFaroController extends BaseFaroController {
 			return projectDisplay;
 		}
 
-		return _createUnprovisioned(
-			name, accountKey, accountName, corpProjectName, corpProjectUuid,
-			emailAddressDomainsFaroParam.getValue(), friendlyURL,
-			incidentReportEmailAddressesFaroParam.getValue(), ownerEmailAddress,
-			serverLocation, timeZoneId, trial);
+		_checkProvisionBackoff(corpProjectUuid);
+
+		try {
+			ProjectDisplay projectDisplay = _createUnprovisioned(
+				name, accountKey, accountName, corpProjectName, corpProjectUuid,
+				emailAddressDomainsFaroParam.getValue(), friendlyURL,
+				incidentReportEmailAddressesFaroParam.getValue(),
+				ownerEmailAddress, serverLocation, timeZoneId, trial);
+
+			_clearProvisionBackoff(corpProjectUuid);
+
+			return projectDisplay;
+		}
+		catch (Exception exception) {
+			_putProvisionBackoff(corpProjectUuid, exception);
+
+			throw exception;
+		}
 	}
 
 	@DELETE
@@ -1065,6 +1093,13 @@ public class ProjectFaroController extends BaseFaroController {
 			_faroProjectLocalService.updateFaroProject(faroProject));
 	}
 
+	@Activate
+	protected void activateProvisionBackoffPortalCache() {
+		_provisionBackoffPortalCache =
+			(PortalCache<String, Long>)_multiVMPool.getPortalCache(
+				_PROVISION_BACKOFF_PORTAL_CACHE_NAME);
+	}
+
 	protected OSBAccountEntry createOSBAccountEntry(boolean trial) {
 		return new OSBAccountEntry() {
 			{
@@ -1086,6 +1121,11 @@ public class ProjectFaroController extends BaseFaroController {
 				setOfferingEntries(Collections.singletonList(osbOfferingEntry));
 			}
 		};
+	}
+
+	@Deactivate
+	protected void deactivateProvisionBackoffPortalCache() {
+		_multiVMPool.removePortalCache(_PROVISION_BACKOFF_PORTAL_CACHE_NAME);
 	}
 
 	protected OSBAccountEntry getOSBAccountEntry(FaroProject faroProject)
@@ -1125,6 +1165,43 @@ public class ProjectFaroController extends BaseFaroController {
 		}
 
 		return _provisioningClient.getOSBAccountEntry(corpProjectUuid);
+	}
+
+	private void _checkProvisionBackoff(String corpProjectUuid) {
+		if (Validator.isNull(corpProjectUuid)) {
+			return;
+		}
+
+		Long retryAfterTime = _provisionBackoffPortalCache.get(corpProjectUuid);
+
+		if (retryAfterTime == null) {
+			return;
+		}
+
+		long now = System.currentTimeMillis();
+
+		if (now >= retryAfterTime) {
+			return;
+		}
+
+		long retryAfterSeconds =
+			((retryAfterTime - now) + (Time.SECOND - 1)) / Time.SECOND;
+
+		throw new FaroException(
+			"Too many failed provisioning attempts for corp project UUID " +
+				corpProjectUuid,
+			Response.Status.TOO_MANY_REQUESTS,
+			HashMapBuilder.<String, Object>put(
+				"Retry-After", String.valueOf(retryAfterSeconds)
+			).build());
+	}
+
+	private void _clearProvisionBackoff(String corpProjectUuid) {
+		if (Validator.isNull(corpProjectUuid)) {
+			return;
+		}
+
+		_provisionBackoffPortalCache.remove(corpProjectUuid);
 	}
 
 	private FaroProject _create(
@@ -1689,6 +1766,25 @@ public class ProjectFaroController extends BaseFaroController {
 		return true;
 	}
 
+	private void _putProvisionBackoff(
+		String corpProjectUuid, Exception exception) {
+
+		if (Validator.isNull(corpProjectUuid)) {
+			return;
+		}
+
+		_log.error(
+			"Unable to provision project for corp project UUID " +
+				corpProjectUuid,
+			exception);
+
+		_provisionBackoffPortalCache.put(
+			corpProjectUuid,
+			System.currentTimeMillis() +
+				FaroPropsValues.
+					OSB_FARO_PROJECT_PROVISION_BACKOFF_WINDOW_MILLIS);
+	}
+
 	private void _refreshProjectState(FaroProject faroProject)
 		throws Exception {
 
@@ -1861,6 +1957,9 @@ public class ProjectFaroController extends BaseFaroController {
 		}
 	}
 
+	private static final String _PROVISION_BACKOFF_PORTAL_CACHE_NAME =
+		ProjectFaroController.class.getName() + "_PROVISION_BACKOFF";
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		ProjectFaroController.class);
 
@@ -1903,10 +2002,15 @@ public class ProjectFaroController extends BaseFaroController {
 	private JSONFactory _jsonFactory;
 
 	@Reference
+	private MultiVMPool _multiVMPool;
+
+	@Reference
 	private PortalExecutorManager _portalExecutorManager;
 
 	@Reference
 	private ProjectUsageHelper _projectUsageHelper;
+
+	private PortalCache<String, Long> _provisionBackoffPortalCache;
 
 	@Reference(
 		policy = ReferencePolicy.DYNAMIC,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
@@ -1096,7 +1096,7 @@ public class ProjectFaroController extends BaseFaroController {
 	}
 
 	@Activate
-	protected void activateProvisionBackoffPortalCache() {
+	protected void activate() {
 		_provisionBackoffPortalCache =
 			(PortalCache<String, Long>)_multiVMPool.getPortalCache(
 				_PROVISION_BACKOFF_PORTAL_CACHE_NAME);
@@ -1126,7 +1126,7 @@ public class ProjectFaroController extends BaseFaroController {
 	}
 
 	@Deactivate
-	protected void deactivateProvisionBackoffPortalCache() {
+	protected void deactivate() {
 		_multiVMPool.removePortalCache(_PROVISION_BACKOFF_PORTAL_CACHE_NAME);
 	}
 
@@ -1186,16 +1186,15 @@ public class ProjectFaroController extends BaseFaroController {
 			return;
 		}
 
-		long retryAfterSeconds =
-			((retryAfterTime - now) + (Time.SECOND - 1)) / Time.SECOND;
-
 		throw new FaroException(
+			HashMapBuilder.<String, Object>put(
+				"Retry-After",
+				String.valueOf(
+					((retryAfterTime - now) + (Time.SECOND - 1)) / Time.SECOND)
+			).build(),
 			"Too many failed provisioning attempts for corp project UUID " +
 				corpProjectUuid,
-			Response.Status.TOO_MANY_REQUESTS,
-			HashMapBuilder.<String, Object>put(
-				"Retry-After", String.valueOf(retryAfterSeconds)
-			).build());
+			Response.Status.TOO_MANY_REQUESTS);
 	}
 
 	private void _clearProvisionBackoff(String corpProjectUuid) {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/exception/FaroException.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/exception/FaroException.java
@@ -11,6 +11,9 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * @author Matthew Kong
  */
@@ -19,18 +22,30 @@ public class FaroException extends WebApplicationException {
 	public FaroException() {
 	}
 
+	public FaroException(
+		Map<String, Object> headers, String message,
+		Response.StatusType statusType) {
+
+		super(getResponse(headers, message, statusType));
+	}
+
 	public FaroException(String message) {
 		this(message, Response.Status.BAD_REQUEST);
 	}
 
 	public FaroException(String message, Response.StatusType statusType) {
-		super(getResponse(message, statusType));
+		this(Collections.emptyMap(), message, statusType);
 	}
 
 	protected static Response getResponse(
-		String message, Response.StatusType statusType) {
+		Map<String, Object> headers, String message,
+		Response.StatusType statusType) {
 
 		Response.ResponseBuilder responseBuilder = Response.status(statusType);
+
+		for (Map.Entry<String, Object> entry : headers.entrySet()) {
+			responseBuilder.header(entry.getKey(), entry.getValue());
+		}
 
 		ErrorResponse errorResponse = new ErrorResponse();
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroControllerTest.java
@@ -9,9 +9,17 @@ import com.liferay.osb.faro.provisioning.client.constants.ProductConstants;
 import com.liferay.osb.faro.provisioning.client.internal.ProvisioningClientImpl;
 import com.liferay.osb.faro.provisioning.client.model.OSBAccountEntry;
 import com.liferay.osb.faro.provisioning.client.model.OSBOfferingEntry;
+import com.liferay.osb.faro.web.internal.exception.FaroException;
+import com.liferay.portal.cache.BasePortalCache;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import jakarta.ws.rs.core.Response;
+
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -36,6 +44,56 @@ public class ProjectFaroControllerTest {
 		ReflectionTestUtils.setField(
 			_projectFaroController, "_provisioningClient",
 			new ProvisioningClientImpl());
+
+		ReflectionTestUtils.setField(
+			_projectFaroController, "_provisionBackoffPortalCache",
+			new TestPortalCache());
+	}
+
+	@Test
+	public void testCheckProvisionBackoffWhenFailureRecordedWithinWindow() {
+		String corpProjectUuid = RandomTestUtil.randomString();
+
+		ReflectionTestUtils.invokeMethod(
+			_projectFaroController, "_putProvisionBackoff", corpProjectUuid,
+			new Exception());
+
+		try {
+			ReflectionTestUtils.invokeMethod(
+				_projectFaroController, "_checkProvisionBackoff",
+				corpProjectUuid);
+
+			Assert.fail();
+		}
+		catch (FaroException faroException) {
+			Response response = faroException.getResponse();
+
+			Assert.assertEquals(
+				Response.Status.TOO_MANY_REQUESTS.getStatusCode(),
+				response.getStatus());
+			Assert.assertNotNull(response.getHeaderString("Retry-After"));
+		}
+	}
+
+	@Test
+	public void testCheckProvisionBackoffWhenFailureWasCleared() {
+		String corpProjectUuid = RandomTestUtil.randomString();
+
+		ReflectionTestUtils.invokeMethod(
+			_projectFaroController, "_putProvisionBackoff", corpProjectUuid,
+			new Exception());
+		ReflectionTestUtils.invokeMethod(
+			_projectFaroController, "_clearProvisionBackoff", corpProjectUuid);
+
+		ReflectionTestUtils.invokeMethod(
+			_projectFaroController, "_checkProvisionBackoff", corpProjectUuid);
+	}
+
+	@Test
+	public void testCheckProvisionBackoffWhenNoFailureWasRecorded() {
+		ReflectionTestUtils.invokeMethod(
+			_projectFaroController, "_checkProvisionBackoff",
+			RandomTestUtil.randomString());
 	}
 
 	@Test
@@ -97,5 +155,67 @@ public class ProjectFaroControllerTest {
 
 	private final ProjectFaroController _projectFaroController =
 		new ProjectFaroController();
+
+	private static class TestPortalCache extends BasePortalCache<String, Long> {
+
+		public TestPortalCache() {
+			super(null);
+		}
+
+		@Override
+		public List<String> getKeys() {
+			return new ArrayList<>(_map.keySet());
+		}
+
+		@Override
+		public String getPortalCacheName() {
+			return TestPortalCache.class.getName();
+		}
+
+		@Override
+		public void removeAll() {
+			_map.clear();
+		}
+
+		@Override
+		protected Long doGet(String key) {
+			return _map.get(key);
+		}
+
+		@Override
+		protected void doPut(String key, Long value, int timeToLive) {
+			_map.put(key, value);
+		}
+
+		@Override
+		protected Long doPutIfAbsent(String key, Long value, int timeToLive) {
+			return _map.putIfAbsent(key, value);
+		}
+
+		@Override
+		protected void doRemove(String key) {
+			_map.remove(key);
+		}
+
+		@Override
+		protected boolean doRemove(String key, Long value) {
+			return _map.remove(key, value);
+		}
+
+		@Override
+		protected Long doReplace(String key, Long value, int timeToLive) {
+			return _map.replace(key, value);
+		}
+
+		@Override
+		protected boolean doReplace(
+			String key, Long oldValue, Long newValue, int timeToLive) {
+
+			return _map.replace(key, oldValue, newValue);
+		}
+
+		private final Map<String, Long> _map = new ConcurrentHashMap<>();
+
+	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102964

## What Is Being Fixed

An external service that provisions Faro projects calls `POST /project/provisioned` and `POST /project/unprovisioned`, and retries aggressively on failure. Every retry re-runs the full, expensive provisioning flow (FaroProject/Group/FaroUser creation, calls to ProvisioningClient/ContactsEngineClient, etc.) with no signal telling the caller to slow down, so a persistently failing request can be retried indefinitely. Separately, `createProvisioned`'s `offeringEntries` form parameter had no default, so omitting it threw an NPE instead of getting the same graceful handling the endpoint's other list parameters already have.

## How It Is Being Fixed

Both endpoints now track the most recent failure per `corpProjectUuid` in a cluster-wide `PortalCache` (via `MultiVMPool`) with a configurable backoff window (`FaroPropsValues.OSB_FARO_PROJECT_PROVISION_BACKOFF_WINDOW_MILLIS`, default 5 minutes). Before running the provisioning logic, a check short-circuits with `429 Too Many Requests` plus a `Retry-After` header when a recent failure is still within the window; on success the tracked failure is cleared, and on any exception (including validation failures, since an automated caller retrying the same malformed payload would otherwise bypass the throttle entirely) a failure is recorded and logged with the `corpProjectUuid`, to support the separate log investigation into root cause that the ticket calls for. `FaroException` gained a headers-capable constructor to carry the `Retry-After` header. `offeringEntriesFaroParam` on `/provisioned` now defaults like its sibling parameters, so omitting it resolves to an empty list instead of NPEing. Unit tests cover the new backoff check/put/clear helpers with a minimal in-memory `PortalCache` test double, following this file's existing pattern of injecting dependencies via `ReflectionTestUtils`.

## PR Check

**pr-check: FAIL** — tested on `1bd5b5a50d0a55463db12964530eeff5ddb0252f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Baseline | FAIL |
| Workspace Build | PASS |

**Baseline note:** `ant baseline-all` found `EXCESSIVE VERSION INCREASE` in `modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo` (3.1.0 → 3.0.0 per bnd's analysis). Confirmed pre-existing on `master`/`upstream/master` — this branch's commits never touch that file, and the version was already committed at 3.1.0 before this branch existed.

<!-- pr-check {"result": "failure", "sha": "1bd5b5a50d0a55463db12964530eeff5ddb0252f"} -->
