### PR TITLE
LPD-102209 Share the anonymous user id across sibling subdomains

### DIFF
--- a/modules/apps/analytics/analytics-client-js/global.d.ts
+++ b/modules/apps/analytics/analytics-client-js/global.d.ts
@@ -41,7 +41,7 @@ interface Window {
 				TYPES?: {
 					[key: string]: string;
 				};
-				get?: (name: string) => string;
+				get?: (name: string, type?: string) => string;
 				set?: (
 					key: string,
 					data: string,

--- a/modules/apps/analytics/analytics-client-js/package.json
+++ b/modules/apps/analytics/analytics-client-js/package.json
@@ -25,7 +25,8 @@
 		"testPathIgnorePatterns": [
 			"<rootDir>/test/.eslintrc.js",
 			"<rootDir>/test/setup.ts",
-			"<rootDir>/test/helpers.ts"
+			"<rootDir>/test/helpers.ts",
+			"<rootDir>/test/subdomainEnvironment.js"
 		]
 	},
 	"keywords": [

--- a/modules/apps/analytics/analytics-client-js/src/analytics.ts
+++ b/modules/apps/analytics/analytics-client-js/src/analytics.ts
@@ -24,6 +24,7 @@ import {
 	VALIDATION_CONTEXT_VALUE_MAXIMUM_LENGTH,
 } from './utils/constants';
 import {getContexts, setContexts} from './utils/contexts';
+import {getCookie, removeHostOnlyCookie, setCookie} from './utils/cookies';
 import {normalizeEvent} from './utils/events';
 import hash from './utils/hash';
 import {getItem, removeItem, setItem} from './utils/storage';
@@ -33,6 +34,8 @@ import {isValidEvent} from './utils/validators';
 // Constants
 
 export const ENV: any = window || global;
+
+const IP_ADDRESS_REGEX = /^[\d.]+$/;
 
 /**
  * Analytics class that is designed to collect events that are captured
@@ -47,6 +50,7 @@ class Analytics {
 
 	_disposed: boolean = false;
 	_pluginDisposers: any[] = [];
+	_sharedUserIdSynced: boolean = false;
 	_queueFlushService!: QueueFlushService;
 
 	config: AnalyticsType.Config = {
@@ -86,6 +90,7 @@ class Analytics {
 		const faroBackendUrl = (config.faroBackendUrl || '').replace(/\/$/, '');
 
 		this.config = Object.assign(config, {
+			cookieDomain: this._resolveCookieDomain(config.cookieDomain),
 			demandbaseAccountEndpoint: `${endpointUrl}/demandbase-account`,
 			endpointUrl,
 			faroBackendUrl,
@@ -352,6 +357,37 @@ class Analytics {
 	}
 
 	/**
+	 * Takes the user id established in the cookie shared with every sibling
+	 * subdomain, whether or not this host already had one of its own. The
+	 * shared cookie is the single answer to who the visitor is, so a host that
+	 * minted its own id before the cookie existed converges on the shared one
+	 * the next time it is loaded. Returns an empty string when there is nothing
+	 * to take.
+	 */
+	_syncSharedUserId(userId?: string) {
+		if (this._sharedUserIdSynced || !this._getCookieDomain()) {
+			return '';
+		}
+
+		// Converging is a decision for this page load, not for every message
+		// the queues build: leaving it on the read path would pay a cookie read
+		// per message and let the id change under a live page whenever a
+		// sibling subdomain writes the cookie.
+
+		this._sharedUserIdSynced = true;
+
+		const sharedUserId = getCookie(AnalyticsType.Keys.UserId);
+
+		if (!sharedUserId || sharedUserId === userId) {
+			return '';
+		}
+
+		setItem(AnalyticsType.Keys.UserId, sharedUserId);
+
+		return sharedUserId;
+	}
+
+	/**
 	 * Clears interval and calls plugins disposers if available
 	 */
 	_disposeInternal() {
@@ -369,10 +405,21 @@ class Analytics {
 	}
 
 	_ensureIntegrity() {
+		if (this._getCookieDomain()) {
+
+			// Retires the cookie a previous version of the client scoped to
+			// this exact host before anything reads the shared one. A cookie is
+			// identified by its domain as well as its name, so leaving it in
+			// place would let two cookies with the same name coexist and make
+			// every later read, here and on the server, ambiguous.
+
+			removeHostOnlyCookie(AnalyticsType.Keys.UserId);
+		}
+
 		const userId = getItem<string>(AnalyticsType.Keys.UserId);
 
 		if (userId) {
-			this._setCookie(AnalyticsType.Keys.UserId, userId);
+			this._setUserIdCookie(userId);
 		}
 	}
 
@@ -410,6 +457,40 @@ class Analytics {
 		}
 
 		return clonedContext;
+	}
+
+	/**
+	 * Validates the domain the server computed for this request. The browser
+	 * drops a domain it cannot set, so a value this host is not under, an IP
+	 * address, or one without a dot is discarded here rather than producing
+	 * cookies that never land.
+	 * @protected
+	 */
+	_resolveCookieDomain(configuredDomain: string = '') {
+		const cookieDomain = configuredDomain.replace(/^\./, '');
+
+		const {hostname} = window.location;
+
+		if (
+			!cookieDomain.includes('.') ||
+			IP_ADDRESS_REGEX.test(cookieDomain) ||
+			(hostname !== cookieDomain &&
+				!hostname.endsWith(`.${cookieDomain}`))
+		) {
+			return '';
+		}
+
+		return cookieDomain;
+	}
+
+	/**
+	 * The domain the user id cookie is shared at, resolved once when the client
+	 * is created. An empty string means the cookie stays scoped to the exact
+	 * host, as it was before the server started sending a domain.
+	 * @protected
+	 */
+	_getCookieDomain() {
+		return this.config.cookieDomain || '';
 	}
 
 	_getIdentityHash(
@@ -460,8 +541,18 @@ class Analytics {
 			AnalyticsType.Keys.PrevEmailAddressHash
 		);
 
+		// An identified visit is stitched by its email hash downstream, so it
+		// gains nothing from taking the shared anonymous id and could bind that
+		// id to a second person.
+
+		if (!emailAddressHashed) {
+			userId = this._syncSharedUserId(userId as string) || userId;
+		}
+
 		if (!userId) {
 			userId = this._generateUserId();
+
+			this._setUserIdCookie(userId);
 		}
 
 		if (
@@ -469,7 +560,14 @@ class Analytics {
 			emailAddressHashed !== previousEmailAddressHashed
 		) {
 			if (previousEmailAddressHashed) {
+
+				// The visitor is a different person now, so the shared cookie
+				// has to follow rather than pull this host back to the old id
+				// on the next anonymous load.
+
 				userId = this._generateUserId();
+
+				this._replaceUserIdCookie(userId);
 			}
 
 			setItem(
@@ -490,7 +588,6 @@ class Analytics {
 		const userId: string = uuidv4();
 
 		setItem(AnalyticsType.Keys.UserId, userId);
-		this._setCookie(AnalyticsType.Keys.UserId, userId);
 
 		removeItem(AnalyticsType.Keys.Identity);
 
@@ -541,38 +638,35 @@ class Analytics {
 	}
 
 	/**
-	 * Sets a browser cookie
+	 * Seeds the user id cookie, leaving it alone when it already holds another
+	 * id. Refreshing an id this client merely happens to hold must not
+	 * overwrite what a sibling subdomain shared, or the write would race the
+	 * read that is about to take that shared id.
 	 * @protected
 	 */
-	_setCookie(key: string, data: string) {
-		const Liferay = window.Liferay;
-		const expires = new Date();
+	_setUserIdCookie(userId: string) {
+		const cookieDomain = this._getCookieDomain();
 
-		expires.setDate(expires.getDate() + 365);
+		if (cookieDomain) {
+			const sharedUserId = getCookie(AnalyticsType.Keys.UserId);
 
-		// Checks if the client is being loaded with the Liferay global
-		// variable and if there is a Cookie method because the client
-		// is Liferay Portal agnostic and may have versions that do not
-		// yet have the Cookie method.
-
-		if (Liferay?.Util?.Cookie) {
-			Liferay.Util.Cookie.set?.(
-				key,
-				data,
-				Liferay?.Util?.Cookie?.TYPES?.PERSONALIZATION,
-				{
-					expires,
-					secure: true,
-				}
-			);
-		}
-		else {
-			const path = Liferay?.ThemeDisplay?.getPathContext?.() || '/';
-
-			document.cookie = `${key}=${data}; expires=${expires.toUTCString()}; path=${path}; Secure`;
+			if (sharedUserId && sharedUserId !== userId) {
+				return;
+			}
 		}
 
-		return;
+		setCookie(AnalyticsType.Keys.UserId, userId, cookieDomain);
+	}
+
+	/**
+	 * Publishes an id this client has decided on, replacing whatever the shared
+	 * cookie held. Used when an identity change regenerates the id, so the
+	 * change reaches every sibling subdomain instead of stranding them on an id
+	 * nobody uses any more.
+	 * @protected
+	 */
+	_replaceUserIdCookie(userId: string) {
+		setCookie(AnalyticsType.Keys.UserId, userId, this._getCookieDomain());
 	}
 
 	/**

--- a/modules/apps/analytics/analytics-client-js/src/types.ts
+++ b/modules/apps/analytics/analytics-client-js/src/types.ts
@@ -56,6 +56,7 @@ export namespace Analytics {
 
 	export type Config = {
 		channelId: string;
+		cookieDomain?: string;
 		dataSourceId: string;
 		demandbaseAccountEndpoint: string;
 		endpointUrl: string;

--- a/modules/apps/analytics/analytics-client-js/src/utils/constants.ts
+++ b/modules/apps/analytics/analytics-client-js/src/utils/constants.ts
@@ -12,6 +12,10 @@ export const ANALYTICS_BATCH_SEGMENT_EXTERNAL_REFERENCE_CODES =
 
 // Default Config
 
+export const COOKIE_EXPIRATION_DAYS = 365;
+
+export const COOKIE_EXPIRED_DATE = 'Thu, 01 Jan 1970 00:00:00 GMT';
+
 export const DEBOUNCE = 1500;
 
 export const FLUSH_INTERVAL = 2000;

--- a/modules/apps/analytics/analytics-client-js/src/utils/cookies.ts
+++ b/modules/apps/analytics/analytics-client-js/src/utils/cookies.ts
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {COOKIE_EXPIRATION_DAYS, COOKIE_EXPIRED_DATE} from './constants';
+
+/**
+ * The path this client writes its cookies at. Reading and expiring a cookie
+ * have to agree with the write on this, or they address a different cookie and
+ * silently do nothing.
+ */
+const getCookiePath = () =>
+	window.Liferay?.ThemeDisplay?.getPathContext?.() || '/';
+
+/**
+ * Reads a cookie through the same API that wrote it. The client is Liferay
+ * Portal agnostic and may run on a page that has no Liferay global, or an older
+ * one without the cookie API, so both paths have to work.
+ */
+const getCookie = (key: string) => {
+	const Liferay = window.Liferay;
+
+	if (Liferay?.Util?.Cookie) {
+		return (
+			Liferay.Util.Cookie.get?.(
+				key,
+				Liferay.Util.Cookie.TYPES?.PERSONALIZATION
+			) || ''
+		);
+	}
+
+	const cookie = document.cookie
+		.split('; ')
+		.find((item) => item.startsWith(`${key}=`));
+
+	return cookie ? cookie.slice(key.length + 1) : '';
+};
+
+/**
+ * Writes a cookie, optionally scoped to a domain so every host under it shares
+ * the one cookie rather than each holding its own.
+ */
+const setCookie = (key: string, value: string, domain: string = '') => {
+	const Liferay = window.Liferay;
+
+	const expires = new Date();
+
+	expires.setDate(expires.getDate() + COOKIE_EXPIRATION_DAYS);
+
+	if (Liferay?.Util?.Cookie) {
+		const options: {domain?: string; expires: Date; secure: boolean} = {
+			expires,
+			secure: true,
+		};
+
+		if (domain) {
+			options.domain = domain;
+		}
+
+		Liferay.Util.Cookie.set?.(
+			key,
+			value,
+			Liferay.Util.Cookie.TYPES?.PERSONALIZATION,
+			options
+		);
+
+		return;
+	}
+
+	const cookie = [`${key}=${value}`];
+
+	if (domain) {
+		cookie.push(`domain=${domain}`);
+	}
+
+	cookie.push(
+		`expires=${expires.toUTCString()}`,
+		`path=${getCookiePath()}`,
+		'Secure'
+	);
+
+	document.cookie = cookie.join('; ');
+};
+
+/**
+ * Expires the cookie scoped to this exact host. Omitting the domain is what
+ * makes the browser expire that cookie rather than one shared with sibling
+ * hosts, and both paths are covered because the Liferay API writes at the root
+ * while the fallback above writes at the path context.
+ */
+const removeHostOnlyCookie = (key: string) => {
+	const paths = new Set([getCookiePath(), '/']);
+
+	paths.forEach((path) => {
+		document.cookie = `${key}=; expires=${COOKIE_EXPIRED_DATE}; path=${path}`;
+	});
+};
+
+export {getCookie, getCookiePath, removeHostOnlyCookie, setCookie};

--- a/modules/apps/analytics/analytics-client-js/test/cookieDomain.ts
+++ b/modules/apps/analytics/analytics-client-js/test/cookieDomain.ts
@@ -1,0 +1,291 @@
+/**
+ * @jest-environment ./test/subdomainEnvironment.js
+ */
+
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore - Check possibility to install package in ts format
+
+import fetchMock from 'fetch-mock';
+
+import AnalyticsClient from '../src/analytics';
+import {Analytics as AnalyticsType} from '../src/types';
+import {COOKIE_EXPIRED_DATE} from '../src/utils/constants';
+import {getItem, setItem} from '../src/utils/storage';
+import {INITIAL_ANALYTICS_CONFIG} from './helpers';
+
+const COOKIE_DOMAIN = 'liferay.com';
+
+const INITIAL_CONFIG = {...INITIAL_ANALYTICS_CONFIG, flushInterval: 100};
+
+/**
+ * Every value the browser holds under the user id cookie name. A cookie is
+ * identified by its domain as well as its name, so a host scoped cookie and one
+ * scoped to the shared domain show up here as two separate entries.
+ */
+const getUserIdCookies = () =>
+	document.cookie
+		.split('; ')
+		.filter((cookie) => cookie.startsWith(`${AnalyticsType.Keys.UserId}=`))
+		.map((cookie) => cookie.slice(AnalyticsType.Keys.UserId.length + 1));
+
+const setCookie = (userId: string, domain?: string, expires?: string) => {
+	const attributes = [`${AnalyticsType.Keys.UserId}=${userId}`];
+
+	if (domain) {
+		attributes.push(`domain=${domain}`);
+	}
+
+	if (expires) {
+		attributes.push(`expires=${expires}`);
+	}
+
+	attributes.push('path=/', 'Secure');
+
+	document.cookie = attributes.join('; ');
+};
+
+const expireCookie = (domain?: string) =>
+	setCookie('', domain, COOKIE_EXPIRED_DATE);
+
+/**
+ * Expiring the host scoped cookie leaves a cookie written at the shared domain
+ * untouched, which is the only way to tell the two apart through
+ * `document.cookie`.
+ */
+const expireHostOnlyCookie = () => expireCookie();
+
+describe('Cookie shared across subdomains', () => {
+	beforeEach(() => {
+		fetchMock.mock(/ac-server/i, () => Promise.resolve(200));
+
+		expireCookie();
+		expireCookie(COOKIE_DOMAIN);
+
+		localStorage.clear();
+	});
+
+	afterEach(() => {
+		AnalyticsClient.dispose();
+
+		fetchMock.restore();
+
+		jest.restoreAllMocks();
+	});
+
+	describe('when a cookie domain is configured', () => {
+		const CONFIG = {...INITIAL_CONFIG, cookieDomain: COOKIE_DOMAIN};
+
+		it('shares the id it already had on this host', () => {
+			setItem(AnalyticsType.Keys.UserId, 'local-id');
+
+			AnalyticsClient.create(CONFIG);
+
+			expect(getUserIdCookies()).toEqual(['local-id']);
+
+			expireHostOnlyCookie();
+
+			expect(getUserIdCookies()).toEqual(['local-id']);
+		});
+
+		it('adopts the id already shared when it has none of its own', () => {
+			setCookie('shared-id', COOKIE_DOMAIN);
+
+			const analytics = AnalyticsClient.create(CONFIG);
+
+			expect(getItem(AnalyticsType.Keys.UserId)).toBe('shared-id');
+			expect(analytics._getUserId()).toBe('shared-id');
+		});
+
+		it('adopts the id when the domain is configured with a leading dot', () => {
+			setCookie('shared-id', COOKIE_DOMAIN);
+
+			AnalyticsClient.create({
+				...CONFIG,
+				cookieDomain: `.${COOKIE_DOMAIN}`,
+			});
+
+			expect(getItem(AnalyticsType.Keys.UserId)).toBe('shared-id');
+		});
+
+		it('takes the shared id over the one it had of its own', () => {
+			setCookie('shared-id', COOKIE_DOMAIN);
+			setItem(AnalyticsType.Keys.UserId, 'local-id');
+
+			AnalyticsClient.create(CONFIG);
+
+			expect(getItem(AnalyticsType.Keys.UserId)).toBe('shared-id');
+			expect(getUserIdCookies()).toEqual(['shared-id']);
+		});
+
+		it('reports the identity again once the id has changed', () => {
+			fetchMock.mock(/identity$/, () => Promise.resolve(200));
+
+			setCookie('shared-id', COOKIE_DOMAIN);
+			setItem(AnalyticsType.Keys.UserId, 'local-id');
+
+			const analytics = AnalyticsClient.create(CONFIG);
+
+			const items = analytics[
+				AnalyticsType.Queues.IdentityMessage
+			].getItems<{userId: string}>();
+
+			expect(items[items.length - 1].userId).toBe('shared-id');
+		});
+
+		it('retires the cookie a previous version scoped to this host', () => {
+			setCookie('legacy-id');
+			setItem(AnalyticsType.Keys.UserId, 'legacy-id');
+
+			AnalyticsClient.create(CONFIG);
+
+			expect(getUserIdCookies()).toEqual(['legacy-id']);
+
+			expireHostOnlyCookie();
+
+			expect(getUserIdCookies()).toEqual(['legacy-id']);
+		});
+
+		it('does not take the shared id when the visitor is identified', () => {
+			setCookie('shared-id', COOKIE_DOMAIN);
+
+			const themeDisplay = window.Liferay.ThemeDisplay || {};
+
+			themeDisplay.getUserEmailAddress = () => 'john@liferay.com';
+			themeDisplay.getUserName = () => 'John';
+
+			try {
+				AnalyticsClient.create(CONFIG);
+
+				expect(getItem(AnalyticsType.Keys.UserId)).not.toBe(
+					'shared-id'
+				);
+				expect(getUserIdCookies()).toEqual(['shared-id']);
+			}
+			finally {
+				delete themeDisplay.getUserEmailAddress;
+				delete themeDisplay.getUserName;
+			}
+		});
+
+		it('carries a regenerated id into the shared cookie', async () => {
+			fetchMock.mock(/identity$/, () => Promise.resolve(200));
+
+			const analytics = AnalyticsClient.create(CONFIG);
+
+			const [sharedUserId] = getUserIdCookies();
+
+			await analytics.setIdentity({
+				email: 'john@liferay.com',
+				name: 'John',
+			});
+
+			await analytics.setIdentity({
+				email: 'brian@liferay.com',
+				name: 'Brian',
+			});
+
+			const regeneratedUserId = getItem(AnalyticsType.Keys.UserId);
+
+			expect(regeneratedUserId).not.toBe(sharedUserId);
+
+			// The cookie follows the id in use, so the identity change reaches
+			// every sibling subdomain instead of stranding them on the old id.
+
+			expect(getUserIdCookies()).toEqual([regeneratedUserId]);
+		});
+
+		it('accepts a domain equal to the host it is serving', () => {
+
+			// The server resolves liferay.com to liferay.com, so the site that
+			// owns the registrable domain is handed its own host as the domain
+			// to share at, and sharing has to stay on for it.
+			//
+			// Only the resolved domain is asserted, because jsdom keys a cookie
+			// by its domain and path alone. A browser holds a host scoped and a
+			// domain scoped cookie of the same name as two separate cookies
+			// even when the domains are equal, and expires them independently,
+			// while jsdom merges them into one. The cookie behavior for this
+			// host shape is covered by test/manual/cookie-domain.html instead.
+
+			const analytics = AnalyticsClient.create({
+				...CONFIG,
+				cookieDomain: window.location.hostname,
+			});
+
+			expect(analytics._getCookieDomain()).toBe(window.location.hostname);
+		});
+
+		it('writes the cookie at the shared domain through the Liferay API', () => {
+			const cookieSet = jest.fn();
+
+			window.Liferay.Util = {
+				Cookie: {
+					TYPES: {
+						PERSONALIZATION: 'CONSENT_TYPE_PERSONALIZATION',
+					},
+					get: () => '',
+					set: cookieSet,
+				},
+			};
+
+			try {
+				setItem(AnalyticsType.Keys.UserId, 'local-id');
+
+				AnalyticsClient.create(CONFIG);
+
+				expect(cookieSet).toHaveBeenCalledWith(
+					AnalyticsType.Keys.UserId,
+					'local-id',
+					'CONSENT_TYPE_PERSONALIZATION',
+					{
+						domain: COOKIE_DOMAIN,
+						expires: expect.any(Date),
+						secure: true,
+					}
+				);
+			}
+			finally {
+				delete window.Liferay.Util;
+			}
+		});
+	});
+
+	describe('when no cookie domain is configured', () => {
+		it('keeps the cookie scoped to this host', () => {
+			setItem(AnalyticsType.Keys.UserId, 'local-id');
+
+			AnalyticsClient.create(INITIAL_CONFIG);
+
+			expect(getUserIdCookies()).toEqual(['local-id']);
+
+			expireHostOnlyCookie();
+
+			expect(getUserIdCookies()).toEqual([]);
+		});
+
+		it('ignores an id already present in the cookie', () => {
+			setCookie('shared-id', COOKIE_DOMAIN);
+
+			AnalyticsClient.create(INITIAL_CONFIG);
+
+			expect(getItem(AnalyticsType.Keys.UserId)).not.toBe('shared-id');
+		});
+
+		it.each(['example.com', '127.0.0.1', 'com'])(
+			'ignores the cookie domain %s, which the browser would reject',
+			(cookieDomain) => {
+				setCookie('shared-id', COOKIE_DOMAIN);
+
+				AnalyticsClient.create({...INITIAL_CONFIG, cookieDomain});
+
+				expect(getItem(AnalyticsType.Keys.UserId)).not.toBe(
+					'shared-id'
+				);
+			}
+		);
+	});
+});

--- a/modules/apps/analytics/analytics-client-js/test/manual/cookie-domain.html
+++ b/modules/apps/analytics/analytics-client-js/test/manual/cookie-domain.html
@@ -27,13 +27,15 @@
 					bundle alone on port 8081, so this page needs a static
 					server of its own, from the module root:
 				</p>
-				<pre>yarn start                      # bundle at localhost:8081
-python3 -m http.server 8000     # this page, from the module root</pre>
+
+				<pre>yarn start # bundle at localhost:8081
+python3 -m http.server 8000 # this page, from the module root</pre>
 
 				<p>
 					Then open the page through two names under
 					<code>test.localhost</code>:
 				</p>
+
 				<pre>http://a.test.localhost:8000/test/manual/cookie-domain.html
 http://b.test.localhost:8000/test/manual/cookie-domain.html</pre>
 

--- a/modules/apps/analytics/analytics-client-js/test/manual/cookie-domain.html
+++ b/modules/apps/analytics/analytics-client-js/test/manual/cookie-domain.html
@@ -1,0 +1,223 @@
+<!doctype html>
+
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta content="IE=edge" http-equiv="X-UA-Compatible" />
+		<meta content="width=device-width, initial-scale=1.0" name="viewport" />
+
+		<title>Cookie Domain</title>
+
+		<link href="style.css" rel="stylesheet" />
+	</head>
+
+	<body>
+		<div class="header">
+			<h1 class="title">
+				Anonymous user id shared across subdomains
+			</h1>
+
+			<div>
+				Reach this page through two hostnames that share one parent domain,
+				so the browser can be seen sharing the
+				<code>ac_client_user_id</code> cookie between them.
+
+				<p>
+					Two servers are needed. <code>yarn start</code> serves the
+					bundle alone on port 8081, so this page needs a static
+					server of its own, from the module root:
+				</p>
+				<pre>yarn start                      # bundle at localhost:8081
+python3 -m http.server 8000     # this page, from the module root</pre>
+
+				<p>
+					Then open the page through two names under
+					<code>test.localhost</code>:
+				</p>
+				<pre>http://a.test.localhost:8000/test/manual/cookie-domain.html
+http://b.test.localhost:8000/test/manual/cookie-domain.html</pre>
+
+				<p>
+					Nothing else is needed. The browser resolves every
+					<code>*.localhost</code> name to the loopback address itself,
+					so there is no <code>/etc/hosts</code> entry to add and no
+					domain owned by anyone else to depend on. It also treats those
+					names as a secure context, which matters because the client
+					marks the cookie <code>Secure</code> and a browser stores such
+					a cookie only from an origin it trusts — over plain HTTP any
+					other hostname would need
+					<code>--unsafely-treat-insecure-origin-as-secure</code> for
+					the cookie to land at all.
+				</p>
+			</div>
+		</div>
+
+		<div class="container">
+			<div class="box">
+				<h2 class="box__title">State</h2>
+
+				<pre id="state"></pre>
+
+				<div class="btns-header">
+					<button class="btn" data-action="reload">reload</button>
+					<button class="btn" data-action="clearAll">
+						clear everything
+					</button>
+
+					<button class="btn" data-action="clearStorage">
+						clear localStorage only
+					</button>
+
+					<button class="btn" data-action="seedShared">
+						seed shared cookie
+					</button>
+
+					<button class="btn" data-action="seedHostOnly">
+						seed legacy host only cookie
+					</button>
+				</div>
+			</div>
+
+			<div class="box">
+				<h2 class="box__title">What to expect</h2>
+
+				<ol>
+					<li>
+						Clear everything here, then reload: this host mints an id
+						and the cookie carries
+						<code>Domain=.test.localhost</code> (check DevTools ▸
+						Application ▸ Cookies). No second cookie of the same
+						name exists.
+					</li>
+					<li>
+						Open the other host and clear its localStorage only: it
+						adopts the same id instead of minting a second one.
+					</li>
+					<li>
+						Give the other host its own id first (clear everything
+						there, reload), then come back and reload here: the host
+						holding an id the shared cookie disagrees with gives way
+						to it, so both ends settle on one id.
+					</li>
+					<li>
+						Seed the legacy host only cookie and reload: it is
+						expired, leaving exactly one cookie of that name. Run
+						this on the parent host too, at
+						<code>http://test.localhost:8000</code>, where the shared
+						domain equals the host itself. A browser really does keep
+						the two cookies apart there, so it is the case the
+						automated tests cannot reach: jsdom keys a cookie by its
+						domain and path alone and merges them into one.
+					</li>
+				</ol>
+			</div>
+		</div>
+
+		<!-- AC Script -->
+
+		<script>
+			const COOKIE_NAME = 'ac_client_user_id';
+
+			// The parent domain the hostnames above share. The server normally
+			// computes this per request with CookiesManager.getDomain() and
+			// injects it into the client config.
+
+			const COOKIE_DOMAIN = 'test.localhost';
+
+			function getCookies() {
+				return document.cookie
+					.split('; ')
+					.filter((cookie) => cookie.startsWith(COOKIE_NAME + '='))
+					.map((cookie) => cookie.slice(COOKIE_NAME.length + 1));
+			}
+
+			function render() {
+				const cookies = getCookies();
+
+				document.getElementById('state').textContent = [
+					'host                ' + window.location.hostname,
+					'cookieDomain        ' + COOKIE_DOMAIN,
+					'cookies (' + cookies.length + ')         ' +
+						(cookies.join(', ') || '(none)'),
+					'localStorage        ' +
+						(localStorage.getItem(COOKIE_NAME) || '(none)'),
+					'id used by the SDK  ' +
+						(window.Analytics && window.Analytics._getUserId
+							? window.Analytics._getUserId()
+							: '(SDK not loaded)'),
+				].join('\n');
+			}
+
+			function expireCookie(domain) {
+				const attributes = [COOKIE_NAME + '='];
+
+				if (domain) {
+					attributes.push('domain=' + domain);
+				}
+
+				attributes.push(
+					'expires=Thu, 01 Jan 1970 00:00:00 GMT',
+					'path=/'
+				);
+
+				document.cookie = attributes.join('; ');
+			}
+
+			const ACTIONS = {
+				clearAll() {
+					localStorage.clear();
+					expireCookie();
+					expireCookie(COOKIE_DOMAIN);
+				},
+				clearStorage() {
+					localStorage.clear();
+				},
+				reload() {},
+				seedHostOnly() {
+					document.cookie =
+						COOKIE_NAME + '=seeded-legacy-id; path=/; Secure';
+				},
+				seedShared() {
+					document.cookie =
+						COOKIE_NAME +
+						'=seeded-shared-id; domain=' +
+						COOKIE_DOMAIN +
+						'; path=/; Secure';
+				},
+			};
+
+			document.querySelector('body').addEventListener('click', (event) => {
+				const action = ACTIONS[event.target.dataset.action];
+
+				if (action) {
+					action();
+
+					window.location.reload();
+				}
+			});
+
+			(function (u, c, a, m, o, l) {
+				(o = 'script'),
+					(l = document),
+					(a = l.createElement(o)),
+					(m = l.getElementsByTagName(o)[0]),
+					(a.async = 1),
+					(a.src = u),
+					(a.onload = c),
+					m.parentNode.insertBefore(a, m);
+			})('http://localhost:8081/analytics-all-min.js', function () {
+				Analytics.create({
+					channelId: '[CHANNEL_ID]',
+					cookieDomain: COOKIE_DOMAIN,
+					dataSourceId: '[DATA_SOURCE_ID]',
+					endpointUrl: '[ENDPOINT_URL]',
+					projectId: '[PROJECT_ID]',
+				});
+
+				render();
+			});
+
+			render();
+		</script>
+	</body>
+</html>

--- a/modules/apps/analytics/analytics-client-js/test/subdomainEnvironment.js
+++ b/modules/apps/analytics/analytics-client-js/test/subdomainEnvironment.js
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// Provided by the shared Jest configuration in @liferay/node-scripts.
+
+// eslint-disable-next-line @liferay/no-extraneous-dependencies
+const JSDOMEnvironment = require('jest-environment-jsdom');
+
+const TEST_URL = 'https://learn.liferay.com/';
+
+/**
+ * Runs a test file on a secure subdomain instead of the default
+ * `http://localhost`. Cookie behavior is only observable there: jsdom drops a
+ * `Secure` cookie written from an insecure origin, and rejects a `Domain`
+ * attribute that is not a suffix of the current host, which is what the user id
+ * cookie shared across subdomains relies on.
+ *
+ * A test file opts in through the `@jest-environment` docblock. Both keys are
+ * set because Jest 27 reads the URL from `testURL` while later versions read it
+ * from `testEnvironmentOptions`, and the shared portal configuration sets the
+ * latter to `http://localhost`.
+ */
+class SubdomainEnvironment extends JSDOMEnvironment {
+	constructor(config, context) {
+		super(
+			{
+				...config,
+				testEnvironmentOptions: {
+					...config.testEnvironmentOptions,
+					url: TEST_URL,
+				},
+				testURL: TEST_URL,
+			},
+			context
+		);
+	}
+}
+
+module.exports = SubdomainEnvironment;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102209

## What Is Being Fixed

A visitor who reached liferay.com and later learn.liferay.com on their own, with no click through, counted as two anonymous individuals. The client wrote its `ac_client_user_id` cookie with no `Domain`, so the browser scoped it to the exact host, and it never read the cookie back either, which left every host minting an id of its own.

## How It Is Being Fixed

The cookie is now written at the domain the server computes for the request and passes in as `cookieDomain` (LPD-102208, already in master), and the shared cookie is the single answer to who the visitor is: a host that established an id before the cookie existed converges on the shared one, and the identity message follows on its own because the hash it is keyed by includes the user id. Converging is decided once per page load rather than on every read, so a live page keeps the id it started with and the queues pay nothing per message.

Any cookie a previous version scoped to the exact host is retired before anything reads the shared one. A cookie is identified by its domain as well as its name, so two of them under one name would make every later read ambiguous — here and in `SegmentsAsahRequestContextContributor`, which reads the same cookie server side and takes the first match.

An identified visit keeps its own id, being stitched by its email hash downstream, where taking an anonymous id could bind that id to a second person. Reading, writing and expiring the cookie moved to `src/utils/cookies.ts`, alongside the existing `storage.ts`, so the write and the expiry cannot drift apart on the path they address.

Without a `cookieDomain`, or with one the browser would reject, the client behaves exactly as it did before.

## PR Check

**pr-check: PASS** — tested on `1c73ac3ad682828d63b05e5aa7f07d48784fbb27`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

Baseline reported `EXCESSIVE VERSION INCREASE` on two `portal-kernel` packages, `com.liferay.exportimport.kernel.xstream` and `com.liferay.portal.kernel.servlet`. Both are inherited from master: this branch changes no Java at all and its module exports no package, so neither finding is attributable to it. The repairs the task wrote in place were restored and the tree left clean.

<!-- pr-check {"result": "success", "sha": "1c73ac3ad682828d63b05e5aa7f07d48784fbb27"} -->
