### PR TITLE
LPD-103157 Run analytics export dispatch triggers on a single node

### DIFF
--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/AnalyticsDXPEntityBatchExporterImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/AnalyticsDXPEntityBatchExporterImpl.java
@@ -14,6 +14,7 @@ import com.liferay.dispatch.executor.DispatchTaskExecutorRegistry;
 import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchLogLocalService;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -207,9 +208,17 @@ public class AnalyticsDXPEntityBatchExporterImpl
 				null, user.getUserId(), dispatchTaskExecutor,
 				dispatchTriggerName, null, dispatchTriggerName, false);
 
+		DispatchTaskClusterMode dispatchTaskClusterMode =
+			DispatchTaskClusterMode.NOT_APPLICABLE;
+
+		if (ClusterExecutorUtil.isEnabled()) {
+			dispatchTaskClusterMode =
+				DispatchTaskClusterMode.SINGLE_NODE_PERSISTED;
+		}
+
 		return _dispatchTriggerLocalService.updateDispatchTrigger(
 			dispatchTrigger.getDispatchTriggerId(), true, _CRON_EXPRESSION,
-			DispatchTaskClusterMode.NOT_APPLICABLE, 0, 0, 0, 0, 0, true, false,
+			dispatchTaskClusterMode, 0, 0, 0, 0, 0, true, false,
 			localDateTime.getMonthValue() - 1, localDateTime.getDayOfMonth(),
 			localDateTime.getYear(), localDateTime.getHour(),
 			localDateTime.getMinute(), "UTC");

--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/dispatch/executor/BaseAnalyticsDispatchTaskExecutor.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/dispatch/executor/BaseAnalyticsDispatchTaskExecutor.java
@@ -28,6 +28,11 @@ import org.osgi.service.component.annotations.Reference;
 public abstract class BaseAnalyticsDispatchTaskExecutor
 	extends BaseDispatchTaskExecutor {
 
+	@Override
+	public boolean isClusterModeSingle() {
+		return true;
+	}
+
 	protected UnsafeConsumer<String, Exception> getNotificationUnsafeConsumer(
 		long dispatchTriggerId,
 		DispatchTaskExecutorOutput dispatchTaskExecutorOutput) {

--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/dispatch/executor/DXPEntityAnalyticsExportDispatchTaskExecutor.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/dispatch/executor/DXPEntityAnalyticsExportDispatchTaskExecutor.java
@@ -92,6 +92,9 @@ public class DXPEntityAnalyticsExportDispatchTaskExecutor
 		if (forceFullExport) {
 			dispatchTaskSettingsUnicodeProperties.remove("forceFullExport");
 
+			dispatchTrigger.setDispatchTaskSettingsUnicodeProperties(
+				dispatchTaskSettingsUnicodeProperties);
+
 			_dispatchTriggerLocalService.updateDispatchTrigger(dispatchTrigger);
 		}
 	}

--- a/modules/apps/analytics/analytics-batch-export-import-test/src/testIntegration/java/com/liferay/analytics/batch/exportimport/internal/dispatch/executor/test/AnalyticsExportDispatchTaskExecutorTest.java
+++ b/modules/apps/analytics/analytics-batch-export-import-test/src/testIntegration/java/com/liferay/analytics/batch/exportimport/internal/dispatch/executor/test/AnalyticsExportDispatchTaskExecutorTest.java
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.batch.exportimport.internal.dispatch.executor.test;
+
+import com.liferay.analytics.batch.exportimport.constants.AnalyticsDXPEntityBatchExporterConstants;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dispatch.executor.DispatchTaskClusterMode;
+import com.liferay.dispatch.executor.DispatchTaskExecutorRegistry;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.scheduler.StorageType;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rachael Koestartyo
+ */
+@RunWith(Arquillian.class)
+public class AnalyticsExportDispatchTaskExecutorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testIsClusterModeSingle() {
+		for (String dispatchTaskExecutorType : _DISPATCH_TASK_EXECUTOR_TYPES) {
+			Assert.assertTrue(
+				_dispatchTaskExecutorRegistry.isClusterModeSingle(
+					dispatchTaskExecutorType));
+		}
+	}
+
+	@Test
+	public void testUpdateDispatchTriggerRejectsAllNodesClusterMode()
+		throws Exception {
+
+		for (String dispatchTaskExecutorType : _DISPATCH_TASK_EXECUTOR_TYPES) {
+			DispatchTrigger dispatchTrigger =
+				_dispatchTriggerLocalService.addDispatchTrigger(
+					null, TestPropsValues.getUserId(), dispatchTaskExecutorType,
+					null, RandomTestUtil.randomString(), false);
+
+			try {
+				dispatchTrigger =
+					_dispatchTriggerLocalService.updateDispatchTrigger(
+						dispatchTrigger.getDispatchTriggerId(), false,
+						"0 0 * * * ?", DispatchTaskClusterMode.ALL_NODES, 0, 0,
+						0, 0, 0, true, false, 0, 1, 2026, 0, 0, "UTC");
+
+				DispatchTaskClusterMode dispatchTaskClusterMode =
+					DispatchTaskClusterMode.valueOf(
+						dispatchTrigger.getDispatchTaskClusterMode());
+
+				Assert.assertNotEquals(
+					StorageType.MEMORY,
+					dispatchTaskClusterMode.getStorageType());
+			}
+			finally {
+				_dispatchTriggerLocalService.deleteDispatchTrigger(
+					dispatchTrigger);
+			}
+		}
+	}
+
+	private static final String[] _DISPATCH_TASK_EXECUTOR_TYPES = {
+		"export-analytics-asset-entities",
+		AnalyticsDXPEntityBatchExporterConstants.
+			DISPATCH_TRIGGER_NAME_DXP_ENTITIES
+	};
+
+	@Inject
+	private DispatchTaskExecutorRegistry _dispatchTaskExecutorRegistry;
+
+	@Inject
+	private DispatchTriggerLocalService _dispatchTriggerLocalService;
+
+}

