### PR TITLE
LPD-103772 Group the activity stream by the key the API returns

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/ActivityStreamCard.tsx
@@ -157,7 +157,7 @@ const AccountActivityStreamCard: React.FC<IActivityStreamCardProps> = ({
 						}
 					),
 					total:
-						eventsByUserSessions?.totalSessionsMetric?.value ?? 0,
+						eventsByUserSessions?.totalPageGroupsMetric?.value ?? 0,
 				})
 			),
 		[

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/ActivityStreamCard.tsx
@@ -103,13 +103,13 @@ describe('ActivityStreamCard', () => {
 		expect(link.getAttribute('href')).toContain('accountName=Acme');
 	});
 
-	it('drives pagination from the activity stream session total, not the event count', async () => {
+	it('drives pagination from the activity stream page group total, not the event count', async () => {
 		const {container} = render(
 			<Wrapper
 				mocks={[
 					mockAccountEventMetricsReq(),
 					mockAccountEventsTrendReq(),
-					mockAccountUserSessionsReq({totalSessions: 186}),
+					mockAccountUserSessionsReq({totalPageGroups: 186}),
 				]}
 			/>
 		);
@@ -133,7 +133,7 @@ describe('ActivityStreamCard', () => {
 					}),
 					mockAccountUserSessionsReq({
 						sessions: [],
-						totalSessions: 0,
+						totalPageGroups: 0,
 					}),
 				]}
 			/>
@@ -162,7 +162,7 @@ describe('ActivityStreamCard', () => {
 					mockAccountUserSessionsReq({
 						keywords: SEARCH_KEYWORDS,
 						sessions: [],
-						totalSessions: 0,
+						totalPageGroups: 0,
 					}),
 					mockAccountEventMetricsReq(),
 					mockAccountEventsTrendReq(),

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/utils/__tests__/formatAccountSessions.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/utils/__tests__/formatAccountSessions.ts
@@ -39,6 +39,7 @@ const buildSession = (
 				canonicalUrl: 'https://liferay.com/home',
 				createDate: '2026-07-16T10:00:00.000Z',
 				name: 'pageViewed',
+				pageGroupId: 'https://liferay.com/home',
 				properties: [],
 			},
 		],
@@ -276,6 +277,7 @@ describe('formatAccountSessions', () => {
 						canonicalUrl: 'https://liferay.com/home',
 						createDate: '2026-07-16T10:00:00.000Z',
 						name: 'pageViewed',
+						pageGroupId: 'https://liferay.com/home',
 						pageTitle: 'Home',
 					},
 					{
@@ -283,6 +285,7 @@ describe('formatAccountSessions', () => {
 						canonicalUrl: 'https://liferay.com/home',
 						createDate: '2026-07-16T10:01:00.000Z',
 						name: 'formSubmitted',
+						pageGroupId: 'https://liferay.com/home',
 					},
 				],
 			}),

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/ProfileCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/ProfileCard.tsx
@@ -201,13 +201,13 @@ const ProfileCard: React.FC<IProfileCardProps> = ({
 
 	const sessionsMappedResults = mapListResultsToProps(
 		sessionsResponse,
-		({eventsByUserSessions: {totalEvents, userSessions}}) => ({
+		({eventsByUserSessions: {totalPageGroupsMetric, userSessions}}) => ({
 			items: formatSessions(userSessions, {
 				channelId,
 				groupId,
 				rangeSelectors,
 			}),
-			total: totalEvents,
+			total: totalPageGroupsMetric?.value ?? 0,
 		})
 	);
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/ProfileCardWithDataCDP.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/ProfileCardWithDataCDP.tsx
@@ -147,7 +147,8 @@ const ProfileCardWithDataCDP: React.FC<IProfileCardWithDataCDPProps> = ({
 							rangeSelectors,
 						}
 					),
-					total: eventsByUserSessions?.totalEvents ?? 0,
+					total:
+						eventsByUserSessions?.totalPageGroupsMetric?.value ?? 0,
 				})
 			),
 		[

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/ProfileCard.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/individual/profile/components/__tests__/ProfileCard.tsx
@@ -90,6 +90,10 @@ describe('IndividualProfileCard', () => {
 				eventsByUserSessions: {
 					__typename: 'EventsByUserSession',
 					totalEvents: 0,
+					totalPageGroupsMetric: {
+						__typename: 'Metric',
+						value: 0,
+					},
 					userSessions: [],
 				},
 			},

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AccountUserSessionQuery.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/AccountUserSessionQuery.ts
@@ -10,6 +10,7 @@ export interface AccountUserSessionEvent {
 	eventId: string;
 	name: string;
 	pageDescription: string;
+	pageGroupId?: string | null;
 	pageKeywords: string;
 	pageTitle: string;
 	properties: Array<{name: string; value: string}>;
@@ -37,7 +38,7 @@ export interface AccountUserSession {
 
 export interface AccountUserSessionData {
 	eventsByUserSessions: {
-		totalSessionsMetric: {value: number} | null;
+		totalPageGroupsMetric: {value: number} | null;
 		userSessions: AccountUserSession[];
 	};
 }
@@ -81,7 +82,7 @@ export default gql`
 			rangeStart: $rangeStart
 			size: $size
 		) {
-			totalSessionsMetric {
+			totalPageGroupsMetric {
 				value
 			}
 			userSessions {
@@ -101,6 +102,7 @@ export default gql`
 						eventId
 						name
 						pageDescription
+						pageGroupId
 						pageKeywords
 						pageTitle
 						properties {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/UserSessionQuery.ts
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/queries/UserSessionQuery.ts
@@ -10,6 +10,7 @@ export interface UserSessionEvent {
 	eventId: string;
 	name: string;
 	pageDescription: string;
+	pageGroupId?: string | null;
 	pageTitle: string;
 	properties: Array<{name: string; value: string}>;
 	referrer: string;
@@ -37,6 +38,7 @@ export interface UserSession {
 export interface UserSessionData {
 	eventsByUserSessions: {
 		totalEvents: number;
+		totalPageGroupsMetric: {value: number} | null;
 		userSessions: UserSession[];
 	};
 }
@@ -95,6 +97,7 @@ export default gql`
 						eventId
 						name
 						pageDescription
+						pageGroupId
 						pageKeywords
 						pageTitle
 						properties {
@@ -112,6 +115,9 @@ export default gql`
 				}
 			}
 			totalEvents
+			totalPageGroupsMetric {
+				value
+			}
 		}
 	}
 `;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/activities.jsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/__tests__/activities.jsx
@@ -158,20 +158,22 @@ describe('activities', () => {
 	});
 
 	describe('groupEventsByPage', () => {
-		it('groups DXP events that share a canonical URL into a single page entry', () => {
+		it('groups events that share a page group key into a single page entry', () => {
 			const result = groupEventsByPage([
 				{
 					applicationId: 'Page',
 					canonicalUrl: 'https://liferay.com/home',
 					createDate: '2026-07-16T10:00:00.000Z',
 					name: 'pageViewed',
+					pageGroupId: 'https://liferay.com/home',
 					pageTitle: 'Home'
 				},
 				{
 					applicationId: 'Form',
 					canonicalUrl: 'https://liferay.com/home',
 					createDate: '2026-07-16T10:01:00.000Z',
-					name: 'formSubmitted'
+					name: 'formSubmitted',
+					pageGroupId: 'https://liferay.com/home'
 				}
 			]);
 
@@ -191,14 +193,15 @@ describe('activities', () => {
 					applicationId: 'Page',
 					canonicalUrl: 'https://liferay.com/home',
 					createDate: '2026-07-16T10:00:00.000Z',
-					name: 'pageViewed'
+					name: 'pageViewed',
+					pageGroupId: 'https://liferay.com/home'
 				}
 			]);
 
 			expect(result[0].nestedItems[0].subtitle).toBeUndefined();
 		});
 
-		it('leaves an event from an external data source ungrouped', () => {
+		it('leaves an event the API gave no page group key ungrouped', () => {
 			const result = groupEventsByPage(
 				[
 					{
@@ -216,13 +219,14 @@ describe('activities', () => {
 			expect(result[0].title).toBe('emailViewed');
 		});
 
-		it('leaves a DXP event with no URL ungrouped', () => {
+		it('leaves a DXP event with no page group key ungrouped', () => {
 			const result = groupEventsByPage([
 				{
 					applicationId: 'Page',
 					canonicalUrl: null,
 					createDate: '2026-07-16T10:00:00.000Z',
 					name: 'somethingHappened',
+					pageGroupId: null,
 					url: null
 				}
 			]);
@@ -238,6 +242,7 @@ describe('activities', () => {
 					canonicalUrl: 'https://liferay.com/older-page',
 					createDate: '2026-07-16T09:00:00.000Z',
 					name: 'pageViewed',
+					pageGroupId: 'https://liferay.com/older-page',
 					pageTitle: 'Older Page'
 				},
 				{
@@ -251,6 +256,7 @@ describe('activities', () => {
 					canonicalUrl: 'https://liferay.com/newer-page',
 					createDate: '2026-07-16T10:00:00.000Z',
 					name: 'pageViewed',
+					pageGroupId: 'https://liferay.com/newer-page',
 					pageTitle: 'Newer Page'
 				}
 			]);

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/activities.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/util/activities.tsx
@@ -6,11 +6,7 @@ import getEventDashboardUrl, {
 } from './getEventDashboardUrl';
 import {getCustomDateFormat} from 'shared/util/date';
 import {getSafeDecodedURIComponent} from './util';
-import {
-	AssetTypes,
-	LIFERAY_DXP_APPLICATION_IDS,
-	TimeIntervals,
-} from 'shared/util/constants';
+import {AssetTypes, TimeIntervals} from 'shared/util/constants';
 import {RangeSelectors} from 'shared/types';
 import {sub} from 'shared/util/lang';
 import {toLocale} from 'shared/util/numbers';
@@ -227,30 +223,26 @@ export const formatEvents = (
 };
 
 /**
- * Only DXP events are page bound — they carry the page they happened on in
- * their canonical URL. Events from an external data source are not, so they get
- * no key and stay out of the grouping.
+ * The key the API grouped the event under, which is also the key it paged the
+ * results on. Deriving it here as well would let the rendered groups and the
+ * page boundaries drift apart, so the backend owns it: it is the page's
+ * canonical URL, and absent for an event that is not page bound.
  */
-const getPageGroupKey = ({
-	applicationId,
-	canonicalUrl,
-	url,
-}: UserSessionEvent): string =>
-	LIFERAY_DXP_APPLICATION_IDS.has(applicationId)
-		? canonicalUrl || url || ''
-		: '';
+const getPageGroupKey = ({pageGroupId}: UserSessionEvent): string =>
+	pageGroupId || '';
 
 /**
  * Groups a session's events by the page they happened on, so the activity
  * stream shows one entry per visited page instead of a raw list of events.
  *
- * Events are keyed by their canonical URL, so a page visited more than once in
- * the same session collapses into a single entry carrying the time range and
- * event count of every event on that page. Events that are not page bound (an
- * external data source, or a DXP event with no URL) stay as direct session
- * items. Groups and those loose events are ordered by their most recent event,
- * newest first, matching how the timeline already orders days and sessions.
- * Within a group the events keep the order they arrive in.
+ * Events are keyed by the page group the API assigned them, so a page visited
+ * more than once in the same session collapses into a single entry carrying the
+ * time range and event count of every event on that page. Events that are not
+ * page bound (an external data source, or a DXP event with no URL) carry no key
+ * and stay as direct session items. Groups and those loose events are ordered by
+ * their most recent event, newest first, matching how the timeline already
+ * orders days and sessions. Within a group the events keep the order they
+ * arrive in.
  */
 export const groupEventsByPage = (
 	events: UserSessionEvent[],

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/test/graphql-data.js
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/test/graphql-data.js
@@ -2263,6 +2263,10 @@ export const mockSessions = (variables) => ({
 			eventsByUserSessions: {
 				__typename: 'EventsByUserSession',
 				totalEvents: 14314,
+				totalPageGroupsMetric: {
+					__typename: 'Metric',
+					value: 42,
+				},
 				userSessions: [
 					{
 						__typename: 'UserSession',
@@ -2281,6 +2285,7 @@ export const mockSessions = (variables) => ({
 								createDate: 'Mon Dec 06 17:28:48 GMT 2021',
 								name: 'tabBlurred',
 								pageDescription: '',
+								pageGroupId: 'http://localhost:8080',
 								pageKeywords: '',
 								pageTitle: 'Home - Liferay DXP',
 								referrer: '',
@@ -2478,6 +2483,7 @@ const DEFAULT_ACCOUNT_USER_SESSIONS = [
 				eventId: 'pageViewed',
 				name: 'pageViewed',
 				pageDescription: '',
+				pageGroupId: 'https://liferay.com/home',
 				pageKeywords: '',
 				pageTitle: 'Home',
 				properties: [],
@@ -2504,7 +2510,7 @@ export const mockAccountUserSessionsReq = ({
 	rangeKey = 30,
 	sessions = DEFAULT_ACCOUNT_USER_SESSIONS,
 	size = 2,
-	totalSessions = 1,
+	totalPageGroups = 1,
 } = {}) => ({
 	request: {
 		query: AccountUserSessionQuery,
@@ -2525,9 +2531,9 @@ export const mockAccountUserSessionsReq = ({
 		data: {
 			eventsByUserSessions: {
 				__typename: 'EventsByUserSession',
-				totalSessionsMetric: {
+				totalPageGroupsMetric: {
 					__typename: 'Metric',
-					value: totalSessions,
+					value: totalPageGroups,
 				},
 				userSessions: sessions,
 			},


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103772

## What Is Being Fixed

`getPageGroupKey` derived the group key from the event's canonical URL and its application id, deriving a second time what the backend already derives to page the results on. The two rules had to be kept in step by hand across repositories, so a page of results and the rows it rendered could drift apart without anything failing.

The pagers compounded this by counting the wrong thing. The account stream read `totalSessionsMetric`, which the API no longer returns for this query, and the individual streams read `totalEvents`, a count of every event that a page of page groups could never line up with.

## How It Is Being Fixed

The events now carry the `pageGroupId` they were grouped under, so the frontend consumes the key the backend already assigned instead of recomputing it. `groupEventsByPage` keeps only what is presentational: the title, the dashboard link and the subtitle.

Both streams now paginate on the page group total that the same page boundaries are drawn from, so the count and the rendered rows come from one source.

The grouping fixtures previously carried an application id and a canonical URL for the rule to derive a key from. They carry the key itself now, and the mocked responses return it alongside the page group total the pagers read.

## PR Check

**pr-check: PASS** — tested on `24ce7a95fa425fcdf4c267aed642576ca8133779`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "24ce7a95fa425fcdf4c267aed642576ca8133779"} -->
