### PR TITLE
LPD-103814 Add the date range selector to the individuals cards

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/AccountIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/AccountIndividuals.tsx
@@ -2,7 +2,13 @@ import Card from 'shared/components/Card';
 import classNames from 'classnames';
 import IndividualsDataSet from './IndividualsDataSet';
 import React from 'react';
+import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
+import {pickBy} from 'lodash';
+import {RangeSelectors} from 'shared/types';
+import {removeUriQueryParam, setUriQueryValues} from 'shared/util/router';
 import {Text} from '@clayui/core';
+import {useHistory} from 'react-router-dom';
+import {useQueryRangeSelectors} from 'shared/hooks/useQueryRangeSelectors';
 
 interface IAccountIndividualsProps {
 	className?: string;
@@ -10,28 +16,61 @@ interface IAccountIndividualsProps {
 
 const AccountIndividuals: React.FC<IAccountIndividualsProps> = ({
 	className,
-}) => (
-	<Card className={classNames(className)} minHeight={300}>
-		<Card.Title className="mt-3 mx-3">
-			<Text size={4} weight="semi-bold">
-				<span className="text-uppercase">
-					{Liferay.Language.get('account-individuals')}
-				</span>
-			</Text>
-		</Card.Title>
-		<Card.Body noPadding>
-			<div className="mt-1 mx-3">
-				<Text color="secondary" size={3}>
-					{Liferay.Language.get(
-						'lists-all-individuals-associated-with-this-account'
-					)}
+}) => {
+	const history = useHistory();
+
+	const rangeSelectors = useQueryRangeSelectors();
+
+	const handleRangeSelectorChange = ({
+		rangeEnd,
+		rangeKey,
+		rangeStart,
+	}: RangeSelectors) => {
+
+		// The bounds belong to a custom range only, so drop the previous ones
+		// before writing rather than leaving them behind to narrow a preset.
+
+		history.push(
+			setUriQueryValues(
+				pickBy({rangeEnd, rangeKey, rangeStart}),
+				removeUriQueryParam(
+					window.location.href,
+					'rangeEnd',
+					'rangeStart'
+				)
+			)
+		);
+	};
+
+	return (
+		<Card className={classNames(className)} minHeight={300}>
+			<Card.Title className="align-items-center d-flex justify-content-between mt-3 mx-3">
+				<Text size={4} weight="semi-bold">
+					<span className="text-uppercase">
+						{Liferay.Language.get('account-individuals')}
+					</span>
 				</Text>
-			</div>
-			<div className="mt-3">
-				<IndividualsDataSet />
-			</div>
-		</Card.Body>
-	</Card>
-);
+
+				<DropdownRangeKey
+					legacy={false}
+					onRangeSelectorChange={handleRangeSelectorChange}
+					rangeSelectors={rangeSelectors}
+				/>
+			</Card.Title>
+			<Card.Body noPadding>
+				<div className="mt-1 mx-3">
+					<Text color="secondary" size={3}>
+						{Liferay.Language.get(
+							'lists-all-individuals-associated-with-this-account'
+						)}
+					</Text>
+				</div>
+				<div className="mt-3">
+					<IndividualsDataSet />
+				</div>
+			</Card.Body>
+		</Card>
+	);
+};
 
 export default AccountIndividuals;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/AccountIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/AccountIndividuals.tsx
@@ -7,7 +7,7 @@ import {pickBy} from 'lodash';
 import {RangeSelectors} from 'shared/types';
 import {removeUriQueryParam, setUriQueryValues} from 'shared/util/router';
 import {Text} from '@clayui/core';