--- a/modules/apps/analytics/analytics-batch-export-import-test/src/testIntegration/java/com/liferay/analytics/batch/exportimport/internal/test/AnalyticsDXPEntityBatchExporterTest.java
+++ b/modules/apps/analytics/analytics-batch-export-import-test/src/testIntegration/java/com/liferay/analytics/batch/exportimport/internal/test/AnalyticsDXPEntityBatchExporterTest.java
@@ -9,7 +9,10 @@ import com.liferay.analytics.batch.exportimport.AnalyticsDXPEntityBatchExporter;
 import com.liferay.analytics.batch.exportimport.constants.AnalyticsDXPEntityBatchExporterConstants;
 import com.liferay.analytics.settings.security.constants.AnalyticsSecurityConstants;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dispatch.executor.DispatchTaskClusterMode;
+import com.liferay.dispatch.model.DispatchTrigger;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -62,6 +65,46 @@ public class AnalyticsDXPEntityBatchExporterTest {
 				TestPropsValues.getCompanyId(),
 				AnalyticsDXPEntityBatchExporterConstants.
 					DISPATCH_TRIGGER_NAME_DXP_ENTITIES));
+	}
+
+	@Test
+	public void testScheduleExportTriggersSchedulesOnSingleNode()
+		throws Exception {
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		String[] dispatchTriggerNames = {
+			AnalyticsDXPEntityBatchExporterConstants.
+				DISPATCH_TRIGGER_NAME_DXP_ENTITIES
+		};
+
+		_analyticsDXPEntityBatchExporter.unscheduleExportTriggers(
+			companyId, dispatchTriggerNames);
+
+		try {
+			_analyticsDXPEntityBatchExporter.scheduleExportTriggers(
+				companyId, dispatchTriggerNames);
+
+			DispatchTrigger dispatchTrigger =
+				_dispatchTriggerLocalService.fetchDispatchTrigger(
+					companyId, dispatchTriggerNames[0]);
+
+			DispatchTaskClusterMode dispatchTaskClusterMode =
+				DispatchTaskClusterMode.NOT_APPLICABLE;
+
+			if (ClusterExecutorUtil.isEnabled()) {
+				dispatchTaskClusterMode =
+					DispatchTaskClusterMode.SINGLE_NODE_PERSISTED;
+			}
+
+			Assert.assertEquals(
+				dispatchTaskClusterMode.getMode(),
+				dispatchTrigger.getDispatchTaskClusterMode());
+		}
+		finally {
+			_analyticsDXPEntityBatchExporter.unscheduleExportTriggers(
+				companyId, dispatchTriggerNames);
+		}
 	}
 
 	@Inject

--- a/modules/apps/analytics/analytics-settings-web-test/build.gradle
+++ b/modules/apps/analytics/analytics-settings-web-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationImplementation project(":apps:analytics:analytics-settings-api")
+	testIntegrationImplementation project(":apps:dispatch:dispatch-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")

