### PR TITLE
LPD-102942 Require administration permission for performance metrics

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/depot/entry/util/DepotEntryUtil.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/depot/entry/util/DepotEntryUtil.java
@@ -17,7 +17,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.service.Snapshot;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
@@ -32,12 +31,34 @@ import java.util.Objects;
  */
 public class DepotEntryUtil {
 
-	public static List<DepotEntry> getAdministeredDepotEntries(
-			long companyId, Long... depotEntryIds)
+	public static List<DepotEntry> getDepotEntries(
+			String actionId, long companyId, Long... depotEntryIds)
 		throws PortalException {
 
-		return _getDepotEntries(
-			ActionKeys.VIEW_SITE_ADMINISTRATION, companyId, depotEntryIds);
+		DepotEntryLocalService depotEntryLocalService =
+			_depotEntryLocalServiceSnapshot.get();
+
+		Predicate predicate = DepotEntryTable.INSTANCE.companyId.eq(companyId);
+
+		Long[] filteredDepotEntryIds = ArrayUtil.filter(
+			depotEntryIds, Objects::nonNull);
+
+		if (ArrayUtil.isNotEmpty(filteredDepotEntryIds)) {
+			predicate = predicate.and(
+				DepotEntryTable.INSTANCE.depotEntryId.in(
+					filteredDepotEntryIds));
+		}
+
+		List<DepotEntry> depotEntries = depotEntryLocalService.dslQuery(
+			DSLQueryFactoryUtil.select(
+				DepotEntryTable.INSTANCE
+			).from(
+				DepotEntryTable.INSTANCE
+			).where(
+				predicate
+			));
+
+		return _filterDepotEntries(actionId, depotEntries);
 	}
 
 	public static Long[] getGroupIds(List<DepotEntry> depotEntries) {
@@ -59,13 +80,6 @@ public class DepotEntryUtil {
 		}
 
 		return groupIds.toArray(new Long[0]);
-	}
-
-	public static List<DepotEntry> getViewableDepotEntries(
-			long companyId, Long... depotEntryIds)
-		throws PortalException {
-
-		return _getDepotEntries(ActionKeys.VIEW, companyId, depotEntryIds);
 	}
 
 	private static List<DepotEntry> _filterDepotEntries(
@@ -95,36 +109,6 @@ public class DepotEntryUtil {
 		}
 
 		return filteredDepotEntries;
-	}
-
-	private static List<DepotEntry> _getDepotEntries(
-			String actionId, long companyId, Long[] depotEntryIds)
-		throws PortalException {
-
-		DepotEntryLocalService depotEntryLocalService =
-			_depotEntryLocalServiceSnapshot.get();
-
-		Predicate predicate = DepotEntryTable.INSTANCE.companyId.eq(companyId);
-
-		Long[] filteredDepotEntryIds = ArrayUtil.filter(
-			depotEntryIds, Objects::nonNull);
-
-		if (ArrayUtil.isNotEmpty(filteredDepotEntryIds)) {
-			predicate = predicate.and(
-				DepotEntryTable.INSTANCE.depotEntryId.in(
-					filteredDepotEntryIds));
-		}
-
-		List<DepotEntry> depotEntries = depotEntryLocalService.dslQuery(
-			DSLQueryFactoryUtil.select(
-				DepotEntryTable.INSTANCE
-			).from(
-				DepotEntryTable.INSTANCE
-			).where(
-				predicate
-			));
-
-		return _filterDepotEntries(actionId, depotEntries);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(DepotEntryUtil.class);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/depot/entry/util/DepotEntryUtil.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/depot/entry/util/DepotEntryUtil.java
@@ -10,9 +10,9 @@ import com.liferay.depot.model.DepotEntryGroupRel;
 import com.liferay.depot.model.DepotEntryTable;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.depot.service.DepotEntryService;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -25,36 +25,19 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Thiago Buarque
  */
 public class DepotEntryUtil {
 
-	public static List<DepotEntry> getDepotEntries(
-			long companyId, Long depotEntryId)
+	public static List<DepotEntry> getAdministeredDepotEntries(
+			long companyId, Long... depotEntryIds)
 		throws PortalException {
 
-		List<DepotEntry> depotEntries = new ArrayList<>();
-
-		if (depotEntryId == null) {
-			depotEntries.addAll(_getDepotEntries(companyId, null));
-		}
-		else {
-			DepotEntryService depotEntryService =
-				_depotEntryServiceSnapshot.get();
-
-			depotEntries.add(depotEntryService.getDepotEntry(depotEntryId));
-		}
-
-		return depotEntries;
-	}
-
-	public static List<DepotEntry> getDepotEntries(
-			long companyId, Long[] depotEntryIds)
-		throws PortalException {
-
-		return _getDepotEntries(companyId, depotEntryIds);
+		return _getDepotEntries(
+			ActionKeys.VIEW_SITE_ADMINISTRATION, companyId, depotEntryIds);
 	}
 
 	public static Long[] getGroupIds(List<DepotEntry> depotEntries) {
@@ -78,11 +61,18 @@ public class DepotEntryUtil {
 		return groupIds.toArray(new Long[0]);
 	}
 
-	private static List<DepotEntry> _filterViewableDepotEntries(
-			List<DepotEntry> depotEntries)
+	public static List<DepotEntry> getViewableDepotEntries(
+			long companyId, Long... depotEntryIds)
 		throws PortalException {
 
-		List<DepotEntry> viewableDepotEntries = new ArrayList<>();
+		return _getDepotEntries(ActionKeys.VIEW, companyId, depotEntryIds);
+	}
+
+	private static List<DepotEntry> _filterDepotEntries(
+			String actionId, List<DepotEntry> depotEntries)
+		throws PortalException {
+
+		List<DepotEntry> filteredDepotEntries = new ArrayList<>();
 
 		ModelResourcePermission<DepotEntry> modelResourcePermission =
 			_depotEntryModelResourcePermissionSnapshot.get();
@@ -91,25 +81,24 @@ public class DepotEntryUtil {
 
 		for (DepotEntry depotEntry : depotEntries) {
 			if (modelResourcePermission.contains(
-					permissionChecker, depotEntry, ActionKeys.VIEW) ||
-				modelResourcePermission.contains(
-					permissionChecker, depotEntry,
-					ActionKeys.VIEW_SITE_ADMINISTRATION)) {
+					permissionChecker, depotEntry, actionId)) {
 
-				viewableDepotEntries.add(depotEntry);
+				filteredDepotEntries.add(depotEntry);
 			}
 			else if (_log.isInfoEnabled()) {
 				_log.info(
-					"User does not have access to view depot entry " +
-						depotEntry.getDepotEntryId());
+					StringBundler.concat(
+						"User does not have the ", actionId,
+						" permission on depot entry ",
+						depotEntry.getDepotEntryId()));
 			}
 		}
 
-		return viewableDepotEntries;
+		return filteredDepotEntries;
 	}
 
 	private static List<DepotEntry> _getDepotEntries(
-			long companyId, Long[] depotEntryIds)
+			String actionId, long companyId, Long[] depotEntryIds)
 		throws PortalException {
 
 		DepotEntryLocalService depotEntryLocalService =
@@ -117,9 +106,13 @@ public class DepotEntryUtil {
 
 		Predicate predicate = DepotEntryTable.INSTANCE.companyId.eq(companyId);
 
-		if (ArrayUtil.isNotEmpty(depotEntryIds)) {
+		Long[] filteredDepotEntryIds = ArrayUtil.filter(
+			depotEntryIds, Objects::nonNull);
+
+		if (ArrayUtil.isNotEmpty(filteredDepotEntryIds)) {
 			predicate = predicate.and(
-				DepotEntryTable.INSTANCE.depotEntryId.in(depotEntryIds));
+				DepotEntryTable.INSTANCE.depotEntryId.in(
+					filteredDepotEntryIds));
 		}
 
 		List<DepotEntry> depotEntries = depotEntryLocalService.dslQuery(
@@ -131,7 +124,7 @@ public class DepotEntryUtil {
 				predicate
 			));
 
-		return _filterViewableDepotEntries(depotEntries);
+		return _filterDepotEntries(actionId, depotEntries);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(DepotEntryUtil.class);
@@ -146,8 +139,5 @@ public class DepotEntryUtil {
 		_depotEntryModelResourcePermissionSnapshot = new Snapshot<>(
 			DepotEntryUtil.class, Snapshot.cast(ModelResourcePermission.class),
 			"(model.class.name=com.liferay.depot.model.DepotEntry)");
-	private static final Snapshot<DepotEntryService>
-		_depotEntryServiceSnapshot = new Snapshot<>(
-			DepotEntryUtil.class, DepotEntryService.class);
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ExpiredAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ExpiredAssetResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -62,8 +63,8 @@ public class ExpiredAssetResourceImpl extends BaseExpiredAssetResourceImpl {
 
 		LicenseManagerUtil.checkFreeTier();
 
-		List<DepotEntry> depotEntries = DepotEntryUtil.getViewableDepotEntries(
-			contextCompany.getCompanyId(), depotEntryId);
+		List<DepotEntry> depotEntries = DepotEntryUtil.getDepotEntries(
+			ActionKeys.VIEW, contextCompany.getCompanyId(), depotEntryId);
 
 		if (depotEntries.isEmpty()) {
 			return Page.of(Collections.emptyList(), pagination, 0);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ExpiredAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ExpiredAssetResourceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.analytics.cms.rest.dto.v1_0.ExpiredAsset;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.internal.resource.v1_0.util.ObjectEntryVersionTitleExpressionUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.ExpiredAssetResource;
+import com.liferay.depot.model.DepotEntry;
 import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.model.ObjectDefinitionTable;
@@ -37,6 +38,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -60,9 +62,14 @@ public class ExpiredAssetResourceImpl extends BaseExpiredAssetResourceImpl {
 
 		LicenseManagerUtil.checkFreeTier();
 
-		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getViewableDepotEntries(
-				contextCompany.getCompanyId(), depotEntryId));
+		List<DepotEntry> depotEntries = DepotEntryUtil.getViewableDepotEntries(
+			contextCompany.getCompanyId(), depotEntryId);
+
+		if (depotEntries.isEmpty()) {
+			return Page.of(Collections.emptyList(), pagination, 0);
+		}
+
+		Long[] groupIds = DepotEntryUtil.getGroupIds(depotEntries);
 
 		Locale locale = LocaleUtil.fromLanguageId(languageId, true, false);
 

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ExpiredAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/ExpiredAssetResourceImpl.java
@@ -61,7 +61,7 @@ public class ExpiredAssetResourceImpl extends BaseExpiredAssetResourceImpl {
 		LicenseManagerUtil.checkFreeTier();
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getDepotEntries(
+			DepotEntryUtil.getViewableDepotEntries(
 				contextCompany.getCompanyId(), depotEntryId));
 
 		Locale locale = LocaleUtil.fromLanguageId(languageId, true, false);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/InventoryAnalysisResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/InventoryAnalysisResourceImpl.java
@@ -34,6 +34,7 @@ import com.liferay.petra.sql.dsl.query.FromStep;
 import com.liferay.petra.sql.dsl.query.GroupByStep;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Localization;
@@ -72,8 +73,8 @@ public class InventoryAnalysisResourceImpl
 
 		LicenseManagerUtil.checkFreeTier();
 
-		List<DepotEntry> depotEntries = DepotEntryUtil.getViewableDepotEntries(
-			contextCompany.getCompanyId(), depotEntryId);
+		List<DepotEntry> depotEntries = DepotEntryUtil.getDepotEntries(
+			ActionKeys.VIEW, contextCompany.getCompanyId(), depotEntryId);
 
 		if (depotEntries.isEmpty()) {
 			inventoryAnalysis.setInventoryAnalysisItems(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/InventoryAnalysisResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/InventoryAnalysisResourceImpl.java
@@ -72,7 +72,7 @@ public class InventoryAnalysisResourceImpl
 
 		LicenseManagerUtil.checkFreeTier();
 
-		List<DepotEntry> depotEntries = DepotEntryUtil.getDepotEntries(
+		List<DepotEntry> depotEntries = DepotEntryUtil.getViewableDepotEntries(
 			contextCompany.getCompanyId(), depotEntryId);
 
 		if (depotEntries.isEmpty()) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OverviewResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OverviewResourceImpl.java
@@ -59,7 +59,7 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 
 		LicenseManagerUtil.checkFreeTier();
 
-		List<DepotEntry> depotEntries = DepotEntryUtil.getDepotEntries(
+		List<DepotEntry> depotEntries = DepotEntryUtil.getViewableDepotEntries(
 			contextCompany.getCompanyId(), depotEntryId);
 
 		if (depotEntries.isEmpty()) {
@@ -85,7 +85,7 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 
 		LicenseManagerUtil.checkFreeTier();
 
-		List<DepotEntry> depotEntries = DepotEntryUtil.getDepotEntries(
+		List<DepotEntry> depotEntries = DepotEntryUtil.getViewableDepotEntries(
 			contextCompany.getCompanyId(), depotEntryId);
 
 		if (depotEntries.isEmpty()) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OverviewResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/OverviewResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -59,8 +60,8 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 
 		LicenseManagerUtil.checkFreeTier();
 
-		List<DepotEntry> depotEntries = DepotEntryUtil.getViewableDepotEntries(
-			contextCompany.getCompanyId(), depotEntryId);
+		List<DepotEntry> depotEntries = DepotEntryUtil.getDepotEntries(
+			ActionKeys.VIEW, contextCompany.getCompanyId(), depotEntryId);
 
 		if (depotEntries.isEmpty()) {
 			return _toOverview(0, Trend.Classification.NEUTRAL, 0.0, 0, 0, 0);
@@ -85,8 +86,8 @@ public class OverviewResourceImpl extends BaseOverviewResourceImpl {
 
 		LicenseManagerUtil.checkFreeTier();
 
-		List<DepotEntry> depotEntries = DepotEntryUtil.getViewableDepotEntries(
-			contextCompany.getCompanyId(), depotEntryId);
+		List<DepotEntry> depotEntries = DepotEntryUtil.getDepotEntries(
+			ActionKeys.VIEW, contextCompany.getCompanyId(), depotEntryId);
 
 		if (depotEntries.isEmpty()) {
 			return _toOverview(0, Trend.Classification.NEUTRAL, 0.0, 0, 0, 0);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
@@ -15,6 +15,7 @@ import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -54,7 +55,8 @@ public class PerformanceAssetConsumptionResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getAdministeredDepotEntries(
+			DepotEntryUtil.getDepotEntries(
+				ActionKeys.VIEW_SITE_ADMINISTRATION,
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		if (ArrayUtil.isEmpty(groupIds)) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.analytics.cms.rest.internal.resource.v1_0;
 
 import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumption;
+import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceAssetConsumptionItem;
 import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
 import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceAssetConsumptionResource;
@@ -14,6 +15,7 @@ import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -54,6 +56,19 @@ public class PerformanceAssetConsumptionResourceImpl
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
 			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			PerformanceAssetConsumption performanceAssetConsumption =
+				new PerformanceAssetConsumption();
+
+			performanceAssetConsumption.setPerformanceAssetConsumptionItems(
+				() -> new PerformanceAssetConsumptionItem[0]);
+			performanceAssetConsumption.
+				setPerformanceAssetConsumptionItemsCount(() -> 0L);
+			performanceAssetConsumption.setTotalCount(() -> 0L);
+
+			return performanceAssetConsumption;
+		}
 
 		String objectType = null;
 

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceAssetConsumptionResourceImpl.java
@@ -52,7 +52,7 @@ public class PerformanceAssetConsumptionResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getDepotEntries(
+			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		String objectType = null;

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceHistogramMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceHistogramMetricResourceImpl.java
@@ -49,7 +49,7 @@ public class PerformanceHistogramMetricResourceImpl
 				contextCompany.getCompanyId()),
 			Arrays.asList(
 				DepotEntryUtil.getGroupIds(
-					DepotEntryUtil.getDepotEntries(
+					DepotEntryUtil.getAdministeredDepotEntries(
 						contextCompany.getCompanyId(), depotEntryIds))),
 			rangeKey, selectedMetric);
 	}

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceHistogramMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceHistogramMetricResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.analytics.cms.rest.internal.resource.v1_0;
 
+import com.liferay.analytics.cms.rest.dto.v1_0.Histogram;
 import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceHistogramMetric;
 import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
@@ -12,6 +13,7 @@ import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceHistogramMetricRe
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 
 import java.util.Arrays;
@@ -41,17 +43,26 @@ public class PerformanceHistogramMetricResourceImpl
 		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
+		Long[] groupIds = DepotEntryUtil.getGroupIds(
+			DepotEntryUtil.getAdministeredDepotEntries(
+				contextCompany.getCompanyId(), depotEntryIds));
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			PerformanceHistogramMetric performanceHistogramMetric =
+				new PerformanceHistogramMetric();
+
+			performanceHistogramMetric.setHistograms(() -> new Histogram[0]);
+
+			return performanceHistogramMetric;
+		}
+
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
 			_http);
 
 		return analyticsCloudClient.getPerformanceHistogramMetric(
 			_analyticsSettingsManager.getAnalyticsConfiguration(
 				contextCompany.getCompanyId()),
-			Arrays.asList(
-				DepotEntryUtil.getGroupIds(
-					DepotEntryUtil.getAdministeredDepotEntries(
-						contextCompany.getCompanyId(), depotEntryIds))),
-			rangeKey, selectedMetric);
+			Arrays.asList(groupIds), rangeKey, selectedMetric);
 	}
 
 	@Reference

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceHistogramMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceHistogramMetricResourceImpl.java
@@ -13,6 +13,7 @@ import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceHistogramMetricRe
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 
@@ -44,7 +45,8 @@ public class PerformanceHistogramMetricResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getAdministeredDepotEntries(
+			DepotEntryUtil.getDepotEntries(
+				ActionKeys.VIEW_SITE_ADMINISTRATION,
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		if (ArrayUtil.isEmpty(groupIds)) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.analytics.cms.rest.internal.resource.v1_0;
 
+import com.liferay.analytics.cms.rest.dto.v1_0.Metric;
 import com.liferay.analytics.cms.rest.dto.v1_0.PerformanceMetric;
 import com.liferay.analytics.cms.rest.internal.client.AnalyticsCloudClient;
 import com.liferay.analytics.cms.rest.internal.depot.entry.util.DepotEntryUtil;
@@ -14,6 +15,7 @@ import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -59,6 +61,15 @@ public class PerformanceMetricResourceImpl
 			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
 
+		if (ArrayUtil.isEmpty(groupIds)) {
+			PerformanceMetric performanceMetric = new PerformanceMetric();
+
+			performanceMetric.setMetricType(() -> metricType);
+			performanceMetric.setMetrics(() -> new Metric[0]);
+
+			return performanceMetric;
+		}
+
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
 			_http);
 
@@ -85,6 +96,13 @@ public class PerformanceMetricResourceImpl
 			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
 
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return _getResponse(
+				groupBy,
+				outputStream -> {
+				});
+		}
+
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
 			_http);
 
@@ -94,15 +112,9 @@ public class PerformanceMetricResourceImpl
 			null, Arrays.asList(groupIds), null, metricType,
 			_getPath(groupBy) + "/export", rangeKey, null);
 
-		return Response.ok(
-			(StreamingOutput)outputStream -> StreamUtil.transfer(
-				inputStream, outputStream)
-		).header(
-			"Content-Disposition",
-			StringBundler.concat(
-				"attachment; filename=performance-metric-",
-				StringUtil.toLowerCase(groupBy), "-", LocalDate.now(), ".csv")
-		).build();
+		return _getResponse(
+			groupBy,
+			outputStream -> StreamUtil.transfer(inputStream, outputStream));
 	}
 
 	private String _getPath(String groupBy) {
@@ -115,6 +127,19 @@ public class PerformanceMetricResourceImpl
 		}
 
 		throw new ValidationException("Invalid group by: " + groupBy);
+	}
+
+	private Response _getResponse(
+		String groupBy, StreamingOutput streamingOutput) {
+
+		return Response.ok(
+			streamingOutput
+		).header(
+			"Content-Disposition",
+			StringBundler.concat(
+				"attachment; filename=performance-metric-",
+				StringUtil.toLowerCase(groupBy), "-", LocalDate.now(), ".csv")
+		).build();
 	}
 
 	private void _validateMetricType(String metricType) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
@@ -15,6 +15,7 @@ import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -58,7 +59,8 @@ public class PerformanceMetricResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getAdministeredDepotEntries(
+			DepotEntryUtil.getDepotEntries(
+				ActionKeys.VIEW_SITE_ADMINISTRATION,
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		if (ArrayUtil.isEmpty(groupIds)) {
@@ -93,7 +95,8 @@ public class PerformanceMetricResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getAdministeredDepotEntries(
+			DepotEntryUtil.getDepotEntries(
+				ActionKeys.VIEW_SITE_ADMINISTRATION,
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		if (ArrayUtil.isEmpty(groupIds)) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceMetricResourceImpl.java
@@ -56,7 +56,7 @@ public class PerformanceMetricResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getDepotEntries(
+			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
@@ -82,7 +82,7 @@ public class PerformanceMetricResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getDepotEntries(
+			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
@@ -12,6 +12,7 @@ import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceOverviewMetricRes
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 
 import java.util.Arrays;
@@ -44,6 +45,10 @@ public class PerformanceOverviewMetricResourceImpl
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
 			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return new PerformanceOverviewMetric();
+		}
 
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
 			_http);

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
@@ -42,7 +42,7 @@ public class PerformanceOverviewMetricResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getDepotEntries(
+			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceOverviewMetricResourceImpl.java
@@ -12,6 +12,7 @@ import com.liferay.analytics.cms.rest.resource.v1_0.PerformanceOverviewMetricRes
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.analytics.settings.rest.util.AnalyticsSettingsManagerUtil;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 
@@ -43,7 +44,8 @@ public class PerformanceOverviewMetricResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getAdministeredDepotEntries(
+			DepotEntryUtil.getDepotEntries(
+				ActionKeys.VIEW_SITE_ADMINISTRATION,
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		if (ArrayUtil.isEmpty(groupIds)) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -41,6 +42,7 @@ import java.io.InputStream;
 import java.time.LocalDate;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -74,6 +76,12 @@ public class PerformanceTopAssetResourceImpl
 			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
 
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return _getResponse(
+				outputStream -> {
+				});
+		}
+
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
 			_http);
 
@@ -83,14 +91,8 @@ public class PerformanceTopAssetResourceImpl
 			_getFilterString(), Arrays.asList(groupIds), search, null,
 			"/summaries/export", rangeKey, sorts);
 
-		return Response.ok(
-			(StreamingOutput)outputStream -> StreamUtil.transfer(
-				inputStream, outputStream)
-		).header(
-			"Content-Disposition",
-			StringBundler.concat(
-				"attachment; filename=top-assets-", LocalDate.now(), ".csv")
-		).build();
+		return _getResponse(
+			outputStream -> StreamUtil.transfer(inputStream, outputStream));
 	}
 
 	@Override
@@ -104,12 +106,16 @@ public class PerformanceTopAssetResourceImpl
 		AnalyticsSettingsManagerUtil.checkAnalyticsEnabled(
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
-		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
-			_http);
-
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
 			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
+
+		if (ArrayUtil.isEmpty(groupIds)) {
+			return Page.of(Collections.emptyList(), pagination, 0);
+		}
+
+		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
+			_http);
 
 		Page<PerformanceTopAsset> performanceTopAssetPage =
 			analyticsCloudClient.getPerformanceTopAssetPage(
@@ -187,6 +193,16 @@ public class PerformanceTopAssetResourceImpl
 		}
 
 		return null;
+	}
+
+	private Response _getResponse(StreamingOutput streamingOutput) {
+		return Response.ok(
+			streamingOutput
+		).header(
+			"Content-Disposition",
+			StringBundler.concat(
+				"attachment; filename=top-assets-", LocalDate.now(), ".csv")
+		).build();
 	}
 
 	private void _setEmbedded(

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -73,7 +74,8 @@ public class PerformanceTopAssetResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getAdministeredDepotEntries(
+			DepotEntryUtil.getDepotEntries(
+				ActionKeys.VIEW_SITE_ADMINISTRATION,
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		if (ArrayUtil.isEmpty(groupIds)) {
@@ -107,7 +109,8 @@ public class PerformanceTopAssetResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getAdministeredDepotEntries(
+			DepotEntryUtil.getDepotEntries(
+				ActionKeys.VIEW_SITE_ADMINISTRATION,
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		if (ArrayUtil.isEmpty(groupIds)) {

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/PerformanceTopAssetResourceImpl.java
@@ -71,7 +71,7 @@ public class PerformanceTopAssetResourceImpl
 			_analyticsSettingsManager, contextCompany.getCompanyId());
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getDepotEntries(
+			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		AnalyticsCloudClient analyticsCloudClient = new AnalyticsCloudClient(
@@ -108,7 +108,7 @@ public class PerformanceTopAssetResourceImpl
 			_http);
 
 		Long[] groupIds = DepotEntryUtil.getGroupIds(
-			DepotEntryUtil.getDepotEntries(
+			DepotEntryUtil.getAdministeredDepotEntries(
 				contextCompany.getCompanyId(), depotEntryIds));
 
 		Page<PerformanceTopAsset> performanceTopAssetPage =

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ExpiredAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ExpiredAssetResourceTest.java
@@ -103,6 +103,7 @@ public class ExpiredAssetResourceTest extends BaseExpiredAssetResourceTestCase {
 		assertContains(expiredAsset2, (List<ExpiredAsset>)page.getItems());
 
 		_testGetExpiredAssetsPageWithDepotEntryMemberUser();
+		_testGetExpiredAssetsPageWithDepotEntryNonmemberUser();
 	}
 
 	@Override
@@ -239,6 +240,28 @@ public class ExpiredAssetResourceTest extends BaseExpiredAssetResourceTestCase {
 					_depotEntry.getDepotEntryId(), "en_US",
 					com.liferay.portal.vulcan.pagination.Pagination.of(1, 10)
 				).getTotalCount()));
+	}
+
+	private void _testGetExpiredAssetsPageWithDepotEntryNonmemberUser()
+		throws Exception {
+
+		ExpiredAssetResource expiredAssetResource =
+			ReflectionTestUtil.getFieldValue(this, "_expiredAssetResource");
+
+		Assert.assertEquals(
+			0L,
+			(long)DepotEntryTestUtil.withDepotEntryNonmemberUser(
+				_depotEntry,
+				() -> {
+					com.liferay.portal.vulcan.pagination.Page
+						<com.liferay.analytics.cms.rest.dto.v1_0.ExpiredAsset>
+							page = expiredAssetResource.getExpiredAssetsPage(
+								_depotEntry.getDepotEntryId(), "en_US",
+								com.liferay.portal.vulcan.pagination.Pagination.
+									of(1, 10));
+
+					return page.getTotalCount();
+				}));
 	}
 
 	private DepotEntry _depotEntry;

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ExpiredAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ExpiredAssetResourceTest.java
@@ -8,6 +8,8 @@ package com.liferay.analytics.cms.rest.resource.v1_0.test;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.ExpiredAsset;
 import com.liferay.analytics.cms.rest.client.pagination.Page;
 import com.liferay.analytics.cms.rest.client.pagination.Pagination;
+import com.liferay.analytics.cms.rest.resource.v1_0.ExpiredAssetResource;
+import com.liferay.analytics.cms.rest.resource.v1_0.test.util.DepotEntryTestUtil;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
@@ -22,6 +24,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -98,6 +101,8 @@ public class ExpiredAssetResourceTest extends BaseExpiredAssetResourceTestCase {
 		expiredAsset2.setTitle(portugueseTitle);
 
 		assertContains(expiredAsset2, (List<ExpiredAsset>)page.getItems());
+
+		_testGetExpiredAssetsPageWithDepotEntryMemberUser();
 	}
 
 	@Override
@@ -212,6 +217,28 @@ public class ExpiredAssetResourceTest extends BaseExpiredAssetResourceTestCase {
 			null, DepotConstants.TYPE_SPACE, _serviceContext);
 
 		_themeDisplay = _getThemeDisplay();
+	}
+
+	private void _testGetExpiredAssetsPageWithDepotEntryMemberUser()
+		throws Exception {
+
+		ExpiredAssetResource expiredAssetResource =
+			ReflectionTestUtil.getFieldValue(this, "_expiredAssetResource");
+
+		Long totalCount = expiredAssetResource.getExpiredAssetsPage(
+			_depotEntry.getDepotEntryId(), "en_US",
+			com.liferay.portal.vulcan.pagination.Pagination.of(1, 10)
+		).getTotalCount();
+
+		Assert.assertTrue(totalCount > 0);
+		Assert.assertEquals(
+			totalCount,
+			DepotEntryTestUtil.withDepotEntryMemberUser(
+				_depotEntry,
+				() -> expiredAssetResource.getExpiredAssetsPage(
+					_depotEntry.getDepotEntryId(), "en_US",
+					com.liferay.portal.vulcan.pagination.Pagination.of(1, 10)
+				).getTotalCount()));
 	}
 
 	private DepotEntry _depotEntry;

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ExpiredAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/ExpiredAssetResourceTest.java
@@ -226,20 +226,20 @@ public class ExpiredAssetResourceTest extends BaseExpiredAssetResourceTestCase {
 		ExpiredAssetResource expiredAssetResource =
 			ReflectionTestUtil.getFieldValue(this, "_expiredAssetResource");
 
-		Long totalCount = expiredAssetResource.getExpiredAssetsPage(
-			_depotEntry.getDepotEntryId(), "en_US",
-			com.liferay.portal.vulcan.pagination.Pagination.of(1, 10)
-		).getTotalCount();
-
-		Assert.assertTrue(totalCount > 0);
 		Assert.assertEquals(
-			totalCount,
-			DepotEntryTestUtil.withDepotEntryMemberUser(
+			2L,
+			(long)DepotEntryTestUtil.withDepotEntryMemberUser(
 				_depotEntry,
-				() -> expiredAssetResource.getExpiredAssetsPage(
-					_depotEntry.getDepotEntryId(), "en_US",
-					com.liferay.portal.vulcan.pagination.Pagination.of(1, 10)
-				).getTotalCount()));
+				() -> {
+					com.liferay.portal.vulcan.pagination.Page
+						<com.liferay.analytics.cms.rest.dto.v1_0.ExpiredAsset>
+							page = expiredAssetResource.getExpiredAssetsPage(
+								_depotEntry.getDepotEntryId(), "en_US",
+								com.liferay.portal.vulcan.pagination.Pagination.
+									of(1, 10));
+
+					return page.getTotalCount();
+				}));
 	}
 
 	private void _testGetExpiredAssetsPageWithDepotEntryNonmemberUser()

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/InventoryAnalysisResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/InventoryAnalysisResourceTest.java
@@ -7,6 +7,8 @@ package com.liferay.analytics.cms.rest.resource.v1_0.test;
 
 import com.liferay.analytics.cms.rest.client.dto.v1_0.InventoryAnalysis;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.InventoryAnalysisItem;
+import com.liferay.analytics.cms.rest.resource.v1_0.InventoryAnalysisResource;
+import com.liferay.analytics.cms.rest.resource.v1_0.test.util.DepotEntryTestUtil;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.entry.rel.model.AssetEntryAssetCategoryRel;
 import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalService;
@@ -30,6 +32,7 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -40,6 +43,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.io.ByteArrayInputStream;
 import java.io.Serializable;
@@ -153,6 +157,8 @@ public class InventoryAnalysisResourceTest
 				null, _depotEntry.getDepotEntryId(), null, null, null, 7, null,
 				null, null, null, null),
 			3, 5L, null);
+
+		_testGetInventoryAnalysisWithDepotEntryMemberUser();
 	}
 
 	@Test
@@ -299,6 +305,37 @@ public class InventoryAnalysisResourceTest
 				).put(
 					"videoURL", "https://www.youtube.com/watch?v=HOdbzGCI5ME"
 				).build()));
+	}
+
+	private void _testGetInventoryAnalysisWithDepotEntryMemberUser()
+		throws Exception {
+
+		InventoryAnalysisResource inventoryAnalysisResource =
+			ReflectionTestUtil.getFieldValue(
+				this, "_inventoryAnalysisResource");
+
+		com.liferay.analytics.cms.rest.dto.v1_0.InventoryAnalysis
+			inventoryAnalysis1 = inventoryAnalysisResource.getInventoryAnalysis(
+				null, _depotEntry.getDepotEntryId(), null, null, null, null,
+				null, null, null, null, Pagination.of(1, 10));
+
+		Long totalCount = inventoryAnalysis1.getTotalCount();
+
+		Assert.assertTrue(totalCount > 0);
+		Assert.assertEquals(
+			totalCount,
+			DepotEntryTestUtil.withDepotEntryMemberUser(
+				_depotEntry,
+				() -> {
+					com.liferay.analytics.cms.rest.dto.v1_0.InventoryAnalysis
+						inventoryAnalysis2 =
+							inventoryAnalysisResource.getInventoryAnalysis(
+								null, _depotEntry.getDepotEntryId(), null, null,
+								null, null, null, null, null, null,
+								Pagination.of(1, 10));
+
+					return inventoryAnalysis2.getTotalCount();
+				}));
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/InventoryAnalysisResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/InventoryAnalysisResourceTest.java
@@ -314,27 +314,19 @@ public class InventoryAnalysisResourceTest
 			ReflectionTestUtil.getFieldValue(
 				this, "_inventoryAnalysisResource");
 
-		com.liferay.analytics.cms.rest.dto.v1_0.InventoryAnalysis
-			inventoryAnalysis1 = inventoryAnalysisResource.getInventoryAnalysis(
-				null, _depotEntry.getDepotEntryId(), null, null, null, null,
-				null, null, null, null, Pagination.of(1, 10));
-
-		Long totalCount = inventoryAnalysis1.getTotalCount();
-
-		Assert.assertTrue(totalCount > 0);
 		Assert.assertEquals(
-			totalCount,
-			DepotEntryTestUtil.withDepotEntryMemberUser(
+			5L,
+			(long)DepotEntryTestUtil.withDepotEntryMemberUser(
 				_depotEntry,
 				() -> {
 					com.liferay.analytics.cms.rest.dto.v1_0.InventoryAnalysis
-						inventoryAnalysis2 =
+						inventoryAnalysis =
 							inventoryAnalysisResource.getInventoryAnalysis(
 								null, _depotEntry.getDepotEntryId(), null, null,
 								null, null, null, null, null, null,
 								Pagination.of(1, 10));
 
-					return inventoryAnalysis2.getTotalCount();
+					return inventoryAnalysis.getTotalCount();
 				}));
 	}
 

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
@@ -8,6 +8,8 @@ package com.liferay.analytics.cms.rest.resource.v1_0.test;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.Overview;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.Trend;
 import com.liferay.analytics.cms.rest.client.problem.Problem;
+import com.liferay.analytics.cms.rest.resource.v1_0.OverviewResource;
+import com.liferay.analytics.cms.rest.resource.v1_0.test.util.DepotEntryTestUtil;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.entry.rel.model.AssetEntryAssetCategoryRel;
 import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalService;
@@ -32,6 +34,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -218,6 +221,8 @@ public class OverviewResourceTest extends BaseOverviewResourceTestCase {
 			"Invalid range start: not a date",
 			() -> overviewResource.getContentOverview(
 				null, null, _getRangeDate(0), null, "not a date"));
+
+		_testGetContentOverviewWithDepotEntryMemberUser();
 	}
 
 	@Override
@@ -301,6 +306,8 @@ public class OverviewResourceTest extends BaseOverviewResourceTestCase {
 			},
 			overviewResource.getFileOverview(
 				null, null, null, null, _getRangeDate(-7)));
+
+		_testGetFileOverviewWithDepotEntryMemberUser();
 	}
 
 	private void _assertBadRequest(
@@ -343,6 +350,52 @@ public class OverviewResourceTest extends BaseOverviewResourceTestCase {
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
 			).build(),
 			DepotConstants.TYPE_SPACE, _serviceContext);
+	}
+
+	private void _testGetContentOverviewWithDepotEntryMemberUser()
+		throws Exception {
+
+		OverviewResource overviewResource = ReflectionTestUtil.getFieldValue(
+			this, "_overviewResource");
+
+		Long totalCount = overviewResource.getContentOverview(
+			_depotEntry.getDepotEntryId(), null, null, 7, null
+		).getTotalCount();
+
+		Assert.assertTrue(totalCount > 0);
+		Assert.assertEquals(
+			totalCount,
+			DepotEntryTestUtil.withDepotEntryMemberUser(
+				_depotEntry,
+				() -> overviewResource.getContentOverview(
+					_depotEntry.getDepotEntryId(), null, null, 7, null
+				).getTotalCount()));
+	}
+
+	private void _testGetFileOverviewWithDepotEntryMemberUser()
+		throws Exception {
+
+		OverviewResource overviewResource = ReflectionTestUtil.getFieldValue(
+			this, "_overviewResource");
+
+		com.liferay.analytics.cms.rest.dto.v1_0.Overview overview1 =
+			overviewResource.getFileOverview(
+				_depotEntry.getDepotEntryId(), null, null, 7, null);
+
+		Long totalCount = overview1.getTotalCount();
+
+		Assert.assertTrue(totalCount > 0);
+		Assert.assertEquals(
+			totalCount,
+			DepotEntryTestUtil.withDepotEntryMemberUser(
+				_depotEntry,
+				() -> {
+					com.liferay.analytics.cms.rest.dto.v1_0.Overview overview2 =
+						overviewResource.getFileOverview(
+							_depotEntry.getDepotEntryId(), null, null, 7, null);
+
+					return overview2.getTotalCount();
+				}));
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/OverviewResourceTest.java
@@ -358,18 +358,17 @@ public class OverviewResourceTest extends BaseOverviewResourceTestCase {
 		OverviewResource overviewResource = ReflectionTestUtil.getFieldValue(
 			this, "_overviewResource");
 
-		Long totalCount = overviewResource.getContentOverview(
-			_depotEntry.getDepotEntryId(), null, null, 7, null
-		).getTotalCount();
-
-		Assert.assertTrue(totalCount > 0);
 		Assert.assertEquals(
-			totalCount,
-			DepotEntryTestUtil.withDepotEntryMemberUser(
+			3L,
+			(long)DepotEntryTestUtil.withDepotEntryMemberUser(
 				_depotEntry,
-				() -> overviewResource.getContentOverview(
-					_depotEntry.getDepotEntryId(), null, null, 7, null
-				).getTotalCount()));
+				() -> {
+					com.liferay.analytics.cms.rest.dto.v1_0.Overview overview =
+						overviewResource.getContentOverview(
+							_depotEntry.getDepotEntryId(), null, null, 7, null);
+
+					return overview.getTotalCount();
+				}));
 	}
 
 	private void _testGetFileOverviewWithDepotEntryMemberUser()
@@ -378,23 +377,16 @@ public class OverviewResourceTest extends BaseOverviewResourceTestCase {
 		OverviewResource overviewResource = ReflectionTestUtil.getFieldValue(
 			this, "_overviewResource");
 
-		com.liferay.analytics.cms.rest.dto.v1_0.Overview overview1 =
-			overviewResource.getFileOverview(
-				_depotEntry.getDepotEntryId(), null, null, 7, null);
-
-		Long totalCount = overview1.getTotalCount();
-
-		Assert.assertTrue(totalCount > 0);
 		Assert.assertEquals(
-			totalCount,
-			DepotEntryTestUtil.withDepotEntryMemberUser(
+			1L,
+			(long)DepotEntryTestUtil.withDepotEntryMemberUser(
 				_depotEntry,
 				() -> {
-					com.liferay.analytics.cms.rest.dto.v1_0.Overview overview2 =
+					com.liferay.analytics.cms.rest.dto.v1_0.Overview overview =
 						overviewResource.getFileOverview(
 							_depotEntry.getDepotEntryId(), null, null, 7, null);
 
-					return overview2.getTotalCount();
+					return overview.getTotalCount();
 				}));
 	}
 

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -9,27 +9,20 @@ import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceAssetConsumptio
 import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceAssetConsumptionItem;
 import com.liferay.analytics.cms.rest.client.pagination.Pagination;
 import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceAssetConsumptionResource;
+import com.liferay.analytics.cms.rest.resource.v1_0.test.util.DepotEntryTestUtil;
 import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
 import com.liferay.analytics.test.util.AnalyticsCompanyConfigurationTemporarySwapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -87,41 +80,9 @@ public class PerformanceAssetConsumptionResourceTest
 		_testGetPerformanceAssetConsumptionWithInvalidGroupBy();
 	}
 
-	private DepotEntry _addDepotEntry() throws Exception {
-		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()
-			).build(),
-			DepotConstants.TYPE_ASSET_LIBRARY,
-			ServiceContextTestUtil.getServiceContext(
-				testGroup.getGroupId(), TestPropsValues.getUserId()));
-
-		_depotEntries.add(depotEntry);
-
-		return depotEntry;
-	}
-
-	private void _assertNoRequest(
-			AnalyticsCloudHttpServer analyticsCloudHttpServer,
-			UnsafeConsumer<Long[], Exception> unsafeConsumer)
-		throws Exception {
-
-		DepotEntry depotEntry1 = _depotEntries.get(0);
-		DepotEntry depotEntry2 = _depotEntries.get(1);
-
-		Long[][] depotEntryIdsArray = {
-			null, {depotEntry1.getDepotEntryId()},
-			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
-		};
-
-		for (Long[] depotEntryIds : depotEntryIdsArray) {
-			unsafeConsumer.accept(depotEntryIds);
-
-			Assert.assertNull(analyticsCloudHttpServer.getLocation());
-		}
+	private void _addDepotEntry() throws Exception {
+		_depotEntries.add(
+			DepotEntryTestUtil.addDepotEntry(testGroup.getGroupId()));
 	}
 
 	private void _assertParameter(
@@ -137,14 +98,10 @@ public class PerformanceAssetConsumptionResourceTest
 			_getPerformanceAssetConsumptionResource()
 		throws Exception {
 
-		DepotEntry depotEntry = _depotEntries.get(0);
-
 		String password = RandomTestUtil.randomString();
 
-		User user = UserTestUtil.addUser(depotEntry.getGroupId());
-
-		_userLocalService.updatePassword(
-			user.getUserId(), password, password, false, true);
+		User user = DepotEntryTestUtil.addDepotEntryMemberUser(
+			_depotEntries.get(0), password);
 
 		_users.add(user);
 
@@ -399,8 +356,8 @@ public class PerformanceAssetConsumptionResourceTest
 				performanceAssetConsumptionResource =
 					_getPerformanceAssetConsumptionResource();
 
-			_assertNoRequest(
-				analyticsCloudHttpServer,
+			DepotEntryTestUtil.assertNoRequest(
+				analyticsCloudHttpServer, _depotEntries,
 				depotEntryIds ->
 					performanceAssetConsumptionResource.
 						getPerformanceAssetConsumption(
@@ -436,13 +393,7 @@ public class PerformanceAssetConsumptionResourceTest
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
 
 	@Inject
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@Inject
-	private UserLocalService _userLocalService;
 
 	@DeleteAfterTestRun
 	private final List<User> _users = new ArrayList<>();

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -17,7 +17,6 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -26,7 +25,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -315,17 +313,13 @@ public class PerformanceAssetConsumptionResourceTest
 
 			String location = analyticsCloudHttpServer.getLocation();
 
+			DepotEntryTestUtil.assertGroupIds(_depotEntries, location);
+
 			_assertParameter("viewsMetric", "assetSummaryMetricType", location);
 			_assertParameter(
 				String.valueOf(categoryId), "categoryId", location);
 			_assertParameter(dataSourceId, "dataSourceId", location);
 			_assertParameter("tag", "groupBy", location);
-			_assertParameter(
-				StringUtil.merge(
-					TransformUtil.transformToArray(
-						_depotEntries, DepotEntry::getGroupId, Long.class),
-					StringPool.COMMA),
-				"groupIds", location);
 			_assertParameter(
 				objectDefinition.getName(), "objectType", location);
 			_assertParameter(String.valueOf(page - 1), "page", location);

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -8,6 +8,7 @@ package com.liferay.analytics.cms.rest.resource.v1_0.test;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceAssetConsumption;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceAssetConsumptionItem;
 import com.liferay.analytics.cms.rest.client.pagination.Pagination;
+import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceAssetConsumptionResource;
 import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
 import com.liferay.analytics.test.util.AnalyticsCompanyConfigurationTemporarySwapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
@@ -16,17 +17,22 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
@@ -77,6 +83,7 @@ public class PerformanceAssetConsumptionResourceTest
 		_testGetPerformanceAssetConsumptionGroupByStructure();
 		_testGetPerformanceAssetConsumptionResponse();
 		_testGetPerformanceAssetConsumptionURL();
+		_testGetPerformanceAssetConsumptionWithDepotEntryMemberUser();
 		_testGetPerformanceAssetConsumptionWithInvalidGroupBy();
 	}
 
@@ -97,6 +104,26 @@ public class PerformanceAssetConsumptionResourceTest
 		return depotEntry;
 	}
 
+	private void _assertNoRequest(
+			AnalyticsCloudHttpServer analyticsCloudHttpServer,
+			UnsafeConsumer<Long[], Exception> unsafeConsumer)
+		throws Exception {
+
+		DepotEntry depotEntry1 = _depotEntries.get(0);
+		DepotEntry depotEntry2 = _depotEntries.get(1);
+
+		Long[][] depotEntryIdsArray = {
+			null, {depotEntry1.getDepotEntryId()},
+			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
+		};
+
+		for (Long[] depotEntryIds : depotEntryIdsArray) {
+			unsafeConsumer.accept(depotEntryIds);
+
+			Assert.assertNull(analyticsCloudHttpServer.getLocation());
+		}
+	}
+
 	private void _assertParameter(
 		String expectedValue, String name, String url) {
 
@@ -104,6 +131,32 @@ public class PerformanceAssetConsumptionResourceTest
 			expectedValue,
 			URLCodec.decodeURL(
 				HttpComponentsUtil.getParameter(url, name, false)));
+	}
+
+	private PerformanceAssetConsumptionResource
+			_getPerformanceAssetConsumptionResource()
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntries.get(0);
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(depotEntry.getGroupId());
+
+		_userLocalService.updatePassword(
+			user.getUserId(), password, password, false, true);
+
+		_users.add(user);
+
+		return PerformanceAssetConsumptionResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private void _testGetPerformanceAssetConsumptionGroupByStructure()
@@ -327,6 +380,36 @@ public class PerformanceAssetConsumptionResourceTest
 		}
 	}
 
+	private void _testGetPerformanceAssetConsumptionWithDepotEntryMemberUser()
+		throws Exception {
+
+		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
+				new AnalyticsCloudHttpServer(
+					"/api/1.0/asset-metric/objectEntry/asset-consumption",
+					() -> "{}");
+
+			AnalyticsCompanyConfigurationTemporarySwapper
+				analyticsCompanyConfigurationTemporarySwapper =
+					new AnalyticsCompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						RandomTestUtil.randomString(), true,
+						analyticsCloudHttpServer.getURL())) {
+
+			PerformanceAssetConsumptionResource
+				performanceAssetConsumptionResource =
+					_getPerformanceAssetConsumptionResource();
+
+			_assertNoRequest(
+				analyticsCloudHttpServer,
+				depotEntryIds ->
+					performanceAssetConsumptionResource.
+						getPerformanceAssetConsumption(
+							null, depotEntryIds, "tag",
+							RandomTestUtil.nextInt(), null, null, null,
+							Pagination.of(1, 10)));
+		}
+	}
+
 	private void _testGetPerformanceAssetConsumptionWithInvalidGroupBy()
 		throws Exception {
 
@@ -357,5 +440,11 @@ public class PerformanceAssetConsumptionResourceTest
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceAssetConsumptionResourceTest.java
@@ -18,13 +18,12 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -90,28 +89,6 @@ public class PerformanceAssetConsumptionResourceTest
 			expectedValue,
 			URLCodec.decodeURL(
 				HttpComponentsUtil.getParameter(url, name, false)));
-	}
-
-	private PerformanceAssetConsumptionResource
-			_getPerformanceAssetConsumptionResource()
-		throws Exception {
-
-		String password = RandomTestUtil.randomString();
-
-		User user = DepotEntryTestUtil.addDepotEntryMemberUser(
-			_depotEntries.get(0), password);
-
-		_users.add(user);
-
-		return PerformanceAssetConsumptionResource.builder(
-		).authentication(
-			user.getEmailAddress(), password
-		).endpoint(
-			testCompany.getVirtualHostname(),
-			PortalUtil.getPortalServerPort(false), "http"
-		).locale(
-			LocaleUtil.getDefault()
-		).build();
 	}
 
 	private void _testGetPerformanceAssetConsumptionGroupByStructure()