-import {useHistory} from 'react-router-dom';
+import {useHistoryAdapter} from 'shared/hooks/useHistoryAdapter';
 import {useQueryRangeSelectors} from 'shared/hooks/useQueryRangeSelectors';
 
 interface IAccountIndividualsProps {
@@ -17,7 +17,7 @@ interface IAccountIndividualsProps {
 const AccountIndividuals: React.FC<IAccountIndividualsProps> = ({
 	className,
 }) => {
-	const history = useHistory();
+	const history = useHistoryAdapter();
 
 	const rangeSelectors = useQueryRangeSelectors();
 

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
@@ -2,25 +2,65 @@ import Card from 'shared/components/Card';
 import ClayLink from '@clayui/link';
 import IndividualsDataSet from './IndividualsDataSet';
 import React from 'react';
-import {Routes, toRoute} from 'shared/util/router';
+import {DropdownRangeKey} from 'shared/components/dropdown-range-key/DropdownRangeKey';
+import {pickBy} from 'lodash';
+import {RangeSelectors} from 'shared/types';
+import {
+	removeUriQueryParam,
+	Routes,
+	setUriQueryValues,
+	toRoute,
+} from 'shared/util/router';
 import {Text} from '@clayui/core';
-import {useParams} from 'react-router-dom';
+import {useHistory, useParams} from 'react-router-dom';
+import {useQueryRangeSelectors} from 'shared/hooks/useQueryRangeSelectors';
 
 const MostEngagedIndividuals: React.FC = () => {
+	const history = useHistory();
+
 	const {channelId, groupId, id} = useParams<{
 		channelId: string;
 		groupId: string;
 		id: string;
 	}>();
 
+	const rangeSelectors = useQueryRangeSelectors();
+
+	const handleRangeSelectorChange = ({
+		rangeEnd,
+		rangeKey,
+		rangeStart,
+	}: RangeSelectors) => {
+
+		// The bounds belong to a custom range only, so drop the previous ones
+		// before writing rather than leaving them behind to narrow a preset.
+
+		history.push(
+			setUriQueryValues(
+				pickBy({rangeEnd, rangeKey, rangeStart}),
+				removeUriQueryParam(
+					window.location.href,
+					'rangeEnd',
+					'rangeStart'
+				)
+			)
+		);
+	};
+
 	return (
 		<Card minHeight={260} testId="most-engaged-individuals">
-			<Card.Title className="p-3">
+			<Card.Title className="align-items-center d-flex justify-content-between p-3">
 				<Text size={5} weight="semi-bold">
 					{Liferay.Language.get(
 						'most-engaged-individuals'
 					).toUpperCase()}
 				</Text>
+
+				<DropdownRangeKey
+					legacy={false}
+					onRangeSelectorChange={handleRangeSelectorChange}
+					rangeSelectors={rangeSelectors}
+				/>
 			</Card.Title>
 
 			<Card.Body className="p-0">

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/MostEngagedIndividuals.tsx
@@ -12,11 +12,12 @@ import {
 	toRoute,
 } from 'shared/util/router';
 import {Text} from '@clayui/core';
-import {useHistory, useParams} from 'react-router-dom';
+import {useHistoryAdapter} from 'shared/hooks/useHistoryAdapter';
+import {useParams} from 'react-router-dom';
 import {useQueryRangeSelectors} from 'shared/hooks/useQueryRangeSelectors';
 
 const MostEngagedIndividuals: React.FC = () => {
-	const history = useHistory();
+	const history = useHistoryAdapter();
 
 	const {channelId, groupId, id} = useParams<{
 		channelId: string;

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/AccountIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/AccountIndividuals.tsx
@@ -11,18 +11,107 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 	),
 }));
 
+let lastDropdownProps: any;
+let mockSearch = '';
+
+const mockPush = jest.fn();
+
+// Mocking the dropdown keeps these off the Apollo query it runs to load the
+// range presets; what matters here is the range it is given and the range it
+// hands back.
+
+jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
+	DropdownRangeKey: (props: any) => {
+		lastDropdownProps = props;
+
+		return <div data-testid="dropdown-range-key" />;
+	},
+}));
+
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'),
+	useHistory: () => ({push: mockPush}),
+	useLocation: () => ({search: mockSearch}),
 	useParams: () => ({channelId: '456', groupId: '23', id: 'acc-1'}),
 }));
 
 describe('AccountIndividuals', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		lastDropdownProps = undefined;
+		mockSearch = '';
+
+		// The handler reads window.location, which jsdom shares across tests.
+
+		window.history.replaceState({}, '', '/');
+	});
+
 	afterEach(cleanup);
 
 	it('should render the card title', () => {
 		render(<AccountIndividuals />);
 
 		expect(screen.getByText('Account Individuals')).toBeInTheDocument();
+	});
+
+	it('should render the range dropdown', () => {
+		render(<AccountIndividuals />);
+
+		expect(lastDropdownProps).toBeDefined();
+	});
+
+	it('should default the range to the last thirty days', () => {
+		render(<AccountIndividuals />);
+
+		expect(lastDropdownProps.rangeSelectors.rangeKey).toBe('30');
+	});
+
+	it('should show the range that is on the query string', () => {
+		mockSearch = '?rangeKey=7';
+
+		render(<AccountIndividuals />);
+
+		expect(lastDropdownProps.rangeSelectors.rangeKey).toBe('7');
+	});
+
+	it('should offer the custom range picker', () => {
+		render(<AccountIndividuals />);
+
+		expect(lastDropdownProps.legacy).toBe(false);
+	});
+
+	it('should write the selected preset to the query string', () => {
+		render(<AccountIndividuals />);
+
+		lastDropdownProps.onRangeSelectorChange({
+			rangeEnd: null,
+			rangeKey: '90',
+			rangeStart: null,
+		});
+
+		expect(mockPush).toHaveBeenCalledWith('/?rangeKey=90');
+	});
+
+	it('should drop the previous bounds when a preset is selected', () => {
+		window.history.replaceState(
+			{},
+			'',
+			'/?rangeEnd=2026-02-20&rangeKey=CUSTOM&rangeStart=2026-02-10'
+		);
+
+		render(<AccountIndividuals />);
+
+		lastDropdownProps.onRangeSelectorChange({
+			rangeEnd: null,
+			rangeKey: '30',
+			rangeStart: null,
+		});
+
+		const [pushedURL] = mockPush.mock.calls[0];
+
+		expect(pushedURL).not.toContain('rangeEnd');
+		expect(pushedURL).not.toContain('rangeStart');
+		expect(pushedURL).toContain('rangeKey=30');
 	});
 
 	it('should render the card description', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/AccountIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/AccountIndividuals.tsx
@@ -28,9 +28,12 @@ jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
 	},
 }));
 
