### PR TITLE
LPD-103813 Scope the account individuals list to the selected range

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/IndividualsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/IndividualsDataSet.tsx
@@ -5,9 +5,11 @@ import {
 	pagination,
 } from 'shared/components/FrontendDataSet';
 import {formatTime} from 'shared/util/time';
-import {Routes} from 'shared/util/router';
+import {pickBy} from 'lodash';
+import {Routes, setUriQueryValues} from 'shared/util/router';
 import {toThousands} from 'shared/util/numbers';
 import {useParams} from 'react-router-dom';
+import {useQueryRangeSelectors} from 'shared/hooks/useQueryRangeSelectors';
 
 const FDS_ID = 'account-individuals-dataset';
 
@@ -74,9 +76,22 @@ const IndividualsDataSet: React.FC<IIndividualsDataSetProps> = ({
 		id: string;
 	}>();
 
+	const rangeSelectors = useQueryRangeSelectors();
+
+	/**
+	 * `rangeEnd` and `rangeStart` are only set for a custom range, so drop the
+	 * empty ones rather than sending them as `null`. The individual profile
+	 * link carries the same range so the selection survives the redirect.
+	 */
+
+	const rangeQueryValues = pickBy(rangeSelectors);
+
 	return (
 		<FrontendDataSet
-			apiURL={`/o/faro/contacts/${groupId}/account/${id}/individuals?channelId=${channelId}`}
+			apiURL={setUriQueryValues(
+				{channelId, ...rangeQueryValues},
+				`/o/faro/contacts/${groupId}/account/${id}/individuals`
+			)}
 			customDataRenderers={{
 				avgSessionDurationRenderer: ({value}: {value?: number}) =>
 					value ? formatTime(value) : '',
@@ -91,6 +106,7 @@ const IndividualsDataSet: React.FC<IIndividualsDataSetProps> = ({
 						channelId,
 						groupId,
 						itemData,
+						queryValues: rangeQueryValues,
 						route: Routes.CONTACTS_INDIVIDUAL,
 						value,
 					}),
@@ -107,6 +123,12 @@ const IndividualsDataSet: React.FC<IIndividualsDataSetProps> = ({
 					typeof value === 'number'
 						? columns.cmsLabelRenderer(getVisitorType(value))
 						: '',
+			}}
+			emptyState={{
+				description: Liferay.Language.get(
+					'no-activities-were-found-on-the-selected-period'
+				),
+				title: Liferay.Language.get('no-individuals-were-found'),
 			}}
 			id={preview ? PREVIEW_FDS_ID : FDS_ID}
 			pagination={preview ? undefined : pagination}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/IndividualsDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/IndividualsDataSet.tsx
@@ -5,6 +5,7 @@ import {cleanup, render, screen} from '@testing-library/react';
 jest.unmock('react-dom');
 
 let lastFDSProps: any;
+let mockSearch = '';
 
 jest.mock('@liferay/frontend-data-set-web', () => ({
 	...jest.requireActual('@liferay/frontend-data-set-web'),
@@ -17,6 +18,7 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'),
+	useLocation: () => ({search: mockSearch}),
 	useParams: () => ({channelId: '456', groupId: '23', id: 'acc-1'}),
 }));
 
@@ -24,6 +26,7 @@ describe('IndividualsDataSet', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		lastFDSProps = undefined;
+		mockSearch = '';
 	});
 
 	afterEach(cleanup);
@@ -41,7 +44,45 @@ describe('IndividualsDataSet', () => {
 		render(<IndividualsDataSet />);
 
 		expect(lastFDSProps.apiURL).toBe(
-			'/o/faro/contacts/23/account/acc-1/individuals?channelId=456'
+			'/o/faro/contacts/23/account/acc-1/individuals?channelId=456&rangeKey=30'
+		);
+	});
+
+	it('should default the range to the last thirty days', () => {
+		render(<IndividualsDataSet />);
+
+		expect(lastFDSProps.apiURL).toContain('rangeKey=30');
+	});
+
+	it('should request the range that is on the query string', () => {
+		mockSearch = '?rangeKey=7';
+
+		render(<IndividualsDataSet />);
+
+		expect(lastFDSProps.apiURL).toBe(
+			'/o/faro/contacts/23/account/acc-1/individuals?channelId=456&rangeKey=7'
+		);
+	});
+
+	it('should request the bounds of a custom range', () => {
+		mockSearch =
+			'?rangeEnd=2026-02-20&rangeKey=CUSTOM&rangeStart=2026-02-10';
+
+		render(<IndividualsDataSet />);
+
+		expect(lastFDSProps.apiURL).toContain('rangeEnd=2026-02-20');
+		expect(lastFDSProps.apiURL).toContain('rangeKey=CUSTOM');
+		expect(lastFDSProps.apiURL).toContain('rangeStart=2026-02-10');
+	});
+
+	it('should tell an empty result apart by the selected period', () => {
+		render(<IndividualsDataSet />);
+
+		expect(lastFDSProps.emptyState.description).toBe(
+			'No activities were found on the selected period.'
+		);
+		expect(lastFDSProps.emptyState.title).toBe(
+			'No individuals were found.'
 		);
 	});
 
@@ -203,6 +244,39 @@ describe('IndividualsDataSet', () => {
 			'/contacts/individuals/known-individuals/individual-1'
 		);
 		expect(link.props.children).toBe('Ada Lovelace');
+	});
+
+	it('should carry the range to the individual profile', () => {
+		mockSearch =
+			'?rangeEnd=2026-02-20&rangeKey=CUSTOM&rangeStart=2026-02-10';
+
+		render(<IndividualsDataSet />);
+
+		const renderer =
+			lastFDSProps.customDataRenderers.individualNameRenderer;
+
+		const link = renderer({
+			itemData: {id: 'individual-1'},
+			value: 'Ada Lovelace',
+		});
+
+		expect(link.props.href).toContain('rangeEnd=2026-02-20');
+		expect(link.props.href).toContain('rangeKey=CUSTOM');
+		expect(link.props.href).toContain('rangeStart=2026-02-10');
+	});
+
+	it('should not put the channel id on the individual profile query', () => {
+		render(<IndividualsDataSet />);
+
+		const renderer =
+			lastFDSProps.customDataRenderers.individualNameRenderer;
+
+		const link = renderer({
+			itemData: {id: 'individual-1'},
+			value: 'Ada Lovelace',
+		});
+
+		expect(link.props.href).not.toContain('channelId=');
 	});
 
 	it('should format the last active date', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/MostEngagedIndividuals.tsx
@@ -14,6 +14,7 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'),
+	useLocation: () => ({search: ''}),
 	useParams: jest.fn(),
 }));
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/FrontendDataSet.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/shared/components/FrontendDataSet.tsx
@@ -10,7 +10,7 @@ import {
 } from '@liferay/frontend-data-set-web';
 import {formatUTCDate, getCustomDateFormat} from 'shared/util/date';
 import {Text} from '@clayui/core';
