### PR TITLE
LPD-101231 Upgrade the workspace and fix the Faro project reindex

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/gradle-local.properties
+++ b/workspaces/liferay-osbfaro-workspace/gradle-local.properties
@@ -1,1 +1,1 @@
-liferay.workspace.product=dxp-2026.q1.5-lts
+liferay.workspace.product=dxp-2026.q2.11

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/search/FaroProjectIndexer.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/search/FaroProjectIndexer.java
@@ -15,6 +15,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.search.BaseIndexer;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
@@ -253,12 +254,18 @@ public class FaroProjectIndexer extends BaseIndexer<FaroProject> {
 	}
 
 	@Override
-	protected void doReindex(String[] ids) throws Exception {
-		for (String id : ids) {
-			doReindex(FaroProject.class.getName(), GetterUtil.getLong(id));
-		}
+	protected void doReindexCompany(long companyId) throws Exception {
+		IndexableActionableDynamicQuery indexableActionableDynamicQuery =
+			getIndexableActionableDynamicQuery();
+
+		indexableActionableDynamicQuery.setCompanyId(CompanyConstants.SYSTEM);
+		indexableActionableDynamicQuery.setPerformActionMethod(
+			this::safeGetDocument);
+
+		indexableActionableDynamicQuery.performActions();
 	}
 
+	@Override
 	protected IndexableActionableDynamicQuery
 		getIndexableActionableDynamicQuery() {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101231

## What Is Being Fixed

`FaroProjectIndexer.doReindex(String[] ids)` does not compile against DXP 2026.Q2.11. `BaseIndexer` dropped that method in LPD-83771, replacing it with a concrete `doReindexCompany(long)` plus a `getIndexableActionableDynamicQuery()` hook.

The override was also wrong on its own terms. `BaseIndexer.reindex(String[] ids)` always passed a single element array holding the company ID, and the override fed that value straight to `getFaroProject` as a primary key, so a full reindex threw `NoSuchFaroProjectException`.

## How It Is Being Fixed

The first commit bumps the workspace product version to `dxp-2026.q2.11`. The second replaces the obsolete override with `doReindexCompany`.

Deleting the override alone is not enough. The inherited `doReindexCompany` filters the query by the company ID it receives from `SearchEngineInitializer`, and no `FaroProject` row carries one — `addFaroProject` never calls `setCompanyId`, unlike `FaroProjectUsage` and `FaroDataSourceUsage`. A full reindex would then report success and index nothing, which is harder to notice than the current exception.

Scoping the query to `CompanyConstants.SYSTEM` matches how the rest of this indexer already addresses the index (`updateDocument(0L, ...)` and `deleteDocument(0, ...)`) and how both of its consumers search it (`FaroAdminDisplayContext` and `InfoPanelMVCResourceCommand`, each using a bare `SearchContext`). `ConfigurationModelIndexer` in `configuration-admin-web` solves the same problem the same way, overriding `doReindexCompany`, discarding the company ID, and writing to `CompanyConstants.SYSTEM`.

`getIndexableActionableDynamicQuery()` gains `@Override`, since it now genuinely overrides the new `BaseIndexer` hook rather than standing alone.

## Why Are There No Tests?

No faro test exercises this path today, which is why the broken override went unnoticed. Covering it needs an integration test that runs a full reindex against the search index, and no such harness exists for this indexer.

## PR Check

Not yet run. It will be published separately with the `pr-check-publish` skill.
