### PR TITLE
LPD-103258 Add a public Analytics.flush() method

### DIFF
--- a/modules/apps/analytics/analytics-client-js/src/analytics.ts
+++ b/modules/apps/analytics/analytics-client-js/src/analytics.ts
@@ -183,6 +183,21 @@ class Analytics {
 		}
 	}
 
+	/**
+	 * Sends every queued message now instead of waiting for the next flush
+	 * interval, and returns a Promise that settles once the in-flight requests
+	 * settle. Each request is already bounded by the client adapter's
+	 * REQUEST_TIMEOUT, so a stalled endpoint cannot hold the Promise open
+	 * indefinitely.
+	 */
+	flush() {
+		if (!this._queueFlushService) {
+			return Promise.resolve();
+		}
+
+		return this._queueFlushService.flush();
+	}
+
 	getEvents() {
 		return this[
 			AnalyticsType.Queues.Events

--- a/modules/apps/analytics/analytics-client-js/src/queueFlushService.ts
+++ b/modules/apps/analytics/analytics-client-js/src/queueFlushService.ts
@@ -39,6 +39,7 @@ class QueueFlushService {
 	}[];
 	flushInterval: number;
 	processInterval: NodeJS.Timeout | null = null;
+	_flushing: Promise<void> | null = null;
 
 	constructor(config: Analytics.Config) {
 		this.attemptNumber = 1;
@@ -118,11 +119,11 @@ class QueueFlushService {
 	 *
 	 */
 	flush() {
-		if (this.processing) {
-			return;
+		if (this.processing && this._flushing) {
+			return this._flushing;
 		}
 
-		this.queues
+		this._flushing = this.queues
 			.reduce((previousPromise, {instance: queue}) => {
 				return previousPromise
 					.then(() => {
@@ -165,6 +166,8 @@ class QueueFlushService {
 					});
 			}, Promise.resolve())
 			.catch(() => {});
+
+		return this._flushing;
 	}
 
 	/**

--- a/modules/apps/analytics/analytics-client-js/test/analytics.ts
+++ b/modules/apps/analytics/analytics-client-js/test/analytics.ts
@@ -469,6 +469,45 @@ describe('Analytics', () => {
 		expect(firstUserId).not.toEqual(secondUserId);
 	});
 
+	it('sends the queued messages when flush is called', async () => {
+		let identityCalled = 0;
+
+		Analytics.reset();
+		AnalyticsClient.dispose();
+
+		// A long interval keeps the flush loop out of the way, so the send can
+		// only be attributed to the explicit flush() call below.
+
+		Analytics = AnalyticsClient.create({
+			...INITIAL_CONFIG,
+			flushInterval: 60000,
+		});
+
+		// Earlier tests leave items behind in this queue, and the flush below
+		// would send every one of them.
+
+		Analytics[AnalyticsType.Queues.IdentityMessage].reset();
+
+		fetchMock.restore();
+		fetchMock.mock(/identity$/, () => {
+			identityCalled += 1;
+
+			return '';
+		});
+		fetchMock.mock(/ac-server/i, () => Promise.resolve(200));
+
+		await Analytics.setIdentity({
+			email: 'flush@liferay.com',
+			name: 'Flush',
+		});
+
+		expect(identityCalled).toBe(0);
+
+		await Analytics.flush();
+
+		expect(identityCalled).toBe(1);
+	});
+
 	it('regenerates the user id on logouts or session expirations ', async () => {
 		fetchMock.mock(/ac-server/i, () => Promise.resolve(200));
 		fetchMock.mock(/identity$/, () => Promise.resolve(200));

--- a/modules/apps/analytics/analytics-client-js/test/queueFlushService.ts
+++ b/modules/apps/analytics/analytics-client-js/test/queueFlushService.ts
@@ -12,6 +12,7 @@ import QueueFlushService from '../src/queueFlushService';
 import EventMessageQueue from '../src/queues/eventMessageQueue';
 import IdentityMessageQueue from '../src/queues/identityMessageQueue';
 import {Analytics as AnalyticsTypes} from '../src/types';
+import {REQUEST_TIMEOUT} from '../src/utils/constants';
 import {INITIAL_ANALYTICS_CONFIG, wait} from './helpers';
 
 // We don't need any of the timing callbacks to run during these tests.
@@ -74,6 +75,116 @@ describe('QueueFlushService', () => {
 
 		expect(fetchCalled).toBe(1);
 	});
+
+	it('resolves the returned promise once the in-flight send settles', async () => {
+		let resolveFetch: (value: unknown) => void = () => {};
+		let settled = false;
+
+		fetchMock.mock(
+			/ac-server/i,
+			() =>
+				new Promise((resolve) => {
+					resolveFetch = resolve;
+				})
+		);
+
+		queueFlushService.addQueue(identityQueue);
+
+		identityQueue.addItem(getMockMessageItem('test-1'));
+
+		const flushed = queueFlushService.flush().then(() => {
+			settled = true;
+		});
+
+		await wait(FLUSH_INTERVAL);
+
+		expect(settled).toBe(false);
+
+		resolveFetch(200);
+
+		await flushed;
+
+		expect(settled).toBe(true);
+	});
+
+	it('returns the in-flight promise when a flush is already running', async () => {
+		let resolveFetch: (value: unknown) => void = () => {};
+		let secondSettled = false;
+
+		fetchMock.mock(
+			/ac-server/i,
+			() =>
+				new Promise((resolve) => {
+					resolveFetch = resolve;
+				})
+		);
+
+		queueFlushService.addQueue(identityQueue);
+
+		identityQueue.addItem(getMockMessageItem('test-1'));
+
+		const first = queueFlushService.flush();
+
+		await wait(FLUSH_INTERVAL);
+
+		expect(queueFlushService.processing).toBe(true);
+
+		const second = queueFlushService.flush().then(() => {
+			secondSettled = true;
+		});
+
+		expect(secondSettled).toBe(false);
+
+		resolveFetch(200);
+
+		await Promise.all([first, second]);
+
+		expect(secondSettled).toBe(true);
+	});
+
+	it('resolves the flush when no queue has anything to send', async () => {
+		let fetchCalled = 0;
+
+		fetchMock.mock(/ac-server/i, () => {
+			fetchCalled += 1;
+
+			return Promise.resolve(200);
+		});
+
+		queueFlushService.addQueue(identityQueue);
+
+		await queueFlushService.flush();
+
+		expect(fetchCalled).toBe(0);
+	});
+
+	it(
+		'settles the flush through the request timeout when the endpoint never responds',
+		async () => {
+			let settled = false;
+
+			fetchMock.mock(/ac-server/i, () => new Promise(() => {}));
+
+			queueFlushService.addQueue(identityQueue);
+
+			identityQueue.addItem(getMockMessageItem('test-1'));
+
+			const flushed = queueFlushService.flush().then(() => {
+				settled = true;
+			});
+
+			// Well inside REQUEST_TIMEOUT, so nothing should have settled yet.
+
+			await wait(1000);
+
+			expect(settled).toBe(false);
+
+			await flushed;
+
+			expect(settled).toBe(true);
+		},
+		REQUEST_TIMEOUT * 3
+	);
 
 	it('flush queue items ordered by queue priority', async () => {
 		const sentEvents: string[] = [];


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103258

## What Is Being Fixed

Queued messages only left the client on the flush loop's own schedule, and nothing exposed when a send had actually finished. A caller that needs the data to reach the backend before the page goes away — the Marketo trial-form script, which navigates to a follow-up URL right after submitting — had no way to wait, and had to guess with a fixed delay.

## How It Is Being Fixed

`Analytics.flush()` sends every queued message now instead of waiting for the next interval, and returns a Promise that settles once the in-flight requests settle.

`QueueFlushService.flush()` already did the work but threw its promise chain away in a trailing `.catch(() => {})`, so the first change is simply to return it. The second is the `processing` guard: it used to `return` bare, which would hand the caller an immediately-resolved Promise while a send was still in flight — precisely the lie the method exists to avoid. It now returns the in-flight Promise instead.

No new timeout mechanism was added, as the ticket requires. Each request is already bounded by `sendWithTimeout`, which races the send against `_timeout()` at `REQUEST_TIMEOUT` (5000ms), and `Promise.allSettled` means a failed send never rejects the chain.

## Worth Knowing Before Review

The NFR on the parent story says `flush()` settles within the 5000ms `REQUEST_TIMEOUT` bound. That holds per queue, not overall: `QueueFlushService` processes the four queues **sequentially** (`reduce((previousPromise, ...) => previousPromise.then(...))`), so the ceiling is a multiple of 5s when more than one queue holds items. Measured against a deliberately stalled endpoint: 5.1s with one queue occupied, 10.2s with two.

That matters for the integration script, because `marketo.js` enqueues `formSubmitted` on submit, so in practice at least two queues normally hold items. Bounding the whole flush would mean adding a timeout mechanism, which this ticket explicitly rules out, so it is left as is and raised here for Product to decide whether a global bound is wanted later.

Both behaviours were verified end to end against a real build, alongside the two integration modes documented on LPD-103259: leaving without flushing (the queue survives in `localStorage` and the SDK sends it one interval after the next page load) and flushing before navigating (the request is gone and the queue empty on departure).

## PR Check

**pr-check: PASS** — tested on `b67dbc76d5b1ef8e68713cd3fc9b92c243d3d6db`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b67dbc76d5b1ef8e68713cd3fc9b92c243d3d6db"} -->