@@ -334,6 +311,12 @@ public class PerformanceAssetConsumptionResourceTest
 	private void _testGetPerformanceAssetConsumptionWithDepotEntryMemberUser()
 		throws Exception {
 
+		com.liferay.analytics.cms.rest.resource.v1_0.
+			PerformanceAssetConsumptionResource
+				performanceAssetConsumptionResource =
+					ReflectionTestUtil.getFieldValue(
+						this, "_performanceAssetConsumptionResource");
+
 		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
 				new AnalyticsCloudHttpServer(
 					"/api/1.0/asset-metric/objectEntry/asset-consumption",
@@ -346,18 +329,41 @@ public class PerformanceAssetConsumptionResourceTest
 						RandomTestUtil.randomString(), true,
 						analyticsCloudHttpServer.getURL())) {
 
-			PerformanceAssetConsumptionResource
-				performanceAssetConsumptionResource =
-					_getPerformanceAssetConsumptionResource();
+			DepotEntryTestUtil.withDepotEntryMemberUser(
+				_depotEntries.get(0),
+				() -> {
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer, null,
+						depotEntryIds ->
+							performanceAssetConsumptionResource.
+								getPerformanceAssetConsumption(
+									null, depotEntryIds, "tag",
+									RandomTestUtil.nextInt(), null, null, null,
+									com.liferay.portal.vulcan.pagination.
+										Pagination.of(1, 10)));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						new DepotEntry[] {_depotEntries.get(0)},
+						depotEntryIds ->
+							performanceAssetConsumptionResource.
+								getPerformanceAssetConsumption(
+									null, depotEntryIds, "tag",
+									RandomTestUtil.nextInt(), null, null, null,
+									com.liferay.portal.vulcan.pagination.
+										Pagination.of(1, 10)));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						_depotEntries.toArray(new DepotEntry[0]),
+						depotEntryIds ->
+							performanceAssetConsumptionResource.
+								getPerformanceAssetConsumption(
+									null, depotEntryIds, "tag",
+									RandomTestUtil.nextInt(), null, null, null,
+									com.liferay.portal.vulcan.pagination.
+										Pagination.of(1, 10)));
 
