### PR TITLE
LPD-103293 Run osb-faro-web unit tests on pull requests

### DIFF
--- a/.github/workflows/ci-test-liferay-osbfaro-workspace.yaml
+++ b/.github/workflows/ci-test-liferay-osbfaro-workspace.yaml
@@ -1,0 +1,46 @@
+concurrency:
+    cancel-in-progress: true
+    group: test-liferay-osbfaro-workspace-${{github.ref_name}}
+defaults:
+    run:
+        shell: bash
+        working-directory: workspaces/liferay-osbfaro-workspace
+jobs:
+    test-liferay-osbfaro-workspace:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v4
+            -   name: Set up Node
+                uses: actions/setup-node@v4
+                with:
+                    cache: yarn
+                    cache-dependency-path: workspaces/liferay-osbfaro-workspace/yarn.lock
+                    node-version: "22"
+            -   name: Install dependencies
+                run: yarn install --frozen-lockfile
+            -   name: Run unit tests
+                run: yarn workspace osb-faro-web test
+            -   if: ${{!cancelled() && hashFiles('workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/TEST-frontend-js.xml') != ''}}
+                name: Publish test report
+                uses: dorny/test-reporter@v2
+                with:
+                    name: osb-faro-web unit tests
+                    path: workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/TEST-frontend-js.xml
+                    reporter: java-junit
+            -   if: ${{!cancelled() && hashFiles('workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/TEST-frontend-js.xml') != ''}}
+                name: Upload test results
+                uses: actions/upload-artifact@v4
+                with:
+                    name: osb-faro-web-test-results
+                    path: workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/TEST-frontend-js.xml
+on:
+    pull_request:
+        paths:
+            -   .github/workflows/ci-test-liferay-osbfaro-workspace.yaml
+            -   workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/**
+            -   workspaces/liferay-osbfaro-workspace/package.json
+            -   workspaces/liferay-osbfaro-workspace/yarn.lock
+permissions:
+    checks: write
+    contents: read


### PR DESCRIPTION
*Proposal: move the osb-faro-web unit tests to GitHub Actions*

  Today, when we open a PR that touches `osb-faro-web`, pr-check fires the `workspace-build` validation, which runs `./gradlew build` in `liferay-osbfaro-workspace`. That build does more than compile: the chain `packageRunTest → osbYarnTest →
  osbYarnWebpack` means it runs *the production webpack build and then the full suite of 4134 Jest tests*, with `--maxWorkers=4`.

  All of that runs on the machine of whoever is developing or reviewing. With more than one worktree open, those 4 workers compete with everything else and the machine is unusable while the suite runs.

  Worth noting that nobody designed it this way: pr-check's `javascript-unit-test` validation is anchored on `^modules/`, and `osb-faro-web` lives under `^workspaces/`. So that validation never fires for this module — the tests only run as a side effect
  of `gradlew build`.

  *The proposal is to give the tests a place of their own in CI*, in a GitHub Actions workflow that runs on every PR touching the module. I have already validated both paths: green when it passes, and red with a `4133 passed, 1 failed` report when I
  broke a test on purpose. It takes ~12 min, and it costs nothing — Actions on standard runners is free for public repositories.

  This is not new ground in the repo. The `ci-test-cloud-{helm-chart,operator,terraform}.yaml` workflows already run unit tests on `pull_request` and publish a JUnit report, and the `ci-publish-liferay-*-workspace.yaml` ones are already one workflow per
  workspace filtered by path. The PR follows both conventions.

  *Being upfront about the scope:* this PR only *adds* the CI run. It does not remove the tests from `gradlew build` — that is a separate conversation, since it would take the tests out of the official build and not just off our machines. 