### PR TITLE
LPD-103295 Fix the between date filter in segment criteria

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/__tests__/DateFilterConjunctionInput.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/__tests__/DateFilterConjunctionInput.jsx
@@ -3,6 +3,7 @@ import DateFilterConjunctionInput from '../DateFilterConjunctionInput';
 import mockStore from 'test/mock-store';
 import React from 'react';
 import {ApolloProvider} from '@apollo/client';
+import {clickFirstSelectableDay} from 'test/helpers';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import {
 	FunctionalOperators,
@@ -120,5 +121,32 @@ describe('DateFilterConjunctionInput', () => {
 		);
 
 		expect(getByTestId('date-range-input')).toBeTruthy();
+	});
+
+	it('should emit an ISO date when picking a day for the between operator', () => {
+		const onChange = jest.fn();
+
+		const {getByTestId} = render(
+			<WrapperComponent>
+				<DateFilterConjunctionInput
+					conjunctionCriterion={{
+						operatorName: FunctionalOperators.Between,
+						propertyName: 'day',
+						touched: false,
+						valid: false,
+						value: {end: '', start: ''}
+					}}
+					onChange={onChange}
+				/>
+			</WrapperComponent>
+		);
+
+		fireEvent.click(getByTestId('date-range-input'));
+
+		clickFirstSelectableDay();
+
+		expect(onChange.mock.calls[0][0].value.start).toMatch(
+			/^\d{4}-\d{2}-\d{2}$/
+		);
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/__tests__/DateFilterConjunctionInput.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/inputs/components/__tests__/DateFilterConjunctionInput.jsx
@@ -123,6 +123,37 @@ describe('DateFilterConjunctionInput', () => {
 		expect(getByTestId('date-range-input')).toBeTruthy();
 	});
 
+	it('should clear the date when switching from between to a single date operator', () => {
+		const ControlledInput = () => {
+			const [conjunctionCriterion, setConjunctionCriterion] =
+				React.useState({
+					operatorName: FunctionalOperators.Between,
+					propertyName: 'day',
+					touched: false,
+					valid: true,
+					value: {end: '2020-12-20', start: '2020-12-12'}
+				});
+
+			return (
+				<DateFilterConjunctionInput
+					conjunctionCriterion={conjunctionCriterion}
+					onChange={setConjunctionCriterion}
+				/>
+			);
+		};
+
+		const {getByTestId, getByText} = render(
+			<WrapperComponent>
+				<ControlledInput />
+			</WrapperComponent>
+		);
+
+		fireEvent.click(getByText('between'));
+		fireEvent.click(getByText('after'));
+
+		expect(getByTestId('date-input').value).toBe('');
+	});
+
 	it('should emit an ISO date when picking a day for the between operator', () => {
 		const onChange = jest.fn();
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/__tests__/odata.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/__tests__/odata.js
@@ -809,6 +809,13 @@ describe('odata', () => {
 			testConversionToAndFrom(testQuery);
 		});
 
+		it('should be able to translate a query string with a "between" day filter to a map and back to a string', () => {
+			const testQuery =
+				"(activities.filterByCount(filter='(applicationId eq ''WebContent'' and eventId eq ''webContentViewed'' and between(day,''2020-2-2'',''2020-2-3''))',operator='ge',value=1))";
+
+			testConversionToAndFrom(testQuery);
+		});
+
 		it('should be able to translate a query string that contains a single quote', () => {
 			const testQuery = "(firstName eq 'o''hara')";
 
@@ -1193,6 +1200,14 @@ describe('odata', () => {
 			testConversionToAndFrom(
 				buildTagQuery(
 					"tags/id eq 'tag-id' and tags/name eq 'My Tag' and activityKey eq 'WebContent' and day gt '2023-01-01'"
+				)
+			);
+		});
+
+		it('should round-trip a tag filter with a "between" day filter', () => {
+			testConversionToAndFrom(
+				buildTagQuery(
+					"tags/id eq 'tag-id' and tags/name eq 'My Tag' and activityKey eq 'WebContent' and between(day,'2020-2-2','2020-2-3')"
 				)
 			);
 		});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/odata.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/segment/segment-editor/dynamic/utils/odata.ts
@@ -191,6 +191,11 @@ const PARAM_REGEX = /\s+((?:criterionGroup|operator|value)=)/g;
 export const trimSpacesBeforeParams = (queryString: string): string =>
 	queryString.replace(PARAM_REGEX, '$1');
 
+const buildBetweenExpression = (
+	propertyName: string | undefined,
+	{end, start}: {end: string; start: string}
+): string => `between(${propertyName},'${start}','${end}')`;
+
 const buildRemoteFilterString = (
 	criterionGroup: any,
 	criterionType: RemoteCriterionType
@@ -244,7 +249,9 @@ const buildRemoteFilterString = (
 
 	if (dayItem) {
 		parts.push(
-			`${dayItem.propertyName} ${dayItem.operatorName} '${dayItem.value}'`
+			dayItem.operatorName === FunctionalOperators.Between
+				? buildBetweenExpression(dayItem.propertyName, dayItem.value)
+				: `${dayItem.propertyName} ${dayItem.operatorName} '${dayItem.value}'`
 		);
 	}
 
@@ -386,10 +393,8 @@ const buildQueryString = (
 				}
 				else if (isValueType(FunctionalOperators, operatorName)) {
 					if (operatorName === FunctionalOperators.Between) {
-						const {end, start} = parsedValue;
-
 						queryString = queryString.concat(
-							`between(${propertyName},'${start}','${end}')`
+							buildBetweenExpression(propertyName, parsedValue)
 						);
 					}
 					else {
@@ -928,9 +933,27 @@ const buildInnerFilterItems = (
 		}
 	}
 
+	// A date range is a function call, not a relational comparison, so it needs
+	// its own pattern. Without it the day item is dropped on reload and the
+	// conjunction falls back to "ever".
+
+	const dayBetweenMatch = innerFilter.match(
+		/between\(day,'([^']*)','([^']*)'\)/
+	);
+
 	const dayMatch = innerFilter.match(/day (gt|ge|lt|le|eq|ne) '([^']+)'/);
 
-	if (dayMatch) {
+	if (dayBetweenMatch) {
+		items.push({
+			operatorName: FunctionalOperators.Between,
+			propertyName: 'day',
+			rowId: generateRowId(),
+			touched: false,
+			valid: true,
+			value: {end: dayBetweenMatch[2], start: dayBetweenMatch[1]},
+		} as unknown as Criterion);
+	}
+	else if (dayMatch) {
 		items.push({
 			operatorName: dayMatch[1],
 			propertyName: 'day',

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/DateInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/DateInput.tsx
@@ -66,26 +66,21 @@ const DateInput: React.FC<IDateInputProps> = ({
 		}
 	};
 
+	const date = showTimeSelector
+		? applyTimeZone(value, timeZoneId)
+		: moment(value, format);
+
+	// The displayed text and the calendar highlight read the same parse, so an
+	// empty value leaves the mask placeholder visible on both instead of
+	// rendering moment's "Invalid date" string.
+
 	const getDateValue = (): string => {
 		if (!displayFormat) {
 			return value;
 		}
 
-		let date = value;
-
-		if (showTimeSelector) {
-			date = applyTimeZone(value, timeZoneId);
-		}
-		else {
-			date = moment(value);
-		}
-
-		return date.format(displayFormat);
+		return date.isValid() ? date.format(displayFormat) : '';
 	};
-
-	const date = showTimeSelector
-		? applyTimeZone(value, timeZoneId)
-		: moment(value, format);
 
 	const retentionPeriod = useRetentionPeriod();
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/DateInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/DateInput.tsx
@@ -6,7 +6,7 @@ import getCN from 'classnames';
 import Input from './Input';
 import MaskedInput from './MaskedInput';
 import moment from 'moment';
-import React, {useState} from 'react';
+import React, {useRef, useState} from 'react';
 import {
 	applyTimeZone,
 	DATE_MASK,
@@ -51,6 +51,14 @@ const DateInput: React.FC<IDateInputProps> = ({
 	value,
 }) => {
 	const [active, setActive] = useState(false);
+
+	// Clay closes the picker from its own trigger through a callback it froze on
+	// the first render, so reading the blur handler from that closure would call
+	// a stale one. Route it through a ref instead.
+
+	const onDateInputBlurRef = useRef(onDateInputBlur);
+
+	onDateInputBlurRef.current = onDateInputBlur;
 
 	const handleDateSelect = (value: any): void => {
 		onDateInputChange(value.format(format));
@@ -101,7 +109,7 @@ const DateInput: React.FC<IDateInputProps> = ({
 			onActiveChange={(active) => {
 				setActive(active);
 
-				!active && onDateInputBlur();
+				!active && onDateInputBlurRef.current();
 			}}
 			trigger={
 				<div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/DateRangeInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/DateRangeInput.tsx
@@ -5,7 +5,7 @@ import DatePicker from './date-picker';
 import getCN from 'classnames';
 import Input from './Input';
 import moment from 'moment';
-import React, {useState} from 'react';
+import React, {useRef, useState} from 'react';
 import {DatePickerRetentionPeriodHeader} from './DatePickerRetentionPeriodHeader';
 import {DEFAULT_DATE_FORMAT} from 'shared/util/date';
 import {formatDateWithTimezone} from './dropdown-range-key/utils';
@@ -70,6 +70,14 @@ const DateInput: React.FC<IDateInputProps> = ({
 	const {timeZoneId} = useTimeZone(groupId);
 	const retentionPeriod = useRetentionPeriod();
 
+	// Clay closes the picker from its own trigger through a callback it froze on
+	// the first render, so reading the blur handler from that closure would call
+	// a stale one. Route it through a ref instead.
+
+	const onBlurRef = useRef(onBlur);
+
+	onBlurRef.current = onBlur;
+
 	// The emitted range is read back with `format`, so it is written with
 	// `format`; `displayFormat` is locale aware and only ever reaches the text
 	// the trigger shows.
@@ -119,7 +127,7 @@ const DateInput: React.FC<IDateInputProps> = ({
 			onActiveChange={(active) => {
 				setActive(active);
 
-				!active && onBlur();
+				!active && onBlurRef.current();
 			}}
 			trigger={
 				<div>

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/DateRangeInput.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/DateRangeInput.tsx
@@ -23,6 +23,9 @@ const convertToMoment = (
 	return date.isValid() ? date : null;
 };
 
+const formatMoment = (value: moment.Moment | null, format: string): string =>
+	isNil(value) ? '' : value.format(format);
+
 export type DateRange = {
 	end: string;
 	start: string;
@@ -67,22 +70,22 @@ const DateInput: React.FC<IDateInputProps> = ({
 	const {timeZoneId} = useTimeZone(groupId);
 	const retentionPeriod = useRetentionPeriod();
 
-	const convertMomentToDisplayFormat = (
-		value: moment.Moment | null
-	): string => (isNil(value) ? '' : value.format(displayFormat || format));
+	// The emitted range is read back with `format`, so it is written with
+	// `format`; `displayFormat` is locale aware and only ever reaches the text
+	// the trigger shows.
 
 	const handleDateSelect = ({end, start}: MomentDateRange) => {
 		onChange({
-			end: convertMomentToDisplayFormat(end),
-			start: convertMomentToDisplayFormat(start),
+			end: formatMoment(end, format),
+			start: formatMoment(start, format),
 		});
 	};
 
 	const getDateRangeDisplay = ({end, start}: MomentDateRange): string => {
 		if (end || start) {
 			return sub(Liferay.Language.get('x-to-x'), [
-				convertMomentToDisplayFormat(start),
-				convertMomentToDisplayFormat(end),
+				formatMoment(start, displayFormat || format),
+				formatMoment(end, displayFormat || format),
 			]) as string;
 		}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/DateInput.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/DateInput.jsx
@@ -40,4 +40,21 @@ describe('DateInput', () => {
 
 		expect(getByDisplayValue('1970 01 01 00:00')).toBeTruthy();
 	});
+
+	// An empty value must read as empty so the mask placeholder shows, rather
+	// than as moment's "Invalid date" string.
+
+	it('should render an empty value as empty when a displayFormat is set', () => {
+		const {getByTestId} = render(
+			<WrapperComponent>
+				<DateInput
+					displayFormat='MMM D, YYYY'
+					onDateInputChange={jest.fn()}
+					value=''
+				/>
+			</WrapperComponent>
+		);
+
+		expect(getByTestId('date-input').value).toBe('');
+	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/DateRangeInput.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/DateRangeInput.jsx
@@ -3,7 +3,7 @@ import DateRangeInput from '../DateRangeInput';
 import mockStore from 'test/mock-store';
 import moment from 'moment';
 import React from 'react';
-import {cleanup, fireEvent, render} from '@testing-library/react';
+import {act, cleanup, fireEvent, render} from '@testing-library/react';
 import {ApolloProvider} from '@apollo/client';
 import {clickFirstSelectableDay} from 'test/helpers';
 import {getCustomDateFormat} from 'shared/util/date';
@@ -12,6 +12,27 @@ import {mockPreferenceReq} from 'test/graphql-data';
 import {Provider} from 'react-redux';
 
 jest.unmock('react-dom');
+
+// Records the props of every ClayDropDown render so a test can invoke the
+// callback of an earlier render, the way Clay does when the picker is closed
+// from its own trigger. The real component still renders.
+
+const clayDropDownProps = [];
+
+jest.mock('@clayui/drop-down', () => {
+	const actual = jest.requireActual('@clayui/drop-down');
+	const ClayDropDown = actual.default;
+
+	return {
+		...actual,
+		__esModule: true,
+		default: props => {
+			clayDropDownProps.push(props);
+
+			return <ClayDropDown {...props} />;
+		}
+	};
+});
 
 jest.mock('shared/hooks/useTimeZone', () => ({
 	useTimeZone: () => ({timeZoneId: 'UTC'})
@@ -41,7 +62,11 @@ const WrapperComponent = ({children}) => (
 );
 
 describe('DateRangeInput', () => {
-	afterEach(cleanup);
+	afterEach(() => {
+		clayDropDownProps.length = 0;
+
+		cleanup();
+	});
 
 	it('renders', () => {
 		const {getByTestId} = render(
@@ -96,5 +121,37 @@ describe('DateRangeInput', () => {
 
 		expect(onChange).toHaveBeenCalledTimes(1);
 		expect(onChange.mock.calls[0][0].start).toMatch(ISO_DATE);
+	});
+
+	it('blurs with the current handler when closed through a frozen callback', () => {
+		const blurredValues = [];
+
+		const ControlledInput = () => {
+			const [value, setValue] = React.useState({end: '', start: ''});
+
+			return (
+				<DateRangeInput
+					displayFormat={getCustomDateFormat()}
+					onBlur={() => blurredValues.push(value)}
+					onChange={setValue}
+					value={value}
+				/>
+			);
+		};
+
+		render(
+			<WrapperComponent>
+				<ControlledInput />
+			</WrapperComponent>
+		);
+
+		const {onActiveChange: closeFromFirstRender} = clayDropDownProps[0];
+
+		clickFirstSelectableDay();
+
+		act(() => closeFromFirstRender(false));
+
+		expect(blurredValues).toHaveLength(1);
+		expect(blurredValues[0].start).toMatch(ISO_DATE);
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/DateRangeInput.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/__tests__/DateRangeInput.jsx
@@ -3,8 +3,10 @@ import DateRangeInput from '../DateRangeInput';
 import mockStore from 'test/mock-store';
 import moment from 'moment';
 import React from 'react';
+import {cleanup, fireEvent, render} from '@testing-library/react';
 import {ApolloProvider} from '@apollo/client';
-import {cleanup, render} from '@testing-library/react';
+import {clickFirstSelectableDay} from 'test/helpers';
+import {getCustomDateFormat} from 'shared/util/date';
 import {MockedProvider} from '@apollo/client/testing';
 import {mockPreferenceReq} from 'test/graphql-data';
 import {Provider} from 'react-redux';
@@ -26,25 +28,73 @@ jest.mock('react-router-dom', () => ({
 	})
 }));
 
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+const WrapperComponent = ({children}) => (
+	<ApolloProvider client={client}>
+		<Provider store={mockStore()}>
+			<MockedProvider mocks={[mockPreferenceReq()]}>
+				{children}
+			</MockedProvider>
+		</Provider>
+	</ApolloProvider>
+);
+
 describe('DateRangeInput', () => {
 	afterEach(cleanup);
 
 	it('renders', () => {
 		const {getByTestId} = render(
-			<ApolloProvider client={client}>
-				<Provider store={mockStore()}>
-					<MockedProvider mocks={[mockPreferenceReq()]}>
-						<DateRangeInput
-							value={{
-								end: moment(100000000000).format('YYYY-MM-DD'),
-								start: moment(0).format('YYYY-MM-DD')
-							}}
-						/>
-					</MockedProvider>
-				</Provider>
-			</ApolloProvider>
+			<WrapperComponent>
+				<DateRangeInput
+					value={{
+						end: moment(100000000000).format('YYYY-MM-DD'),
+						start: moment(0).format('YYYY-MM-DD')
+					}}
+				/>
+			</WrapperComponent>
 		);
 
 		expect(getByTestId('date-range-input')).toBeInTheDocument();
+	});
+
+	it('displays the range in the given display format', () => {
+		const {getByTestId} = render(
+			<WrapperComponent>
+				<DateRangeInput
+					displayFormat={getCustomDateFormat()}
+					value={{end: '2026-02-10', start: '2026-02-01'}}
+				/>
+			</WrapperComponent>
+		);
+
+		expect(getByTestId('date-range-input').value).toBe(
+			'Feb 1, 2026 to Feb 10, 2026'
+		);
+	});
+
+	// The emitted range is read back with `format`, so a `displayFormat` must
+	// never leak into it. It used to, which left the picker unable to read its
+	// own selection back.
+
+	it('emits the selected date in the value format, not the display format', () => {
+		const onChange = jest.fn();
+
+		const {getByTestId} = render(
+			<WrapperComponent>
+				<DateRangeInput
+					displayFormat={getCustomDateFormat()}
+					onChange={onChange}
+					value={{end: '', start: ''}}
+				/>
+			</WrapperComponent>
+		);
+
+		fireEvent.click(getByTestId('date-range-input'));
+
+		clickFirstSelectableDay();
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		expect(onChange.mock.calls[0][0].start).toMatch(ISO_DATE);
 	});
 });

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/test/helpers.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/test/helpers.js
@@ -104,6 +104,18 @@ export const waitForLoadingToBeRemoved = async (
 	);
 };
 
+export const clickFirstSelectableDay = () => {
+	const days = Array.prototype.slice.call(
+		document.body.querySelectorAll('.day-root')
+	);
+
+	fireEvent.click(
+		days.find(
+			(day) => !day.disabled && !day.classList.contains('outside-month')
+		)
+	);
+};
+
 export const selectDropdownItem = (labelText) => {
 	const overlay = getByTestId(document.body, 'overlay');
 	fireEvent.click(getByText(overlay, labelText));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103295

## What Is Being Fixed

A segment criterion date filter set to the `between` operator could not be filled in: the calendar opened, but clicking a date did nothing. `after`, `before` and `on` worked. A customer reported it through LPP-65262 and it reproduced on ldp-stg and ldp-internal, so it was not specific to one instance.

`DateRangeInput` emitted the selected range formatted with `displayFormat` (locale aware, for example `Aug 2, 2026`) while reading it back with `format` (`YYYY-MM-DD`), so the picker could never parse its own selection. LPD-100563 introduced the asymmetry when it added `displayFormat` to the range input. The single-date operators were unaffected because `DateInput` emits with `format` and uses `displayFormat` only for the visible text.

Unblocking the selection exposed four more defects on the same feature, latent for as long as the range could not be filled in. Saving and reopening a segment lost the range and fell back to `ever`, because `buildInnerFilterItems` matched only the relational form `day <op> 'x'` and silently dropped the criterion. Tag and vocabulary criteria serialized `day between '[object Object]'`, because `buildRemoteFilterString` interpolated the `{start, end}` value through that same relational template. Switching the operator away from `between` rendered moment's `Invalid date` string. And a freshly picked range reverted to its previous value whenever the picker was closed by clicking its own trigger.

## How It Is Being Fixed

Three commits, one behaviour change each.

The first makes the range round-trip. `DateRangeInput` emits with `format` and `displayFormat` now reaches only the displayed text, with both formats visible side by side at the call sites so the asymmetry cannot creep back unnoticed. `buildInnerFilterItems` learns the functional form `between(day,'a','b')`, and `buildRemoteFilterString` serializes it instead of interpolating an object into the relational template. Both serializers share a `buildBetweenExpression` helper rather than repeating a template that already existed in `buildQueryString`.

The second removes the `Invalid date` string. Switching the operator already cleared the value; the problem was that `DateInput` parsed the same value twice under different rules — loosely for the text, with `format` for the calendar — so the displayed text and the calendar highlight could disagree. Both now read one parse, and an empty value leaves the mask placeholder visible.

The third fixes the reverting range. Clay memoises `openMenu` on the first render, so closing the picker from its trigger always invokes the first render's `onActiveChange`, and the blur handler behind it resent that stale criterion over the dates picked since. Clicking outside the popover was unaffected because that path gets a fresh callback each render. `DateRangeInput` and `DateInput` now call the blur handler through a ref, which fixes it for every consumer instead of defending one.

Each new test was confirmed failing without its fix. The stale-callback case is not reproducible in jsdom, since Clay keeps the menu mounted there, so that test captures the `onActiveChange` of the first render through a pass-through `ClayDropDown` mock and invokes it after the value changed. All five defects were also verified by hand against the reported segment on ldp-stg.

One thing worth a reviewer's attention: the `DateRangeInput` fix also reaches `ExportLogModal`, whose range flows straight into the data-privacy export URL. That request previously carried `fromDate=Feb 1, 2026`, with an unencoded comma and space, and now carries `fromDate=2026-02-01`. This looks like the intended contract, but it is a behaviour change outside Segments.

## PR Check

**pr-check: PASS** — tested on `bbfb7398547703f4adb7c181c093c607c349defa`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | N/A |
| Workspace Build | PASS |

Baseline note: the run could not execute, and the reason is not attributable to this branch. `ant baseline-all` aborted in 57 seconds because this worktree has no locally installed portal snapshots — `portal-kernel` failed to compile against absent dependency jars and the Gradle half reported 117 missing `com.liferay.portal.kernel:189.0.0-SNAPSHOT` resolutions. Nexus itself was reachable; only the local `~/.m2` artifacts are missing, and provisioning them needs `ant setup-libs` plus `ant deploy install-portal-snapshot`. The validation is also structurally inapplicable here: its fileset is `modules/**/bnd.bnd` carrying `Export-Package:` plus the seven top level Ant projects, while all eight changed files live under `workspaces/liferay-osbfaro-workspace` and none is `.java`, `bnd.bnd`, or `packageinfo` — so a fully provisioned run could not have produced a finding either. No repair reached the tree.

Workspace Build is the load-bearing check for this diff and it covered more than the branch: a production webpack pass over the three TypeScript files, `packageRunCheckFormat` over all 1556 source files in the module, and the full Jest suite at 717 suites and 4112 tests, all green.

<!-- pr-check {"result": "success", "sha": "bbfb7398547703f4adb7c181c093c607c349defa"} -->
