### PR TITLE
LPD-101224 faro-v5.1.x Show lifecycle date range on dashboard

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/LifecycleDateRangeIndicator.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/LifecycleDateRangeIndicator.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {formatUTCDate, getCustomDateFormat, getDateNow} from 'shared/util/date';
+import {Text} from '@clayui/core';
+
+// The backend computes every lifecycle metric over the trailing 90 days, not
+// counting today (i.e. yesterday back through 90 days prior). The window is a
+// fixed rule rather than a configurable value, so it is derived here instead
+// of being fetched.
+
+const LIFECYCLE_DATE_RANGE_DAYS = 90;
+
+const LifecycleDateRangeIndicator: React.FC = () => {
+	const today = getDateNow();
+
+	const endDate = today.clone().subtract(1, 'day');
+	const startDate = today.clone().subtract(LIFECYCLE_DATE_RANGE_DAYS, 'days');
+
+	const format = getCustomDateFormat();
+
+	return (
+		<span className="mr-2">
+			<Text color="secondary" size={4}>
+				{`${formatUTCDate(startDate, format)} – ${formatUTCDate(endDate, format)}`}
+			</Text>
+		</span>
+	);
+};
+
+export default LifecycleDateRangeIndicator;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/__tests__/LifecycleDateRangeIndicator.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/components/__tests__/LifecycleDateRangeIndicator.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom';
+import LifecycleDateRangeIndicator from '../LifecycleDateRangeIndicator';
+import React from 'react';
+import {cleanup, render, screen} from '@testing-library/react';
+
+jest.unmock('react-dom');
+
+describe('LifecycleDateRangeIndicator', () => {
+	afterEach(() => {
+		cleanup();
+		jest.useRealTimers();
+	});
+
+	beforeEach(() => {
+		jest.useFakeTimers().setSystemTime(
+			new Date('2026-06-15T12:00:00.000Z')
+		);
+	});
+
+	it('shows the trailing 90-day range, not including today', () => {
+		render(<LifecycleDateRangeIndicator />);
+
+		expect(
+			screen.getByText('Mar 17, 2026 – Jun 14, 2026')
+		).toBeInTheDocument();
+	});
+});

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/BaseLifecycle.tsx
@@ -7,6 +7,7 @@ import ClayLink from '@clayui/link';
 import {ClayButtonWithIcon} from '@clayui/button';
 import FilterPicker from '../components/FilterPicker';
 import LifecycleChart from 'lifecycle/components/LifecycleChart';
+import LifecycleDateRangeIndicator from '../components/LifecycleDateRangeIndicator';
 import Loading from 'shared/components/Loading';
 import NoResultsDisplay from 'shared/components/NoResultsDisplay';
 import OverviewSection from '../components/OverviewSection';
@@ -405,6 +406,8 @@ const BaseLifecycle = () => {
 									onFilterChange={setSegment}
 								/>
 							</div>
+
+							<LifecycleDateRangeIndicator />
 						</div>
 					</BasePage.SubHeader>
 				)}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/BaseLifecycle.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/lifecycle/pages/__tests__/BaseLifecycle.tsx
@@ -405,6 +405,9 @@ describe('BaseLifecycle', () => {
 			'Countries'
 		);
 		expect(screen.getByTestId('segment-dropdown')).toBeInTheDocument();
+		expect(
+			screen.getByText(/^\S+ \d+, \d{4} – \S+ \d+, \d{4}$/)
+		).toBeInTheDocument();
 		expect(screen.queryByText('No Account Data Available')).toBeNull();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101224

Backport of #3931 to `faro-v5.1.x`.