-			DepotEntryTestUtil.assertNoRequest(
-				analyticsCloudHttpServer, _depotEntries,
-				depotEntryIds ->
-					performanceAssetConsumptionResource.
-						getPerformanceAssetConsumption(
-							null, depotEntryIds, "tag",
-							RandomTestUtil.nextInt(), null, null, null,
-							Pagination.of(1, 10)));
+					return null;
+				});
 		}
 	}
 
@@ -388,8 +394,5 @@ public class PerformanceAssetConsumptionResourceTest
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
-
-	@DeleteAfterTestRun
-	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceHistogramMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceHistogramMetricResourceTest.java
@@ -17,12 +17,10 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -75,28 +73,6 @@ public class PerformanceHistogramMetricResourceTest
 	private void _addDepotEntry() throws Exception {
 		_depotEntries.add(
 			DepotEntryTestUtil.addDepotEntry(testGroup.getGroupId()));
-	}
-
-	private PerformanceHistogramMetricResource
-			_getPerformanceHistogramMetricResource()
-		throws Exception {
-
-		String password = RandomTestUtil.randomString();
-
-		User user = DepotEntryTestUtil.addDepotEntryMemberUser(
-			_depotEntries.get(0), password);
-
-		_users.add(user);
-
-		return PerformanceHistogramMetricResource.builder(
-		).authentication(
-			user.getEmailAddress(), password
-		).endpoint(
-			testCompany.getVirtualHostname(),
-			PortalUtil.getPortalServerPort(false), "http"
-		).locale(
-			LocaleUtil.getDefault()
-		).build();
 	}
 
 	private void _testGetPerformanceHistogramMetric() throws Exception {
@@ -198,6 +174,12 @@ public class PerformanceHistogramMetricResourceTest
 	private void _testGetPerformanceHistogramMetricWithDepotEntryMemberUser()
 		throws Exception {
 
+		com.liferay.analytics.cms.rest.resource.v1_0.
+			PerformanceHistogramMetricResource
+				performanceHistogramMetricResource =
+					ReflectionTestUtil.getFieldValue(
+						this, "_performanceHistogramMetricResource");
+
 		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
 				new AnalyticsCloudHttpServer(
 					"/api/1.0/asset-metric/objectEntry" +
@@ -211,24 +193,39 @@ public class PerformanceHistogramMetricResourceTest
 						RandomTestUtil.randomString(), true,
 						analyticsCloudHttpServer.getURL())) {
 
-			PerformanceHistogramMetricResource
-				performanceHistogramMetricResource =
-					_getPerformanceHistogramMetricResource();
+			DepotEntryTestUtil.withDepotEntryMemberUser(
+				_depotEntries.get(0),
+				() -> {
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer, null,
+						depotEntryIds ->
+							performanceHistogramMetricResource.
+								getPerformanceHistogramMetric(
+									depotEntryIds, RandomTestUtil.nextInt(),
+									"downloadsMetric"));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						new DepotEntry[] {_depotEntries.get(0)},
+						depotEntryIds ->
+							performanceHistogramMetricResource.
+								getPerformanceHistogramMetric(
+									depotEntryIds, RandomTestUtil.nextInt(),
+									"downloadsMetric"));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						_depotEntries.toArray(new DepotEntry[0]),
+						depotEntryIds ->
+							performanceHistogramMetricResource.
+								getPerformanceHistogramMetric(
+									depotEntryIds, RandomTestUtil.nextInt(),
+									"downloadsMetric"));
 
-			DepotEntryTestUtil.assertNoRequest(
-				analyticsCloudHttpServer, _depotEntries,
-				depotEntryIds ->
-					performanceHistogramMetricResource.
-						getPerformanceHistogramMetric(
-							depotEntryIds, RandomTestUtil.nextInt(),
-							"downloadsMetric"));
+					return null;
+				});
 		}
 	}
 
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
-
-	@DeleteAfterTestRun
-	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceHistogramMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceHistogramMetricResourceTest.java
@@ -9,29 +9,22 @@ import com.liferay.analytics.cms.rest.client.dto.v1_0.Histogram;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.Metric;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceHistogramMetric;
 import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceHistogramMetricResource;