+jest.mock('shared/hooks/useHistoryAdapter', () => ({
+	useHistoryAdapter: () => ({push: mockPush}),
+}));
+
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'),
-	useHistory: () => ({push: mockPush}),
 	useLocation: () => ({search: mockSearch}),
 	useParams: () => ({channelId: '456', groupId: '23', id: 'acc-1'}),
 }));

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/MostEngagedIndividuals.tsx
@@ -12,8 +12,27 @@ jest.mock('@liferay/frontend-data-set-web', () => ({
 	),
 }));
 
+let lastDropdownProps: any;
+let mockSearch = '';
+
+const mockPush = jest.fn();
+
+// Mocking the dropdown keeps these off the Apollo query it runs to load the
+// range presets; what matters here is the range it is given and the range it
+// hands back.
+
+jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
+	DropdownRangeKey: (props: any) => {
+		lastDropdownProps = props;
+
+		return <div data-testid="dropdown-range-key" />;
+	},
+}));
+
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'),
+	useHistory: () => ({push: mockPush}),
+	useLocation: () => ({search: mockSearch}),
 	useParams: jest.fn(),
 }));
 
@@ -23,6 +42,14 @@ describe('MostEngagedIndividuals', () => {
 	afterEach(cleanup);
 
 	beforeEach(() => {
+		jest.clearAllMocks();
+		lastDropdownProps = undefined;
+		mockSearch = '';
+
+		// The handler reads window.location, which jsdom shares across tests.
+
+		window.history.replaceState({}, '', '/');
+
 		mockedUseParams.mockReturnValue({
 			channelId: '456',
 			groupId: '23',
@@ -53,6 +80,66 @@ describe('MostEngagedIndividuals', () => {
 		expect(
 			screen.getByRole('link', {name: 'View All'}).getAttribute('href')
 		).toContain('/contacts/accounts/acc-1/profile');
+	});
+
+	it('should render the range dropdown', () => {
+		render(<MostEngagedIndividuals />);
+
+		expect(lastDropdownProps).toBeDefined();
+	});
+
+	it('should default the range to the last thirty days', () => {
+		render(<MostEngagedIndividuals />);
+
+		expect(lastDropdownProps.rangeSelectors.rangeKey).toBe('30');
+	});
+
+	it('should show the range that is on the query string', () => {
+		mockSearch = '?rangeKey=7';
+
+		render(<MostEngagedIndividuals />);
+
+		expect(lastDropdownProps.rangeSelectors.rangeKey).toBe('7');
+	});
+
+	it('should offer the custom range picker', () => {
+		render(<MostEngagedIndividuals />);
+
+		expect(lastDropdownProps.legacy).toBe(false);
+	});
+
+	it('should write the selected preset to the query string', () => {
+		render(<MostEngagedIndividuals />);
+
+		lastDropdownProps.onRangeSelectorChange({
+			rangeEnd: null,
+			rangeKey: '90',
+			rangeStart: null,
+		});
+
+		expect(mockPush).toHaveBeenCalledWith('/?rangeKey=90');
+	});
+
+	it('should drop the previous bounds when a preset is selected', () => {
+		window.history.replaceState(
+			{},
+			'',
+			'/?rangeEnd=2026-02-20&rangeKey=CUSTOM&rangeStart=2026-02-10'
+		);
+
+		render(<MostEngagedIndividuals />);
+
+		lastDropdownProps.onRangeSelectorChange({
+			rangeEnd: null,
+			rangeKey: '30',
+			rangeStart: null,
+		});
+
+		const [pushedURL] = mockPush.mock.calls[0];
+
+		expect(pushedURL).not.toContain('rangeEnd');
+		expect(pushedURL).not.toContain('rangeStart');
+		expect(pushedURL).toContain('rangeKey=30');
 	});
 
 	it('should render no link while the account id is missing', () => {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/MostEngagedIndividuals.tsx
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-web/src/main/js/contacts/pages/account/components/__tests__/MostEngagedIndividuals.tsx
@@ -29,9 +29,12 @@ jest.mock('shared/components/dropdown-range-key/DropdownRangeKey', () => ({
 	},
 }));
 
+jest.mock('shared/hooks/useHistoryAdapter', () => ({
+	useHistoryAdapter: () => ({push: mockPush}),
+}));
+
 jest.mock('react-router-dom', () => ({
 	...jest.requireActual('react-router-dom'),
-	useHistory: () => ({push: mockPush}),
 	useLocation: () => ({search: mockSearch}),
 	useParams: jest.fn(),
 }));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103814

## What Is Being Fixed

The account individuals reports have no way to pick a date range. Without a selector the range plumbing added in LPD-103813 has nothing driving it.

## How It Is Being Fixed

Both cards — Most Engaged Individuals on the account overview and Account Individuals on the account profile — render `DropdownRangeKey` directly and write the selection to the query string. Keeping the selection in the URL rather than in component state is what lets `IndividualsDataSet` read the same value from both surfaces, and what makes it survive the redirect to the individual profile.

`legacy` is `false`, which is what renders the "see more" entry and the date picker, so the dropdown offers a custom range on top of the presets rather than presets alone. The handler clears `rangeEnd` and `rangeStart` before writing, following `WithToolbar`; without that, the bounds of a previous custom range survive and silently narrow the preset the user just picked. It does not reset `page`, which `WithToolbar` does, because this data set runs with `configInURLBehavior` off and does not read a page from the URL.

The handler is the same on both cards. That duplication is deliberate per review: the alternative was a wrapper component, and using the dropdown directly was preferred. Because the logic lives on each card, each card's test covers it.

Navigation goes through `useHistoryAdapter` rather than `useHistory`, which no longer exists on the React Router 7 this module now builds against.

This is inert until the rest of the story lands: LPD-103813 reads the query string into the request, and the numbers only change once LPD-103812 and LPD-103811 reach the backend. All four are worth holding behind the same release, since a selector that visibly changes nothing reads as broken data.

## PR Check

**pr-check: PASS** — tested on `4a1b51fa9362997567813780333ff317f662281c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

Baseline matched the diff (its trigger is a catch-all) but is not applicable here and was not run: the change is four TypeScript files under `workspaces/`, none of the seven top level Ant projects it compares.

The JavaScript Unit Tests validation did not fire, because its trigger is scoped to `^modules/` and this module lives under `workspaces/`. The suites were run by hand instead: `yarn test --testPathPattern 'MostEngagedIndividuals|AccountIndividuals'` — 19 tests, 2 suites, all passing.

Worth noting for reviewers: an earlier revision of this branch failed Workspace Build with `TS2305: Module '"react-router-dom"' has no exported member 'useHistory'`. The card tests mock `react-router-dom` wholesale, so neither they nor a pre-rebase `tsc` run caught it; the webpack compile in this validation is what did.

<!-- pr-check {"result": "success", "sha": "4a1b51fa9362997567813780333ff317f662281c"} -->