-import {toRoute} from 'shared/util/router';
+import {setUriQueryValues, toRoute} from 'shared/util/router';
 
 export * from '@liferay/frontend-data-set-web';
 
@@ -98,25 +98,29 @@ export const columns = {
 		channelId,
 		groupId,
 		itemData,
+		queryValues,
 		route,
 		value,
 	}: {
 		channelId: string;
 		groupId: string;
 		itemData: {id: string | number};
+		queryValues?: {[key: string]: any};
 		route: string;
 		value: string;
 	}) => {
 		const itemTitle = value || itemData.id;
 
+		const href = toRoute(route, {
+			channelId,
+			groupId,
+			id: itemData.id,
+		});
+
 		return (
 			<ClayLink
 				className="font-weight-semi-bold text-dark"
-				href={toRoute(route, {
-					channelId,
-					groupId,
-					id: itemData.id,
-				})}
+				href={queryValues ? setUriQueryValues(queryValues, href) : href}
 			>
 				{itemTitle}
 			</ClayLink>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103813

## What Is Being Fixed

The account individuals data set requests an all-time list, and the range a user picks has nowhere to live. It also loses that selection when the user clicks through to an individual's profile, which is the redirect the story is trying to reconcile with.

## How It Is Being Fixed

`IndividualsDataSet` backs both reports — the Most Engaged Individuals preview on the account overview and the full Account Individuals list on the account profile — so the plumbing lands in one place and serves both.

The selection lives on the query string rather than in component state. `useQueryRangeSelectors` already reads `rangeKey`, `rangeStart` and `rangeEnd` from there and already defaults to the last 30 days, which is the default the story asks for, so this consumes what exists instead of adding a parallel mechanism. Keeping it in the URL is also what makes the selection survive the redirect to the individual profile and what makes the view deep-linkable.

An empty result inside a window is about the window rather than about the account, so the data set declares an empty state that says so, reusing existing language keys. `nameAndLinkRenderer` gains an optional `queryValues` appended to the href it builds; existing callers pass nothing and are unaffected.

This is inert against today's backend: the endpoint ignores the range parameters until LPD-103812 forwards them and LPD-103811 makes Analytics Cloud honour them. The dropdown that writes the range to the query string is LPD-103814. All four are worth holding behind the same release, since a selector that visibly changes nothing reads as broken data.

## PR Check

**pr-check: PASS** — tested on `58d0b8c769b6c27195f09a0a50b01068a52a58bf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

Baseline matched the diff (its trigger is a catch-all) but is not applicable here and was not run: the change is four TypeScript files under `workspaces/`, none of the seven top level Ant projects it compares.

The JavaScript Unit Tests validation did not fire, because its trigger is scoped to `^modules/` and this module lives under `workspaces/`. The suites were run by hand instead: `yarn test --testPathPattern 'IndividualsDataSet|MostEngagedIndividuals|FrontendDataSet'` — 44 tests, 3 suites, all passing. `tsc --noEmit` reports no errors outside the path-mapped `frontend-data-set` sources, which are pre-existing.

<!-- pr-check {"result": "success", "sha": "58d0b8c769b6c27195f09a0a50b01068a52a58bf"} -->
