### PR TITLE
LPD-101231 Prepare CSV export for Asset List column visibility

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/List.tsx
@@ -40,8 +40,59 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 	}) => {
 		const [transformerResult, setTransformerResult] = React.useState('');
 
+		// The real data set drops a hidden column from the rendered table
+		// rather than marking it hidden, and each header cell carries its
+		// field name in `data-id`. That is what List reads to resolve the
+		// columns the CSV export should ask for, so the stub reproduces it.
+
+		const [hiddenFieldNames, setHiddenFieldNames] = React.useState<
+			Array<string>
+		>([]);
+
+		const fields = views?.[0]?.schema?.fields ?? [];
+
 		return (
 			<div data-testid="fds-component" id={id}>
+				<table>
+					<thead>
+						<tr>
+							{fields
+								.filter(
+									({fieldName}) =>
+										!hiddenFieldNames.includes(
+											String(fieldName)
+										)
+								)
+								.map(({fieldName}) => (
+									<th
+										data-id={`string,${fieldName}`}
+										key={String(fieldName)}
+									/>
+								))}
+
+							<th data-id="string,visibility" />
+						</tr>
+					</thead>
+				</table>
+
+				<button
+					data-testid="fds-hide-views-metric"
+					onClick={() => setHiddenFieldNames(['viewsMetric'])}
+				>
+					{'Hide Views'}
+				</button>
+
+				<button
+					data-testid="fds-hide-every-column"
+					onClick={() =>
+						setHiddenFieldNames(
+							fields.map(({fieldName}) => String(fieldName))
+						)
+					}
+				>
+					{'Hide Every Column'}
+				</button>
+
 				<button
 					data-testid="fds-run-transformer"
 					onClick={() => {
@@ -231,7 +282,11 @@ jest.mock('shared/components/download-report/DownloadStaticCSVReport', () => ({
 		rangeSelectors,
 		type,
 	}: {
-		getFDSQuery?: () => {filter: string; query: string};
+		getFDSQuery?: () => {
+			fields?: string;
+			filter: string;
+			query: string;
+		};
 		rangeSelectors?: any;
 		type?: string;
 	}) => {
@@ -718,6 +773,12 @@ describe('List', () => {
 	});
 
 	describe('Download CSV', () => {
+		const getFDSQueryResult = () =>
+			JSON.parse(
+				screen.getByTestId('download-csv-fds-query-result')
+					.textContent || '{}'
+			);
+
 		it('should render the Download CSV button for the asset type', () => {
 			renderList();
 
@@ -741,9 +802,7 @@ describe('List', () => {
 				screen.getByTestId('download-csv-call-get-fds-query')
 			);
 
-			expect(
-				screen.getByTestId('download-csv-fds-query-result')
-			).toHaveTextContent(JSON.stringify({filter: '', query: ''}));
+			expect(getFDSQueryResult()).toMatchObject({filter: '', query: ''});
 		});
 
 		it('should capture the filter and query the data set reports and expose them via getFDSQuery', () => {
@@ -754,14 +813,10 @@ describe('List', () => {
 				screen.getByTestId('download-csv-call-get-fds-query')
 			);
 
-			expect(
-				screen.getByTestId('download-csv-fds-query-result')
-			).toHaveTextContent(
-				JSON.stringify({
-					filter: "(assetType eq 'blog')",
-					query: 'liferay',
-				})
-			);
+			expect(getFDSQueryResult()).toMatchObject({
+				filter: "(assetType eq 'blog')",
+				query: 'liferay',
+			});
 		});
 
 		it('should pass the additionalAPIURLParameters through unchanged', () => {
@@ -772,6 +827,54 @@ describe('List', () => {
 			expect(
 				screen.getByTestId('fds-transformer-result')
 			).toHaveTextContent('unchanged=1');
+		});
+
+		describe('visible columns', () => {
+			it('should list every column the table is rendering', () => {
+				renderList();
+
+				fireEvent.click(
+					screen.getByTestId('download-csv-call-get-fds-query')
+				);
+
+				expect(getFDSQueryResult().fields).toBe(
+					'assetTitle,assetType,objectType,viewsMetric,impressionsMetric,downloadsMetric'
+				);
+			});
+
+			it('should drop a column the user has hidden', () => {
+				renderList();
+
+				fireEvent.click(screen.getByTestId('fds-hide-views-metric'));
+				fireEvent.click(
+					screen.getByTestId('download-csv-call-get-fds-query')
+				);
+
+				expect(getFDSQueryResult().fields).toBe(
+					'assetTitle,assetType,objectType,impressionsMetric,downloadsMetric'
+				);
+			});
+
+			it('should ignore the header cell of the columns visibility menu', () => {
+				renderList();
+
+				fireEvent.click(
+					screen.getByTestId('download-csv-call-get-fds-query')
+				);
+
+				expect(getFDSQueryResult().fields).not.toContain('visibility');
+			});
+
+			it('should omit fields when no header cell matches a known column', () => {
+				renderList();
+
+				fireEvent.click(screen.getByTestId('fds-hide-every-column'));
+				fireEvent.click(
+					screen.getByTestId('download-csv-call-get-fds-query')
+				);
+
+				expect(getFDSQueryResult().fields).toBeUndefined();
+			});
 		});
 	});
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/__tests__/__snapshots__/List.tsx.snap
@@ -117,122 +117,161 @@ exports[`List rendering should match the snapshot 1`] = `
         class="card card-root"
         style="min-height: 300px;"
       >
-        <div
-          data-testid="fds-component"
-          id="assetTable"
-        >
-          <button
-            data-testid="fds-run-transformer"
-          >
-            Run Transformer
-          </button>
+        <div>
           <div
-            data-testid="fds-transformer-result"
-          />
-          <div
-            data-testid="fds-sorts"
+            data-testid="fds-component"
+            id="assetTable"
           >
-            null
-          </div>
-          <div
-            data-testid="fds-fields"
-          >
-            [{"contentRenderer":"assetTitleRenderer","fieldName":"assetTitle","label":"Title","sortable":true,"truncate":true},{"fieldName":"assetType","label":"Type","sortable":true},{"contentRenderer":"assetObjectTypeRenderer","fieldName":"objectType","label":"Object Type","sortable":true},{"contentRenderer":"assetMetricRenderer","fieldName":"viewsMetric","label":"Views","sortable":true},{"contentRenderer":"assetMetricRenderer","fieldName":"impressionsMetric","label":"Impressions","sortable":true},{"contentRenderer":"assetMetricRenderer","fieldName":"downloadsMetric","label":"Downloads","sortable":true}]
-          </div>
-          <div
-            data-testid="fds-object-type-cells"
-          >
-            <div
-              data-testid="fds-object-type-cell-undefined"
+            <table>
+              <thead>
+                <tr>
+                  <th
+                    data-id="string,assetTitle"
+                  />
+                  <th
+                    data-id="string,assetType"
+                  />
+                  <th
+                    data-id="string,objectType"
+                  />
+                  <th
+                    data-id="string,viewsMetric"
+                  />
+                  <th
+                    data-id="string,impressionsMetric"
+                  />
+                  <th
+                    data-id="string,downloadsMetric"
+                  />
+                  <th
+                    data-id="string,visibility"
+                  />
+                </tr>
+              </thead>
+            </table>
+            <button
+              data-testid="fds-hide-views-metric"
             >
-              <span />
+              Hide Views
+            </button>
+            <button
+              data-testid="fds-hide-every-column"
+            >
+              Hide Every Column
+            </button>
+            <button
+              data-testid="fds-run-transformer"
+            >
+              Run Transformer
+            </button>
+            <div
+              data-testid="fds-transformer-result"
+            />
+            <div
+              data-testid="fds-sorts"
+            >
+              null
             </div>
             <div
-              data-testid="fds-object-type-cell-content"
+              data-testid="fds-fields"
             >
-              <span>
-                Content
-              </span>
+              [{"contentRenderer":"assetTitleRenderer","fieldName":"assetTitle","label":"Title","sortable":true,"truncate":true},{"fieldName":"assetType","label":"Type","sortable":true},{"contentRenderer":"assetObjectTypeRenderer","fieldName":"objectType","label":"Object Type","sortable":true},{"contentRenderer":"assetMetricRenderer","fieldName":"viewsMetric","label":"Views","sortable":true},{"contentRenderer":"assetMetricRenderer","fieldName":"impressionsMetric","label":"Impressions","sortable":true},{"contentRenderer":"assetMetricRenderer","fieldName":"downloadsMetric","label":"Downloads","sortable":true}]
             </div>
             <div
-              data-testid="fds-object-type-cell-file"
+              data-testid="fds-object-type-cells"
             >
-              <span>
-                File
-              </span>
-            </div>
-            <div
-              data-testid="fds-object-type-cell-unknown"
-            >
-              <span />
-            </div>
-          </div>
-          <div
-            data-testid="fds-empty-state"
-          >
-            <div
-              data-testid="fds-empty-state-title"
-            >
-              No assets were found.
-            </div>
-            <div
-              data-testid="fds-empty-state-description"
-            >
-              <span
-                class="mr-1"
+              <div
+                data-testid="fds-object-type-cell-undefined"
               >
-                Check back later to verify if data has been received from your data sources, or you can try a different date range.
-              </span>
-              <a
-                class=""
-                href="https://learn.liferay.com/w/dxp/personalization/analytics-cloud/touchpoints/assets-analytics"
-                rel="noreferrer noopener"
-                target="_blank"
+                <span />
+              </div>
+              <div
+                data-testid="fds-object-type-cell-content"
               >
-                Learn more about assets.
-                <span
-                  class="sr-only"
-                >
-                  (Opens a new window)
+                <span>
+                  Content
                 </span>
-              </a>
+              </div>
+              <div
+                data-testid="fds-object-type-cell-file"
+              >
+                <span>
+                  File
+                </span>
+              </div>
+              <div
+                data-testid="fds-object-type-cell-unknown"
+              >
+                <span />
+              </div>
             </div>
+            <div
+              data-testid="fds-empty-state"
+            >
+              <div
+                data-testid="fds-empty-state-title"
+              >
+                No assets were found.
+              </div>
+              <div
+                data-testid="fds-empty-state-description"
+              >
+                <span
+                  class="mr-1"
+                >
+                  Check back later to verify if data has been received from your data sources, or you can try a different date range.
+                </span>
+                <a
+                  class=""
+                  href="https://learn.liferay.com/w/dxp/personalization/analytics-cloud/touchpoints/assets-analytics"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
+                  Learn more about assets.
+                  <span
+                    class="sr-only"
+                  >
+                    (Opens a new window)
+                  </span>
+                </a>
+              </div>
+            </div>
+            <div
+              data-testid="fds-filters"
+            >
+              [{"apiURL":"/o/faro/contacts/23/account/search?channelId=123&filter=(rangeKey eq '30')","autocompleteEnabled":true,"entityFieldType":"string","id":"accountIds","itemKey":"id","itemLabel":"accountName","label":"Accounts","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/individual_segment/search?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"segmentIds","itemKey":"id","itemLabel":"name","label":"Segments","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-types?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"assetType","itemKey":"name","itemLabel":"name","label":"Type","multiple":true,"type":"selection"},{"entityFieldType":"string","id":"objectType","items":[{"label":"Content","value":"content"},{"label":"File","value":"file"}],"label":"Object Type","multiple":false,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-tags?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"tags/id","itemKey":"id","itemLabel":"name","label":"Tags","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-categories?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"categories/id","itemKey":"id","itemLabel":"name","label":"Categories","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-mime-types?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"mimeType","itemKey":"id","itemLabel":"name","label":"File Type","multiple":true,"type":"selection"}]
+            </div>
+            <div
+              data-testid="fds-grouped-filters"
+            >
+              [{"filters":["assetType","objectType","tags/id","categories/id","mimeType"],"label":"Filter By"},{"filters":["accountIds","segmentIds"],"label":"Filter by People"}]
+            </div>
+            <button
+              data-testid="trigger-info-panel"
+            >
+              Open Info Panel
+            </button>
+            <button
+              data-testid="trigger-info-panel-no-mime"
+            >
+              Open Info Panel No Mime
+            </button>
+            <button
+              data-testid="trigger-info-panel-no-title"
+            >
+              Open Info Panel No Title
+            </button>
+            <button
+              data-testid="trigger-info-panel-with-items"
+            >
+              Open Info Panel With Items
+            </button>
+            <button
+              data-testid="trigger-info-panel-empty-vocab"
+            >
+              Open Info Panel Empty Vocab
+            </button>
           </div>
-          <div
-            data-testid="fds-filters"
-          >
-            [{"apiURL":"/o/faro/contacts/23/account/search?channelId=123&filter=(rangeKey eq '30')","autocompleteEnabled":true,"entityFieldType":"string","id":"accountIds","itemKey":"id","itemLabel":"accountName","label":"Accounts","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/individual_segment/search?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"segmentIds","itemKey":"id","itemLabel":"name","label":"Segments","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-types?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"assetType","itemKey":"name","itemLabel":"name","label":"Type","multiple":true,"type":"selection"},{"entityFieldType":"string","id":"objectType","items":[{"label":"Content","value":"content"},{"label":"File","value":"file"}],"label":"Object Type","multiple":false,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-tags?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"tags/id","itemKey":"id","itemLabel":"name","label":"Tags","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-categories?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"categories/id","itemKey":"id","itemLabel":"name","label":"Categories","multiple":true,"type":"selection"},{"apiURL":"/o/faro/contacts/23/asset-summary-mime-types?channelId=123&rangeKey=30","autocompleteEnabled":true,"entityFieldType":"string","id":"mimeType","itemKey":"id","itemLabel":"name","label":"File Type","multiple":true,"type":"selection"}]
-          </div>
-          <div
-            data-testid="fds-grouped-filters"
-          >
-            [{"filters":["assetType","objectType","tags/id","categories/id","mimeType"],"label":"Filter By"},{"filters":["accountIds","segmentIds"],"label":"Filter by People"}]
-          </div>
-          <button
-            data-testid="trigger-info-panel"
-          >
-            Open Info Panel
-          </button>
-          <button
-            data-testid="trigger-info-panel-no-mime"
-          >
-            Open Info Panel No Mime
-          </button>
-          <button
-            data-testid="trigger-info-panel-no-title"
-          >
-            Open Info Panel No Title
-          </button>
-          <button
-            data-testid="trigger-info-panel-with-items"
-          >
-            Open Info Panel With Items
-          </button>
-          <button
-            data-testid="trigger-info-panel-empty-vocab"
-          >
-            Open Info Panel Empty Vocab
-          </button>
         </div>
       </div>
       <div

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/assets/pages/List.tsx
@@ -264,6 +264,42 @@ const List = () => {
 
 	const fdsQueryRef = useRef({filter: '', query: ''});
 
+	// The data set offers no way to read which columns the user has toggled
+	// visible: that state lives in its internal ViewsContext and the module
+	// exports no reader for it, nor an event to listen to. A hidden column is
+	// genuinely absent from the rendered table though, so the header cells are
+	// the source of truth -- each one carries its field name in `data-id` (see
+	// the @clayui/core table Cell). Read it when the export is submitted.
+
+	const tableRef = useRef<HTMLDivElement>(null);
+
+	const getVisibleTableFields = () => {
+
+		// `data-id` carries the key's type as a prefix, as in
+		// 'string,assetTitle'.
+
+		const renderedFieldNames = new Set(
+			Array.from(
+				tableRef.current?.querySelectorAll('thead th[data-id]') ?? []
+			).map((headerCell) => {
+				const dataId = headerCell.getAttribute('data-id') ?? '';
+
+				return dataId.slice(dataId.indexOf(',') + 1);
+			})
+		);
+
+		const visibleFieldNames = TABLE_FIELDS.filter((field) =>
+			renderedFieldNames.has(field.fieldName)
+		).map((field) => field.fieldName);
+
+		// Falling back to an undefined `fields` exports every column, which is
+		// how the export behaved before it took visibility into account.
+
+		return visibleFieldNames.length
+			? visibleFieldNames.join(',')
+			: undefined;
+	};
+
 	let rangeSelectorParams = `rangeKey=${rangeSelectors.rangeKey}`;
 
 	if (rangeSelectors.rangeKey === RangeKeyTimeRanges.CustomRange) {
@@ -422,7 +458,10 @@ const List = () => {
 					<div className="mr-1">
 						<DownloadStaticCSVReport
 							disabled={false}
-							getFDSQuery={() => fdsQueryRef.current}
+							getFDSQuery={() => ({
+								...fdsQueryRef.current,
+								fields: getVisibleTableFields(),
+							})}
 							rangeSelectors={rangeSelectors}
 							type={CSVType.Asset}
 							typeLang={Liferay.Language.get('assets')}
@@ -455,129 +494,138 @@ const List = () => {
 
 			<BasePage.Body fluid sidebarOpened={!!infoPanelData}>
 				<Card minHeight={300}>
-					<FrontendDataSet
+					<div ref={tableRef}>
+						<FrontendDataSet
 
-						// Not a real transformation: this reports the query the
-						// data set is about to send so the CSV export can match
-						// what is on screen, and hands back the additional
-						// parameters unchanged.
+							// Not a real transformation: this reports the query the
+							// data set is about to send so the CSV export can match
+							// what is on screen, and hands back the additional
+							// parameters unchanged.
 
-						additionalAPIURLParametersTransformer={(
-							loadDataArgs
-						) => {
-							const {odataFiltersStrings = [], searchParam = ''} =
-								loadDataArgs;
+							additionalAPIURLParametersTransformer={(
+								loadDataArgs
+							) => {
+								const {
+									odataFiltersStrings = [],
+									searchParam = '',
+								} = loadDataArgs;
 
-							fdsQueryRef.current = {
-								filter: odataFiltersStrings
-									.filter(Boolean)
-									.map((odataString) => `(${odataString})`)
-									.join(' and '),
-								query: searchParam,
-							};
+								fdsQueryRef.current = {
+									filter: odataFiltersStrings
+										.filter(Boolean)
+										.map(
+											(odataString) => `(${odataString})`
+										)
+										.join(' and '),
+									query: searchParam,
+								};
 
-							return loadDataArgs.additionalAPIURLParameters;
-						}}
-						apiURL={`/o/faro/contacts/${groupId}/asset-summary?channelId=${channelId}&${rangeSelectorParams}`}
-						customDataRenderers={{
-							assetMetricRenderer: columns.assetMetricRenderer,
-							assetObjectTypeRenderer:
-								columns.assetObjectTypeRenderer,
-							assetTitleRenderer: columns.assetTitleRenderer({
-								accountId,
-								accountName,
-								channelId: channelId!,
-								groupId: groupId!,
-								rangeSelectorParams,
-								segmentId,
-								segmentName,
-							}),
-						}}
-						emptyState={{
-							description:
-								assetsEmptyStateDescription as unknown as string,
-							image: '/states/satellite.svg',
-							title: Liferay.Language.get('no-assets-were-found'),
-						}}
-						filters={filters}
-						groupedFilters={[
-							{
-								filters: [
-									'assetType',
-									'objectType',
-									'tags/id',
-									'categories/id',
-									'mimeType',
-								],
-								label: Liferay.Language.get('filter-by'),
-							},
-							...(LDPEnabled
-								? [
-										{
-											filters: [
-												'accountIds',
-												'segmentIds',
-											],
-											label: Liferay.Language.get(
-												'filter-by-people'
-											),
-										},
-									]
-								: []),
-						]}
-						id="assetTable"
-						itemsActions={[
-							{
-								data: {
-									id: 'infoPanel',
+								return loadDataArgs.additionalAPIURLParameters;
+							}}
+							apiURL={`/o/faro/contacts/${groupId}/asset-summary?channelId=${channelId}&${rangeSelectorParams}`}
+							customDataRenderers={{
+								assetMetricRenderer:
+									columns.assetMetricRenderer,
+								assetObjectTypeRenderer:
+									columns.assetObjectTypeRenderer,
+								assetTitleRenderer: columns.assetTitleRenderer({
+									accountId,
+									accountName,
+									channelId: channelId!,
+									groupId: groupId!,
+									rangeSelectorParams,
+									segmentId,
+									segmentName,
+								}),
+							}}
+							emptyState={{
+								description:
+									assetsEmptyStateDescription as unknown as string,
+								image: '/states/satellite.svg',
+								title: Liferay.Language.get(
+									'no-assets-were-found'
+								),
+							}}
+							filters={filters}
+							groupedFilters={[
+								{
+									filters: [
+										'assetType',
+										'objectType',
+										'tags/id',
+										'categories/id',
+										'mimeType',
+									],
+									label: Liferay.Language.get('filter-by'),
 								},
-								icon: 'info-circle-open',
-								label: Liferay.Language.get('show-details'),
-								onClick: setInfoPanelData,
-							},
-							{
-								data: {
-									id: 'viewAsset',
+								...(LDPEnabled
+									? [
+											{
+												filters: [
+													'accountIds',
+													'segmentIds',
+												],
+												label: Liferay.Language.get(
+													'filter-by-people'
+												),
+											},
+										]
+									: []),
+							]}
+							id="assetTable"
+							itemsActions={[
+								{
+									data: {
+										id: 'infoPanel',
+									},
+									icon: 'info-circle-open',
+									label: Liferay.Language.get('show-details'),
+									onClick: setInfoPanelData,
 								},
-								icon: 'view',
-								label: Liferay.Language.get('view'),
-								onClick: ({itemData}: {itemData: any}) => {
-									history.push(
-										getAssetURL({
-											accountId,
-											accountName,
-											channelId: channelId!,
-											groupId: groupId!,
-											itemData,
-											rangeSelectorParams,
-											segmentId,
-											segmentName,
-										})
-									);
+								{
+									data: {
+										id: 'viewAsset',
+									},
+									icon: 'view',
+									label: Liferay.Language.get('view'),
+									onClick: ({itemData}: {itemData: any}) => {
+										history.push(
+											getAssetURL({
+												accountId,
+												accountName,
+												channelId: channelId!,
+												groupId: groupId!,
+												itemData,
+												rangeSelectorParams,
+												segmentId,
+												segmentName,
+											})
+										);
+									},
 								},
-							},
-						]}
+							]}
 
-						// Trick to restart FDS every time the rangeSelectors changes.
+							// Trick to restart FDS every time the rangeSelectors changes.
 
-						key={Object.values(rangeSelectors).join()}
-						pagination={pagination}
-						showPagination
-						snapshotsEnabled
-						sorts={sorts}
-						views={[
-							{
-								contentRenderer: 'table',
-								default: true,
-								label: Liferay.Language.get('default-view'),
-								name: 'table',
-								schema: {
-									fields: TABLE_FIELDS,
+							key={Object.values(rangeSelectors).join()}
+							pagination={pagination}
+							showPagination
+							snapshotsEnabled
+							sorts={sorts}
+							views={[
+								{
+									contentRenderer: 'table',
+									default: true,
+									label: Liferay.Language.get('default-view'),
+									name: 'table',
+									schema: {
+										fields: TABLE_FIELDS,
+									},
+									thumbnail: 'table',
 								},
-								thumbnail: 'table',
-							},
-						]}
-					/>
+							]}
+						/>
+					</div>
 				</Card>
 
 				<InfoPanel

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/DownloadStaticCSVReport.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/DownloadStaticCSVReport.tsx
@@ -12,6 +12,16 @@ import {toLocale} from 'shared/util/numbers';
 import {useDispatch} from 'react-redux';
 import {useParams} from 'react-router-dom';
 
+/**
+ * The state of the list being exported: the filters and search it is showing,
+ * and the columns it is rendering.
+ */
+export interface IFDSQuery {
+	fields?: string;
+	filter: string;
+	query: string;
+}
+
 interface IDownloadStaticCSVReport {
 	children?: any;
 	disabled: boolean;
@@ -27,7 +37,7 @@ interface IDownloadStaticCSVReport {
 	 * current value has to be read when the export is submitted, not when
 	 * this component last rendered.
 	 */
-	getFDSQuery?: () => {filter: string; query: string};
+	getFDSQuery?: () => IFDSQuery;
 	objectType?: string;
 	rangeSelectors?: RangeSelectors;
 	segmentId?: string;
@@ -75,6 +85,7 @@ export const DownloadStaticCSVReport: React.FC<IDownloadStaticCSVReport> = ({
 							const fdsQuery = getFDSQuery?.();
 
 							const url = generateURL(rangeSelectors, {
+								fields: fdsQuery?.fields,
 								filter: fdsQuery?.filter,
 								query: fdsQuery?.query,
 							});
@@ -100,6 +111,9 @@ export const DownloadStaticCSVReport: React.FC<IDownloadStaticCSVReport> = ({
 
 							a.href = url;
 							a.click();
+
+							// The row count does not depend on which columns are
+							// visible, so `fields` is not forwarded here.
 
 							const count = await API.csv.fetchCount({
 								channelId: channelId!,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/DownloadStaticCSVReport.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/DownloadStaticCSVReport.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {addAlert} from 'shared/actions/alerts';
 import {Alert} from 'shared/types';
 import {CSVType} from '../utils';
-import {DownloadStaticCSVReport} from '../DownloadStaticCSVReport';
+import {DownloadStaticCSVReport, IFDSQuery} from '../DownloadStaticCSVReport';
 import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {InMemoryCache} from '@apollo/client';
 import {MemoryRouter, Route} from 'react-router-dom';
@@ -49,7 +49,7 @@ const DefaultComponent = ({
 	rangeSelectors,
 	type = CSVType.Individual,
 }: {
-	getFDSQuery?: () => {filter: string; query: string};
+	getFDSQuery?: () => IFDSQuery;
 	objectType?: string;
 	rangeSelectors?: any;
 	type?: CSVType;
@@ -235,8 +235,9 @@ describe('DownloadStaticCSVReport', () => {
 		);
 	});
 
-	it('reads the filter and query from getFDSQuery and forwards them to the export URL and count request', async () => {
+	it('reads the list state from getFDSQuery and forwards it to the export URL and count request', async () => {
 		const getFDSQuery = jest.fn(() => ({
+			fields: 'assetTitle,assetType',
 			filter: "(assetType eq 'blog')",
 			query: 'liferay',
 		}));
@@ -274,16 +275,23 @@ describe('DownloadStaticCSVReport', () => {
 
 		await waitFor(() => {
 			expect(mockedGenerateURL).toHaveBeenCalledWith(rangeSelectors, {
+				fields: 'assetTitle,assetType',
 				filter: "(assetType eq 'blog')",
 				query: 'liferay',
 			});
 		});
+
+		// The row count does not depend on the visible columns, so `fields` is
+		// not part of the count request.
 
 		expect(API.csv.fetchCount).toHaveBeenCalledWith(
 			expect.objectContaining({
 				filter: "(assetType eq 'blog')",
 				query: 'liferay',
 			})
+		);
+		expect(API.csv.fetchCount).not.toHaveBeenCalledWith(
+			expect.objectContaining({fields: expect.anything()})
 		);
 		expect(getFDSQuery).toHaveBeenCalledTimes(1);
 	});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/useDownloadCSV.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/__tests__/useDownloadCSV.ts
@@ -138,6 +138,23 @@ describe('useDownloadCSV', () => {
 		);
 	});
 
+	it('should include the fields override in the URL when provided', () => {
+		const {result} = renderHook(() =>
+			useDownloadCSV({type: CSVType.Asset})
+		);
+
+		const url = result.current(
+			{
+				rangeEnd: '',
+				rangeKey: RangeKeyTimeRanges.Last30Days,
+				rangeStart: '',
+			},
+			{fields: 'assetTitle,viewsMetric'}
+		);
+
+		expect(url).toContain('fields=assetTitle,viewsMetric');
+	});
+
 	it('should include order by fields if field and sortOrder are present', () => {
 		(window as {location: unknown}).location = new URL(
 			'https://ldp.liferay.com/workspace/liferay.com/420253908131944590/?field=name&page=1&sortOrder=DESC'

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/utils.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/download-report/utils.ts
@@ -46,7 +46,7 @@ export function useDownloadCSV({
 
 	return (
 		rangeSelectors: RangeSelectors = DEFAULT_RANGE_SELECTORS as unknown as RangeSelectors,
-		overrides: {filter?: string; query?: string} = {}
+		overrides: {fields?: string; filter?: string; query?: string} = {}
 	) => {
 		const searchParams = new URLSearchParams(location.search);
 
@@ -70,6 +70,7 @@ export function useDownloadCSV({
 			assetId: assetId && encodeURIComponent(assetId),
 			assetTitle: title,
 			assetType,
+			fields: overrides.fields,
 			filter: resolvedFilter && encodeURIComponent(resolvedFilter),
 			individualId,
 			objectType,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101231

## What Is Being Fixed

Hiding or showing columns in the Asset List table has no effect on the exported CSV — the export always includes every column regardless of what is currently visible on screen.

## How It Is Being Fixed

The FDS module (`@liferay/frontend-data-set-web`) keeps which columns are visible in an internal context that it does not expose, and offers no change event for it either. An earlier attempt used `configInURLBehavior` so the module would persist that state to the URL and `List.tsx` could read it back with `readConfigFromURL`. That broke the page: the module routes every URL write through `Liferay.SPA.app.updateHistory_`, and since this fires on every filter/search/sort/column change, the app's own SPA navigation kept reprocessing the page.

Instead, `List.tsx` now reads the rendered `<thead>` directly when the export is submitted. A hidden column is genuinely absent from the table (confirmed in the FDS/Clay source), and each header cell carries its field name in `data-id`, so the visible columns are derived from that and intersected with the page's own column definitions to derive a `fields` parameter. A wrapper `<div ref>` around the data set scopes the query to this table. Failure is safe throughout: no header cells, or none matching a known column, both fall back to exporting every column, exactly like before this change.

`fields` is threaded through `useDownloadCSV` and `DownloadStaticCSVReport` down to the CSV export URL (not the count request, since the row count does not depend on which columns are visible). This is still frontend-only, preparatory plumbing: the backend does not accept the `fields` parameter yet, so the export's actual output is unchanged today.

## PR Check

Not yet re-run since the commits were rebuilt on top of the DOM-based approach above. Will follow up with `/pr-check` against the new head SHA.
