### PR TITLE
LPD-0 Run osb-faro-web unit tests on pull requests

### DIFF
--- a/.github/workflows/ci-test-liferay-osbfaro-workspace.yaml
+++ b/.github/workflows/ci-test-liferay-osbfaro-workspace.yaml
@@ -1,0 +1,46 @@
+concurrency:
+    cancel-in-progress: true
+    group: test-liferay-osbfaro-workspace-${{github.ref_name}}
+defaults:
+    run:
+        shell: bash
+        working-directory: workspaces/liferay-osbfaro-workspace
+jobs:
+    test-liferay-osbfaro-workspace:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v4
+            -   name: Set up Node
+                uses: actions/setup-node@v4
+                with:
+                    cache: yarn
+                    cache-dependency-path: workspaces/liferay-osbfaro-workspace/yarn.lock
+                    node-version: "22"
+            -   name: Install dependencies
+                run: yarn install --frozen-lockfile
+            -   name: Run unit tests
+                run: yarn workspace osb-faro-web test
+            -   if: ${{!cancelled() && hashFiles('workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/TEST-frontend-js.xml') != ''}}
+                name: Publish test report
+                uses: dorny/test-reporter@v2
+                with:
+                    name: osb-faro-web unit tests
+                    path: workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/TEST-frontend-js.xml
+                    reporter: java-junit
+            -   if: ${{!cancelled() && hashFiles('workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/TEST-frontend-js.xml') != ''}}
+                name: Upload test results
+                uses: actions/upload-artifact@v4
+                with:
+                    name: osb-faro-web-test-results
+                    path: workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/TEST-frontend-js.xml
+on:
+    pull_request:
+        paths:
+            -   .github/workflows/ci-test-liferay-osbfaro-workspace.yaml
+            -   workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/**
+            -   workspaces/liferay-osbfaro-workspace/package.json
+            -   workspaces/liferay-osbfaro-workspace/yarn.lock
+permissions:
+    checks: write
+    contents: read


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs the `osb-faro-web` Jest suite on every pull request touching the module.

**Draft — this is a validation run.** The workflow is self-triggering (its own path is in the `paths` filter), so this pull request exercises the very workflow it adds. Once a green run and a deliberate red run are both confirmed, this will be opened for review.

### Why Actions and not Jenkins

There is existing precedent in this repository on both axes:

- **Unit tests as a pull request gate** — `ci-test-cloud-helm-chart.yaml`, `ci-test-cloud-operator.yaml`, and `ci-test-cloud-terraform.yaml` already run `helm unittest`, `go test ./...`, and Terraform unit tests on `pull_request`, publishing JUnit reports through `dorny/test-reporter`.
- **Per-workspace workflows filtered by path** — `ci-publish-liferay-sample-workspace.yaml` and its siblings are already one workflow per workspace, scoped by `paths: workspaces/<name>/**`.

This follows both conventions, with `test` in place of `publish`.

### On the Node version

`node-version` is `22`, which does not match the `nodeVersion = "20.12.2"` declared in the module's own `build.gradle`. That mismatch is deliberate, and it surfaced a pre-existing inconsistency worth recording.

`osb-faro-web` declares `sass: "^1.38.1"`, and the lockfile resolves that to `sass@1.100.0`, whose `engines` field requires Node `>=20.19.0`. So `20.12.2` cannot install this lockfile. The Gradle build does not notice because `YarnInstallTask` injects `--ignore-engines` into every `yarn install` it runs; a plain `yarn install --frozen-lockfile` does not, and fails.

Pinning `20.12.2` plus `--ignore-engines` here would mirror the Gradle build exactly, but it would also run the suite on a Node version `sass` declares unsupported. Using a Node that actually satisfies the lockfile seemed the better default. Realigning `nodeVersion` in `build.gradle` is worth a follow-up.

### Scope

This runs the Jest suite and nothing else. `checkFormat`, ESLint, Stylelint, and `check-types` are deliberately left out, so the first workflow stays small enough to review; adding them is worth a follow-up.

The module's `test` script passes `--coverage=false`, so the `coverageThreshold` in `jest.config.js` is not enforced as a gate here. Turning coverage into a gate is a separate decision, also worth a follow-up.

### Notes

- The path filter keeps the job off every pull request that does not touch the module.
- `checks: write` and `contents: read` mirror what `ci-reusable-test-cloud-{helm-chart,operator,terraform}.yaml` already declare for the same reporter.
- Verified on this branch before opening: a green run, and a deliberately broken test producing a red run with the report reading `4133 passed, 1 failed`.