--- a/modules/apps/analytics/analytics-settings-web-test/src/testIntegration/java/com/liferay/analytics/settings/web/internal/upgrade/v1_0_4/test/AnalyticsDispatchTriggerClusterModeUpgradeTest.java
+++ b/modules/apps/analytics/analytics-settings-web-test/src/testIntegration/java/com/liferay/analytics/settings/web/internal/upgrade/v1_0_4/test/AnalyticsDispatchTriggerClusterModeUpgradeTest.java
@@ -1,0 +1,138 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.settings.web.internal.upgrade.v1_0_4.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dispatch.executor.DispatchTaskClusterMode;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.dispatch.service.persistence.DispatchTriggerPersistence;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rachael Koestartyo
+ */
+@RunWith(Arquillian.class)
+public class AnalyticsDispatchTriggerClusterModeUpgradeTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testUpgradeKeepsClusterModeOfOtherDispatchTriggers()
+		throws Exception {
+
+		DispatchTrigger dispatchTrigger = _addAllNodesDispatchTrigger(
+			"batch-planner");
+
+		try {
+			_runUpgrade();
+
+			Assert.assertEquals(
+				DispatchTaskClusterMode.ALL_NODES.getMode(),
+				_getDispatchTaskClusterMode(
+					dispatchTrigger.getDispatchTriggerId()));
+		}
+		finally {
+			_dispatchTriggerLocalService.deleteDispatchTrigger(
+				dispatchTrigger.getDispatchTriggerId());
+		}
+	}
+
+	@Test
+	public void testUpgradeUpdatesAllNodesAnalyticsDispatchTriggers()
+		throws Exception {
+
+		for (String dispatchTaskExecutorType : _DISPATCH_TASK_EXECUTOR_TYPES) {
+			DispatchTrigger dispatchTrigger = _addAllNodesDispatchTrigger(
+				dispatchTaskExecutorType);
+
+			try {
+				_runUpgrade();
+
+				Assert.assertEquals(
+					DispatchTaskClusterMode.SINGLE_NODE_PERSISTED.getMode(),
+					_getDispatchTaskClusterMode(
+						dispatchTrigger.getDispatchTriggerId()));
+			}
+			finally {
+				_dispatchTriggerLocalService.deleteDispatchTrigger(
+					dispatchTrigger.getDispatchTriggerId());
+			}
+		}
+	}
+
+	private DispatchTrigger _addAllNodesDispatchTrigger(
+			String dispatchTaskExecutorType)
+		throws Exception {
+
+		DispatchTrigger dispatchTrigger =
+			_dispatchTriggerLocalService.addDispatchTrigger(
+				null, TestPropsValues.getUserId(), dispatchTaskExecutorType,
+				null, RandomTestUtil.randomString(), false);
+
+		dispatchTrigger.setDispatchTaskClusterMode(
+			DispatchTaskClusterMode.ALL_NODES.getMode());
+
+		return _dispatchTriggerLocalService.updateDispatchTrigger(
+			dispatchTrigger);
+	}
+
+	private int _getDispatchTaskClusterMode(long dispatchTriggerId)
+		throws Exception {
+
+		_dispatchTriggerPersistence.clearCache();
+
+		DispatchTrigger dispatchTrigger =
+			_dispatchTriggerLocalService.getDispatchTrigger(dispatchTriggerId);
+
+		return dispatchTrigger.getDispatchTaskClusterMode();
+	}
+
+	private void _runUpgrade() throws Exception {
+		for (UpgradeProcess upgradeProcess :
+				UpgradeTestUtil.getUpgradeSteps(
+					_upgradeStepRegistrator, new Version(1, 0, 4))) {
+
+			upgradeProcess.upgrade();
+		}
+	}
+
+	private static final String[] _DISPATCH_TASK_EXECUTOR_TYPES = {
+		"export-analytics-asset-entities", "export-analytics-dxp-entities"
+	};
+
+	@Inject
+	private DispatchTriggerLocalService _dispatchTriggerLocalService;
+
+	@Inject
+	private DispatchTriggerPersistence _dispatchTriggerPersistence;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.analytics.settings.web.internal.upgrade.registry.AnalyticsSettingsWebUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/upgrade/registry/AnalyticsSettingsWebUpgradeStepRegistrator.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/upgrade/registry/AnalyticsSettingsWebUpgradeStepRegistrator.java
@@ -7,12 +7,15 @@ package com.liferay.analytics.settings.web.internal.upgrade.registry;
 
 import com.liferay.analytics.settings.web.internal.upgrade.v1_0_2.AnalyticsDispatchTriggersUpgradeProcess;
 import com.liferay.analytics.settings.web.internal.upgrade.v1_0_3.AnalyticsAdministratorUserUpgradeProcess;