+import com.liferay.analytics.cms.rest.resource.v1_0.test.util.DepotEntryTestUtil;
 import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
 import com.liferay.analytics.test.util.AnalyticsCompanyConfigurationTemporarySwapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
@@ -39,7 +32,6 @@ import java.net.HttpURLConnection;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -82,48 +74,17 @@ public class PerformanceHistogramMetricResourceTest
 
 	private void _addDepotEntry() throws Exception {
 		_depotEntries.add(
-			_depotEntryLocalService.addDepotEntry(
-				Collections.singletonMap(
-					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-				Collections.singletonMap(
-					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-				DepotConstants.TYPE_ASSET_LIBRARY,
-				ServiceContextTestUtil.getServiceContext(
-					testGroup.getGroupId(), TestPropsValues.getUserId())));
-	}
-
-	private void _assertNoRequest(
-			AnalyticsCloudHttpServer analyticsCloudHttpServer,
-			UnsafeConsumer<Long[], Exception> unsafeConsumer)
-		throws Exception {
-
-		DepotEntry depotEntry1 = _depotEntries.get(0);
-		DepotEntry depotEntry2 = _depotEntries.get(1);
-
-		Long[][] depotEntryIdsArray = {
-			null, {depotEntry1.getDepotEntryId()},
-			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
-		};
-
-		for (Long[] depotEntryIds : depotEntryIdsArray) {
-			unsafeConsumer.accept(depotEntryIds);
-
-			Assert.assertNull(analyticsCloudHttpServer.getLocation());
-		}
+			DepotEntryTestUtil.addDepotEntry(testGroup.getGroupId()));
 	}
 
 	private PerformanceHistogramMetricResource
 			_getPerformanceHistogramMetricResource()
 		throws Exception {
 
-		DepotEntry depotEntry = _depotEntries.get(0);
-
 		String password = RandomTestUtil.randomString();
 
-		User user = UserTestUtil.addUser(depotEntry.getGroupId());
-
-		_userLocalService.updatePassword(
-			user.getUserId(), password, password, false, true);
+		User user = DepotEntryTestUtil.addDepotEntryMemberUser(
+			_depotEntries.get(0), password);
 
 		_users.add(user);
 
@@ -251,8 +212,8 @@ public class PerformanceHistogramMetricResourceTest
 				performanceHistogramMetricResource =
 					_getPerformanceHistogramMetricResource();
 
-			_assertNoRequest(
-				analyticsCloudHttpServer,
+			DepotEntryTestUtil.assertNoRequest(
+				analyticsCloudHttpServer, _depotEntries,
 				depotEntryIds ->
 					performanceHistogramMetricResource.
 						getPerformanceHistogramMetric(
@@ -263,12 +224,6 @@ public class PerformanceHistogramMetricResourceTest
 
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
-
-	@Inject
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Inject
-	private UserLocalService _userLocalService;
 
 	@DeleteAfterTestRun
 	private final List<User> _users = new ArrayList<>();

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceHistogramMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceHistogramMetricResourceTest.java
@@ -166,6 +166,9 @@ public class PerformanceHistogramMetricResourceTest
 			Metric[] metrics = histogram.getMetrics();
 
 			Assert.assertEquals(Arrays.toString(metrics), 2, metrics.length);
+
+			DepotEntryTestUtil.assertGroupIds(
+				_depotEntries, analyticsCloudHttpServer.getLocation());
 		}
 	}
 

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceHistogramMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceHistogramMetricResourceTest.java
@@ -8,20 +8,27 @@ package com.liferay.analytics.cms.rest.resource.v1_0.test;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.Histogram;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.Metric;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceHistogramMetric;
+import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceHistogramMetricResource;
 import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
 import com.liferay.analytics.test.util.AnalyticsCompanyConfigurationTemporarySwapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -30,8 +37,10 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.net.HttpURLConnection;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -59,14 +68,8 @@ public class PerformanceHistogramMetricResourceTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		_depotEntry = _depotEntryLocalService.addDepotEntry(
-			Collections.singletonMap(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			Collections.singletonMap(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			DepotConstants.TYPE_ASSET_LIBRARY,
-			ServiceContextTestUtil.getServiceContext(
-				testGroup.getGroupId(), TestPropsValues.getUserId()));
+		_addDepotEntry();
+		_addDepotEntry();
 	}
 
 	@Override
@@ -74,6 +77,65 @@ public class PerformanceHistogramMetricResourceTest
 	public void testGetPerformanceHistogramMetric() throws Exception {
 		_testGetPerformanceHistogramMetric();
 		_testGetPerformanceHistogramMetricWithAnalyticsCloudNotConnected();
+		_testGetPerformanceHistogramMetricWithDepotEntryMemberUser();
+	}
+
+	private void _addDepotEntry() throws Exception {
+		_depotEntries.add(
+			_depotEntryLocalService.addDepotEntry(
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				DepotConstants.TYPE_ASSET_LIBRARY,
+				ServiceContextTestUtil.getServiceContext(
+					testGroup.getGroupId(), TestPropsValues.getUserId())));
+	}
+
+	private void _assertNoRequest(
+			AnalyticsCloudHttpServer analyticsCloudHttpServer,
+			UnsafeConsumer<Long[], Exception> unsafeConsumer)
+		throws Exception {
+
+		DepotEntry depotEntry1 = _depotEntries.get(0);
+		DepotEntry depotEntry2 = _depotEntries.get(1);
+
+		Long[][] depotEntryIdsArray = {
+			null, {depotEntry1.getDepotEntryId()},
+			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
+		};
+
+		for (Long[] depotEntryIds : depotEntryIdsArray) {
+			unsafeConsumer.accept(depotEntryIds);
+
+			Assert.assertNull(analyticsCloudHttpServer.getLocation());
+		}
+	}
+
+	private PerformanceHistogramMetricResource
+			_getPerformanceHistogramMetricResource()
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntries.get(0);
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(depotEntry.getGroupId());
+
+		_userLocalService.updatePassword(
+			user.getUserId(), password, password, false, true);
+
+		_users.add(user);
+
+		return PerformanceHistogramMetricResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private void _testGetPerformanceHistogramMetric() throws Exception {
@@ -124,7 +186,9 @@ public class PerformanceHistogramMetricResourceTest
 			PerformanceHistogramMetric performanceHistogramMetric =
 				performanceHistogramMetricResource.
 					getPerformanceHistogramMetric(
-						new Long[] {_depotEntry.getDepotEntryId()},
+						TransformUtil.transformToArray(
+							_depotEntries, DepotEntry::getDepotEntryId,
+							Long.class),
 						RandomTestUtil.nextInt(), "downloadsMetric");
 
 			Histogram[] histograms = performanceHistogramMetric.getHistograms();
@@ -160,15 +224,53 @@ public class PerformanceHistogramMetricResourceTest
 				HttpURLConnection.HTTP_FORBIDDEN,
 				performanceHistogramMetricResource.
 					getPerformanceHistogramMetricHttpResponse(
-						new Long[] {_depotEntry.getDepotEntryId()},
+						TransformUtil.transformToArray(
+							_depotEntries, DepotEntry::getDepotEntryId,
+							Long.class),
 						RandomTestUtil.nextInt(), "downloadsMetric"));
 		}
 	}
 
+	private void _testGetPerformanceHistogramMetricWithDepotEntryMemberUser()
+		throws Exception {
+
+		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
+				new AnalyticsCloudHttpServer(
+					"/api/1.0/asset-metric/objectEntry" +
+						"/performance-overview-metric/histogram",
+					() -> "{}");
+
+			AnalyticsCompanyConfigurationTemporarySwapper
+				analyticsCompanyConfigurationTemporarySwapper =
+					new AnalyticsCompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						RandomTestUtil.randomString(), true,
+						analyticsCloudHttpServer.getURL())) {
+
+			PerformanceHistogramMetricResource
+				performanceHistogramMetricResource =
+					_getPerformanceHistogramMetricResource();
+
+			_assertNoRequest(
+				analyticsCloudHttpServer,
+				depotEntryIds ->
+					performanceHistogramMetricResource.
+						getPerformanceHistogramMetric(
+							depotEntryIds, RandomTestUtil.nextInt(),
+							"downloadsMetric"));
+		}
+	}
+
 	@DeleteAfterTestRun
