### PR TITLE
LPD-102241 Fix the CMS dashboards on DB2 and Oracle

### DIFF
--- a/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/util/ObjectEntryVersionTitleExpressionUtil.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/main/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/util/ObjectEntryVersionTitleExpressionUtil.java
@@ -10,13 +10,17 @@ import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.expression.Expression;
 import com.liferay.petra.sql.dsl.spi.expression.DSLFunction;
 import com.liferay.petra.sql.dsl.spi.expression.DSLFunctionType;
+import com.liferay.petra.sql.dsl.spi.expression.NullExpression;
 import com.liferay.petra.sql.dsl.spi.expression.Scalar;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.util.LocaleUtil;
 
 import java.sql.Clob;
+
+import java.util.Locale;
 
 /**
  * @author Thiago Buarque
@@ -25,6 +29,14 @@ public class ObjectEntryVersionTitleExpressionUtil {
 
 	public static Expression<Clob> getLocalizedTitleExpression(
 		String languageId) {
+
+		Locale locale = LocaleUtil.fromLanguageId(languageId, true, false);
+
+		if (locale == null) {
+			return (Expression<Clob>)(Expression<?>)NullExpression.INSTANCE;
+		}
+
+		String validLanguageId = LocaleUtil.toLanguageId(locale);
 
 		Column<ObjectEntryVersionTable, Clob> contentColumn =
 			ObjectEntryVersionTable.INSTANCE.content;
@@ -47,7 +59,8 @@ public class ObjectEntryVersionTitleExpressionUtil {
 					new DSLFunctionType("CAST(", " AS LONGVARCHAR)"),
 					new Scalar<>(
 						StringBundler.concat(
-							"\"", languageId, "\"\\s*:\\s*\"([^\"]*)\""))));
+							"\"", validLanguageId,
+							"\"\\s*:\\s*\"([^\"]*)\""))));
 
 			return new DSLFunction<>(
 				new DSLFunctionType("REGEXP_REPLACE(", ")"), dslFunction2,
@@ -55,14 +68,15 @@ public class ObjectEntryVersionTitleExpressionUtil {
 					new DSLFunctionType("CAST(", " AS LONGVARCHAR)"),
 					new Scalar<>(
 						StringBundler.concat(
-							"^\"", languageId, "\"\\s*:\\s*\"([^\"]*)\"$"))),
+							"^\"", validLanguageId,
+							"\"\\s*:\\s*\"([^\"]*)\"$"))),
 				new DSLFunction<>(
 					new DSLFunctionType("CAST(", " AS LONGVARCHAR)"),
 					new Scalar<>("$1")));
 		}
 
 		return _getPropertyValueExpression(
-			contentColumn, "properties.title_i18n." + languageId);
+			contentColumn, "properties.title_i18n." + validLanguageId);
 	}
 
 	public static Expression<Clob> getTitleExpression() {
@@ -128,8 +142,8 @@ public class ObjectEntryVersionTitleExpressionUtil {
 		}
 
 		return new DSLFunction<>(
-			new DSLFunctionType("JSON_VALUE(", ")"), columnExpression,
-			new Scalar<>("$." + propertyPath));
+			new DSLFunctionType("JSON_VALUE(", ", '$." + propertyPath + "')"),
+			columnExpression);
 	}
 
 }

--- a/modules/apps/analytics/analytics-cms-rest-impl/src/test/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/util/ObjectEntryVersionTitleExpressionUtilTest.java
+++ b/modules/apps/analytics/analytics-cms-rest-impl/src/test/java/com/liferay/analytics/cms/rest/internal/resource/v1_0/util/ObjectEntryVersionTitleExpressionUtilTest.java
@@ -1,0 +1,162 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.cms.rest.internal.resource.v1_0.util;
+
+import com.liferay.petra.sql.dsl.expression.Expression;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManager;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.sql.Clob;
+
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class ObjectEntryVersionTitleExpressionUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_originalLanguage = LanguageUtil.getLanguage();
+
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		Language language = Mockito.mock(Language.class);
+
+		Mockito.when(
+			language.isAvailableLocale(Mockito.any(Locale.class))
+		).thenReturn(
+			true
+		);
+
+		languageUtil.setLanguage(language);
+	}
+
+	@After
+	public void tearDown() {
+		DBManagerUtil.reset();
+
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		languageUtil.setLanguage(_originalLanguage);
+	}
+
+	@Test
+	public void testGetLocalizedTitleExpressionDB2() {
+		_setUpDBType(DBType.DB2);
+
+		Assert.assertEquals(
+			"JSON_VALUE(ObjectEntryVersion.content, " +
+				"'$.properties.title_i18n.en_US')",
+			_toSQL(
+				ObjectEntryVersionTitleExpressionUtil.
+					getLocalizedTitleExpression("en_US")));
+	}
+
+	@Test
+	public void testGetLocalizedTitleExpressionInvalidLanguageId() {
+		_setUpDBType(DBType.ORACLE);
+
+		Assert.assertEquals(
+			"NULL",
+			_toSQL(
+				ObjectEntryVersionTitleExpressionUtil.
+					getLocalizedTitleExpression("invalid")));
+	}
+
+	@Test
+	public void testGetLocalizedTitleExpressionOracle() {
+		_setUpDBType(DBType.ORACLE);
+
+		Assert.assertEquals(
+			"JSON_VALUE(ObjectEntryVersion.content, " +
+				"'$.properties.title_i18n.en_US')",
+			_toSQL(
+				ObjectEntryVersionTitleExpressionUtil.
+					getLocalizedTitleExpression("en_US")));
+	}
+
+	@Test
+	public void testGetLocalizedTitleExpressionSQLServer() {
+		_setUpDBType(DBType.SQLSERVER);
+
+		Assert.assertEquals(
+			"JSON_VALUE(ObjectEntryVersion.content, " +
+				"'$.properties.title_i18n.en_US')",
+			_toSQL(
+				ObjectEntryVersionTitleExpressionUtil.
+					getLocalizedTitleExpression("en_US")));
+	}
+
+	@Test
+	public void testGetTitleExpressionDB2() {
+		_setUpDBType(DBType.DB2);
+
+		Assert.assertEquals(
+			"JSON_VALUE(ObjectEntryVersion.content, '$.properties.title')",
+			_toSQL(ObjectEntryVersionTitleExpressionUtil.getTitleExpression()));
+	}
+
+	@Test
+	public void testGetTitleExpressionOracle() {
+		_setUpDBType(DBType.ORACLE);
+
+		Assert.assertEquals(
+			"JSON_VALUE(ObjectEntryVersion.content, '$.properties.title')",
+			_toSQL(ObjectEntryVersionTitleExpressionUtil.getTitleExpression()));
+	}
+
+	private void _setUpDBType(DBType dbType) {
+		DBManager dbManager = Mockito.mock(DBManager.class);
+
+		DB db = Mockito.mock(DB.class);
+
+		Mockito.when(
+			db.getDBType()
+		).thenReturn(
+			dbType
+		);
+
+		Mockito.when(
+			dbManager.getDB()
+		).thenReturn(
+			db
+		);
+
+		DBManagerUtil.setDBManager(dbManager);
+	}
+
+	private String _toSQL(Expression<Clob> expression) {
+		StringBundler sb = new StringBundler();
+
+		expression.toSQL(sb::append, null);
+
+		return sb.toString();
+	}
+
+	private Language _originalLanguage;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102241

## What Is Being Fixed

Every request to the CMS dashboards failed on DB2 and Oracle. `ExpiredAssetResourceImpl`, `InventoryAnalysisResourceImpl` and `OverviewResourceImpl` all returned an error regardless of the parameters they were given.

`ObjectEntryVersionTitleExpressionUtil` built the `JSON_VALUE` json path with a `Scalar`, which the Petra SQL DSL renders as a bind parameter. DB2 and Oracle both require that argument to be a string constant, so the statement was rejected when it was prepared. DB2 reported `SQLCODE=-171, SQLERRMC=2;SYSIBM.JSON_VALUE` and Oracle reported `ORA-40454: path expression not a literal`.

MySQL, MariaDB and PostgreSQL have their own branches above the default, so they were never affected. DB2, Oracle and SQL Server fall through to the default, which is why this survived since LPD-63217. Both `getTitleExpression` and `getLocalizedTitleExpression` were affected.

## How It Is Being Fixed

The json path moved out of the `Scalar` and into the `DSLFunctionType` prefix and postfix, which the DSL emits as statement text rather than as a bind parameter. This is the same idiom the Hypersonic branch already uses.

Because the path is now part of the statement text, `getLocalizedTitleExpression` resolves the language id through `LocaleUtil.fromLanguageId(languageId, true, false)` and rebuilds it with `LocaleUtil.toLanguageId`, returning `NullExpression.INSTANCE` when the value does not resolve. The `validate` argument is the `LanguageUtil.isAvailableLocale` check. Passing `false` is not usable here, because `_fromLanguageId` builds a `Locale` out of any input.

One behavior change follows from this. A `title_i18n` entry whose locale is not enabled in the portal no longer matches.

## How To Execute The Tests

```
gradlew -p modules/apps/analytics/analytics-cms-rest-impl test --tests "com.liferay.analytics.cms.rest.internal.resource.v1_0.util.ObjectEntryVersionTitleExpressionUtilTest"
```

## PR Check

**pr-check: PASS** — tested on `cfbbae2bbcfef6fd0a8909650696cc29c45c3db3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Per-Module Compile ran `gradlew :apps:analytics:analytics-cms-rest-impl:deploy` without the `ant compile install-portal-snapshots` setup step, because this branch changes no `portal-kernel` or `portal-impl` source and the existing snapshot already matches the branch tree.

<!-- pr-check {"result": "success", "sha": "cfbbae2bbcfef6fd0a8909650696cc29c45c3db3"} -->
