### PR TITLE
LPD-103365 Avoid redirecting workspace endpoint requests

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/configs/common/conf.d/liferay.conf
+++ b/workspaces/liferay-osbfaro-workspace/modules/wedeploy/common/webserver/configs/common/conf.d/liferay.conf
@@ -4,7 +4,7 @@ if ($host ~* ^analytics(-internal|-stg)?\.liferay\.com$) {
     set $redirect_host "ldp$1.liferay.com";
 }
 
-if ($uri ~ ^/(api|endpoints|o)(/|$)) {
+if ($uri ~ ^/(api|endpoints|o|workspace/[0-9]+/endpoints)(/|$)) {
     set $redirect_host "";
 }
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103365

## What Is Being Fixed

The webserver redirects requests on the legacy `analytics(-internal|-stg).liferay.com` domains to their `ldp*.liferay.com` counterparts, exempting API paths (`/api`, `/endpoints`, `/o`) that external callers still use on the old domains. Workspace-scoped endpoint URIs such as `/workspace/<id>/endpoints/...` were not part of the exemption, so those API requests were redirected to the new domain and broke.

## How It Is Being Fixed

The redirect-exclusion pattern in the wedeploy webserver's `liferay.conf` gains a `workspace/[0-9]+/endpoints` alternative, so workspace-scoped endpoint requests keep being served on the original domain instead of being redirected.

## Why Are There No Tests?

The change is a one-line nginx configuration edit; there is no test harness for webserver configuration in this repository.

## PR Check

**pr-check: PASS** — tested on `88c6db6fc35b107d16d545498d4bdcf75d0e16d6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "88c6db6fc35b107d16d545498d4bdcf75d0e16d6"} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