-	private DepotEntry _depotEntry;
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -137,15 +136,11 @@ public class PerformanceMetricResourceTest
 
 			String location = analyticsCloudHttpServer.getLocation();
 
+			DepotEntryTestUtil.assertGroupIds(_depotEntries, location);
+
 			_assertParameter(metricType, "assetSummaryMetricType", location);
 			_assertParameter(
 				String.valueOf(dataSourceId), "dataSourceId", location);
-			_assertParameter(
-				StringUtil.merge(
-					TransformUtil.transformToArray(
-						_depotEntries, DepotEntry::getGroupId, Long.class),
-					StringPool.COMMA),
-				"groupIds", location);
 			_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
 
 			return performanceMetric;
@@ -249,15 +244,11 @@ public class PerformanceMetricResourceTest
 
 			String location = analyticsCloudHttpServer.getLocation();
 
+			DepotEntryTestUtil.assertGroupIds(_depotEntries, location);
+
 			_assertParameter(metricType, "assetSummaryMetricType", location);
 			_assertParameter(
 				String.valueOf(dataSourceId), "dataSourceId", location);
-			_assertParameter(
-				StringUtil.merge(
-					TransformUtil.transformToArray(
-						_depotEntries, DepotEntry::getGroupId, Long.class),
-					StringPool.COMMA),
-				"groupIds", location);
 			_assertParameter(String.valueOf(rangeKey), "rangeKey", location);
 		}
 	}

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
@@ -18,13 +18,11 @@ import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -147,27 +145,6 @@ public class PerformanceMetricResourceTest
 		}
 	}
 
-	private PerformanceMetricResource _getPerformanceMetricResource()
-		throws Exception {
-
-		String password = RandomTestUtil.randomString();
-
-		User user = DepotEntryTestUtil.addDepotEntryMemberUser(
-			_depotEntries.get(0), password);
-
-		_users.add(user);
-
-		return PerformanceMetricResource.builder(
-		).authentication(
-			user.getEmailAddress(), password
-		).endpoint(
-			testCompany.getVirtualHostname(),
-			PortalUtil.getPortalServerPort(false), "http"
-		).locale(
-			LocaleUtil.getDefault()
-		).build();
-	}
-
 	private void _testGetPerformanceMetric(
 			String groupBy, String metricType, String path)
 		throws Exception {
@@ -279,6 +256,10 @@ public class PerformanceMetricResourceTest
 	private void _testGetPerformanceMetricExportWithDepotEntryMemberUser()
 		throws Exception {
 
+		com.liferay.analytics.cms.rest.resource.v1_0.PerformanceMetricResource
+			performanceMetricResource = ReflectionTestUtil.getFieldValue(
+				this, "_performanceMetricResource");
+
 		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
 				new AnalyticsCloudHttpServer(
 					"/api/1.0/asset-metric/objectEntry/categories/export",
@@ -291,16 +272,35 @@ public class PerformanceMetricResourceTest
 						RandomTestUtil.randomString(), true,
 						analyticsCloudHttpServer.getURL())) {
 
-			PerformanceMetricResource performanceMetricResource =
-				_getPerformanceMetricResource();
+			DepotEntryTestUtil.withDepotEntryMemberUser(
+				_depotEntries.get(0),
+				() -> {
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer, null,
+						depotEntryIds ->
+							performanceMetricResource.
+								getPerformanceMetricExport(
+									depotEntryIds, "categories", "viewsMetric",
+									RandomTestUtil.nextInt()));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						new DepotEntry[] {_depotEntries.get(0)},
+						depotEntryIds ->
+							performanceMetricResource.
+								getPerformanceMetricExport(
+									depotEntryIds, "categories", "viewsMetric",
+									RandomTestUtil.nextInt()));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						_depotEntries.toArray(new DepotEntry[0]),
+						depotEntryIds ->
+							performanceMetricResource.
+								getPerformanceMetricExport(
+									depotEntryIds, "categories", "viewsMetric",
+									RandomTestUtil.nextInt()));
 
-			DepotEntryTestUtil.assertNoRequest(
-				analyticsCloudHttpServer, _depotEntries,
-				depotEntryIds ->
-					performanceMetricResource.
-						getPerformanceMetricExportHttpResponse(
-							depotEntryIds, "categories", "viewsMetric",
-							RandomTestUtil.nextInt()));
+					return null;
+				});
 		}
 	}
 
@@ -353,6 +353,10 @@ public class PerformanceMetricResourceTest
 	private void _testGetPerformanceMetricWithDepotEntryMemberUser()
 		throws Exception {
 
+		com.liferay.analytics.cms.rest.resource.v1_0.PerformanceMetricResource
+			performanceMetricResource = ReflectionTestUtil.getFieldValue(
+				this, "_performanceMetricResource");
+
 		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
 				new AnalyticsCloudHttpServer(
 					"/api/1.0/asset-metric/objectEntry/categories", () -> "{}");
@@ -364,14 +368,32 @@ public class PerformanceMetricResourceTest
 						RandomTestUtil.randomString(), true,
 						analyticsCloudHttpServer.getURL())) {
 
-			PerformanceMetricResource performanceMetricResource =
-				_getPerformanceMetricResource();
+			DepotEntryTestUtil.withDepotEntryMemberUser(
+				_depotEntries.get(0),
+				() -> {
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer, null,
+						depotEntryIds ->
+							performanceMetricResource.getPerformanceMetric(
+								depotEntryIds, "categories", "viewsMetric",
+								RandomTestUtil.nextInt()));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						new DepotEntry[] {_depotEntries.get(0)},
+						depotEntryIds ->
+							performanceMetricResource.getPerformanceMetric(
+								depotEntryIds, "categories", "viewsMetric",
+								RandomTestUtil.nextInt()));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						_depotEntries.toArray(new DepotEntry[0]),
+						depotEntryIds ->
+							performanceMetricResource.getPerformanceMetric(
+								depotEntryIds, "categories", "viewsMetric",
+								RandomTestUtil.nextInt()));
 
-			DepotEntryTestUtil.assertNoRequest(
-				analyticsCloudHttpServer, _depotEntries,
-				depotEntryIds -> performanceMetricResource.getPerformanceMetric(
-					depotEntryIds, "categories", "viewsMetric",
-					RandomTestUtil.nextInt()));
+					return null;
+				});
 		}
 	}
 
@@ -422,8 +444,5 @@ public class PerformanceMetricResourceTest
 
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
-
-	@DeleteAfterTestRun
-	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
@@ -9,26 +9,19 @@ import com.liferay.analytics.cms.rest.client.dto.v1_0.Metric;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceMetric;
 import com.liferay.analytics.cms.rest.client.http.HttpInvoker;
 import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceMetricResource;
+import com.liferay.analytics.cms.rest.resource.v1_0.test.util.DepotEntryTestUtil;
 import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
 import com.liferay.analytics.test.util.AnalyticsCompanyConfigurationTemporarySwapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -36,7 +29,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
@@ -105,46 +97,14 @@ public class PerformanceMetricResourceTest
 		_testGetPerformanceMetricExportWithInvalidMetricType();
 	}
 
