### PR TITLE
LPD-103229 Fix download report crash on unsupported color function

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/package.json
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/package.json
@@ -49,7 +49,7 @@
 		"date-fns": "^1.30.1",
 		"formik": "^2.1.4",
 		"graphql": "^16.8.1",
-		"html2canvas": "^1.4.1",
+		"html2canvas-pro": "^2.3.9",
 		"immutable": "^3.8.2",
 		"jspdf": "^3.0.4",
 		"lodash": "^4.17.15",

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/DownloadPDFReport.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/DownloadPDFReport.tsx
@@ -1,5 +1,5 @@
 import ClayForm, {ClayCheckbox} from '@clayui/form';
-import html2canvas from 'html2canvas';
+import html2canvas from 'html2canvas-pro';
 import React, {useEffect, useMemo, useState} from 'react';
 import {addAlert} from 'shared/actions/alerts';
 import {Alert} from 'shared/types';

--- a/workspaces/liferay-osbfaro-workspace/yarn.lock
+++ b/workspaces/liferay-osbfaro-workspace/yarn.lock
@@ -8505,7 +8505,15 @@ html-minifier@^4.0.0:
     relateurl "^0.2.7"
     uglify-js "^3.5.1"
 
-html2canvas@^1.0.0-rc.5, html2canvas@^1.4.1:
+html2canvas-pro@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/html2canvas-pro/-/html2canvas-pro-2.3.9.tgz#70508080cb48d0f77d881d2693b71e06268a6dfa"
+  integrity sha512-s5LCNV8QHkKm4DkOuoXDnC+CvIsXjftn9mEA5BOPFWGa9A2M+Tn7wwitRivS5cch2/Bby6KuFmLZac5jlM51Sw==
+  dependencies:
+    css-line-break "^2.1.0"
+    text-segmentation "^1.0.3"
+
+html2canvas@^1.0.0-rc.5:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.1.tgz#7cef1888311b5011d507794a066041b14669a543"
   integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103229

## What Is Being Fixed

Downloading the PDF report from Event Analysis (and any other dashboard card using the shared Download Report feature) throws `Attempting to parse an unsupported color function "color"` and aborts. html2canvas, used to rasterize the report cards before assembling the PDF, has an internal color parser that only understands rgb/rgba/hsl/hsla. Chrome can serialize linear-gradient color stops using the CSS Color 4 color() function, which trips this unmaintained parser.

## How It Is Being Fixed

Swapped the html2canvas dependency for html2canvas-pro, a maintained fork exposing the same API that adds support for color(), oklch(), lab(), and lch(). This is a drop-in replacement — only the import and the package.json entry changed; the report generation flow (DownloadPDFReport.tsx -> jsPDF.ts) is untouched.

## Why Are There No Tests?

This is a drop-in dependency swap with an unchanged API; the existing download-report test suite already covers the component and passes unmodified. The failure itself only reproduces in a real browser under specific CSS color serialization conditions and is not reproducible in jsdom.

## PR Check

**pr-check: PASS** — tested on `8e24a4fa711bafec8f6cf3b61a98b738640edbde`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | FAIL |
| Workspace Build | PASS |

**Baseline** found one finding, but it is pre-existing drift unrelated to this branch's diff: `com.liferay.headless.cms.resource.v1_0` (packageinfo in `headless-cms-api`) is at version 3.1.0 on `master` with an `EXCESSIVE VERSION INCREASE` warning (`DELTA UNCHANGED` since the 3.0.0 baseline). This branch touches only `osb-faro-web` frontend files and never this package, so the overall result is reported as passing.

<!-- pr-check {"result": "success", "sha": "8e24a4fa711bafec8f6cf3b61a98b738640edbde"} -->
