### PR TITLE
LPD-104020 Prevent a blank Projects tab when a workspace has no owner

### DIFF
--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-admin-web/build.gradle
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-admin-web/build.gradle
@@ -2,6 +2,12 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "release.dxp.api", version: "2026.q1.5"
 	compileOnly project(":modules:osb-faro-api")
 	compileOnly project(":modules:osb-faro-engine-client")
+	testImplementation group: "com.liferay.portal", name: "release.dxp.api", version: "2026.q1.5"
+	testImplementation group: "junit", name: "junit", version: "4.13.1"
+	testImplementation group: "org.apache.logging.log4j", name: "log4j-api", version: "2.20.0"
+	testImplementation group: "org.apache.logging.log4j", name: "log4j-core", version: "2.20.0"
+	testImplementation group: "org.mockito", name: "mockito-core", version: "5.14.2"
+	testImplementation project(":modules:osb-faro-api")
 }
 
 generateJSPJava {

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-admin-web/src/main/java/com/liferay/osb/faro/admin/web/internal/model/FaroProjectAdminDisplay.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-admin-web/src/main/java/com/liferay/osb/faro/admin/web/internal/model/FaroProjectAdminDisplay.java
@@ -263,6 +263,10 @@ public class FaroProjectAdminDisplay {
 		FaroUser faroUser = FaroUserLocalServiceUtil.fetchOwnerFaroUser(
 			_groupId);
 
+		if (faroUser == null) {
+			return null;
+		}
+
 		if (faroUser.getLiveUserId() <= 0) {
 			return faroUser.getEmailAddress();
 		}

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-admin-web/src/test/java/com/liferay/osb/faro/admin/web/internal/model/FaroProjectAdminDisplayTest.java
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-admin-web/src/test/java/com/liferay/osb/faro/admin/web/internal/model/FaroProjectAdminDisplayTest.java
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.admin.web.internal.model;
+
+import com.liferay.osb.faro.model.FaroUser;
+import com.liferay.osb.faro.service.FaroUserLocalServiceUtil;
+import com.liferay.portal.kernel.search.Document;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Adriano Interaminense
+ */
+public class FaroProjectAdminDisplayTest {
+
+	@AfterClass
+	public static void tearDownClass() {
+		_faroUserLocalServiceUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testGetOwnerWhenOwnerFaroUserIsNull() {
+		_setUpOwnerFaroUser(null);
+
+		FaroProjectAdminDisplay faroProjectAdminDisplay =
+			new FaroProjectAdminDisplay(Mockito.mock(Document.class));
+
+		Assert.assertNull(faroProjectAdminDisplay.getOwner());
+	}
+
+	@Test
+	public void testGetOwnerWhenOwnerFaroUserLiveUserIdIsNotSet() {
+		FaroUser faroUser = Mockito.mock(FaroUser.class);
+
+		Mockito.when(
+			faroUser.getEmailAddress()
+		).thenReturn(
+			"test@liferay.com"
+		);
+
+		_setUpOwnerFaroUser(faroUser);
+
+		FaroProjectAdminDisplay faroProjectAdminDisplay =
+			new FaroProjectAdminDisplay(Mockito.mock(Document.class));
+
+		Assert.assertEquals(
+			"test@liferay.com", faroProjectAdminDisplay.getOwner());
+	}
+
+	private void _setUpOwnerFaroUser(FaroUser faroUser) {
+		_faroUserLocalServiceUtilMockedStatic.when(
+			() -> FaroUserLocalServiceUtil.fetchOwnerFaroUser(Mockito.anyLong())
+		).thenReturn(
+			faroUser
+		);
+	}
+
+	private static final MockedStatic<FaroUserLocalServiceUtil>
+		_faroUserLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			FaroUserLocalServiceUtil.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-104020

## What Is Being Fixed

The Projects tab of the Faro Admin portlet renders completely empty — no management toolbar, no table, no error message — while still returning HTTP 200. `FaroProjectAdminDisplay._getOwner()` dereferences the result of `FaroUserLocalServiceUtil.fetchOwnerFaroUser(groupId)` without a null check, and that method returns null when the Site Owner role is missing or when the group has no `FaroUser` row carrying it. The resulting `NullPointerException` is thrown while the search container results are transformed, aborting the JSP render right after the navigation bar.

On ldp-stg a single workspace in that state was enough to break the default listing. Paging with `delta=1` showed rows 1 to 19 rendering and row 20 failing, and every page window that included row 20 failed, the default `delta=20` first page among them. Filters and keyword searches whose result set excluded that project rendered normally, including empty result sets, which rules out an out-of-range pagination problem. The System Info tab of the same portlet was unaffected, narrowing the failure to `projects.jsp`.

## How It Is Being Fixed

`_getOwner()` now returns null when `fetchOwnerFaroUser` returns null, so the affected row renders with an empty Owner cell instead of taking the whole tab down. This matches the three other callers of that method, which already guard against null: `ProjectDisplay`, `FaroUserLocalServiceImpl.sendCreatedWorkspaceEmail` and `FaroProjectLocalServiceImpl.sendCreatedWorkspaceEmail`. The guard has never existed on this caller, whose only commit is the original Faro import.

`FaroProjectAdminDisplayTest` covers both branches and reproduces the original `NullPointerException` when the guard is removed. The module had no test source set, so `build.gradle` gains the test dependencies explicitly, following the pattern already used in `osb-faro-web`.

## PR Check

**pr-check: PASS** — tested on `0f590d0eae5cd6c1ecb63c913f541258b01b5648`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Baseline | PASS |
| Workspace Build | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "0f590d0eae5cd6c1ecb63c913f541258b01b5648"} -->