-	private DepotEntry _addDepotEntry() throws Exception {
-		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()
-			).build(),
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()
-			).build(),
-			DepotConstants.TYPE_ASSET_LIBRARY,
-			ServiceContextTestUtil.getServiceContext(
-				testGroup.getGroupId(), TestPropsValues.getUserId()));
-
-		_depotEntries.add(depotEntry);
-
-		return depotEntry;
+	private void _addDepotEntry() throws Exception {
+		_depotEntries.add(
+			DepotEntryTestUtil.addDepotEntry(testGroup.getGroupId()));
 	}
 
 	private void _assertMetric(Metric metric, double value, String valueKey) {
 		Assert.assertEquals(value, metric.getValue(), 0);
 		Assert.assertEquals(valueKey, metric.getValueKey());
-	}
-
-	private void _assertNoRequest(
-			AnalyticsCloudHttpServer analyticsCloudHttpServer,
-			UnsafeConsumer<Long[], Exception> unsafeConsumer)
-		throws Exception {
-
-		DepotEntry depotEntry1 = _depotEntries.get(0);
-		DepotEntry depotEntry2 = _depotEntries.get(1);
-
-		Long[][] depotEntryIdsArray = {
-			null, {depotEntry1.getDepotEntryId()},
-			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
-		};
-
-		for (Long[] depotEntryIds : depotEntryIdsArray) {
-			unsafeConsumer.accept(depotEntryIds);
-
-			Assert.assertNull(analyticsCloudHttpServer.getLocation());
-		}
 	}
 
 	private void _assertParameter(
@@ -195,14 +155,10 @@ public class PerformanceMetricResourceTest
 	private PerformanceMetricResource _getPerformanceMetricResource()
 		throws Exception {
 
-		DepotEntry depotEntry = _depotEntries.get(0);
-
 		String password = RandomTestUtil.randomString();
 
-		User user = UserTestUtil.addUser(depotEntry.getGroupId());
-
-		_userLocalService.updatePassword(
-			user.getUserId(), password, password, false, true);
+		User user = DepotEntryTestUtil.addDepotEntryMemberUser(
+			_depotEntries.get(0), password);
 
 		_users.add(user);
 
@@ -347,8 +303,8 @@ public class PerformanceMetricResourceTest
 			PerformanceMetricResource performanceMetricResource =
 				_getPerformanceMetricResource();
 
-			_assertNoRequest(
-				analyticsCloudHttpServer,
+			DepotEntryTestUtil.assertNoRequest(
+				analyticsCloudHttpServer, _depotEntries,
 				depotEntryIds ->
 					performanceMetricResource.
 						getPerformanceMetricExportHttpResponse(
@@ -420,8 +376,8 @@ public class PerformanceMetricResourceTest
 			PerformanceMetricResource performanceMetricResource =
 				_getPerformanceMetricResource();
 
-			_assertNoRequest(
-				analyticsCloudHttpServer,
+			DepotEntryTestUtil.assertNoRequest(
+				analyticsCloudHttpServer, _depotEntries,
 				depotEntryIds -> performanceMetricResource.getPerformanceMetric(
 					depotEntryIds, "categories", "viewsMetric",
 					RandomTestUtil.nextInt()));
@@ -475,12 +431,6 @@ public class PerformanceMetricResourceTest
 
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
-
-	@Inject
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Inject
-	private UserLocalService _userLocalService;
 
 	@DeleteAfterTestRun
 	private final List<User> _users = new ArrayList<>();

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceMetricResourceTest.java
@@ -8,24 +8,30 @@ package com.liferay.analytics.cms.rest.resource.v1_0.test;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.Metric;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceMetric;
 import com.liferay.analytics.cms.rest.client.http.HttpInvoker;
+import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceMetricResource;
 import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
 import com.liferay.analytics.test.util.AnalyticsCompanyConfigurationTemporarySwapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
@@ -80,6 +86,7 @@ public class PerformanceMetricResourceTest
 			"location", "downloadsMetric",
 			"/api/1.0/asset-metric/objectEntry/geolocation");
 		_testGetPerformanceMetricWithAnalyticsCloudNotConnected();
+		_testGetPerformanceMetricWithDepotEntryMemberUser();
 		_testGetPerformanceMetricWithInvalidMetricType();
 		_testGetPerformanceMetricWithNoData();
 	}
@@ -94,6 +101,7 @@ public class PerformanceMetricResourceTest
 			"location", "downloadsMetric",
 			"/api/1.0/asset-metric/objectEntry/geolocation/export");
 		_testGetPerformanceMetricExportWithAnalyticsCloudNotConnected();
+		_testGetPerformanceMetricExportWithDepotEntryMemberUser();
 		_testGetPerformanceMetricExportWithInvalidMetricType();
 	}
 
@@ -117,6 +125,26 @@ public class PerformanceMetricResourceTest
 	private void _assertMetric(Metric metric, double value, String valueKey) {
 		Assert.assertEquals(value, metric.getValue(), 0);
 		Assert.assertEquals(valueKey, metric.getValueKey());
+	}
+
+	private void _assertNoRequest(
+			AnalyticsCloudHttpServer analyticsCloudHttpServer,
+			UnsafeConsumer<Long[], Exception> unsafeConsumer)
+		throws Exception {
+
+		DepotEntry depotEntry1 = _depotEntries.get(0);
+		DepotEntry depotEntry2 = _depotEntries.get(1);
+
+		Long[][] depotEntryIdsArray = {
+			null, {depotEntry1.getDepotEntryId()},
+			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
+		};
+
+		for (Long[] depotEntryIds : depotEntryIdsArray) {
+			unsafeConsumer.accept(depotEntryIds);
+
+			Assert.assertNull(analyticsCloudHttpServer.getLocation());
+		}
 	}
 
 	private void _assertParameter(
@@ -162,6 +190,31 @@ public class PerformanceMetricResourceTest
 
 			return performanceMetric;
 		}
+	}
+
+	private PerformanceMetricResource _getPerformanceMetricResource()
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntries.get(0);
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(depotEntry.getGroupId());
+
+		_userLocalService.updatePassword(
+			user.getUserId(), password, password, false, true);
+
+		_users.add(user);
+
+		return PerformanceMetricResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private void _testGetPerformanceMetric(
@@ -276,6 +329,34 @@ public class PerformanceMetricResourceTest
 		}
 	}
 
+	private void _testGetPerformanceMetricExportWithDepotEntryMemberUser()
+		throws Exception {
+
+		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
+				new AnalyticsCloudHttpServer(
+					"/api/1.0/asset-metric/objectEntry/categories/export",
+					() -> "{}");
+
+			AnalyticsCompanyConfigurationTemporarySwapper
+				analyticsCompanyConfigurationTemporarySwapper =
+					new AnalyticsCompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						RandomTestUtil.randomString(), true,
+						analyticsCloudHttpServer.getURL())) {
+
+			PerformanceMetricResource performanceMetricResource =
+				_getPerformanceMetricResource();
+
+			_assertNoRequest(
+				analyticsCloudHttpServer,
+				depotEntryIds ->
+					performanceMetricResource.
+						getPerformanceMetricExportHttpResponse(
+							depotEntryIds, "categories", "viewsMetric",
+							RandomTestUtil.nextInt()));
+		}
+	}
+
 	private void _testGetPerformanceMetricExportWithInvalidMetricType()
 		throws Exception {
 
@@ -319,6 +400,31 @@ public class PerformanceMetricResourceTest
 					TransformUtil.transformToArray(
 						_depotEntries, DepotEntry::getDepotEntryId, Long.class),
 					"categories", "viewsMetric", RandomTestUtil.nextInt()));
+		}
+	}
+
+	private void _testGetPerformanceMetricWithDepotEntryMemberUser()
+		throws Exception {
+
+		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
+				new AnalyticsCloudHttpServer(
+					"/api/1.0/asset-metric/objectEntry/categories", () -> "{}");
+
+			AnalyticsCompanyConfigurationTemporarySwapper
+				analyticsCompanyConfigurationTemporarySwapper =
+					new AnalyticsCompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						RandomTestUtil.randomString(), true,
+						analyticsCloudHttpServer.getURL())) {
+
+			PerformanceMetricResource performanceMetricResource =
+				_getPerformanceMetricResource();
+
+			_assertNoRequest(
+				analyticsCloudHttpServer,
+				depotEntryIds -> performanceMetricResource.getPerformanceMetric(
+					depotEntryIds, "categories", "viewsMetric",
+					RandomTestUtil.nextInt()));
 		}
 	}
 
@@ -372,5 +478,11 @@ public class PerformanceMetricResourceTest
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
@@ -9,36 +9,28 @@ import com.liferay.analytics.cms.rest.client.dto.v1_0.Metric;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceOverviewMetric;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.Trend;
 import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceOverviewMetricResource;
+import com.liferay.analytics.cms.rest.resource.v1_0.test.util.DepotEntryTestUtil;
 import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
 import com.liferay.analytics.test.util.AnalyticsCompanyConfigurationTemporarySwapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.net.HttpURLConnection;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -81,14 +73,7 @@ public class PerformanceOverviewMetricResourceTest
 
 	private void _addDepotEntry() throws Exception {
 		_depotEntries.add(
-			_depotEntryLocalService.addDepotEntry(
-				Collections.singletonMap(
-					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-				Collections.singletonMap(
-					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-				DepotConstants.TYPE_ASSET_LIBRARY,
-				ServiceContextTestUtil.getServiceContext(
-					testGroup.getGroupId(), TestPropsValues.getUserId())));
+			DepotEntryTestUtil.addDepotEntry(testGroup.getGroupId()));
 	}
 
 	private void _assertMetric(
@@ -107,38 +92,14 @@ public class PerformanceOverviewMetricResourceTest
 		Assert.assertEquals(percentage, trend.getPercentage(), 0);
 	}
 
-	private void _assertNoRequest(
-			AnalyticsCloudHttpServer analyticsCloudHttpServer,
-			UnsafeConsumer<Long[], Exception> unsafeConsumer)
-		throws Exception {
-
-		DepotEntry depotEntry1 = _depotEntries.get(0);
-		DepotEntry depotEntry2 = _depotEntries.get(1);
-
-		Long[][] depotEntryIdsArray = {
-			null, {depotEntry1.getDepotEntryId()},
-			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
-		};
-
-		for (Long[] depotEntryIds : depotEntryIdsArray) {
-			unsafeConsumer.accept(depotEntryIds);
-
-			Assert.assertNull(analyticsCloudHttpServer.getLocation());
-		}
-	}
-
 	private PerformanceOverviewMetricResource
 			_getPerformanceOverviewMetricResource()
 		throws Exception {
 
-		DepotEntry depotEntry = _depotEntries.get(0);
-
 		String password = RandomTestUtil.randomString();
 
-		User user = UserTestUtil.addUser(depotEntry.getGroupId());
-
-		_userLocalService.updatePassword(
-			user.getUserId(), password, password, false, true);
+		User user = DepotEntryTestUtil.addDepotEntryMemberUser(
+			_depotEntries.get(0), password);
 
 		_users.add(user);
 
@@ -288,8 +249,8 @@ public class PerformanceOverviewMetricResourceTest
 				performanceOverviewMetricResource =
 					_getPerformanceOverviewMetricResource();
 
-			_assertNoRequest(
-				analyticsCloudHttpServer,
+			DepotEntryTestUtil.assertNoRequest(
+				analyticsCloudHttpServer, _depotEntries,
 				depotEntryIds ->
 					performanceOverviewMetricResource.
 						getPerformanceOverviewMetric(
@@ -299,12 +260,6 @@ public class PerformanceOverviewMetricResourceTest
 
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
-
-	@Inject
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Inject
-	private UserLocalService _userLocalService;
 
 	@DeleteAfterTestRun
 	private final List<User> _users = new ArrayList<>();

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
@@ -17,12 +17,10 @@ import com.liferay.depot.model.DepotEntry;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -90,28 +88,6 @@ public class PerformanceOverviewMetricResourceTest
 			classification.toString(),
 			String.valueOf(trend.getClassification()));
 		Assert.assertEquals(percentage, trend.getPercentage(), 0);
-	}
-
-	private PerformanceOverviewMetricResource
-			_getPerformanceOverviewMetricResource()
-		throws Exception {
-
-		String password = RandomTestUtil.randomString();
-
-		User user = DepotEntryTestUtil.addDepotEntryMemberUser(
-			_depotEntries.get(0), password);
-
-		_users.add(user);
-
-		return PerformanceOverviewMetricResource.builder(
-		).authentication(
-			user.getEmailAddress(), password
-		).endpoint(
-			testCompany.getVirtualHostname(),
-			PortalUtil.getPortalServerPort(false), "http"
-		).locale(
-			LocaleUtil.getDefault()
-		).build();
 	}
 
 	private void _testGetPerformanceOverviewMetric() throws Exception {
@@ -235,6 +211,12 @@ public class PerformanceOverviewMetricResourceTest
 	private void _testGetPerformanceOverviewMetricWithDepotEntryMemberUser()
 		throws Exception {
 
+		com.liferay.analytics.cms.rest.resource.v1_0.
+			PerformanceOverviewMetricResource
+				performanceOverviewMetricResource =
+					ReflectionTestUtil.getFieldValue(
+						this, "_performanceOverviewMetricResource");
+
 		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
 				new AnalyticsCloudHttpServer(
 					"/api/1.0/asset-metric/objectEntry" +
@@ -248,23 +230,36 @@ public class PerformanceOverviewMetricResourceTest
 						RandomTestUtil.randomString(), true,
 						analyticsCloudHttpServer.getURL())) {
 
-			PerformanceOverviewMetricResource
-				performanceOverviewMetricResource =
-					_getPerformanceOverviewMetricResource();
+			DepotEntryTestUtil.withDepotEntryMemberUser(
+				_depotEntries.get(0),
+				() -> {
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer, null,
+						depotEntryIds ->
+							performanceOverviewMetricResource.
+								getPerformanceOverviewMetric(
+									depotEntryIds, RandomTestUtil.nextInt()));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						new DepotEntry[] {_depotEntries.get(0)},
+						depotEntryIds ->
+							performanceOverviewMetricResource.
+								getPerformanceOverviewMetric(
+									depotEntryIds, RandomTestUtil.nextInt()));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						_depotEntries.toArray(new DepotEntry[0]),
+						depotEntryIds ->
+							performanceOverviewMetricResource.
+								getPerformanceOverviewMetric(
+									depotEntryIds, RandomTestUtil.nextInt()));
 
-			DepotEntryTestUtil.assertNoRequest(
-				analyticsCloudHttpServer, _depotEntries,
-				depotEntryIds ->
-					performanceOverviewMetricResource.
-						getPerformanceOverviewMetric(
-							depotEntryIds, RandomTestUtil.nextInt()));
+					return null;
+				});
 		}
 	}
 
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
-
-	@DeleteAfterTestRun
-	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
@@ -8,20 +8,27 @@ package com.liferay.analytics.cms.rest.resource.v1_0.test;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.Metric;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.PerformanceOverviewMetric;
 import com.liferay.analytics.cms.rest.client.dto.v1_0.Trend;
