### PR TITLE
LPD-103257 Add an optional fields array to Analytics.setIdentity()

### DIFF
--- a/modules/apps/analytics/analytics-client-js/src/analytics.ts
+++ b/modules/apps/analytics/analytics-client-js/src/analytics.ts
@@ -313,7 +313,7 @@ class Analytics {
 	 * different than the previously stored one, we will save this new identity and
 	 * send a request updating the Identity Service.
 	 */
-	setIdentity(identity: {email: string; name: string}) {
+	setIdentity(identity: AnalyticsType.SetIdentity) {
 		if (this._isTrackingDisabled()) {
 			return;
 		}
@@ -322,6 +322,7 @@ class Analytics {
 			emailAddressHashed: identity.email
 				? hash(identity.email.toLowerCase())
 				: '',
+			fields: this._getNormalizedFields(identity.fields),
 		};
 
 		this.config.identity = hashedIdentity;
@@ -411,6 +412,26 @@ class Analytics {
 	}
 
 	/**
+	 * Returns the given fields sorted by name, so that the same data always
+	 * produces the same identity hash regardless of the order the caller used.
+	 * The array is copied because sorting is done in place and the caller's
+	 * array must not be modified.
+	 */
+	_getNormalizedFields(fields?: AnalyticsType.Field[]) {
+		if (!fields) {
+			return fields;
+		}
+
+		return [...fields].sort((fieldA, fieldB) => {
+			if (fieldA.name === fieldB.name) {
+				return 0;
+			}
+
+			return fieldA.name < fieldB.name ? -1 : 1;
+		});
+	}
+
+	/**
 	 * Gets the userId for the existing analytics user. Previously generated ids
 	 * are stored and retrieved before generating a new one. If an anonymous
 	 * navigation is started after an identified navigation, the user ID token
@@ -488,7 +509,7 @@ class Analytics {
 			identityHash !== storedIdentityHash ||
 			channelId !== storedChannelId
 		) {
-			const {emailAddressHashed} = identity;
+			const {emailAddressHashed, fields} = identity;
 
 			setItem(AnalyticsType.Keys.ChannelId, channelId);
 			setItem(AnalyticsType.Keys.Identity, identityHash);
@@ -497,6 +518,7 @@ class Analytics {
 				channelId,
 				dataSourceId,
 				emailAddressHashed,
+				fields,
 				id: identityHash,
 				userId,
 			});

--- a/modules/apps/analytics/analytics-client-js/src/types.ts
+++ b/modules/apps/analytics/analytics-client-js/src/types.ts
@@ -63,6 +63,7 @@ export namespace Analytics {
 		flushInterval: number;
 		identity: {
 			emailAddressHashed: string;
+			fields?: Field[];
 		};
 		identityEndpoint: string;
 		projectId: string;
@@ -156,12 +157,24 @@ export namespace Analytics {
 		assetType?: Analytics.ApplicationId;
 	};
 
+	export type Field = {
+		name: string;
+		value: string;
+	};
+
 	export type Identity = {
 		channelId: string;
 		dataSourceId: string;
 		emailAddressHashed: string;
+		fields?: Field[];
 		id: string;
 		userId: string;
+	};
+
+	export type SetIdentity = {
+		email?: string;
+		fields?: Field[];
+		name?: string;
 	};
 
 	export type Context = {

--- a/modules/apps/analytics/analytics-client-js/test/analytics.ts
+++ b/modules/apps/analytics/analytics-client-js/test/analytics.ts
@@ -141,6 +141,174 @@ describe('Analytics', () => {
 		expect(identityCalled).toBe(1);
 	});
 
+	it('sends the given fields to the Identity Service', async () => {
+		Analytics.reset();
+		AnalyticsClient.dispose();
+
+		Analytics = AnalyticsClient.create(INITIAL_CONFIG);
+
+		let identityBody: {[key: string]: any} = {};
+
+		fetchMock.restore();
+		fetchMock.mock(/identity$/, (_url: string, options: RequestInit) => {
+			identityBody = JSON.parse(options.body as string);
+
+			return 200;
+		});
+		fetchMock.mock(/ac-server/i, () => Promise.resolve(200));
+
+		await Analytics.setIdentity({
+			email: 'john@liferay.com',
+			fields: [
+				{name: 'firstName', value: 'John'},
+				{name: 'lastName', value: 'Doe'},
+			],
+			name: 'John Doe',
+		});
+
+		await wait(FLUSH_INTERVAL);
+
+		expect(identityBody.fields).toEqual([
+			{name: 'firstName', value: 'John'},
+			{name: 'lastName', value: 'Doe'},
+		]);
+	});
+
+	it('does not request the Identity Service when only the field order changed', async () => {
+		fetchMock.mock(/identity$/, () => Promise.resolve(200));
+
+		Analytics.reset();
+		AnalyticsClient.dispose();
+
+		Analytics = AnalyticsClient.create(INITIAL_CONFIG);
+
+		await Analytics.setIdentity({
+			email: 'john@liferay.com',
+			fields: [
+				{name: 'firstName', value: 'John'},
+				{name: 'lastName', value: 'Doe'},
+			],
+			name: 'John Doe',
+		});
+
+		await wait(FLUSH_INTERVAL);
+
+		let identityCalled = 0;
+
+		fetchMock.restore();
+		fetchMock.mock(/identity$/, () => {
+			identityCalled += 1;
+
+			return '';
+		});
+
+		await Analytics.setIdentity({
+			email: 'john@liferay.com',
+			fields: [
+				{name: 'lastName', value: 'Doe'},
+				{name: 'firstName', value: 'John'},
+			],
+			name: 'John Doe',
+		});
+
+		await wait(FLUSH_INTERVAL);
+
+		expect(identityCalled).toBe(0);
+	});
+
+	it('requests the Identity Service when a field value changed', async () => {
+		fetchMock.mock(/identity$/, () => Promise.resolve(200));
+
+		Analytics.reset();
+		AnalyticsClient.dispose();
+
+		Analytics = AnalyticsClient.create(INITIAL_CONFIG);
+
+		await Analytics.setIdentity({
+			email: 'john@liferay.com',
+			fields: [
+				{name: 'firstName', value: 'John'},
+				{name: 'lastName', value: ''},
+			],
+			name: 'John Doe',
+		});
+
+		await wait(FLUSH_INTERVAL);
+
+		let identityCalled = 0;
+
+		fetchMock.restore();
+		fetchMock.mock(/identity$/, () => {
+			identityCalled += 1;
+
+			return '';
+		});
+
+		await Analytics.setIdentity({
+			email: 'john@liferay.com',
+			fields: [
+				{name: 'firstName', value: 'John'},
+				{name: 'lastName', value: 'Doe'},
+			],
+			name: 'John Doe',
+		});
+
+		await wait(FLUSH_INTERVAL);
+
+		expect(identityCalled).toBe(1);
+	});
+
+	it('does not add fields to the payload when none are given', async () => {
+		Analytics.reset();
+		AnalyticsClient.dispose();
+
+		Analytics = AnalyticsClient.create(INITIAL_CONFIG);
+
+		let identityBody: {[key: string]: any} = {};
+
+		fetchMock.restore();
+		fetchMock.mock(/identity$/, (_url: string, options: RequestInit) => {
+			identityBody = JSON.parse(options.body as string);
+
+			return 200;
+		});
+		fetchMock.mock(/ac-server/i, () => Promise.resolve(200));
+
+		await Analytics.setIdentity(ANALYTICS_IDENTITY);
+
+		await wait(FLUSH_INTERVAL);
+
+		expect(identityBody).not.toHaveProperty('fields');
+	});
+
+	it('sends the fields as an anonymous identity when the email is omitted', async () => {
+		Analytics.reset();
+		AnalyticsClient.dispose();
+
+		Analytics = AnalyticsClient.create(INITIAL_CONFIG);
+
+		let identityBody: {[key: string]: any} = {};
+
+		fetchMock.restore();
+		fetchMock.mock(/identity$/, (_url: string, options: RequestInit) => {
+			identityBody = JSON.parse(options.body as string);
+
+			return 200;
+		});
+		fetchMock.mock(/ac-server/i, () => Promise.resolve(200));
+
+		await Analytics.setIdentity({
+			fields: [{name: 'emailAddress', value: 'john@liferay.com'}],
+		});
+
+		await wait(FLUSH_INTERVAL);
+
+		expect(identityBody.emailAddressHashed).toBe('');
+		expect(identityBody.fields).toEqual([
+			{name: 'emailAddress', value: 'john@liferay.com'},
+		]);
+	});
+
 	it("does not request the Identity Service when identity hasn't changed", async () => {
 		fetchMock.mock(/identity$/, () => Promise.resolve(200));
 
@@ -253,6 +421,52 @@ describe('Analytics', () => {
 		const secondUserId = getItem(AnalyticsType.Keys.UserId);
 
 		expect(firstUserId).toEqual(secondUserId);
+	});
+
+	it('does not replace the user id whenever only the fields changed', async () => {
+		fetchMock.mock(/ac-server/i, () => Promise.resolve(200));
+		fetchMock.mock(/identity$/, () => Promise.resolve(200));
+
+		await Analytics.setIdentity({
+			email: 'john@liferay.com',
+			fields: [{name: 'lastName', value: ''}],
+			name: 'John',
+		});
+
+		const firstUserId = getItem(AnalyticsType.Keys.UserId);
+
+		await Analytics.setIdentity({
+			email: 'john@liferay.com',
+			fields: [{name: 'lastName', value: 'Doe'}],
+			name: 'John',
+		});
+
+		const secondUserId = getItem(AnalyticsType.Keys.UserId);
+
+		expect(firstUserId).toEqual(secondUserId);
+	});
+
+	it('replaces the user id whenever the email changed and fields are sent', async () => {
+		fetchMock.mock(/ac-server/i, () => Promise.resolve(200));
+		fetchMock.mock(/identity$/, () => Promise.resolve(200));
+
+		await Analytics.setIdentity({
+			email: 'john@liferay.com',
+			fields: [{name: 'firstName', value: 'John'}],
+			name: 'John',
+		});
+
+		const firstUserId = getItem(AnalyticsType.Keys.UserId);
+
+		await Analytics.setIdentity({
+			email: 'brian@liferay.com',
+			fields: [{name: 'firstName', value: 'Brian'}],
+			name: 'Brian',
+		});
+
+		const secondUserId = getItem(AnalyticsType.Keys.UserId);
+
+		expect(firstUserId).not.toEqual(secondUserId);
 	});
 
 	it('regenerates the user id on logouts or session expirations ', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103257

## What Is Being Fixed

`setIdentity()` could only carry a hashed email address. A caller had no way to send the contact details a form submitter provides — first name, last name, company — so a trial-form submitter could not be resolved into a Known Individual downstream.

## How It Is Being Fixed

`setIdentity()` now accepts an optional generic `fields: [{name, value}]` array alongside `email` and `name`, and `_sendIdentity` carries it in the `/identity` payload.

The fields go inside the object that `_getIdentityHash` hashes rather than beside it. That is deliberate: the hash is the client-side dedup guard, so leaving the fields out would mean a resubmit with the same email but different data hashes identically and gets swallowed before it ever reaches the backend.

They are sorted by name before hashing, because the SDK's `hash()` sorts object keys but preserves array order — the same data handed over in a different order would otherwise produce a different hash and a redundant request. The sort runs on a copy, since `Array.prototype.sort` mutates in place and the caller's array must not be touched.

`email` and `name` are now optional. The integration script that will consume this cannot be forced to pass either, and omitting the email already had a defined meaning at runtime: `emailAddressHashed` goes out empty, which the backend treats as anonymous. Making the type reflect that is a widening, so no existing caller is affected.

## PR Check

**pr-check: PASS** — tested on `8517d827bc364492f9096e42473ae99d9d3a9621`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

Baseline note: the run reported one `EXCESSIVE VERSION INCREASE`, on `modules/apps/headless/headless-cms/headless-cms-api/src/main/resources/com/liferay/headless/cms/resource/v1_0/packageinfo` (`3.1.0` in the tree, `3.0.0` released on Nexus). It is not attributable to this branch — the diff is three TypeScript files under `analytics-client-js` and touches no `.java`, `bnd.bnd`, or `packageinfo`, and the `3.1.0` value comes from `master`. The bnd baseline resolves its comparison target from Nexus on every run, so an untouched module can start reporting between one run and the next. The repair baseline wrote to the tree was reverted and is not part of this branch.

<!-- pr-check {"result": "success", "sha": "8517d827bc364492f9096e42473ae99d9d3a9621"} -->