+import com.liferay.dispatch.executor.DispatchTaskClusterMode;
 import com.liferay.dispatch.executor.DispatchTaskExecutor;
 import com.liferay.dispatch.service.DispatchLogLocalService;
 import com.liferay.dispatch.service.DispatchTriggerLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -54,6 +57,18 @@ public class AnalyticsSettingsWebUpgradeStepRegistrator
 			new AnalyticsAdministratorUserUpgradeProcess(
 				_companyLocalService, _configurationAdmin, _roleLocalService,
 				_userLocalService));
+
+		registry.register(
+			"1.0.3", "1.0.4",
+			UpgradeProcessFactory.runSQL(
+				StringBundler.concat(
+					"update DispatchTrigger set dispatchTaskClusterMode = ",
+					DispatchTaskClusterMode.SINGLE_NODE_PERSISTED.getMode(),
+					" where dispatchTaskClusterMode = ",
+					DispatchTaskClusterMode.ALL_NODES.getMode(),
+					" and dispatchTaskExecutorType in ",
+					"('export-analytics-asset-entities', ",
+					"'export-analytics-dxp-entities')")));
 	}
 
 	@Reference


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103157

## What Is Being Fixed

The analytics export executors inherited `DispatchTaskExecutor.isClusterModeSingle`, which defaults to false, so the Dispatch UI offered the full Cluster Mode dropdown and persisted whatever an administrator selected. `ALL_NODES` maps to `StorageType.MEMORY`, which schedules the trigger locally on every node with no coordination. On a two node cluster the hourly export fired once per node, creating two `DispatchLog` rows at the same timestamp, and the "Only one instance in progress is allowed" check then cancelled the runs, so no export succeeded and the flow of data to Analytics Cloud stopped.

Two further problems surfaced in the same area. Every analytics trigger was created with `NOT_APPLICABLE`, which the Cluster Mode dropdown excludes from its options, so in a cluster the dropdown had nothing selected and fell back to displaying `ALL_NODES`; an administrator who opened one of the analytics triggers whose executor is not single instance and saved without touching the field silently converted it to `ALL_NODES`. Separately, `DXPEntityAnalyticsExportDispatchTaskExecutor` removed the `forceFullExport` flag from the properties it read but never handed them back to the model, so the flag was never re-serialized and every later run still performed a full export.

## How It Is Being Fixed

`BaseAnalyticsDispatchTaskExecutor` now declares itself single instance, so both `EditDispatchTriggerMVCActionCommand` and `DispatchTriggerLocalServiceImpl` force a single node mode regardless of what is submitted, and the UI renders the field disabled. `AnalyticsDXPEntityBatchExporterImpl` creates the triggers with `SINGLE_NODE_PERSISTED` when clustering is enabled and keeps `NOT_APPLICABLE` otherwise, which gives the dropdown a real selection while keeping the same persisted storage type. An upgrade step rewrites the rows an administrator already saved, since the executor change only blocks new selections; it targets `SINGLE_NODE_PERSISTED` rather than `NOT_APPLICABLE` because `DispatchConfigurator` only re-adds a scheduler job for a mode it considers schedulable, and an `ALL_NODES` trigger has no persisted job to fall back on. Finally, the executor hands the mutated properties back to the trigger before updating it.

Integration tests cover the executors declaring themselves single instance, the cluster mode chosen at creation, and the upgrade of already saved rows. The `forceFullExport` fix ships without automated coverage: a unit test cannot instantiate the executor because `BaseDispatchTaskExecutor` opens service trackers in a static initializer that needs a live OSGi framework, and an integration test cannot reach the flag removal because it sits after `exportToAnalyticsCloud`, which requires a real Analytics Cloud endpoint.

## PR Check

**pr-check: PASS** — tested on `33965bb24f21d1dd355bec2304223915804041f7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

Structural Smoke passes 8/8, but only with two Windows path-separator defects in `ModulesStructureTest` itself neutralized locally — the `"modules/build.gradle"` exemption at line 1552 and the module id construction at lines 343-350, which both assume `/`. That patch was reverted and is not part of this branch; stock, the test fails on Windows against any diff. The branch's own Gradle change is clean.

Java Unit Tests passes because the branch contributes no unit test class, which is the validation's documented outcome when selection finds nothing to run, not because a unit test executed.

<!-- pr-check {"result": "success", "sha": "33965bb24f21d1dd355bec2304223915804041f7"} -->