+import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceOverviewMetricResource;
 import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
 import com.liferay.analytics.test.util.AnalyticsCompanyConfigurationTemporarySwapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -30,7 +37,9 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.net.HttpURLConnection;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,14 +67,8 @@ public class PerformanceOverviewMetricResourceTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		_depotEntry = _depotEntryLocalService.addDepotEntry(
-			Collections.singletonMap(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			Collections.singletonMap(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-			DepotConstants.TYPE_ASSET_LIBRARY,
-			ServiceContextTestUtil.getServiceContext(
-				testGroup.getGroupId(), TestPropsValues.getUserId()));
+		_addDepotEntry();
+		_addDepotEntry();
 	}
 
 	@Override
@@ -73,6 +76,19 @@ public class PerformanceOverviewMetricResourceTest
 	public void testGetPerformanceOverviewMetric() throws Exception {
 		_testGetPerformanceOverviewMetric();
 		_testGetPerformanceOverviewMetricWithAnalyticsCloudNotConnected();
+		_testGetPerformanceOverviewMetricWithDepotEntryMemberUser();
+	}
+
+	private void _addDepotEntry() throws Exception {
+		_depotEntries.add(
+			_depotEntryLocalService.addDepotEntry(
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				DepotConstants.TYPE_ASSET_LIBRARY,
+				ServiceContextTestUtil.getServiceContext(
+					testGroup.getGroupId(), TestPropsValues.getUserId())));
 	}
 
 	private void _assertMetric(
@@ -89,6 +105,52 @@ public class PerformanceOverviewMetricResourceTest
 			classification.toString(),
 			String.valueOf(trend.getClassification()));
 		Assert.assertEquals(percentage, trend.getPercentage(), 0);
+	}
+
+	private void _assertNoRequest(
+			AnalyticsCloudHttpServer analyticsCloudHttpServer,
+			UnsafeConsumer<Long[], Exception> unsafeConsumer)
+		throws Exception {
+
+		DepotEntry depotEntry1 = _depotEntries.get(0);
+		DepotEntry depotEntry2 = _depotEntries.get(1);
+
+		Long[][] depotEntryIdsArray = {
+			null, {depotEntry1.getDepotEntryId()},
+			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
+		};
+
+		for (Long[] depotEntryIds : depotEntryIdsArray) {
+			unsafeConsumer.accept(depotEntryIds);
+
+			Assert.assertNull(analyticsCloudHttpServer.getLocation());
+		}
+	}
+
+	private PerformanceOverviewMetricResource
+			_getPerformanceOverviewMetricResource()
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntries.get(0);
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(depotEntry.getGroupId());
+
+		_userLocalService.updatePassword(
+			user.getUserId(), password, password, false, true);
+
+		_users.add(user);
+
+		return PerformanceOverviewMetricResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private void _testGetPerformanceOverviewMetric() throws Exception {
@@ -164,7 +226,8 @@ public class PerformanceOverviewMetricResourceTest
 
 			PerformanceOverviewMetric performanceOverviewMetric =
 				performanceOverviewMetricResource.getPerformanceOverviewMetric(
-					new Long[] {_depotEntry.getDepotEntryId()},
+					TransformUtil.transformToArray(
+						_depotEntries, DepotEntry::getDepotEntryId, Long.class),
 					RandomTestUtil.nextInt());
 
 			_assertMetric(
@@ -198,15 +261,52 @@ public class PerformanceOverviewMetricResourceTest
 				HttpURLConnection.HTTP_FORBIDDEN,
 				performanceOverviewMetricResource.
 					getPerformanceOverviewMetricHttpResponse(
-						new Long[] {_depotEntry.getDepotEntryId()},
+						TransformUtil.transformToArray(
+							_depotEntries, DepotEntry::getDepotEntryId,
+							Long.class),
 						RandomTestUtil.nextInt()));
 		}
 	}
 
+	private void _testGetPerformanceOverviewMetricWithDepotEntryMemberUser()
+		throws Exception {
+
+		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
+				new AnalyticsCloudHttpServer(
+					"/api/1.0/asset-metric/objectEntry" +
+						"/performance-overview-metric",
+					() -> "{}");
+
+			AnalyticsCompanyConfigurationTemporarySwapper
+				analyticsCompanyConfigurationTemporarySwapper =
+					new AnalyticsCompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						RandomTestUtil.randomString(), true,
+						analyticsCloudHttpServer.getURL())) {
+
+			PerformanceOverviewMetricResource
+				performanceOverviewMetricResource =
+					_getPerformanceOverviewMetricResource();
+
+			_assertNoRequest(
+				analyticsCloudHttpServer,
+				depotEntryIds ->
+					performanceOverviewMetricResource.
+						getPerformanceOverviewMetric(
+							depotEntryIds, RandomTestUtil.nextInt()));
+		}
+	}
+
 	@DeleteAfterTestRun
-	private DepotEntry _depotEntry;
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceOverviewMetricResourceTest.java
@@ -203,6 +203,9 @@ public class PerformanceOverviewMetricResourceTest
 			_assertMetric(
 				performanceOverviewMetric.getViewsMetric(), "viewsMetric", 1, 2,
 				Trend.Classification.POSITIVE, 100);
+
+			DepotEntryTestUtil.assertGroupIds(
+				_depotEntries, analyticsCloudHttpServer.getLocation());
 		}
 	}
 

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -11,24 +11,18 @@ import com.liferay.analytics.cms.rest.client.http.HttpInvoker;
 import com.liferay.analytics.cms.rest.client.pagination.Page;
 import com.liferay.analytics.cms.rest.client.pagination.Pagination;
 import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceTopAssetResource;
+import com.liferay.analytics.cms.rest.resource.v1_0.test.util.DepotEntryTestUtil;
 import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
 import com.liferay.analytics.test.util.AnalyticsCompanyConfigurationTemporarySwapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -36,14 +30,12 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.net.HttpURLConnection;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -126,34 +118,7 @@ public class PerformanceTopAssetResourceTest
 
 	private void _addDepotEntry() throws Exception {
 		_depotEntries.add(
-			_depotEntryLocalService.addDepotEntry(
-				Collections.singletonMap(
-					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-				Collections.singletonMap(
-					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-				DepotConstants.TYPE_ASSET_LIBRARY,
-				ServiceContextTestUtil.getServiceContext(
-					testGroup.getGroupId(), TestPropsValues.getUserId())));
-	}
-
-	private void _assertNoRequest(
-			AnalyticsCloudHttpServer analyticsCloudHttpServer,
-			UnsafeConsumer<Long[], Exception> unsafeConsumer)
-		throws Exception {
-
-		DepotEntry depotEntry1 = _depotEntries.get(0);
-		DepotEntry depotEntry2 = _depotEntries.get(1);
-
-		Long[][] depotEntryIdsArray = {
-			null, {depotEntry1.getDepotEntryId()},
-			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
-		};
-
-		for (Long[] depotEntryIds : depotEntryIdsArray) {
-			unsafeConsumer.accept(depotEntryIds);
-
-			Assert.assertNull(analyticsCloudHttpServer.getLocation());
-		}
+			DepotEntryTestUtil.addDepotEntry(testGroup.getGroupId()));
 	}
 
 	private void _assertParameter(
@@ -168,14 +133,10 @@ public class PerformanceTopAssetResourceTest
 	private PerformanceTopAssetResource _getPerformanceTopAssetResource()
 		throws Exception {
 
-		DepotEntry depotEntry = _depotEntries.get(0);
-
 		String password = RandomTestUtil.randomString();
 
-		User user = UserTestUtil.addUser(depotEntry.getGroupId());
-
-		_userLocalService.updatePassword(
-			user.getUserId(), password, password, false, true);
+		User user = DepotEntryTestUtil.addDepotEntryMemberUser(
+			_depotEntries.get(0), password);
 
 		_users.add(user);
 
@@ -294,8 +255,8 @@ public class PerformanceTopAssetResourceTest
 			PerformanceTopAssetResource performanceTopAssetResource =
 				_getPerformanceTopAssetResource();
 
-			_assertNoRequest(
-				analyticsCloudHttpServer,
+			DepotEntryTestUtil.assertNoRequest(
+				analyticsCloudHttpServer, _depotEntries,
 				depotEntryIds ->
 					performanceTopAssetResource.
 						getPerformanceTopAssetExportHttpResponse(
@@ -483,8 +444,8 @@ public class PerformanceTopAssetResourceTest
 			PerformanceTopAssetResource performanceTopAssetResource =
 				_getPerformanceTopAssetResource();
 
-			_assertNoRequest(
-				analyticsCloudHttpServer,
+			DepotEntryTestUtil.assertNoRequest(
+				analyticsCloudHttpServer, _depotEntries,
 				depotEntryIds ->
 					performanceTopAssetResource.getPerformanceTopAssetPage(
 						depotEntryIds, RandomTestUtil.nextInt(), null, null,
@@ -494,12 +455,6 @@ public class PerformanceTopAssetResourceTest
 
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
-
-	@Inject
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Inject
-	private UserLocalService _userLocalService;
 
 	@DeleteAfterTestRun
 	private final List<User> _users = new ArrayList<>();

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -10,27 +10,44 @@ import com.liferay.analytics.cms.rest.client.dto.v1_0.Trend;
 import com.liferay.analytics.cms.rest.client.http.HttpInvoker;
 import com.liferay.analytics.cms.rest.client.pagination.Page;
 import com.liferay.analytics.cms.rest.client.pagination.Pagination;
+import com.liferay.analytics.cms.rest.client.resource.v1_0.PerformanceTopAssetResource;
 import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
 import com.liferay.analytics.test.util.AnalyticsCompanyConfigurationTemporarySwapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.net.HttpURLConnection;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,12 +67,22 @@ public class PerformanceTopAssetResourceTest
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_addDepotEntry();
+		_addDepotEntry();
+	}
+
 	@Override
 	@Test
 	public void testGetPerformanceTopAssetExport() throws Exception {
 		_testGetPerformanceTopAssetExportWithAnalyticsCloudNotConnected();
 		_testGetPerformanceTopAssetExportResponse();
 		_testGetPerformanceTopAssetExportURL();
+		_testGetPerformanceTopAssetExportWithDepotEntryMemberUser();
 	}
 
 	@Override
@@ -64,6 +91,7 @@ public class PerformanceTopAssetResourceTest
 		_testGetPerformanceTopAssetPageWithAnalyticsCloudNotConnected();
 		_testGetPerformanceTopAssetPageResponse();
 		_testGetPerformanceTopAssetPageURL();
+		_testGetPerformanceTopAssetPageWithDepotEntryMemberUser();
 	}
 
 	@Override
@@ -96,6 +124,38 @@ public class PerformanceTopAssetResourceTest
 		}
 	}
 
+	private void _addDepotEntry() throws Exception {
+		_depotEntries.add(
+			_depotEntryLocalService.addDepotEntry(
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				DepotConstants.TYPE_ASSET_LIBRARY,
+				ServiceContextTestUtil.getServiceContext(
+					testGroup.getGroupId(), TestPropsValues.getUserId())));
+	}
+
+	private void _assertNoRequest(
+			AnalyticsCloudHttpServer analyticsCloudHttpServer,
+			UnsafeConsumer<Long[], Exception> unsafeConsumer)
+		throws Exception {
+
+		DepotEntry depotEntry1 = _depotEntries.get(0);
+		DepotEntry depotEntry2 = _depotEntries.get(1);
+
+		Long[][] depotEntryIdsArray = {
+			null, {depotEntry1.getDepotEntryId()},
+			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
+		};
+
+		for (Long[] depotEntryIds : depotEntryIdsArray) {
+			unsafeConsumer.accept(depotEntryIds);
+
+			Assert.assertNull(analyticsCloudHttpServer.getLocation());
+		}
+	}
+
 	private void _assertParameter(
 		String expectedValue, String name, String url) {
 
@@ -103,6 +163,31 @@ public class PerformanceTopAssetResourceTest
 			expectedValue,
 			URLCodec.decodeURL(
 				HttpComponentsUtil.getParameter(url, name, false)));
+	}
+
+	private PerformanceTopAssetResource _getPerformanceTopAssetResource()
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntries.get(0);
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(depotEntry.getGroupId());
+
+		_userLocalService.updatePassword(
+			user.getUserId(), password, password, false, true);
+
+		_users.add(user);
+
+		return PerformanceTopAssetResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
 	}
 
 	private void _testGetPerformanceTopAssetExportResponse() throws Exception {
@@ -188,6 +273,34 @@ public class PerformanceTopAssetResourceTest
 					getPerformanceTopAssetExportHttpResponse(
 						null, RandomTestUtil.nextInt(),
 						RandomTestUtil.randomString(), null, null));
+		}
+	}
+
+	private void _testGetPerformanceTopAssetExportWithDepotEntryMemberUser()
+		throws Exception {
+
+		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
+				new AnalyticsCloudHttpServer(
+					"/api/1.0/asset-metric/objectEntry/summaries/export",
+					() -> "{}");
+
+			AnalyticsCompanyConfigurationTemporarySwapper
+				analyticsCompanyConfigurationTemporarySwapper =
+					new AnalyticsCompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						RandomTestUtil.randomString(), true,
+						analyticsCloudHttpServer.getURL())) {
+
+			PerformanceTopAssetResource performanceTopAssetResource =
+				_getPerformanceTopAssetResource();
+
+			_assertNoRequest(
+				analyticsCloudHttpServer,
+				depotEntryIds ->
+					performanceTopAssetResource.
+						getPerformanceTopAssetExportHttpResponse(
+							depotEntryIds, RandomTestUtil.nextInt(), null, null,
+							null));
 		}
 	}
 
@@ -352,5 +465,43 @@ public class PerformanceTopAssetResourceTest
 						Pagination.of(1, 10), null));
 		}
 	}
+
+	private void _testGetPerformanceTopAssetPageWithDepotEntryMemberUser()
+		throws Exception {
+
+		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
+				new AnalyticsCloudHttpServer(
+					"/api/1.0/asset-metric/objectEntry/summaries", () -> "{}");
+
+			AnalyticsCompanyConfigurationTemporarySwapper
+				analyticsCompanyConfigurationTemporarySwapper =
+					new AnalyticsCompanyConfigurationTemporarySwapper(
+						testCompany.getCompanyId(),
+						RandomTestUtil.randomString(), true,
+						analyticsCloudHttpServer.getURL())) {
+
+			PerformanceTopAssetResource performanceTopAssetResource =
+				_getPerformanceTopAssetResource();
+
+			_assertNoRequest(
+				analyticsCloudHttpServer,
+				depotEntryIds ->
+					performanceTopAssetResource.getPerformanceTopAssetPage(
+						depotEntryIds, RandomTestUtil.nextInt(), null, null,
+						Pagination.of(1, 10), null));
+		}
+	}
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	@DeleteAfterTestRun
+	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -16,6 +16,7 @@ import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
 import com.liferay.analytics.test.util.AnalyticsCompanyConfigurationTemporarySwapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.model.DepotEntry;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -199,11 +200,15 @@ public class PerformanceTopAssetResourceTest
 			String sortFieldName2 = RandomTestUtil.randomString();
 
 			performanceTopAssetResource.getPerformanceTopAssetExport(
-				null, rangeKey, search, filterString,
+				TransformUtil.transformToArray(
+					_depotEntries, DepotEntry::getDepotEntryId, Long.class),
+				rangeKey, search, filterString,
 				StringBundler.concat(
 					sortFieldName1, ":desc,", sortFieldName2, ":asc"));
 
 			String location = analyticsCloudHttpServer.getLocation();
+
+			DepotEntryTestUtil.assertGroupIds(_depotEntries, location);
 
 			_assertParameter(dataSourceId, "dataSourceId", location);
 			_assertParameter(filterString, "filter", location);
@@ -385,12 +390,15 @@ public class PerformanceTopAssetResourceTest
 			String sortFieldName2 = RandomTestUtil.randomString();
 
 			performanceTopAssetResource.getPerformanceTopAssetPage(
-				null, rangeKey, search, filterString,
-				Pagination.of(page, pageSize),
+				TransformUtil.transformToArray(
+					_depotEntries, DepotEntry::getDepotEntryId, Long.class),
+				rangeKey, search, filterString, Pagination.of(page, pageSize),
 				StringBundler.concat(
 					sortFieldName1, ":desc,", sortFieldName2, ":asc"));
 
 			String location = analyticsCloudHttpServer.getLocation();
