### PR TITLE
faro-v5.1.x | LPD-101231

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ReportFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/ReportFaroController.java
@@ -62,9 +62,11 @@ public class ReportFaroController extends BaseFaroController {
 			@QueryParam("assetTitle") String assetTitle,
 			@QueryParam("assetType") String assetType,
 			@QueryParam("channelId") String channelId,
+			@QueryParam("filter") String filterString,
 			@QueryParam("fromDate") String fromDateString,
 			@PathParam("groupId") long groupId,
 			@QueryParam("individualId") String individualId,
+			@QueryParam("objectType") String objectType,
 			@DefaultValue(StringPool.BLANK) @QueryParam("orderByFields")
 				FaroParam<List<OrderByField>> orderByFieldsFaroParam,
 			@QueryParam("query") String query,
@@ -75,9 +77,9 @@ public class ReportFaroController extends BaseFaroController {
 		throws Exception {
 
 		Object result = _buildQueryParameters(
-			assetId, assetType, channelId, fromDateString, individualId,
-			orderByFieldsFaroParam, query, rangeKey, segmentId, toDateString,
-			type);
+			assetId, assetType, channelId, filterString, fromDateString,
+			individualId, objectType, orderByFieldsFaroParam, query, rangeKey,
+			segmentId, toDateString, type);
 
 		Map<String, List<String>> queryParameters;
 
@@ -146,9 +148,11 @@ public class ReportFaroController extends BaseFaroController {
 			@QueryParam("assetId") String assetId,
 			@QueryParam("assetType") String assetType,
 			@QueryParam("channelId") String channelId,
+			@QueryParam("filter") String filterString,
 			@QueryParam("fromDate") String fromDateString,
 			@PathParam("groupId") long groupId,
 			@QueryParam("individualId") String individualId,
+			@QueryParam("objectType") String objectType,
 			@QueryParam("query") String query,
 			@QueryParam("rangeKey") String rangeKey,
 			@QueryParam("segmentId") String segmentId,
@@ -157,8 +161,9 @@ public class ReportFaroController extends BaseFaroController {
 		throws Exception {
 
 		Object result = _buildQueryParameters(
-			assetId, assetType, channelId, fromDateString, individualId, null,
-			query, rangeKey, segmentId, toDateString, type);
+			assetId, assetType, channelId, filterString, fromDateString,
+			individualId, objectType, null, query, rangeKey, segmentId,
+			toDateString, type);
 
 		if (!(result instanceof Map<?, ?>)) {
 			return result;
@@ -174,16 +179,17 @@ public class ReportFaroController extends BaseFaroController {
 	}
 
 	private Object _buildQueryParameters(
-		String assetId, String assetType, String channelId,
-		String fromDateString, String individualId,
+		String assetId, String assetType, String channelId, String filterString,
+		String fromDateString, String individualId, String objectType,
 		FaroParam<List<OrderByField>> orderByFieldsFaroParam, String query,
 		String rangeKey, String segmentId, String toDateString, String type) {
 
 		if (!_csvExportTypes.contains(type)) {
 			return _reportFaroControllerResponseFactory.create(
-				"The \"type\" query parameter must be either \"blog\", " +
-					"\"document\", \"event\", \"form\", \"individual\", " +
-						"\"journal\", \"membership\", or \"page\".",
+				"The \"type\" query parameter must be either \"asset\", " +
+					"\"blog\", \"document\", \"event\", \"form\", " +
+						"\"individual\", \"journal\", \"membership\", or " +
+							"\"page\".",
 				Response.Status.BAD_REQUEST);
 		}
 
@@ -221,6 +227,16 @@ public class ReportFaroController extends BaseFaroController {
 							orderByField.getOrderBy();
 					})
 			);
+
+		if (Validator.isNotNull(filterString)) {
+			hashMapWrapper.put(
+				"filter", Collections.singletonList(filterString));
+		}
+
+		if (Validator.isNotNull(objectType)) {
+			hashMapWrapper.put(
+				"objectType", Collections.singletonList(objectType));
+		}
 
 		if (Validator.isNotNull(segmentId)) {
 			hashMapWrapper.put(
@@ -305,7 +321,7 @@ public class ReportFaroController extends BaseFaroController {
 		ReportFaroController.class);
 
 	private static final Set<String> _csvExportTypes = SetUtil.fromArray(
-		"blog", "document", "event", "form", "individual", "journal",
+		"asset", "blog", "document", "event", "form", "individual", "journal",
 		"membership", "page", "search-terms");
 	private static final DateTimeFormatter _dateDateTimeFormatter =
 		DateTimeFormatter.ofPattern(DateUtil.PATTERN_DATE);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
@@ -14,6 +14,7 @@ jest.unmock('react-dom');
 jest.mock('@liferay/frontend-data-set-web', () => ({
 	...jest.requireActual('@liferay/frontend-data-set-web'),
 	FrontendDataSet: ({
+		additionalAPIURLParametersTransformer,
 		customDataRenderers,
 		emptyState,
 		filters,
@@ -23,6 +24,7 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 		sorts,
 		views,
 	}: {
+		additionalAPIURLParametersTransformer?: (loadDataArgs: any) => any;
 		customDataRenderers?: {[key: string]: React.FC<any>};
 		emptyState?: {
 			description?: React.ReactNode;
@@ -35,160 +37,231 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 		itemsActions?: Array<{onClick?: (item: any) => void}>;
 		sorts?: any[];
 		views?: Array<{schema: {fields: any[]}}>;
-	}) => (
-		<div data-testid="fds-component" id={id}>
-			<div data-testid="fds-sorts">{JSON.stringify(sorts ?? null)}</div>
+	}) => {
+		const [transformerResult, setTransformerResult] = React.useState('');
 
-			<div data-testid="fds-fields">
-				{JSON.stringify(views?.[0]?.schema?.fields ?? null)}
-			</div>
+		return (
+			<div data-testid="fds-component" id={id}>
+				<button
+					data-testid="fds-run-transformer"
+					onClick={() => {
+						setTransformerResult(
+							String(
+								additionalAPIURLParametersTransformer?.({
+									additionalAPIURLParameters: 'unchanged=1',
+									odataFiltersStrings: [
+										"assetType eq 'blog'",
+										undefined,
+									],
+									searchParam: 'liferay',
+								})
+							)
+						);
+					}}
+				>
+					{'Run Transformer'}
+				</button>
 
-			<div data-testid="fds-object-type-cells">
-				{[undefined, 'content', 'file', 'unknown'].map((value) => {
-					const ObjectTypeCell =
-						customDataRenderers?.assetObjectTypeRenderer;
-
-					return (
-						ObjectTypeCell && (
-							<div
-								data-testid={`fds-object-type-cell-${value}`}
-								key={String(value)}
-							>
-								<ObjectTypeCell value={value} />
-							</div>
-						)
-					);
-				})}
-			</div>
-
-			{emptyState && (
-				<div data-testid="fds-empty-state">
-					<div data-testid="fds-empty-state-title">
-						{emptyState.title}
-					</div>
-
-					<div data-testid="fds-empty-state-description">
-						{emptyState.description}
-					</div>
+				<div data-testid="fds-transformer-result">
+					{transformerResult}
 				</div>
-			)}
-			<div data-testid="fds-filters">{JSON.stringify(filters)}</div>
 
-			<div data-testid="fds-grouped-filters">
-				{JSON.stringify(groupedFilters)}
+				<div data-testid="fds-sorts">
+					{JSON.stringify(sorts ?? null)}
+				</div>
+
+				<div data-testid="fds-fields">
+					{JSON.stringify(views?.[0]?.schema?.fields ?? null)}
+				</div>
+
+				<div data-testid="fds-object-type-cells">
+					{[undefined, 'content', 'file', 'unknown'].map((value) => {
+						const ObjectTypeCell =
+							customDataRenderers?.assetObjectTypeRenderer;
+
+						return (
+							ObjectTypeCell && (
+								<div
+									data-testid={`fds-object-type-cell-${value}`}
+									key={String(value)}
+								>
+									<ObjectTypeCell value={value} />
+								</div>
+							)
+						);
+					})}
+				</div>
+
+				{emptyState && (
+					<div data-testid="fds-empty-state">
+						<div data-testid="fds-empty-state-title">
+							{emptyState.title}
+						</div>
+
+						<div data-testid="fds-empty-state-description">
+							{emptyState.description}
+						</div>
+					</div>
+				)}
+				<div data-testid="fds-filters">{JSON.stringify(filters)}</div>
+
+				<div data-testid="fds-grouped-filters">
+					{JSON.stringify(groupedFilters)}
+				</div>
+
+				<button
+					data-testid="trigger-info-panel"
+					onClick={() =>
+						itemsActions?.[0]?.onClick?.({
+							itemData: {
+								assetCategories: [],
+								assetTags: [],
+								assetTitle: 'Test Asset Title',
+								assetType: 'blog',
+								id: 'asset-id-1',
+								mimeType: 'blog',
+							},
+						})
+					}
+				>
+					{'Open Info Panel'}
+				</button>
+
+				<button
+					data-testid="trigger-info-panel-no-mime"
+					onClick={() =>
+						itemsActions?.[0]?.onClick?.({
+							itemData: {
+								assetCategories: [],
+								assetTags: [],
+								assetTitle: 'Asset Without Mime',
+								assetType: 'document',
+								id: 'asset-id-2',
+							},
+						})
+					}
+				>
+					{'Open Info Panel No Mime'}
+				</button>
+
+				<button
+					data-testid="trigger-info-panel-no-title"
+					onClick={() =>
+						itemsActions?.[0]?.onClick?.({
+							itemData: {
+								assetCategories: [],
+								assetTags: [],
+								assetType: 'folder',
+								id: 'fallback-id-3',
+								mimeType: 'folder',
+							},
+						})
+					}
+				>
+					{'Open Info Panel No Title'}
+				</button>
+
+				<button
+					data-testid="trigger-info-panel-with-items"
+					onClick={() =>
+						itemsActions?.[0]?.onClick?.({
+							itemData: {
+								assetCategories: [
+									{
+										id: 'cat-1',
+										name: 'Category One',
+										vocabularyId: 'vocab-1',
+									},
+									{
+										id: 'cat-2',
+										name: 'Category Two',
+										vocabularyId: 'vocab-1',
+									},
+								],
+								assetTags: [{id: 'tag-1', name: 'Tag One'}],
+								assetTitle: 'Rich Asset',
+								assetType: 'webContent',
+								assetVocabularies: [
+									{id: 'vocab-1', name: 'Topic'},
+								],
+								id: 'asset-id-4',
+								mimeType: 'basic-web-content',
+							},
+						})
+					}
+				>
+					{'Open Info Panel With Items'}
+				</button>
+
+				<button
+					data-testid="trigger-info-panel-empty-vocab"
+					onClick={() =>
+						itemsActions?.[0]?.onClick?.({
+							itemData: {
+								assetCategories: [
+									{
+										id: 'cat-1',
+										name: 'Category One',
+										vocabularyId: 'vocab-1',
+									},
+								],
+								assetTags: [],
+								assetTitle: 'Asset With Empty Vocab',
+								assetType: 'blog',
+								assetVocabularies: [
+									{id: 'vocab-1', name: 'Topics'},
+									{id: 'vocab-2', name: 'Genres'},
+								],
+								id: 'asset-id-5',
+								mimeType: 'blog',
+							},
+						})
+					}
+				>
+					{'Open Info Panel Empty Vocab'}
+				</button>
 			</div>
+		);
+	},
+}));
 
-			<button
-				data-testid="trigger-info-panel"
-				onClick={() =>
-					itemsActions?.[0]?.onClick?.({
-						itemData: {
-							assetCategories: [],
-							assetTags: [],
-							assetTitle: 'Test Asset Title',
-							assetType: 'blog',
-							id: 'asset-id-1',
-							mimeType: 'blog',
-						},
-					})
-				}
-			>
-				{'Open Info Panel'}
-			</button>
+jest.mock('shared/components/download-report/DownloadStaticCSVReport', () => ({
+	DownloadStaticCSVReport: ({
+		getFDSQuery,
+		rangeSelectors,
+		type,
+	}: {
+		getFDSQuery?: () => {filter: string; query: string};
+		rangeSelectors?: any;
+		type?: string;
+	}) => {
+		const [fdsQueryResult, setFDSQueryResult] = React.useState('');
 
-			<button
-				data-testid="trigger-info-panel-no-mime"
-				onClick={() =>
-					itemsActions?.[0]?.onClick?.({
-						itemData: {
-							assetCategories: [],
-							assetTags: [],
-							assetTitle: 'Asset Without Mime',
-							assetType: 'document',
-							id: 'asset-id-2',
-						},
-					})
-				}
-			>
-				{'Open Info Panel No Mime'}
-			</button>
+		return (
+			<div data-testid="download-csv">
+				<div data-testid="download-csv-type">{type}</div>
 
-			<button
-				data-testid="trigger-info-panel-no-title"
-				onClick={() =>
-					itemsActions?.[0]?.onClick?.({
-						itemData: {
-							assetCategories: [],
-							assetTags: [],
-							assetType: 'folder',
-							id: 'fallback-id-3',
-							mimeType: 'folder',
-						},
-					})
-				}
-			>
-				{'Open Info Panel No Title'}
-			</button>
+				<div data-testid="download-csv-range-selectors">
+					{JSON.stringify(rangeSelectors ?? null)}
+				</div>
 
-			<button
-				data-testid="trigger-info-panel-with-items"
-				onClick={() =>
-					itemsActions?.[0]?.onClick?.({
-						itemData: {
-							assetCategories: [
-								{
-									id: 'cat-1',
-									name: 'Category One',
-									vocabularyId: 'vocab-1',
-								},
-								{
-									id: 'cat-2',
-									name: 'Category Two',
-									vocabularyId: 'vocab-1',
-								},
-							],
-							assetTags: [{id: 'tag-1', name: 'Tag One'}],
-							assetTitle: 'Rich Asset',
-							assetType: 'webContent',
-							assetVocabularies: [{id: 'vocab-1', name: 'Topic'}],
-							id: 'asset-id-4',
-							mimeType: 'basic-web-content',
-						},
-					})
-				}
-			>
-				{'Open Info Panel With Items'}
-			</button>
+				<button
+					data-testid="download-csv-call-get-fds-query"
+					onClick={() =>
+						setFDSQueryResult(
+							JSON.stringify(getFDSQuery?.() ?? null)
+						)
+					}
+				>
+					{'Call getFDSQuery'}
+				</button>
 
-			<button
-				data-testid="trigger-info-panel-empty-vocab"
-				onClick={() =>
-					itemsActions?.[0]?.onClick?.({
-						itemData: {
-							assetCategories: [
-								{
-									id: 'cat-1',
-									name: 'Category One',
-									vocabularyId: 'vocab-1',
-								},
-							],
-							assetTags: [],
-							assetTitle: 'Asset With Empty Vocab',
-							assetType: 'blog',
-							assetVocabularies: [
-								{id: 'vocab-1', name: 'Topics'},
-								{id: 'vocab-2', name: 'Genres'},
-							],
-							id: 'asset-id-5',
-							mimeType: 'blog',
-						},
-					})
-				}
-			>
-				{'Open Info Panel Empty Vocab'}
-			</button>
-		</div>
-	),
+				<div data-testid="download-csv-fds-query-result">
+					{fdsQueryResult}
+				</div>
+			</div>
+		);
+	},
 }));
 
 jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
@@ -641,6 +714,64 @@ describe('List', () => {
 			expect(
 				getObjectTypeFilter('?objectType=folder').preloadedData
 			).toBeUndefined();
+		});
+	});
+
+	describe('Download CSV', () => {
+		it('should render the Download CSV button for the asset type', () => {
+			renderList();
+
+			expect(screen.getByTestId('download-csv-type')).toHaveTextContent(
+				'asset'
+			);
+		});
+
+		it('should pass the current rangeSelectors to the Download CSV button', () => {
+			renderList();
+
+			expect(
+				screen.getByTestId('download-csv-range-selectors')
+			).toHaveTextContent(RangeKeyTimeRanges.Last30Days);
+		});
+
+		it('should return an empty filter and query before the data set reports any', () => {
+			renderList();
+
+			fireEvent.click(
+				screen.getByTestId('download-csv-call-get-fds-query')
+			);
+
+			expect(
+				screen.getByTestId('download-csv-fds-query-result')
+			).toHaveTextContent(JSON.stringify({filter: '', query: ''}));
+		});
+
+		it('should capture the filter and query the data set reports and expose them via getFDSQuery', () => {
+			renderList();
+
+			fireEvent.click(screen.getByTestId('fds-run-transformer'));
+			fireEvent.click(
+				screen.getByTestId('download-csv-call-get-fds-query')
+			);
+
+			expect(
+				screen.getByTestId('download-csv-fds-query-result')
+			).toHaveTextContent(
+				JSON.stringify({
+					filter: "(assetType eq 'blog')",
+					query: 'liferay',
+				})
+			);
+		});
+
+		it('should pass the additionalAPIURLParameters through unchanged', () => {
+			renderList();
+
+			fireEvent.click(screen.getByTestId('fds-run-transformer'));
+
+			expect(
+				screen.getByTestId('fds-transformer-result')
+			).toHaveTextContent('unchanged=1');
 		});
 	});
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
@@ -63,6 +63,32 @@ exports[`List rendering should match the snapshot 1`] = `
           class="d-flex justify-content-end w-100"
         >
           <div
+            class="mr-1"
+          >
+            <div
+              data-testid="download-csv"
+            >
+              <div
+                data-testid="download-csv-type"
+              >
+                asset
+              </div>
+              <div
+                data-testid="download-csv-range-selectors"
+              >
+                {"rangeEnd":null,"rangeKey":"30","rangeStart":null}
+              </div>
+              <button
+                data-testid="download-csv-call-get-fds-query"
+              >
+                Call getFDSQuery
+              </button>
+              <div
+                data-testid="download-csv-fds-query-result"
+              />
+            </div>
+          </div>
+          <div
             data-testid="dropdown-range-key"
           >
             <span
@@ -95,6 +121,14 @@ exports[`List rendering should match the snapshot 1`] = `
           data-testid="fds-component"
           id="assetTable"
         >
+          <button
+            data-testid="fds-run-transformer"
+          >
+            Run Transformer
+          </button>
+          <div
+            data-testid="fds-transformer-result"
+          />
           <div
             data-testid="fds-sorts"
           >

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
@@ -5,10 +5,12 @@ import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import ClaySticker from '@clayui/sticker';
 import FaroConstants, {RangeKeyTimeRanges} from 'shared/util/constants';
-import React, {useMemo, useState} from 'react';
+import React, {useMemo, useRef, useState} from 'react';
 import URLConstants from 'shared/util/url-constants';
 import {ASSET_OBJECT_TYPE_LANG_MAP} from 'shared/util/lang';
 import {AssetObjectTypes} from 'shared/util/constants';
+import {CSVType} from 'shared/components/download-report/utils';
+import {DownloadStaticCSVReport} from 'shared/components/download-report/DownloadStaticCSVReport';
 import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
 import {FrontendDataSet, pagination} from 'shared/components/FrontendDataSet';
 import {getMimeType} from 'assets/components/mime-type';
@@ -255,6 +257,13 @@ const List = () => {
 
 	const [infoPanelData, setInfoPanelData] = useState<any>(null);
 
+	// The data set reports the filters and search it is showing through
+	// additionalAPIURLParametersTransformer, which runs on every data load
+	// rather than during render, so it is kept in a ref and read on demand by
+	// the CSV export (a state update here would re-trigger the same load).
+
+	const fdsQueryRef = useRef({filter: '', query: ''});
+
 	let rangeSelectorParams = `rangeKey=${rangeSelectors.rangeKey}`;
 
 	if (rangeSelectors.rangeKey === RangeKeyTimeRanges.CustomRange) {
@@ -410,6 +419,16 @@ const List = () => {
 
 			<BasePage.SubHeader fluid>
 				<div className="d-flex justify-content-end w-100">
+					<div className="mr-1">
+						<DownloadStaticCSVReport
+							disabled={false}
+							getFDSQuery={() => fdsQueryRef.current}
+							rangeSelectors={rangeSelectors}
+							type={CSVType.Asset}
+							typeLang={Liferay.Language.get('assets')}
+						/>
+					</div>
+
 					<DropdownRangeKey
 						legacy={false}
 						onRangeSelectorChange={(rangeSelectors) => {
@@ -437,6 +456,28 @@ const List = () => {
 			<BasePage.Body fluid sidebarOpened={!!infoPanelData}>
 				<Card minHeight={300}>
 					<FrontendDataSet
+
+						// Not a real transformation: this reports the query the
+						// data set is about to send so the CSV export can match
+						// what is on screen, and hands back the additional
+						// parameters unchanged.
+
+						additionalAPIURLParametersTransformer={(
+							loadDataArgs
+						) => {
+							const {odataFiltersStrings = [], searchParam = ''} =
+								loadDataArgs;
+
+							fdsQueryRef.current = {
+								filter: odataFiltersStrings
+									.filter(Boolean)
+									.map((odataString) => `(${odataString})`)
+									.join(' and '),
+								query: searchParam,
+							};
+
+							return loadDataArgs.additionalAPIURLParameters;
+						}}
 						apiURL={`/o/faro/contacts/${groupId}/asset-summary?channelId=${channelId}&${rangeSelectorParams}`}
 						customDataRenderers={{
 							assetMetricRenderer: columns.assetMetricRenderer,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/csv.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/api/csv.ts
@@ -11,9 +11,12 @@ export const fetchCount = ({
 	assetId?: string;
 	assetType?: string;
 	channelId: string;
+	filter?: string;
 	fromDate?: string;
 	groupId: string;
 	individualId?: string;
+	objectType?: string;
+	query?: string;
 	segmentId?: string;
 	rangeKey?: string;
 	toDate?: string;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/DownloadStaticCSVReport.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/DownloadStaticCSVReport.tsx
@@ -4,7 +4,7 @@ import ClayForm from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
 import React from 'react';
 import {addAlert} from 'shared/actions/alerts';
-import {Alert} from 'shared/types';
+import {Alert, RangeSelectors} from 'shared/types';
 import {CSVType, MAX_CSV_ENTRIES, useDownloadCSV} from './utils';
 import {DownloadReportButton} from './DownloadReportButton';
 import {sub} from 'shared/util/lang';
@@ -15,6 +15,21 @@ import {useParams} from 'react-router-dom';
 interface IDownloadStaticCSVReport {
 	children?: any;
 	disabled: boolean;
+
+	/**
+	 * Resolves the filters and search query currently applied to the list
+	 * being exported, so the CSV matches what is on screen. Callers that
+	 * render a FrontendDataSet get these from its
+	 * `additionalAPIURLParametersTransformer` (see assets/pages/List.tsx).
+	 *
+	 * This is a getter rather than a value because the data set reports its
+	 * query outside React's render cycle, so callers keep it in a ref: the
+	 * current value has to be read when the export is submitted, not when
+	 * this component last rendered.
+	 */
+	getFDSQuery?: () => {filter: string; query: string};
+	objectType?: string;
+	rangeSelectors?: RangeSelectors;
 	segmentId?: string;
 	type: CSVType;
 	typeLang: string;
@@ -23,12 +38,15 @@ interface IDownloadStaticCSVReport {
 export const DownloadStaticCSVReport: React.FC<IDownloadStaticCSVReport> = ({
 	children,
 	disabled,
+	getFDSQuery,
+	objectType,
+	rangeSelectors,
 	segmentId,
 	type,
 	typeLang,
 }) => {
 	const dispatch = useDispatch();
-	const generateURL = useDownloadCSV({segmentId, type});
+	const generateURL = useDownloadCSV({objectType, segmentId, type});
 	const {observer, onOpenChange, open} = useModal();
 	const {channelId, groupId} = useParams();
 
@@ -54,7 +72,12 @@ export const DownloadStaticCSVReport: React.FC<IDownloadStaticCSVReport> = ({
 						onOpenChange(false);
 
 						try {
-							const url = generateURL();
+							const fdsQuery = getFDSQuery?.();
+
+							const url = generateURL(rangeSelectors, {
+								filter: fdsQuery?.filter,
+								query: fdsQuery?.query,
+							});
 							const response = await API.csv.fetchCSV(url);
 
 							if (!response.ok) {
@@ -80,9 +103,12 @@ export const DownloadStaticCSVReport: React.FC<IDownloadStaticCSVReport> = ({
 
 							const count = await API.csv.fetchCount({
 								channelId: channelId!,
+								filter: fdsQuery?.filter,
 								groupId: groupId!,
+								objectType,
+								query: fdsQuery?.query,
 								segmentId,
-								type: CSVType.Individual,
+								type,
 							});
 
 							if (count > MAX_CSV_ENTRIES) {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/DownloadStaticCSVReport.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/DownloadStaticCSVReport.tsx
@@ -29,17 +29,31 @@ jest.mock('shared/api', () => ({
 	},
 }));
 
+const mockedGenerateURL = jest.fn(() => 'http://test-url.com');
+
 jest.mock('../utils', () => {
 	const original = jest.requireActual('../utils');
 	return {
 		...original,
-		useDownloadCSV: jest.fn(() => () => 'http://test-url.com'),
+		useDownloadCSV: jest.fn(() => mockedGenerateURL),
 	};
 });
 
 jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
 
-const DefaultComponent = () => (
+const {useDownloadCSV: mockedUseDownloadCSV} = jest.requireMock('../utils');
+
+const DefaultComponent = ({
+	getFDSQuery,
+	objectType,
+	rangeSelectors,
+	type = CSVType.Individual,
+}: {
+	getFDSQuery?: () => {filter: string; query: string};
+	objectType?: string;
+	rangeSelectors?: any;
+	type?: CSVType;
+}) => (
 	<Provider store={mockStore()}>
 		<MemoryRouter initialEntries={['/workspace/123/456/individuals']}>
 			<Route path="/workspace/:groupId/:channelId/individuals">
@@ -52,7 +66,10 @@ const DefaultComponent = () => (
 				>
 					<DownloadStaticCSVReport
 						disabled={false}
-						type={CSVType.Individual}
+						getFDSQuery={getFDSQuery}
+						objectType={objectType}
+						rangeSelectors={rangeSelectors}
+						type={type}
 						typeLang="Individuals"
 					/>
 				</MockedProvider>
@@ -202,6 +219,133 @@ describe('DownloadStaticCSVReport', () => {
 					'it-was-not-possible-to-generate-a-csv-file-at-this-moment.-please-try-again-later'
 				),
 			});
+		});
+	});
+
+	it('passes objectType and type to the useDownloadCSV hook', () => {
+		render(
+			<DefaultComponent objectType="ObjectType1" type={CSVType.Asset} />
+		);
+
+		expect(mockedUseDownloadCSV).toHaveBeenCalledWith(
+			expect.objectContaining({
+				objectType: 'ObjectType1',
+				type: CSVType.Asset,
+			})
+		);
+	});
+
+	it('reads the filter and query from getFDSQuery and forwards them to the export URL and count request', async () => {
+		const getFDSQuery = jest.fn(() => ({
+			filter: "(assetType eq 'blog')",
+			query: 'liferay',
+		}));
+		const rangeSelectors = {
+			rangeEnd: '',
+			rangeKey: '30',
+			rangeStart: '',
+		};
+
+		(API.csv.fetchCSV as jest.Mock).mockReturnValue(
+			Promise.resolve({ok: true})
+		);
+		(API.csv.fetchCount as jest.Mock).mockReturnValue(
+			Promise.resolve(9000)
+		);
+
+		render(
+			<DefaultComponent
+				getFDSQuery={getFDSQuery}
+				rangeSelectors={rangeSelectors}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: /download report/i,
+			})
+		);
+
+		await waitFor(() =>
+			expect(screen.getByTestId('submit')).toBeInTheDocument()
+		);
+
+		fireEvent.click(screen.getByTestId('submit'));
+
+		await waitFor(() => {
+			expect(mockedGenerateURL).toHaveBeenCalledWith(rangeSelectors, {
+				filter: "(assetType eq 'blog')",
+				query: 'liferay',
+			});
+		});
+
+		expect(API.csv.fetchCount).toHaveBeenCalledWith(
+			expect.objectContaining({
+				filter: "(assetType eq 'blog')",
+				query: 'liferay',
+			})
+		);
+		expect(getFDSQuery).toHaveBeenCalledTimes(1);
+	});
+
+	it('forwards an undefined filter and query when getFDSQuery is not provided', async () => {
+		(API.csv.fetchCSV as jest.Mock).mockReturnValue(
+			Promise.resolve({ok: true})
+		);
+		(API.csv.fetchCount as jest.Mock).mockReturnValue(
+			Promise.resolve(9000)
+		);
+
+		render(<DefaultComponent />);
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: /download report/i,
+			})
+		);
+
+		await waitFor(() =>
+			expect(screen.getByTestId('submit')).toBeInTheDocument()
+		);
+
+		fireEvent.click(screen.getByTestId('submit'));
+
+		await waitFor(() => {
+			expect(mockedGenerateURL).toHaveBeenCalledWith(undefined, {
+				filter: undefined,
+				query: undefined,
+			});
+		});
+	});
+
+	it('requests the count for the type being exported instead of a hardcoded type', async () => {
+		(API.csv.fetchCSV as jest.Mock).mockReturnValue(
+			Promise.resolve({ok: true})
+		);
+		(API.csv.fetchCount as jest.Mock).mockReturnValue(
+			Promise.resolve(9000)
+		);
+
+		render(<DefaultComponent type={CSVType.Asset} />);
+
+		fireEvent.click(
+			screen.getByRole('button', {
+				name: /download report/i,
+			})
+		);
+
+		await waitFor(() =>
+			expect(screen.getByTestId('submit')).toBeInTheDocument()
+		);
+
+		fireEvent.click(screen.getByTestId('submit'));
+
+		await waitFor(() => {
+			expect(API.csv.fetchCount).toHaveBeenCalledWith(
+				expect.objectContaining({
+					type: CSVType.Asset,
+				})
+			);
 		});
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/useDownloadCSV.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/useDownloadCSV.ts
@@ -75,6 +75,69 @@ describe('useDownloadCSV', () => {
 		);
 	});
 
+	it('should include the fixed filter and objectType when provided', () => {
+		const {result} = renderHook(() =>
+			useDownloadCSV({
+				filter: "(assetType eq 'blog')",
+				objectType: 'ObjectType1',
+				type: CSVType.Asset,
+			})
+		);
+
+		const url = result.current({
+			rangeEnd: '',
+			rangeKey: RangeKeyTimeRanges.Last30Days,
+			rangeStart: '',
+		});
+
+		expect(url).toContain(
+			`filter=${encodeURIComponent("(assetType eq 'blog')")}`
+		);
+		expect(url).toContain('objectType=ObjectType1');
+	});
+
+	it('should override the fixed filter and query when overrides are provided', () => {
+		const {result} = renderHook(() =>
+			useDownloadCSV({
+				filter: "(assetType eq 'blog')",
+				type: CSVType.Asset,
+			})
+		);
+
+		const url = result.current(
+			{
+				rangeEnd: '',
+				rangeKey: RangeKeyTimeRanges.Last30Days,
+				rangeStart: '',
+			},
+			{filter: "(assetType eq 'webContent')", query: 'liferay'}
+		);
+
+		expect(url).toContain(
+			`filter=${encodeURIComponent("(assetType eq 'webContent')")}`
+		);
+		expect(url).toContain('query=liferay');
+	});
+
+	it('should fall back to the fixed filter when no override filter is provided', () => {
+		const {result} = renderHook(() =>
+			useDownloadCSV({
+				filter: "(assetType eq 'blog')",
+				type: CSVType.Asset,
+			})
+		);
+
+		const url = result.current({
+			rangeEnd: '',
+			rangeKey: RangeKeyTimeRanges.Last30Days,
+			rangeStart: '',
+		});
+
+		expect(url).toContain(
+			`filter=${encodeURIComponent("(assetType eq 'blog')")}`
+		);
+	});
+
 	it('should include order by fields if field and sortOrder are present', () => {
 		(window as {location: unknown}).location = new URL(
 			'https://ldp.liferay.com/workspace/liferay.com/420253908131944590/?field=name&page=1&sortOrder=DESC'

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/utils.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/utils.ts
@@ -13,6 +13,7 @@ export function formatDate(date: string | Date) {
 }
 
 export enum CSVType {
+	Asset = 'asset',
 	Blog = 'blog',
 	Document = 'document',
 	Event = 'event',
@@ -27,26 +28,32 @@ export enum CSVType {
 export function useDownloadCSV({
 	assetId,
 	assetType,
+	filter,
 	individualId,
+	objectType,
 	segmentId,
 	type,
 }: {
 	assetId?: string;
 	assetType?: string;
+	filter?: string;
 	individualId?: string;
+	objectType?: string;
 	segmentId?: string;
 	type: CSVType;
 }) {
 	const {channelId, groupId, title} = useParams();
 
 	return (
-		rangeSelectors: RangeSelectors = DEFAULT_RANGE_SELECTORS as unknown as RangeSelectors
+		rangeSelectors: RangeSelectors = DEFAULT_RANGE_SELECTORS as unknown as RangeSelectors,
+		overrides: {filter?: string; query?: string} = {}
 	) => {
 		const searchParams = new URLSearchParams(location.search);
 
 		const field = searchParams.get('field');
-		const query = searchParams.get('query');
+		const query = overrides.query ?? searchParams.get('query');
 		const sortOrder = searchParams.get('sortOrder');
+		const resolvedFilter = overrides.filter ?? filter;
 
 		let url = `/o/faro/main/${groupId}/reports/export/csv/${type}?channelId=${channelId}`;
 
@@ -63,7 +70,9 @@ export function useDownloadCSV({
 			assetId: assetId && encodeURIComponent(assetId),
 			assetTitle: title,
 			assetType,
+			filter: resolvedFilter && encodeURIComponent(resolvedFilter),
 			individualId,
+			objectType,
 			orderByFields:
 				field && sortOrder
 					? encodeURIComponent(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101231

Backport of #3866 to `faro-v5.1.x`.

Note: the source PR (#3866) is currently marked [On Hold] and is still open against `master`; this backport was opened ahead of its merge at the requester's explicit request, so it can be tracked alongside the original.

Cherry-picked commits, unchanged:
1. LPD-101231 Add the asset CSV export endpoint
2. LPD-101231 Add Download CSV action to the Asset List
3. LPD-101231 Add test coverage for the Asset List CSV export

See #3866 for the full description of the change.
