### PR TITLE
LPD-103812 Accept a date range on the account individuals endpoint

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/ContactsEngineClient.java
@@ -199,7 +199,8 @@ public interface ContactsEngineClient {
 
 	public Results<Individual> getAccountIndividuals(
 		FaroProject faroProject, String accountId, String channelId,
-		String query, int cur, int delta, String sortString);
+		String query, String rangeEnd, Integer rangeKey, String rangeStart,
+		int cur, int delta, String sortString);
 
 	public Results<IndividualSegment> getAccountIndividualSegments(
 		FaroProject faroProject, String accountId, String channelId,

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/internal/ContactsEngineClientImpl.java
@@ -692,7 +692,8 @@ public class ContactsEngineClientImpl
 	@Override
 	public Results<Individual> getAccountIndividuals(
 		FaroProject faroProject, String accountId, String channelId,
-		String query, int cur, int delta, String sortString) {
+		String query, String rangeEnd, Integer rangeKey, String rangeStart,
+		int cur, int delta, String sortString) {
 
 		Map<String, Object> uriVariables = getUriVariables(
 			faroProject, cur, delta, null);
@@ -705,6 +706,18 @@ public class ContactsEngineClientImpl
 
 		if (Validator.isNotNull(query)) {
 			uriVariables.put("query", query);
+		}
+
+		if (Validator.isNotNull(rangeEnd)) {
+			uriVariables.put("rangeEnd", rangeEnd);
+		}
+
+		if (rangeKey != null) {
+			uriVariables.put("rangeKey", rangeKey);
+		}
+
+		if (Validator.isNotNull(rangeStart)) {
+			uriVariables.put("rangeStart", rangeStart);
 		}
 
 		if (Validator.isNotNull(sortString)) {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/MockContactsEngineClientImpl.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-mock-engine-client/src/main/java/com/liferay/osb/faro/mock/engine/client/internal/MockContactsEngineClientImpl.java
@@ -40,10 +40,12 @@ public class MockContactsEngineClientImpl
 	@Override
 	public Results<Individual> getAccountIndividuals(
 		FaroProject faroProject, String accountId, String channelId,
-		String query, int cur, int delta, String sortString) {
+		String query, String rangeEnd, Integer rangeKey, String rangeStart,
+		int cur, int delta, String sortString) {
 
 		return contactsEngineClient.getAccountIndividuals(
-			faroProject, accountId, channelId, query, cur, delta, sortString);
+			faroProject, accountId, channelId, query, rangeEnd, rangeKey,
+			rangeStart, cur, delta, sortString);
 	}
 
 	@Override

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroController.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroController.java
@@ -200,6 +200,9 @@ public class AccountFaroController extends BaseFaroController {
 			getIndividualsFaroFDSResultsDisplay(
 				@PathParam("groupId") long groupId, @PathParam("id") String id,
 				@QueryParam("channelId") String channelId,
+				@QueryParam("rangeEnd") String rangeEnd,
+				@QueryParam("rangeKey") Integer rangeKey,
+				@QueryParam("rangeStart") String rangeStart,
 				@QueryParam("search") String search,
 				@QueryParam("page") int page,
 				@QueryParam("pageSize") int pageSize,
@@ -210,7 +213,8 @@ public class AccountFaroController extends BaseFaroController {
 		return new FaroFDSResultsDisplay<>(
 			contactsEngineClient.getAccountIndividuals(
 				faroProjectLocalService.getFaroProjectByGroupId(groupId), id,
-				channelId, search, page, pageSize, sortString),
+				channelId, search, rangeEnd, rangeKey, rangeStart, page,
+				pageSize, sortString),
 			IndividualDisplay::new, page, pageSize);
 	}
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroControllerTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/test/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountFaroControllerTest.java
@@ -6,9 +6,12 @@
 package com.liferay.osb.faro.web.internal.controller.contacts;
 
 import com.liferay.osb.faro.engine.client.ContactsEngineClient;
+import com.liferay.osb.faro.engine.client.model.Individual;
 import com.liferay.osb.faro.engine.client.model.Metric;
+import com.liferay.osb.faro.engine.client.model.Results;
 import com.liferay.osb.faro.model.FaroProject;
 import com.liferay.osb.faro.service.FaroProjectLocalService;
+import com.liferay.osb.faro.web.internal.model.display.FaroFDSResultsDisplay;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.util.Collections;
@@ -67,6 +70,44 @@ public class AccountFaroControllerTest {
 			_faroProjectLocalService
 		).getFaroProjectByGroupId(
 			groupId
+		);
+	}
+
+	@Test
+	public void testGetIndividualsFaroFDSResultsDisplay() throws Exception {
+		String channelId = RandomTestUtil.randomString();
+		String id = RandomTestUtil.randomString();
+		int page = RandomTestUtil.randomInt();
+		int pageSize = RandomTestUtil.randomInt();
+		String rangeEnd = RandomTestUtil.randomString();
+		Integer rangeKey = RandomTestUtil.randomInt();
+		String rangeStart = RandomTestUtil.randomString();
+		String search = RandomTestUtil.randomString();
+		String sortString = RandomTestUtil.randomString();
+		int total = RandomTestUtil.randomInt();
+
+		Mockito.when(
+			_contactsEngineClient.getAccountIndividuals(
+				_faroProject, id, channelId, search, rangeEnd, rangeKey,
+				rangeStart, page, pageSize, sortString)
+		).thenReturn(
+			new Results<>(Collections.emptyList(), total)
+		);
+
+		long groupId = RandomTestUtil.randomLong();
+
+		FaroFDSResultsDisplay<Individual> faroFDSResultsDisplay =
+			_accountFaroController.getIndividualsFaroFDSResultsDisplay(
+				groupId, id, channelId, rangeEnd, rangeKey, rangeStart, search,
+				page, pageSize, sortString);
+
+		Assert.assertEquals(total, faroFDSResultsDisplay.getTotalCount());
+
+		Mockito.verify(
+			_contactsEngineClient
+		).getAccountIndividuals(
+			_faroProject, id, channelId, search, rangeEnd, rangeKey, rangeStart,
+			page, pageSize, sortString
 		);
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103812

## What Is Being Fixed

The endpoint backing the Most Engaged Individuals and Account Individuals reports, `/o/faro/contacts/{groupId}/account/{id}/individuals`, accepts no date range. Without one the reports can only ever show all-time event counts, while the individual's Activity Stream is scoped to a date range, so the two surfaces contradict each other.

## How It Is Being Fixed

The handler gains `rangeStart`, `rangeEnd` and `rangeKey`, and forwards them to the Analytics Cloud engine, following the shape the sibling `/search` and `/account-names` handlers on the same controller already use. The engine client puts them into its `uriVariables` map the same way `getAccounts` and the range-aware `getIndividuals` overload do, and the mock engine client mirrors the new signature.

This half is deliberately inert on its own. The engine client does not build the URL: it expands the `account-individuals` URI template that Analytics Cloud publishes on its HAL root, and any variable the template does not declare is dropped without an error. That template gains the three parameters in LPD-103811, on the Analytics Cloud side, which is where the numbers are actually recomputed. Omitting the parameters preserves the current behavior.

Coverage is added to the existing `AccountFaroControllerTest`, stubbing the engine client with the new arguments and verifying the forwarding.

## PR Check

**pr-check: PASS** — tested on `8275234a317bf5b248fc07f7b7bdae14f2c907d2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Workspace Build | PASS |

Baseline matched the diff (its trigger is a catch-all) but is not applicable here and was not run: the change is five Java files under `workspaces/`, none of the seven top level Ant projects it compares, and this worktree has no built jars for it to compare against.

<!-- pr-check {"result": "success", "sha": "8275234a317bf5b248fc07f7b7bdae14f2c907d2"} -->
