### PR TITLE
LPD-102967 Tolerate a no-op friendly URL update

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
@@ -933,32 +933,7 @@ public class ProjectFaroController extends BaseFaroController {
 				timeZoneId)
 		throws Exception {
 
-		if ((friendlyURL == null) || Validator.isBlank(friendlyURL.trim())) {
-			Group group = _groupLocalService.getGroup(groupId);
-
-			group.setFriendlyURL(null);
-
-			_groupLocalService.updateGroup(group);
-		}
-		else {
-			_validateFriendlyURL(friendlyURL);
-
-			Group group = _groupLocalService.getGroup(groupId);
-
-			if (!StringUtil.equals(group.getFriendlyURL(), friendlyURL)) {
-				try {
-					_groupLocalService.updateFriendlyURL(groupId, friendlyURL);
-				}
-				catch (GroupFriendlyURLException groupFriendlyURLException) {
-					_log.error(groupFriendlyURLException);
-
-					throw new FaroValidationException(
-						"friendlyURL",
-						_getFriendlyURLErrorMessage(
-							groupFriendlyURLException.getType()));
-				}
-			}
-		}
+		_updateFriendlyURL(friendlyURL, groupId);
 
 		FaroProject faroProject =
 			faroProjectLocalService.getFaroProjectByGroupId(groupId);
@@ -1751,6 +1726,40 @@ public class ProjectFaroController extends BaseFaroController {
 		}
 
 		return false;
+	}
+
+	private void _updateFriendlyURL(String friendlyURL, long groupId)
+		throws Exception {
+
+		if ((friendlyURL == null) || Validator.isBlank(friendlyURL.trim())) {
+			Group group = _groupLocalService.getGroup(groupId);
+
+			group.setFriendlyURL(null);
+
+			_groupLocalService.updateGroup(group);
+
+			return;
+		}
+
+		_validateFriendlyURL(friendlyURL);
+
+		Group group = _groupLocalService.getGroup(groupId);
+
+		if (StringUtil.equals(group.getFriendlyURL(), friendlyURL)) {
+			return;
+		}
+
+		try {
+			_groupLocalService.updateFriendlyURL(groupId, friendlyURL);
+		}
+		catch (GroupFriendlyURLException groupFriendlyURLException) {
+			_log.error(groupFriendlyURLException);
+
+			throw new FaroValidationException(
+				"friendlyURL",
+				_getFriendlyURLErrorMessage(
+					groupFriendlyURLException.getType()));
+		}
 	}
 
 	private void _validateCorpProjectUuid(String corpProjectUuid)

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroController.java
@@ -943,16 +943,20 @@ public class ProjectFaroController extends BaseFaroController {
 		else {
 			_validateFriendlyURL(friendlyURL);
 
-			try {
-				_groupLocalService.updateFriendlyURL(groupId, friendlyURL);
-			}
-			catch (GroupFriendlyURLException groupFriendlyURLException) {
-				_log.error(groupFriendlyURLException);
+			Group group = _groupLocalService.getGroup(groupId);
 
-				throw new FaroValidationException(
-					"friendlyURL",
-					_getFriendlyURLErrorMessage(
-						groupFriendlyURLException.getType()));
+			if (!StringUtil.equals(group.getFriendlyURL(), friendlyURL)) {
+				try {
+					_groupLocalService.updateFriendlyURL(groupId, friendlyURL);
+				}
+				catch (GroupFriendlyURLException groupFriendlyURLException) {
+					_log.error(groupFriendlyURLException);
+
+					throw new FaroValidationException(
+						"friendlyURL",
+						_getFriendlyURLErrorMessage(
+							groupFriendlyURLException.getType()));
+				}
 			}
 		}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/main/ProjectFaroControllerTest.java
@@ -9,6 +9,9 @@ import com.liferay.osb.faro.provisioning.client.constants.ProductConstants;
 import com.liferay.osb.faro.provisioning.client.internal.ProvisioningClientImpl;
 import com.liferay.osb.faro.provisioning.client.model.OSBAccountEntry;
 import com.liferay.osb.faro.provisioning.client.model.OSBOfferingEntry;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.List;
@@ -18,6 +21,8 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.Mockito;
 
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -70,6 +75,118 @@ public class ProjectFaroControllerTest {
 			"4-EnterpriseLXCTest",
 			ProductConstants.PRODUCT_ENTRY_ID_LXC_ENTERPRISE);
 		_assert("5-ProLXCTest", ProductConstants.PRODUCT_ENTRY_ID_LXC_PRO);
+	}
+
+	@Test
+	public void testUpdateFriendlyURLWhenFriendlyURLIsBlank() throws Exception {
+		GroupLocalService groupLocalService = Mockito.mock(
+			GroupLocalService.class);
+
+		ReflectionTestUtils.setField(
+			_projectFaroController, "_groupLocalService", groupLocalService);
+
+		long groupId = RandomTestUtil.randomLong();
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			groupLocalService.getGroup(groupId)
+		).thenReturn(
+			group
+		);
+
+		ReflectionTestUtils.invokeMethod(
+			_projectFaroController, "_updateFriendlyURL", "", groupId);
+
+		Mockito.verify(
+			group
+		).setFriendlyURL(
+			null
+		);
+
+		Mockito.verify(
+			groupLocalService
+		).updateGroup(
+			group
+		);
+
+		Mockito.verify(
+			groupLocalService, Mockito.never()
+		).updateFriendlyURL(
+			Mockito.anyLong(), Mockito.anyString()
+		);
+	}
+
+	@Test
+	public void testUpdateFriendlyURLWhenFriendlyURLIsChanged()
+		throws Exception {
+
+		GroupLocalService groupLocalService = Mockito.mock(
+			GroupLocalService.class);
+
+		ReflectionTestUtils.setField(
+			_projectFaroController, "_groupLocalService", groupLocalService);
+
+		long groupId = RandomTestUtil.randomLong();
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getFriendlyURL()
+		).thenReturn(
+			"/old-url"
+		);
+
+		Mockito.when(
+			groupLocalService.getGroup(groupId)
+		).thenReturn(
+			group
+		);
+
+		ReflectionTestUtils.invokeMethod(
+			_projectFaroController, "_updateFriendlyURL", "/new-url", groupId);
+
+		Mockito.verify(
+			groupLocalService
+		).updateFriendlyURL(
+			groupId, "/new-url"
+		);
+	}
+
+	@Test
+	public void testUpdateFriendlyURLWhenFriendlyURLIsUnchanged()
+		throws Exception {
+
+		GroupLocalService groupLocalService = Mockito.mock(
+			GroupLocalService.class);
+
+		ReflectionTestUtils.setField(
+			_projectFaroController, "_groupLocalService", groupLocalService);
+
+		long groupId = RandomTestUtil.randomLong();
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getFriendlyURL()
+		).thenReturn(
+			"/same-url"
+		);
+
+		Mockito.when(
+			groupLocalService.getGroup(groupId)
+		).thenReturn(
+			group
+		);
+
+		ReflectionTestUtils.invokeMethod(
+			_projectFaroController, "_updateFriendlyURL", "/same-url", groupId);
+
+		Mockito.verify(
+			groupLocalService, Mockito.never()
+		).updateFriendlyURL(
+			Mockito.anyLong(), Mockito.anyString()
+		);
 	}
 
 	private void _assert(String corpProjectUuid, String productEntryId)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102967

## What Is Being Fixed

`POST /project/provisioned` throws a duplicate friendly URL error whenever a caller passes both `enableAutoConfiguration=true` and a non-blank `friendlyURL`, even though no other workspace is using that URL. `createProvisioned` applies the `friendlyURL` twice: once during project creation (`_create()` → `addFaroProject` → `Group` creation with that URL already set), then again through `configure()` calling `update()`, which unconditionally called `updateFriendlyURL` regardless of whether the group already had that exact URL. The second, redundant call gets treated as a conflict rather than a no-op.

## How It Is Being Fixed

`update()`'s friendly URL handling is pulled into a new `_updateFriendlyURL(groupId, friendlyURL)` helper, which now compares the requested URL against the group's current one and skips the `updateFriendlyURL` call when they already match — tolerating the no-op instead of erroring. The extraction also makes the blank/changed/unchanged branches independently unit-testable with a mocked `GroupLocalService`, without pulling in `update()`'s other dependencies (`User`, `FaroProject`, `cerebroEngineClient`, etc.).

## PR Check

**pr-check: SKIPPED** — will run separately later

<!-- pr-check {"reason": "will run separately later", "result": "skipped", "sha": "2bc08e143da4d061bf1d1653fd9e7074665292e7"} -->