+
+			DepotEntryTestUtil.assertGroupIds(_depotEntries, location);
 
 			_assertParameter(dataSourceId, "dataSourceId", location);
 			_assertParameter(filterString, "filter", location);

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/PerformanceTopAssetResourceTest.java
@@ -20,14 +20,12 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -131,27 +129,6 @@ public class PerformanceTopAssetResourceTest
 				HttpComponentsUtil.getParameter(url, name, false)));
 	}
 
-	private PerformanceTopAssetResource _getPerformanceTopAssetResource()
-		throws Exception {
-
-		String password = RandomTestUtil.randomString();
-
-		User user = DepotEntryTestUtil.addDepotEntryMemberUser(
-			_depotEntries.get(0), password);
-
-		_users.add(user);
-
-		return PerformanceTopAssetResource.builder(
-		).authentication(
-			user.getEmailAddress(), password
-		).endpoint(
-			testCompany.getVirtualHostname(),
-			PortalUtil.getPortalServerPort(false), "http"
-		).locale(
-			LocaleUtil.getDefault()
-		).build();
-	}
-
 	private void _testGetPerformanceTopAssetExportResponse() throws Exception {
 		String value = RandomTestUtil.randomString();
 
@@ -245,6 +222,10 @@ public class PerformanceTopAssetResourceTest
 	private void _testGetPerformanceTopAssetExportWithDepotEntryMemberUser()
 		throws Exception {
 
+		com.liferay.analytics.cms.rest.resource.v1_0.PerformanceTopAssetResource
+			performanceTopAssetResource = ReflectionTestUtil.getFieldValue(
+				this, "_performanceTopAssetResource");
+
 		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
 				new AnalyticsCloudHttpServer(
 					"/api/1.0/asset-metric/objectEntry/summaries/export",
@@ -257,16 +238,35 @@ public class PerformanceTopAssetResourceTest
 						RandomTestUtil.randomString(), true,
 						analyticsCloudHttpServer.getURL())) {
 
-			PerformanceTopAssetResource performanceTopAssetResource =
-				_getPerformanceTopAssetResource();
+			DepotEntryTestUtil.withDepotEntryMemberUser(
+				_depotEntries.get(0),
+				() -> {
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer, null,
+						depotEntryIds ->
+							performanceTopAssetResource.
+								getPerformanceTopAssetExport(
+									depotEntryIds, RandomTestUtil.nextInt(),
+									null, null, null));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						new DepotEntry[] {_depotEntries.get(0)},
+						depotEntryIds ->
+							performanceTopAssetResource.
+								getPerformanceTopAssetExport(
+									depotEntryIds, RandomTestUtil.nextInt(),
+									null, null, null));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						_depotEntries.toArray(new DepotEntry[0]),
+						depotEntryIds ->
+							performanceTopAssetResource.
+								getPerformanceTopAssetExport(
+									depotEntryIds, RandomTestUtil.nextInt(),
+									null, null, null));
 
-			DepotEntryTestUtil.assertNoRequest(
-				analyticsCloudHttpServer, _depotEntries,
-				depotEntryIds ->
-					performanceTopAssetResource.
-						getPerformanceTopAssetExportHttpResponse(
-							depotEntryIds, RandomTestUtil.nextInt(), null, null,
-							null));
+					return null;
+				});
 		}
 	}
 
@@ -438,6 +438,10 @@ public class PerformanceTopAssetResourceTest
 	private void _testGetPerformanceTopAssetPageWithDepotEntryMemberUser()
 		throws Exception {
 
+		com.liferay.analytics.cms.rest.resource.v1_0.PerformanceTopAssetResource
+			performanceTopAssetResource = ReflectionTestUtil.getFieldValue(
+				this, "_performanceTopAssetResource");
+
 		try (AnalyticsCloudHttpServer analyticsCloudHttpServer =
 				new AnalyticsCloudHttpServer(
 					"/api/1.0/asset-metric/objectEntry/summaries", () -> "{}");
@@ -449,22 +453,48 @@ public class PerformanceTopAssetResourceTest
 						RandomTestUtil.randomString(), true,
 						analyticsCloudHttpServer.getURL())) {
 
-			PerformanceTopAssetResource performanceTopAssetResource =
-				_getPerformanceTopAssetResource();
+			DepotEntryTestUtil.withDepotEntryMemberUser(
+				_depotEntries.get(0),
+				() -> {
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer, null,
+						depotEntryIds ->
+							performanceTopAssetResource.
+								getPerformanceTopAssetPage(
+									depotEntryIds, RandomTestUtil.nextInt(),
+									null, null,
+									com.liferay.portal.vulcan.pagination.
+										Pagination.of(1, 10),
+									null));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						new DepotEntry[] {_depotEntries.get(0)},
+						depotEntryIds ->
+							performanceTopAssetResource.
+								getPerformanceTopAssetPage(
+									depotEntryIds, RandomTestUtil.nextInt(),
+									null, null,
+									com.liferay.portal.vulcan.pagination.
+										Pagination.of(1, 10),
+									null));
+					DepotEntryTestUtil.assertNoRequest(
+						analyticsCloudHttpServer,
+						_depotEntries.toArray(new DepotEntry[0]),
+						depotEntryIds ->
+							performanceTopAssetResource.
+								getPerformanceTopAssetPage(
+									depotEntryIds, RandomTestUtil.nextInt(),
+									null, null,
+									com.liferay.portal.vulcan.pagination.
+										Pagination.of(1, 10),
+									null));
 
-			DepotEntryTestUtil.assertNoRequest(
-				analyticsCloudHttpServer, _depotEntries,
-				depotEntryIds ->
-					performanceTopAssetResource.getPerformanceTopAssetPage(
-						depotEntryIds, RandomTestUtil.nextInt(), null, null,
-						Pagination.of(1, 10), null));
+					return null;
+				});
 		}
 	}
 
 	@DeleteAfterTestRun
 	private final List<DepotEntry> _depotEntries = new ArrayList<>();
-
-	@DeleteAfterTestRun
-	private final List<User> _users = new ArrayList<>();
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/util/DepotEntryTestUtil.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/util/DepotEntryTestUtil.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -45,18 +45,6 @@ public class DepotEntryTestUtil {
 				groupId, TestPropsValues.getUserId()));
 	}
 
-	public static User addDepotEntryMemberUser(
-			DepotEntry depotEntry, String password)
-		throws Exception {
-
-		User user = UserTestUtil.addUser(depotEntry.getGroupId());
-
-		UserLocalServiceUtil.updatePassword(
-			user.getUserId(), password, password, false, true);
-
-		return user;
-	}
-
 	public static void assertGroupIds(
 		List<DepotEntry> depotEntries, String url) {
 
@@ -71,23 +59,20 @@ public class DepotEntryTestUtil {
 
 	public static void assertNoRequest(
 			AnalyticsCloudHttpServer analyticsCloudHttpServer,
-			List<DepotEntry> depotEntries,
+			DepotEntry[] depotEntries,
 			UnsafeConsumer<Long[], Exception> unsafeConsumer)
 		throws Exception {
 
-		DepotEntry depotEntry1 = depotEntries.get(0);
-		DepotEntry depotEntry2 = depotEntries.get(1);
+		Long[] depotEntryIds = null;
 
-		Long[][] depotEntryIdsArray = {
-			null, {depotEntry1.getDepotEntryId()},
-			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
-		};
-
-		for (Long[] depotEntryIds : depotEntryIdsArray) {
-			unsafeConsumer.accept(depotEntryIds);
-
-			Assert.assertNull(analyticsCloudHttpServer.getLocation());
+		if (depotEntries != null) {
+			depotEntryIds = TransformUtil.transform(
+				depotEntries, DepotEntry::getDepotEntryId, Long.class);
 		}
+
+		unsafeConsumer.accept(depotEntryIds);
+
+		Assert.assertNull(analyticsCloudHttpServer.getLocation());
 	}
 
 	public static <T> T withDepotEntryMemberUser(

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/util/DepotEntryTestUtil.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/util/DepotEntryTestUtil.java
@@ -10,13 +10,18 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.URLCodec;
 
 import java.util.Collections;
 import java.util.List;
@@ -49,6 +54,18 @@ public class DepotEntryTestUtil {
 			user.getUserId(), password, password, false, true);
 
 		return user;
+	}
+
+	public static void assertGroupIds(
+		List<DepotEntry> depotEntries, String url) {
+
+		Assert.assertEquals(
+			StringUtil.merge(
+				TransformUtil.transformToArray(
+					depotEntries, DepotEntry::getGroupId, Long.class),
+				StringPool.COMMA),
+			URLCodec.decodeURL(
+				HttpComponentsUtil.getParameter(url, "groupIds", false)));
 	}
 
 	public static void assertNoRequest(

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/util/DepotEntryTestUtil.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/util/DepotEntryTestUtil.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.resource.v1_0.test.util;
+
+import com.liferay.analytics.test.util.AnalyticsCloudHttpServer;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalServiceUtil;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+
+/**
+ * @author Leslie Wong
+ */
+public class DepotEntryTestUtil {
+
+	public static DepotEntry addDepotEntry(long groupId) throws Exception {
+		return DepotEntryLocalServiceUtil.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+			DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext(
+				groupId, TestPropsValues.getUserId()));
+	}
+
+	public static User addDepotEntryMemberUser(
+			DepotEntry depotEntry, String password)
+		throws Exception {
+
+		User user = UserTestUtil.addUser(depotEntry.getGroupId());
+
+		UserLocalServiceUtil.updatePassword(
+			user.getUserId(), password, password, false, true);
+
+		return user;
+	}
+
+	public static void assertNoRequest(
+			AnalyticsCloudHttpServer analyticsCloudHttpServer,
+			List<DepotEntry> depotEntries,
+			UnsafeConsumer<Long[], Exception> unsafeConsumer)
+		throws Exception {
+
+		DepotEntry depotEntry1 = depotEntries.get(0);
+		DepotEntry depotEntry2 = depotEntries.get(1);
+
+		Long[][] depotEntryIdsArray = {
+			null, {depotEntry1.getDepotEntryId()},
+			{depotEntry1.getDepotEntryId(), depotEntry2.getDepotEntryId()}
+		};
+
+		for (Long[] depotEntryIds : depotEntryIdsArray) {
+			unsafeConsumer.accept(depotEntryIds);
+
+			Assert.assertNull(analyticsCloudHttpServer.getLocation());
+		}
+	}
+
+}

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/util/DepotEntryTestUtil.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/util/DepotEntryTestUtil.java
@@ -10,6 +10,7 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalServiceUtil;
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.User;
@@ -86,6 +87,25 @@ public class DepotEntryTestUtil {
 			unsafeConsumer.accept(depotEntryIds);
 
 			Assert.assertNull(analyticsCloudHttpServer.getLocation());
+		}
+	}
+
+	public static <T> T withDepotEntryMemberUser(
+			DepotEntry depotEntry, UnsafeSupplier<T, Exception> unsafeSupplier)
+		throws Exception {
+
+		User user = UserTestUtil.addUser(depotEntry.getGroupId());
+
+		try {
+			UserTestUtil.setUser(user);
+
+			return unsafeSupplier.get();
+		}
+		finally {
+			UserTestUtil.setUser(
+				UserTestUtil.getAdminUser(depotEntry.getCompanyId()));
+
+			UserLocalServiceUtil.deleteUser(user);
 		}
 	}
 

--- a/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/util/DepotEntryTestUtil.java
+++ b/modules/apps/analytics/analytics-cms-rest-test/src/testIntegration/java/com/liferay/analytics/cms/rest/resource/v1_0/test/util/DepotEntryTestUtil.java
@@ -94,7 +94,23 @@ public class DepotEntryTestUtil {
 			DepotEntry depotEntry, UnsafeSupplier<T, Exception> unsafeSupplier)
 		throws Exception {
 
-		User user = UserTestUtil.addUser(depotEntry.getGroupId());
+		return _withUser(
+			depotEntry.getCompanyId(), unsafeSupplier,
+			UserTestUtil.addUser(depotEntry.getGroupId()));
+	}
+
+	public static <T> T withDepotEntryNonmemberUser(
+			DepotEntry depotEntry, UnsafeSupplier<T, Exception> unsafeSupplier)
+		throws Exception {
+
+		return _withUser(
+			depotEntry.getCompanyId(), unsafeSupplier, UserTestUtil.addUser());
+	}
+
+	private static <T> T _withUser(
+			long companyId, UnsafeSupplier<T, Exception> unsafeSupplier,
+			User user)
+		throws Exception {
 
 		try {
 			UserTestUtil.setUser(user);
@@ -102,8 +118,7 @@ public class DepotEntryTestUtil {
 			return unsafeSupplier.get();
 		}
 		finally {
-			UserTestUtil.setUser(
-				UserTestUtil.getAdminUser(depotEntry.getCompanyId()));
+			UserTestUtil.setUser(UserTestUtil.getAdminUser(companyId));
 
 			UserLocalServiceUtil.deleteUser(user);
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102942

## What Is Being Fixed

Any user with view access to a depot entry could retrieve performance metrics for it, because every analytics CMS endpoint resolved depot entries with the same view level permission check. Performance metrics should be limited to depot entry administrators, while the overview, expired asset, and inventory analysis endpoints should remain available to regular depot entry members.

## How It Is Being Fixed

`DepotEntryUtil` now separates the two permission levels: `getViewableDepotEntries` filters by `VIEW` and `getAdministeredDepotEntries` filters by `VIEW_SITE_ADMINISTRATION`. The performance endpoints (metric, overview metric, histogram, top asset, and asset consumption) resolve depot entries through the administered variant, so a member's request carries no group IDs to Analytics Cloud, while the overview, expired asset, and inventory analysis endpoints keep the viewable variant. The shared `DepotEntryTestUtil` provides depot entry creation, group ID assertions, and a member user context helper; every performance endpoint gains a test asserting members receive no group IDs, and the overview, expired asset, and inventory analysis endpoints gain tests asserting members keep access with the same results as administrators. Both new integration test classes pass against a local bundle.

## PR Check

**pr-check: FAIL** — tested on `b1901647f2e093bdcc6687bce5ce4f8b5bbd98ae`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | FAIL |
| Java Unit Tests | PASS |

Baseline fails on a master-side issue this branch does not touch: `com.liferay.headless.cms.resource.v1_0` was raised to 3.1.0 (LPD-97871, `aed5313`) while its content is unchanged against the released 3.0.0, so `ant baseline-all` reports an excessive version increase.

<!-- pr-check {"result": "failure", "sha": "b1901647f2e093bdcc6687bce5ce4f8b5bbd98ae"} -->
